### PR TITLE
Report errors with source positions and rule context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- Source positions on tokens: the lexer now returns `PosToken` values
+  (token plus line/column), both in the hand-written lexer and in all
+  generated lexers
+- Parse errors report line, column and a human-readable description of the
+  unexpected token (e.g. `Parse error at line 2, column 1: unexpected
+  identifier 'Foo'`); generated parsers report positions too instead of
+  dumping the remaining token list
+- Errors at end of input carry the position where the input ended, in both
+  the hand-written and generated parsers
+- Grammar normalization errors name the offending rule and its source
+  position (e.g. `Grammar error in rule 'Foo' (at line 2, column 1): ...`)
+- Lexer-generation errors name the lexical rule they occur in
+
+### Fixed
+- A grammar whose first rule is lexical (or has a data-type annotation
+  different from the rule name) no longer crashes with `fromJust: Nothing`;
+  it reports that the first rule must be a syntax rule, or resolves the
+  annotated type correctly
+- Internal `fromJust` calls in code generation replaced with descriptive
+  internal-error messages
+- Invalid clauses in lexical-rule macros now abort generation with an error
+  instead of writing the error text into the generated lexer
+- User-facing errors no longer print a GHC call stack
+
 ## [0.10] - 2025-12-03
 
 ### Added

--- a/Debug.hs
+++ b/Debug.hs
@@ -107,7 +107,7 @@ formatContent FormatTree s = s -- Could be enhanced with tree drawing
 -------------------------------------------------------------------------------
 
 -- | Debug tokens output
-printTokens :: DebugOptions -> [L.Token] -> IO ()
+printTokens :: DebugOptions -> [L.PosToken] -> IO ()
 printTokens opts tokens = do
     debugSection opts "LEXER OUTPUT - TOKENS"
     putStrLn $ "Total tokens: " ++ show (length tokens)

--- a/GenQ.hs
+++ b/GenQ.hs
@@ -107,7 +107,13 @@ replaceAllPatterns str = init $ replaceAllPatterns1 (str ++ " ")
                                                     else listExpGen
                                              else nonListGen )
                                 antiRules
-          qqFunProtoGen typ = [str|?(qqFunName typ) :: Data.Data a => String -> (?(fromJust $ getStartRuleName info) -> a) -> String -> TH.?typ~Q|]
+          startRuleName = fromMaybe (error "Internal error (GenQ): start rule name is not set in grammar info")
+                                    (getStartRuleName info)
+          startTokenFor typeName = fromMaybe (error $ "Internal error (GenQ): no start token recorded for type '" ++ typeName ++ "'")
+                                             (M.lookup typeName $ getRuleToStartInfo info)
+          constructorFor typeName = fromMaybe (error $ "Internal error (GenQ): no start constructor found for type '" ++ typeName ++ "'")
+                                              (M.lookup typeName typeNameToConstructor)
+          qqFunProtoGen typ = [str|?(qqFunName typ) :: Data.Data a => String -> (?startRuleName -> a) -> String -> TH.?typ~Q|]
           dataToExpCall typ var = [str|  dataTo?typ~Q (?(antiExprsGen typ)) ?var|]
           qqFunImplGen typ = [str|?(qqFunName typ ) dummy func s = do
   let s1 = replaceAllPatterns s
@@ -132,9 +138,9 @@ replaceAllPatterns str = init $ replaceAllPatterns1 (str ++ " ")
                                        case getSDataTypeName ruleGroup of
                                          typeName@(s : rest) ->
                                            let sortFunName = sortNameToHaskellName $ C.toLower s : rest
-                                               dummy = "\"" ++ (fromJust $ M.lookup typeName $ getRuleToStartInfo info) ++ "\""
+                                               dummy = "\"" ++ startTokenFor typeName ++ "\""
                                                getFun = "get" ++ typeName
-                                               dataConstructor = fromJust $ M.lookup typeName typeNameToConstructor
+                                               dataConstructor = constructorFor typeName
                                            in
                                              [str|?getFun ( ?dataConstructor s) = s
 

--- a/GenX.hs
+++ b/GenX.hs
@@ -39,10 +39,10 @@ genMacroText sMacroIds macroIds tokens =
                     case lrule of
                       (LexicalRule {getLRuleName = name, getLClause = cl }) ->
                         if name `S.member` macroIds
-                          then (text "@" <> text name) <+> text "=" <+> translateClause sMacroIds cl : result
+                          then (text "@" <> text name) <+> text "=" <+> translateClause name sMacroIds cl : result
                           else result
                       (MacroRule {getLRuleName = name, getLClause = cl }) ->
-                          (text "$" <> text name) <+> text "=" <+> translateClauseForMacro cl : result)
+                          (text "$" <> text name) <+> text "=" <+> translateClauseForMacro name cl : result)
              [] tokens
 
 genX :: NormalGrammar -> String
@@ -61,29 +61,41 @@ genX (NormalGrammar { getNGrammarName = name, getLexicalRules = tokens, getNImpo
           tokensText = genTokens symMacroIds $ removeSymmacros tokens
           macroText = genMacroText symMacroIds macroIds tokens
           adt = genTokenADT $ removeSymmacros tokens
-          header = vcat [text "{", ((text "module" <+> text name) <> text "Lexer(alexScanTokens, Token(..))"), text "where", text imports, text " }", 
+          header = vcat [text "{", ((text "module" <+> text name) <> text "Lexer(alexScanTokens, Token(..), PosToken(..), AlexPosn(..))"), text "where", text imports, text " }",
                          text "%wrapper \"monad\""]
           funs_text = [str|
-alexEOF = return EndOfFile
-alexScanTokens :: String -> [Token]
-alexScanTokens str = 
+-- A token together with the source position where it starts
+data PosToken = PosToken { ptPos :: AlexPosn, ptToken :: Token }
+                deriving (Show)
+
+alexEOF = do
+  (pos, _, _, _) <- alexGetInput
+  return $ PosToken pos EndOfFile
+
+-- The returned list always ends with an EndOfFile token that carries the
+-- position of the end of input, so parse errors at end of input can be
+-- reported with a position too
+alexScanTokens :: String -> [PosToken]
+alexScanTokens str =
                case alexScanTokens1 str of
                   Right toks -> toks
-                  Left err -> error err
+                  Left err -> errorWithoutStackTrace err
 
 alexScanTokens1 str = runAlex str $ do
   let loop toks = do tok <- alexMonadScan
                      case tok of
-                       EndOfFile -> return $ reverse toks
-                       _ -> let toks' = tok : toks 
+                       PosToken _ EndOfFile -> return $ reverse (tok : toks)
+                       _ -> let toks' = tok : toks
                             in toks' `seq` loop toks'
   loop []
-simple1 :: (String -> Token) -> AlexInput -> Int -> Alex Token
-simple1 t (_, _, _, str) len = return $ t (take len str)
 
-simple t input len = return t
+simple1 :: (String -> Token) -> AlexInput -> Int -> Alex PosToken
+simple1 t (pos, _, _, str) len = return $ PosToken pos (t (take len str))
 
-rtkError ((AlexPn _ line column), _, _, str) len = alexError $ "lexical error at " ++ (show line) ++ " line, " ++ (show column) ++ " column" ++ ". Following chars :" ++ (take 10 str)
+simple :: Token -> AlexInput -> Int -> Alex PosToken
+simple t (pos, _, _, _) len = return $ PosToken pos t
+
+rtkError ((AlexPn _ line column), _, _, str) len = alexError $ "lexical error at line " ++ (show line) ++ ", column " ++ (show column) ++ ". Following chars: " ++ (take 10 str)
 |]
           funs = text funs_text             
           footer = vcat [text "{", adt, funs , text "}"]
@@ -103,7 +115,7 @@ genTokens :: S.Set String -> [LexicalRule] -> Doc
 genTokens smacroIds lexical_rules =
   text "tokens" <+> text ":-" <+> vcat (map makeToken lexical_rules ++ [text ". { rtkError }"])
     where makeToken LexicalRule { getLRuleDataType = data_type, getLRuleFunc = func, getLRuleName = name, getLClause = cl } =
-              translateClause smacroIds cl <+> makeProduction name data_type func
+              translateClause name smacroIds cl <+> makeProduction name data_type func
           makeToken (MacroRule _ _) = empty
           makeProduction name data_type func =
             let token_name = text $ tokenName name in
@@ -138,12 +150,12 @@ backquoteStrInBrackets s = concat (map (\chr -> if (case chr of
                                           else [chr] )
                                   s)
 
-translateClauseForMacro :: IClause -> Doc
-translateClauseForMacro (IStrLit s) = text s
-translateClauseForMacro (IRegExpLit re) = brackets $ text $ backquoteStrInBrackets re
-translateClauseForMacro (ISeq cls) = hsep $ punctuate (text " ") (map translateClauseForMacro cls)
-translateClauseForMacro (IAlt clauses) = hsep $ punctuate (text "|") (map translateClauseForMacro clauses)
-translateClauseForMacro cl = text $ "Cannot translate to macro def " ++ (show cl)
+translateClauseForMacro :: ID -> IClause -> Doc
+translateClauseForMacro _ (IStrLit s) = text s
+translateClauseForMacro _ (IRegExpLit re) = brackets $ text $ backquoteStrInBrackets re
+translateClauseForMacro rname (ISeq cls) = hsep $ punctuate (text " ") (map (translateClauseForMacro rname) cls)
+translateClauseForMacro rname (IAlt clauses) = hsep $ punctuate (text "|") (map (translateClauseForMacro rname) clauses)
+translateClauseForMacro rname cl = errorWithoutStackTrace $ "In lexical rule '" ++ rname ++ "': cannot translate clause to a lexer macro definition: " ++ showClause cl
 
 -- Detect Alex escape sequences that should be output as bare escapes, not quoted strings.
 -- In Alex: "\n" = literal backslash+n, but \n = newline character.
@@ -156,25 +168,25 @@ isAlexEscape "\\f" = True   -- form feed
 isAlexEscape "\\v" = True   -- vertical tab
 isAlexEscape _ = False
 
-translateClause :: S.Set ID -> IClause -> Doc
-translateClause sMacroIds (IId name) | name `S.member` sMacroIds =
+translateClause :: ID -> S.Set ID -> IClause -> Doc
+translateClause _ sMacroIds (IId name) | name `S.member` sMacroIds =
   text "$" <> text name
-translateClause _ (IId name) =
+translateClause _ _ (IId name) =
   text "@" <> text name
-translateClause _ (IStrLit s)
+translateClause _ _ (IStrLit s)
   | isAlexEscape s = text s   -- output bare escape: \n, \t, etc.
   | otherwise      = doubleQuotes $ text $ backquoteStr s
-translateClause _ (IDot)              = text "."
-translateClause _ (IRegExpLit re)     = brackets $ text $ backquoteStrInBrackets re
-translateClause sMacroIds (IStar cl Nothing)  = translateClause sMacroIds cl <> text "*"
+translateClause _ _ (IDot)              = text "."
+translateClause _ _ (IRegExpLit re)     = brackets $ text $ backquoteStrInBrackets re
+translateClause rname sMacroIds (IStar cl Nothing)  = translateClause rname sMacroIds cl <> text "*"
 -- a* ~x --> (a(x a)*)?
-translateClause _ (IStar _ (Just _)) = error $ "Star (*) clauses with delimiters are not supported in lexical rules"
-translateClause sMacroIds (IPlus cl Nothing)  = translateClause sMacroIds cl <> text "+"
-translateClause _ (IPlus _ (Just _)) = error $ "Plus (+) clauses with delimiters are not supported in lexical rules"
-translateClause sMacroIds (IAlt clauses)      = parens $ hsep $ punctuate (text "|") (map (translateClause sMacroIds) clauses)
-translateClause sMacroIds (ISeq clauses)    = hsep $ punctuate (text " ") (map (translateClause sMacroIds) clauses)
-translateClause sMacroIds (IOpt clause)       = translateClause sMacroIds clause <+> text "?"
-translateClause _ cl                 = error $ "Can't translate to lexer spec: " ++ (show cl)
+translateClause rname _ (IStar _ (Just _)) = errorWithoutStackTrace $ "In lexical rule '" ++ rname ++ "': star (*) clauses with delimiters (~) are not supported in lexical rules"
+translateClause rname sMacroIds (IPlus cl Nothing)  = translateClause rname sMacroIds cl <> text "+"
+translateClause rname _ (IPlus _ (Just _)) = errorWithoutStackTrace $ "In lexical rule '" ++ rname ++ "': plus (+) clauses with delimiters (~) are not supported in lexical rules"
+translateClause rname sMacroIds (IAlt clauses)      = parens $ hsep $ punctuate (text "|") (map (translateClause rname sMacroIds) clauses)
+translateClause rname sMacroIds (ISeq clauses)    = hsep $ punctuate (text " ") (map (translateClause rname sMacroIds) clauses)
+translateClause rname sMacroIds (IOpt clause)       = translateClause rname sMacroIds clause <+> text "?"
+translateClause rname _ cl                 = errorWithoutStackTrace $ "In lexical rule '" ++ rname ++ "': cannot translate clause to lexer spec: " ++ showClause cl
 
 joinAlts :: [Doc] -> Doc
 joinAlts alts = vcat $ punctuate (text " |") (filter (not.isEmpty) alts)

--- a/GenY.hs
+++ b/GenY.hs
@@ -8,13 +8,13 @@ import GenAST
 import Grammar
 
 genY :: NormalGrammar -> String
-genY g@(NormalGrammar name srules lex_rules _ _ _ _) = 
+genY g@(NormalGrammar name srules lex_rules _ _ _ _) =
     render $ vcat [
                    text header,
                    nl,
                    text "%name parse" <> text name,
-                   text "%tokentype { L.Token }",
-                   text "%error { \\ rest -> error $ \"Parse error \" ++ (show rest) }",
+                   text "%tokentype { L.PosToken }",
+                   text "%error { parseError }",
                    nl,
                    text "%token",
                    nl,
@@ -28,17 +28,33 @@ genY g@(NormalGrammar name srules lex_rules _ _ _ _) =
                   ]
     where normal_rules = normalRules srules
           listRuleSet = makeListRuleSet normal_rules
-          rulesDoc = vcat (map (genRule listRuleSet) normal_rules)
-          lexDoc = vcat (map genToken $ removeSymmacros lex_rules)
+          -- The start rule is wrapped so that the parser consumes the
+          -- EndOfFile token emitted by the lexer; this way errors at end of
+          -- input are reported by parseError with a real source position
+          startWrapper = case normal_rules of
+                           (r : _) -> [(text (name ++ "__top") <+> text ":" <+> text (getSRuleName r)
+                                        <+> text "rtk__eof" <+> text "{ $1 }") <> text "\n"]
+                           []      -> []
+          rulesDoc = vcat (startWrapper ++ map (genRule listRuleSet) normal_rules)
+          lexDoc = vcat (combineAlt (text "rtk__eof") (text "L.PosToken _ L.EndOfFile")
+                         : map genToken (removeSymmacros lex_rules))
           nl = text ""
           header = "{\n\
                    \{-# LANGUAGE DeriveDataTypeable #-}\n\
                    \module " ++ name ++ "Parser where\n\
                    \import qualified Data.Generics as Gen\n\
-                   \import qualified " ++ name ++  "Lexer as L (Token(..), alexScanTokens)\n\
+                   \import qualified " ++ name ++  "Lexer as L (Token(..), PosToken(..), AlexPosn(..), alexScanTokens)\n\
                    \}"
           ast = genAST g
-          footer = "{\n" ++ ast ++ "\n}"
+          parseErrorDefs = "parseError :: [L.PosToken] -> a\n\
+                           \parseError [] = errorWithoutStackTrace \"Parse error: unexpected end of input\"\n\
+                           \parseError (L.PosToken (L.AlexPn _ line col) tok : _) =\n\
+                           \    errorWithoutStackTrace $ \"Parse error at line \" ++ show line ++ \", column \" ++ show col ++ \": unexpected \" ++ showRtkToken tok\n"
+          showTokenDefs = render $ vcat (text "-- Render a token the way it appears in the source, for error messages"
+                                         : text "showRtkToken :: L.Token -> String"
+                                         : text "showRtkToken L.EndOfFile = \"end of input\""
+                                         : map genShowToken (removeSymmacros lex_rules))
+          footer = "{\n" ++ parseErrorDefs ++ "\n" ++ showTokenDefs ++ "\n\n" ++ ast ++ "\n}"
 
 type ListRuleSet = Set.Set ID
 
@@ -50,10 +66,20 @@ makeListRuleSet lst = Set.fromList $ map getSRuleName $ filter isMany lst
 genToken :: LexicalRule -> Doc
 genToken LexicalRule{ getLRuleName = name, getLRuleDataType = dtn } =
     case dtn of
-        "Keyword" -> combineAlt (text name) (text "L." <> text (tokenName name))
+        "Keyword" -> combineAlt (text name) (text "L.PosToken _ L." <> text (tokenName name))
         "Ignore"  -> empty
-        _         -> combineAlt (text name) ((text "L." <> text (tokenName name)) <+> text "$$")
+        _         -> combineAlt (text name) (text "L.PosToken _ (L." <> text (tokenName name) <> text " $$)")
 genToken (MacroRule _ _) = empty
+
+genShowToken :: LexicalRule -> Doc
+genShowToken LexicalRule{ getLRuleName = name, getLRuleDataType = dtn, getLClause = cl } =
+    case dtn of
+        "Ignore"  -> empty
+        "Keyword" -> (text "showRtkToken L." <> text (tokenName name)) <+> text "=" <+> text (show (keywordText cl))
+        _         -> (text "showRtkToken (L." <> text (tokenName name)) <+> text "v) =" <+> text (show (name ++ " ")) <+> text "++ show v"
+    where keywordText (IStrLit s) = "'" ++ s ++ "'"
+          keywordText _           = name
+genShowToken (MacroRule _ _) = empty
 
 genRule :: ListRuleSet -> SyntaxRule -> Doc
 -- <Rule>* with separator can only be expressed using two rules in LR grammar

--- a/Lexer.x
+++ b/Lexer.x
@@ -50,7 +50,7 @@ tokens:-
 getStateCommentDepth = Alex $ \s@AlexState{alex_ust=ust} -> Right (s, getCommentDepth ust)
 setStateCommentDepth i = Alex $ \s@AlexState{alex_ust=ust} -> Right (s{alex_ust=ust{getCommentDepth = i}}, ()) 
 
-beginMultiLineComment :: AlexInput -> Int -> Alex Token
+beginMultiLineComment :: AlexInput -> Int -> Alex PosToken
 beginMultiLineComment alexInput i =
   do
     commentDepth <- getStateCommentDepth
@@ -58,7 +58,7 @@ beginMultiLineComment alexInput i =
     alexSetStartCode mlcomment
     skip alexInput i
 
-tryEndMultiLineComment :: AlexInput -> Int -> Alex Token    
+tryEndMultiLineComment :: AlexInput -> Int -> Alex PosToken
 tryEndMultiLineComment alexInput i =
   do
     commentDepth <- getStateCommentDepth
@@ -100,27 +100,37 @@ data Token = Grammar
     | EndOfFile
       deriving (Eq, Show)
 
-alexScanTokens :: String -> [Token]
-alexScanTokens str = 
+-- A token together with the source position where it starts
+data PosToken = PosToken { ptPos :: AlexPosn, ptToken :: Token }
+                deriving (Eq, Show)
+
+-- The returned list always ends with an EndOfFile token that carries the
+-- position of the end of input, so parse errors at end of input can be
+-- reported with a position too
+alexScanTokens :: String -> [PosToken]
+alexScanTokens str =
                case alexScanTokens1 str of
                   Right toks -> toks
-                  Left err -> error err
+                  Left err -> errorWithoutStackTrace err
 
 alexScanTokens1 str = runAlex str $ do
   let loop toks = do tok <- alexMonadScan
                      case tok of
-                       EndOfFile -> return $ reverse toks
+                       PosToken _ EndOfFile -> return $ reverse (tok : toks)
                        _ -> let toks' = tok : toks
                             in toks' `seq` loop toks'
   loop []
 
-alexEOF = return EndOfFile
+alexEOF = do
+  (pos, _, _, _) <- alexGetInput
+  return $ PosToken pos EndOfFile
 
-rtkError ((AlexPn _ line column), _, _, str) _ = alexError $ "lexical error at " ++ (show line) ++ " line, " ++ (show column) ++ " column" ++ ". Following chars :" ++ (take 10 str)
+rtkError ((AlexPn _ line column), _, _, str) _ = alexError $ "lexical error at line " ++ (show line) ++ ", column " ++ (show column) ++ ". Following chars: " ++ (take 10 str)
 
-simple1 :: (String -> Token) -> AlexInput -> Int -> Alex Token
-simple1 t (_, _, _, str) len = return $ t (take len str)
+simple1 :: (String -> Token) -> AlexInput -> Int -> Alex PosToken
+simple1 t (pos, _, _, str) len = return $ PosToken pos (t (take len str))
 
-simple t _ _ = return t
+simple :: Token -> AlexInput -> Int -> Alex PosToken
+simple t (pos, _, _, _) _ = return $ PosToken pos t
 
 }

--- a/Normalize.hs
+++ b/Normalize.hs
@@ -3,6 +3,7 @@ module Normalize(normalizeTopLevelClauses, fillConstructorNames)
     where
 
 import Parser
+import Grammar (isNotIgnored)
 import Data.Generics
 import Data.Maybe
 import qualified Data.Map as M
@@ -33,12 +34,25 @@ data NormalizationState = NormalizationState {
                                               _proxyRuleNames :: S.Set ID,
                                               _qqLexRuleCache :: M.Map ID ID,
                                               _antiRuleCache :: M.Map ID ID,
-                                              _ruleToTypeName :: M.Map ID ID
+                                              _ruleToTypeName :: M.Map ID ID,
+                                              _currentRule :: Maybe IRule
                                              }
 
 $(makeLenses ''NormalizationState)
 
 type Normalization a = State NormalizationState a
+
+-- Report a grammar error, attaching the rule (and its source position, when
+-- known) that was being normalized when the problem was found
+normError :: String -> Normalization a
+normError msg = do
+  ctx <- gets _currentRule
+  let loc = case ctx of
+              Just r -> "in rule '" ++ getIRuleName r ++ "'"
+                        ++ maybe "" (\p -> " (at " ++ showSourcePos p ++ ")") (getIRulePos r)
+                        ++ ": "
+              Nothing -> ""
+  errorWithoutStackTrace $ "Grammar error " ++ loc ++ msg
 
 newNamePrefixed :: String -> Normalization String
 newNamePrefixed prefix = do
@@ -184,7 +198,7 @@ checkSimpleClause (IIgnore c1) = do
   newC1 <- checkSimpleClause c1
   case newC1 of
     SSId idName -> return $ SSIgnore idName
-    _ -> error $ "Ignore cannot be applied to " ++ show c1
+    _ -> normError $ "ignore (!) cannot be applied to: " ++ showClause c1
 checkSimpleClause c = extractClause c >>= return . SSId
 
 checkNormalClause :: IClause -> Normalization SyntaxTopClause
@@ -213,23 +227,38 @@ checkNormalClause (ILifted c) = do
   c1 <- checkSimpleClause c
   case c1 of
     SSId idName -> return $ STAltOfSeq [STSeq "" [SSLifted idName]]
-    _ -> error $ "Lifted cannot be applied to " ++ show c1
+    _ -> normError $ "lifted (,) cannot be applied to: " ++ showClause c
 checkNormalClause (IIgnore c) = do
   c1 <- checkSimpleClause c
   case c1 of
     SSId idName -> return $ STAltOfSeq [STSeq "" [SSIgnore idName]]
-    _ -> error $ "Ignore cannot be applied to " ++ show c1
+    _ -> normError $ "ignore (!) cannot be applied to: " ++ showClause c
 checkNormalClause (IId idName) = do
   return $ STAltOfSeq [STSeq "" [SSId idName]]
-checkNormalClause c = error $ "Wrong clause " ++ show c
+checkNormalClause c = normError $ "this clause cannot be used in a syntax rule: " ++ showClause c
+                                  ++ " (regular expressions and '.' are only allowed in lexical rules)"
 
 checkNormalClauseSeq :: IClause -> Normalization STSeq
 checkNormalClauseSeq (ISeq cs) = do
   cs1 <- mapM checkSimpleClause cs
+  checkLiftedInSeq cs cs1
   return $ STSeq "" cs1
 checkNormalClauseSeq ic = do
   c1 <- checkSimpleClause ic
   return $ STSeq "" [c1]
+
+-- A lifted (,) clause must be the only non-ignored clause of its sequence.
+-- Check it here, where the offending rule is still known, instead of failing
+-- without context during code generation (see isClauseSeqLifted)
+checkLiftedInSeq :: [IClause] -> [SyntaxSimpleClause] -> Normalization ()
+checkLiftedInSeq orig cs =
+  case filter isNotIgnored cs of
+    [SSLifted _] -> return ()
+    cs1 | any isLifted cs1 -> normError $ "a lifted (,) clause cannot be mixed with other clauses in a sequence: "
+                                          ++ showClause (ISeq orig)
+    _ -> return ()
+  where isLifted SSLifted{} = True
+        isLifted _          = False
 
 normalizeRule :: IRule -> Normalization ()
 normalizeRule r@IRule{getIDataTypeName=dtn, getIRuleName=rn, getIClause=cl, getIDataFunc=_, getIRuleOptions=_} | not (isLexicalRule rn) = do
@@ -259,7 +288,10 @@ buildRuleToTypeMap grammar = M.fromList $ map ruleMapping $ getIRules grammar
 doNM :: InitialGrammar -> Normalization ()
 doNM grammar = do
   let grammar0 = everywhereBut (False `mkQ` (isLexicalRule . getIRuleName)) (mkT removeOpts) grammar
-  mapM_ normalizeRule $ getIRules grammar0
+  mapM_ (\r -> do currentRule .= Just r
+                  normalizeRule r)
+        $ getIRules grammar0
+  currentRule .= Nothing
   postNormalizeGrammar
 
 postNormalizeGroup :: (ID, [SyntaxRule]) -> Normalization (ID, [SyntaxRule])
@@ -297,8 +329,10 @@ addStartGroup ng@NormalGrammar { getSyntaxRuleGroups = rules, getLexicalRules = 
                                      rules
       rulesClauses = map (\s ->
                            let typeName = getSDataTypeName s
-                               dummy = SSIgnore (fromJust (M.lookup typeName ruleToStartInfo))
-                           in 
+                               startTok = fromMaybe (error $ "Internal error: no start token generated for type '" ++ typeName ++ "'")
+                                                    (M.lookup typeName ruleToStartInfo)
+                               dummy = SSIgnore startTok
+                           in
                            STSeq "" [dummy,
                                      SSId typeName,
                                      dummy]) $ filterProxyRules proxyRules rules
@@ -306,7 +340,9 @@ addStartGroup ng@NormalGrammar { getSyntaxRuleGroups = rules, getLexicalRules = 
                                                    getLRuleFunc = "",
                                                    getLRuleName = name, getLClause = (IStrLit name)}) $ M.toList ruleToStartInfo
       
-      qqRule = SyntaxRule (fromJust (getStartRuleName info)) $ STAltOfSeq rulesClauses
+      qqRule = SyntaxRule (fromMaybe (error "Internal error: start rule name is not set in grammar info")
+                                     (getStartRuleName info))
+                          $ STAltOfSeq rulesClauses
     in case rules of
       (startRule:restRules) ->
         ng { getSyntaxRuleGroups = startRule { getSRules = qqRule : getSRules startRule }: restRules,
@@ -317,13 +353,16 @@ addStartGroup ng@NormalGrammar { getSyntaxRuleGroups = rules, getLexicalRules = 
 normalizeTopLevelClauses :: InitialGrammar -> NormalGrammar
 normalizeTopLevelClauses grammar =
   case getIRules grammar of
-    [] -> error $ "Grammar '" ++ (getIGrammarName grammar) ++ "' contains no rules"
+    [] -> errorWithoutStackTrace $ "Grammar '" ++ (getIGrammarName grammar) ++ "' contains no rules"
     (firstIRule:_) ->
-      let firstID = getIRuleName firstIRule
+      let firstID = maybe (getIRuleName firstIRule) Prelude.id (getIDataTypeName firstIRule)
           ruleTypeMap = buildRuleToTypeMap grammar
-          (_, NormalizationState nrs nls counter antiRules shortcuts proxyRules _ _ _) =
-            runState (doNM grammar) (NormalizationState M.empty [] 0 [] [] S.empty M.empty M.empty ruleTypeMap)
-          firstRuleGroupRules = fromJust $ M.lookup firstID nrs
+          (_, NormalizationState nrs nls counter antiRules shortcuts proxyRules _ _ _ _) =
+            runState (doNM grammar) (NormalizationState M.empty [] 0 [] [] S.empty M.empty M.empty ruleTypeMap Nothing)
+          firstRuleGroupRules = fromMaybe firstRuleError $ M.lookup firstID nrs
+          firstRuleError = errorWithoutStackTrace $ "Grammar error: the first rule ('" ++ getIRuleName firstIRule
+                                   ++ "') must be a syntax rule (its name must start with an uppercase letter),"
+                                   ++ " because it defines the start symbol of the grammar"
           nrs1 = M.delete firstID nrs
           firstGroup = SyntaxRuleGroup firstID firstRuleGroupRules
           otherGroups = map (\ (k,v) -> SyntaxRuleGroup k v) $ M.toList nrs1

--- a/Parser.y
+++ b/Parser.y
@@ -1,46 +1,48 @@
 {
 module Parser where
 
-import qualified Lexer as L (Token(..), alexScanTokens)
+import qualified Lexer as L (Token(..), PosToken(..), AlexPosn(..), alexScanTokens)
 import Data.Generics
 import Data.Data
 import Data.Char
+import Data.List (intercalate)
 import qualified Data.Map as M
 import qualified Data.Set as S
 
 }
 
 %name parse
-%tokentype  { L.Token }
+%tokentype  { L.PosToken }
 %error      { parseError }
 
 %token
 
-grammar { L.Grammar }
-imports { L.Imports }
-'='    { L.Eq }
-'|'     { L.OrClause }
-':'     { L.Colon }
-';'     { L.RlEnd }
-'*'     { L.Star }
-'+'     { L.Plus }
-'?'     { L.Question }
-')'     { L.RParen }
-'('     { L.LParen }
-'.'     { L.Dot }
-'!'     { L.Excl }
-'~'     { L.Tilde }
-','     { L.Comma }
-'@shortcuts' { L.Shortcuts }
-'@symmacro' { L.Symmacro }
-id  { L.Id $$ }
-str       { L.StrLit $$ }
-rexplit       { L.RegExpLit $$ }
-bigstr     { L.BigStr $$ }
+grammar { L.PosToken _ L.Grammar }
+imports { L.PosToken _ L.Imports }
+'='    { L.PosToken _ L.Eq }
+'|'     { L.PosToken _ L.OrClause }
+':'     { L.PosToken _ L.Colon }
+';'     { L.PosToken _ L.RlEnd }
+'*'     { L.PosToken _ L.Star }
+'+'     { L.PosToken _ L.Plus }
+'?'     { L.PosToken _ L.Question }
+')'     { L.PosToken _ L.RParen }
+'('     { L.PosToken _ L.LParen }
+'.'     { L.PosToken _ L.Dot }
+'!'     { L.PosToken _ L.Excl }
+'~'     { L.PosToken _ L.Tilde }
+','     { L.PosToken _ L.Comma }
+'@shortcuts' { L.PosToken _ L.Shortcuts }
+'@symmacro' { L.PosToken _ L.Symmacro }
+id  { L.PosToken _ (L.Id _) }
+str       { L.PosToken _ (L.StrLit $$) }
+rexplit       { L.PosToken _ (L.RegExpLit $$) }
+bigstr     { L.PosToken _ (L.BigStr $$) }
+eof     { L.PosToken _ L.EndOfFile }
 
 %%
 
-Grammar : grammar str ';' ImportsOpt Rules { InitialGrammar $2 $4 (reverse $5) }
+Grammar : grammar str ';' ImportsOpt Rules eof { InitialGrammar $2 $4 (reverse $5) }
 
 ImportsOpt : imports bigstr    { $2 }
            | {- empty -}       { "" }
@@ -61,13 +63,13 @@ Option : '@shortcuts' '(' IdListOpt ')'     { OShortcuts (reverse $3)}
 IdListOpt : IdList                  { $1 }
           | {- empty -}             { [] } 
 
-IdList : IdList ',' id              { $3 : $1}
-       | id                         { [$1] }
+IdList : IdList ',' id              { idStr $3 : $1}
+       | id                         { [idStr $1] }
 
-Rule : id '=' ClauseAlt ';'         { IRule Nothing Nothing $1 $3 [] }
-     | id ':' id '=' ClauseAlt ';'  { IRule (Just $1) Nothing $3 $5 [] }
-     | id '.' id ':' id '=' ClauseAlt ';'  { IRule (Just $1) (Just $3) $5 $7 [] }
-     | '.' id ':' id '=' ClauseAlt ';'  { IRule Nothing (Just $2) $4 $6 [] }
+Rule : id '=' ClauseAlt ';'         { IRule Nothing Nothing (idStr $1) $3 [] (Just (idPos $1)) }
+     | id ':' id '=' ClauseAlt ';'  { IRule (Just (idStr $1)) Nothing (idStr $3) $5 [] (Just (idPos $1)) }
+     | id '.' id ':' id '=' ClauseAlt ';'  { IRule (Just (idStr $1)) (Just (idStr $3)) (idStr $5) $7 [] (Just (idPos $1)) }
+     | '.' id ':' id '=' ClauseAlt ';'  { IRule Nothing (Just (idStr $2)) (idStr $4) $6 [] (Just (idPos $2)) }
 
 ClauseAlt : ClauseAlt1              { IAlt (reverse $1) }
 
@@ -90,7 +92,7 @@ ClausePost : ClauseItem '*' OptDelim  { IStar $1 $3 }
 
 
 ClauseItem : '(' ClauseAlt ')'        { $2 }
-           | id                       { IId $1 } 
+           | id                       { IId (idStr $1) }
            | str                      { IStrLit $1 }
            | '.'                      { IDot }
            | rexplit                  { IRegExpLit $1 }
@@ -100,18 +102,66 @@ OptDelim : {- empty -}          { Nothing }
 
 {
 
-parseError :: [L.Token] -> a
-parseError [] = error "Parse error: unexpected end of input. Expected a grammar definition."
-parseError rest = error $ "Parse error near: " ++ (show (take 5 rest))
+parseError :: [L.PosToken] -> a
+parseError [] = errorWithoutStackTrace "Parse error: unexpected end of input. Expected a grammar definition."
+parseError (L.PosToken pos tok : rest) =
+    errorWithoutStackTrace $ "Parse error at " ++ showAlexPos pos ++ ": unexpected " ++ showToken tok ++ following
+  where following = case rest of
+                      [] -> ""
+                      _  -> ", followed by: " ++ intercalate ", " (map (showToken . L.ptToken) (take 4 rest))
+
+showAlexPos :: L.AlexPosn -> String
+showAlexPos (L.AlexPn _ line col) = "line " ++ show line ++ ", column " ++ show col
+
+-- Render a token the way it appears in the grammar source, for error messages
+showToken :: L.Token -> String
+showToken L.Grammar        = "keyword 'grammar'"
+showToken L.Imports        = "keyword 'imports'"
+showToken L.Eq             = "'='"
+showToken L.RlEnd          = "';'"
+showToken L.OrClause       = "'|'"
+showToken L.Dot            = "'.'"
+showToken (L.RegExpLit s)  = "regular expression [" ++ s ++ "]"
+showToken (L.StrLit s)     = "string literal '" ++ s ++ "'"
+showToken (L.BigStr _)     = "multi-line string"
+showToken (L.Id s)         = "identifier '" ++ s ++ "'"
+showToken L.Star           = "'*'"
+showToken L.Plus           = "'+'"
+showToken L.Excl           = "'!'"
+showToken L.Comma          = "','"
+showToken L.RParen         = "')'"
+showToken L.LParen         = "'('"
+showToken L.Dollar         = "'$'"
+showToken L.Question       = "'?'"
+showToken L.Colon          = "':'"
+showToken L.Tilde          = "'~'"
+showToken L.Shortcuts      = "'@shortcuts'"
+showToken L.Symmacro       = "'@symmacro'"
+showToken L.EndOfFile      = "end of input"
+
+idStr :: L.PosToken -> String
+idStr (L.PosToken _ (L.Id s)) = s
+idStr t = error $ "Internal error: identifier token expected, but got: " ++ show t
+
+idPos :: L.PosToken -> SourcePos
+idPos (L.PosToken (L.AlexPn _ line col) _) = SourcePos line col
+
+-- Position in the grammar source file (line and column, both 1-based)
+data SourcePos = SourcePos { srcLine :: Int, srcColumn :: Int }
+                 deriving (Eq, Ord, Show, Typeable, Data)
+
+showSourcePos :: SourcePos -> String
+showSourcePos (SourcePos line col) = "line " ++ show line ++ ", column " ++ show col
 
 data InitialGrammar = InitialGrammar { getIGrammarName :: String, getImports :: String, getIRules :: [IRule] }
                  deriving (Eq, Show, Typeable, Data)
 
-data IRule = IRule { getIDataTypeName :: (Maybe String), 
-                     getIDataFunc :: (Maybe String), 
-                     getIRuleName :: String, 
+data IRule = IRule { getIDataTypeName :: (Maybe String),
+                     getIDataFunc :: (Maybe String),
+                     getIRuleName :: String,
                      getIClause :: IClause,
-                     getIRuleOptions :: [IOption]}
+                     getIRuleOptions :: [IOption],
+                     getIRulePos :: (Maybe SourcePos)}
                   deriving (Eq, Show, Typeable, Data)
 
 data IOption = OShortcuts [ID] | OSymmacro
@@ -136,6 +186,23 @@ data IClause = IId { getIdStr :: ID }
              | ILifted IClause
              | IIgnore IClause
               deriving (Eq, Show, Typeable, Data)
+
+-- Render a clause the way it appears in the grammar source, for error messages
+showClause :: IClause -> String
+showClause (IId name)      = name
+showClause (IStrLit s)     = "'" ++ s ++ "'"
+showClause IDot            = "."
+showClause (IRegExpLit s)  = "[" ++ s ++ "]"
+showClause (IStar c md)    = showClause c ++ "*" ++ showDelim md
+showClause (IPlus c md)    = showClause c ++ "+" ++ showDelim md
+showClause (IAlt cs)       = "(" ++ intercalate " | " (map showClause cs) ++ ")"
+showClause (ISeq cs)       = unwords (map showClause cs)
+showClause (IOpt c)        = showClause c ++ "?"
+showClause (ILifted c)     = "," ++ showClause c
+showClause (IIgnore c)     = "!" ++ showClause c
+
+showDelim :: Maybe IClause -> String
+showDelim = maybe "" (\d -> " ~ " ++ showClause d)
 
 data GrammarInfo =
   GrammarInfo

--- a/StringLiterals.hs
+++ b/StringLiterals.hs
@@ -74,5 +74,5 @@ doSLNM grammar = do
 
 normalizeStringLiterals :: InitialGrammar -> InitialGrammar
 normalizeStringLiterals grammar = let (InitialGrammar nm imports rules, StringLiteralsNormalizationState m _) = runState (doSLNM grammar) (StringLiteralsNormalizationState Map.empty 0)
-                                      slRules sm = map (\ (k, v) -> IRule (Just "Keyword") (Just "id") v (IStrLit k) []) $ Map.toList sm
+                                      slRules sm = map (\ (k, v) -> IRule (Just "Keyword") (Just "id") v (IStrLit k) [] Nothing) $ Map.toList sm
                                   in InitialGrammar nm imports (rules ++ slRules m)

--- a/TokenProcessing.hs
+++ b/TokenProcessing.hs
@@ -4,18 +4,21 @@ module TokenProcessing
     , catBigstrs
     ) where
 
-import Lexer (Token(..))
+import Lexer (Token(..), PosToken(..))
 
 -- | Process tokens after lexical analysis
 -- This applies escape sequence handling and concatenates multi-line strings
-processTokens :: [Token] -> [Token]
+processTokens :: [PosToken] -> [PosToken]
 processTokens = catBigstrs . map processEscapes
 
 -- | Process escape sequences in string and regex tokens
-processEscapes :: Token -> Token
-processEscapes (StrLit s) = StrLit (unBackQuote s)
-processEscapes (RegExpLit s) = RegExpLit (unBackQuote s)
-processEscapes tok = tok
+processEscapes :: PosToken -> PosToken
+processEscapes (PosToken pos tok) = PosToken pos (processEscapesTok tok)
+
+processEscapesTok :: Token -> Token
+processEscapesTok (StrLit s) = StrLit (unBackQuote s)
+processEscapesTok (RegExpLit s) = RegExpLit (unBackQuote s)
+processEscapesTok tok = tok
 
 -- | Handle backslash escape sequences
 -- Preserves \\n, \\t, \\r as-is (for grammar rules)
@@ -30,9 +33,10 @@ unBackQuote [] = []
 
 -- | Concatenate adjacent BigStr tokens with newlines
 -- This handles multi-line triple-quoted strings
-catBigstrs :: [Token] -> [Token]
-catBigstrs (BigStr s1 : toks) = case catBigstrs toks of
-                (BigStr s2 : toks') -> (BigStr (s1 ++ ('\n' : s2)) : toks')
-                _ -> BigStr s1 : toks
+-- The merged token keeps the position of the first part
+catBigstrs :: [PosToken] -> [PosToken]
+catBigstrs (PosToken pos (BigStr s1) : toks) = case catBigstrs toks of
+                (PosToken _ (BigStr s2) : toks') -> (PosToken pos (BigStr (s1 ++ ('\n' : s2))) : toks')
+                _ -> PosToken pos (BigStr s1) : toks
 catBigstrs (tok : toks) = tok : catBigstrs toks
 catBigstrs [] = []

--- a/test/UnitTests.hs
+++ b/test/UnitTests.hs
@@ -19,7 +19,7 @@ import System.FilePath (takeBaseName)
 import Test.HUnit
 
 import Grammar (isClauseSeqLifted)
-import Lexer (Token (..))
+import Lexer (AlexPosn (..), PosToken (..), Token (..))
 import Normalize (fillConstructorNames, normalizeTopLevelClauses)
 import Parser
 import StrQuote (str)
@@ -72,11 +72,20 @@ tokenProcessingTests = TestList
     , TestLabel "unBackQuote unescapes backslash itself" $ TestCase $
         assertEqual "" "\\" (unBackQuote "\\\\")
     , TestLabel "catBigstrs joins adjacent big strings" $ TestCase $
-        assertEqual "" [BigStr "a\nb", Id "x"] (catBigstrs [BigStr "a", BigStr "b", Id "x"])
+        assertEqual "" (map at [BigStr "a\nb", Id "x"])
+                       (catBigstrs (map at [BigStr "a", BigStr "b", Id "x"]))
+    , TestLabel "catBigstrs keeps the position of the first part" $ TestCase $
+        assertEqual "" [PosToken (AlexPn 0 1 1) (BigStr "a\nb")]
+                       (catBigstrs [ PosToken (AlexPn 0 1 1) (BigStr "a")
+                                   , PosToken (AlexPn 5 2 1) (BigStr "b") ])
     , TestLabel "processTokens combines both steps" $ TestCase $
-        assertEqual "" [StrLit "'", BigStr "a\nb"]
-                       (processTokens [StrLit "\\'", BigStr "a", BigStr "b"])
+        assertEqual "" (map at [StrLit "'", BigStr "a\nb"])
+                       (processTokens (map at [StrLit "\\'", BigStr "a", BigStr "b"]))
     ]
+
+-- | Wrap a token at a dummy position; token processing ignores positions.
+at :: Token -> PosToken
+at = PosToken (AlexPn 0 1 1)
 
 --------------------------------------------------------------------------------
 -- Pipeline error handling
@@ -107,6 +116,37 @@ errorHandlingTests = TestList
         case result of
             Left _ -> return ()
             Right msg -> assertFailure $ "valid grammar should normalize, got error: " ++ msg
+    , TestLabel "parse errors report the offending position" $ TestCase $ do
+        -- ';' missing after the grammar declaration: the parser should point
+        -- at the identifier 'Foo' on line 2
+        result <- expectErrorCall $ parseGrammarSource "grammar 'Test'\nFoo = bar;\n"
+        case result of
+            Left err -> assertFailure $ "expected a parse error, got: " ++ err
+            Right msg -> assertBool ("unexpected message: " ++ msg) $
+                "line 2, column 1" `isInfixOf` msg && "identifier 'Foo'" `isInfixOf` msg
+    , TestLabel "errors at end of input carry a position" $ TestCase $ do
+        result <- expectErrorCall $ parseGrammarSource "grammar 'Test';\nFoo =\n"
+        case result of
+            Left err -> assertFailure $ "expected a parse error, got: " ++ err
+            Right msg -> assertBool ("unexpected message: " ++ msg) $
+                "line 3, column 1" `isInfixOf` msg && "end of input" `isInfixOf` msg
+    , TestLabel "a lexical first rule is rejected with an explanation" $ TestCase $ do
+        result <- expectErrorCall $ forceGrammar $
+            normalizeGrammarSource "grammar 'Test';\nfoo = [a-z];\n"
+        case result of
+            Left err -> assertFailure $ "expected an error about the first rule, got: " ++ err
+            Right msg -> assertBool ("unexpected message: " ++ msg) $
+                "must be a syntax rule" `isInfixOf` msg && "foo" `isInfixOf` msg
+    , TestLabel "normalization errors name the offending rule and position" $ TestCase $ do
+        -- a lifted (,) clause mixed with other clauses is rejected; the error
+        -- should point at rule 'Foo' on line 2
+        result <- expectErrorCall $ forceGrammar $
+            normalizeGrammarSource "grammar 'Test';\nFoo = ,Bar Baz;\nBar = 'b';\nBaz = 'z';\n"
+        case result of
+            Left err -> assertFailure $ "expected an error about the lifted clause, got: " ++ err
+            Right msg -> assertBool ("unexpected message: " ++ msg) $
+                "in rule 'Foo'" `isInfixOf` msg && "line 2" `isInfixOf` msg
+                && "lifted" `isInfixOf` msg
     ]
 
 -- | Force the whole grammar value so lazy errors surface where we expect them.

--- a/test/golden/debug-test/DebugTestLexer.x
+++ b/test/golden/debug-test/DebugTestLexer.x
@@ -1,5 +1,5 @@
 {
-module DebugTestLexer(alexScanTokens, Token(..))
+module DebugTestLexer(alexScanTokens, Token(..), PosToken(..), AlexPosn(..))
 where
 
  }
@@ -88,25 +88,37 @@ data Token = EndOfFile |
              Tk__qq_Program String
              deriving (Show)
 
-alexEOF = return EndOfFile
-alexScanTokens :: String -> [Token]
-alexScanTokens str = 
+-- A token together with the source position where it starts
+data PosToken = PosToken { ptPos :: AlexPosn, ptToken :: Token }
+                deriving (Show)
+
+alexEOF = do
+  (pos, _, _, _) <- alexGetInput
+  return $ PosToken pos EndOfFile
+
+-- The returned list always ends with an EndOfFile token that carries the
+-- position of the end of input, so parse errors at end of input can be
+-- reported with a position too
+alexScanTokens :: String -> [PosToken]
+alexScanTokens str =
                case alexScanTokens1 str of
                   Right toks -> toks
-                  Left err -> error err
+                  Left err -> errorWithoutStackTrace err
 
 alexScanTokens1 str = runAlex str $ do
   let loop toks = do tok <- alexMonadScan
                      case tok of
-                       EndOfFile -> return $ reverse toks
-                       _ -> let toks' = tok : toks 
+                       PosToken _ EndOfFile -> return $ reverse (tok : toks)
+                       _ -> let toks' = tok : toks
                             in toks' `seq` loop toks'
   loop []
-simple1 :: (String -> Token) -> AlexInput -> Int -> Alex Token
-simple1 t (_, _, _, str) len = return $ t (take len str)
 
-simple t input len = return t
+simple1 :: (String -> Token) -> AlexInput -> Int -> Alex PosToken
+simple1 t (pos, _, _, str) len = return $ PosToken pos (t (take len str))
 
-rtkError ((AlexPn _ line column), _, _, str) len = alexError $ "lexical error at " ++ (show line) ++ " line, " ++ (show column) ++ " column" ++ ". Following chars :" ++ (take 10 str)
+simple :: Token -> AlexInput -> Int -> Alex PosToken
+simple t (pos, _, _, _) len = return $ PosToken pos t
+
+rtkError ((AlexPn _ line column), _, _, str) len = alexError $ "lexical error at line " ++ (show line) ++ ", column " ++ (show column) ++ ". Following chars: " ++ (take 10 str)
 
 }

--- a/test/golden/debug-test/DebugTestParser.y
+++ b/test/golden/debug-test/DebugTestParser.y
@@ -2,55 +2,58 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 module DebugTestParser where
 import qualified Data.Generics as Gen
-import qualified DebugTestLexer as L (Token(..), alexScanTokens)
+import qualified DebugTestLexer as L (Token(..), PosToken(..), AlexPosn(..), alexScanTokens)
 }
 
 %name parseDebugTest
-%tokentype { L.Token }
-%error { \ rest -> error $ "Parse error " ++ (show rest) }
+%tokentype { L.PosToken }
+%error { parseError }
 
 %token
 
-tok_Assignment_dummy_18 { L.Tk__tok_Assignment_dummy_18 }
-tok_Block_dummy_17 { L.Tk__tok_Block_dummy_17 }
-tok_Expression_dummy_16 { L.Tk__tok_Expression_dummy_16 }
-tok_Factor_dummy_15 { L.Tk__tok_Factor_dummy_15 }
-tok_IfStatement_dummy_14 { L.Tk__tok_IfStatement_dummy_14 }
-tok_Program_dummy_19 { L.Tk__tok_Program_dummy_19 }
-tok_Statement_dummy_13 { L.Tk__tok_Statement_dummy_13 }
-tok_Term_dummy_12 { L.Tk__tok_Term_dummy_12 }
-tok_UnusedRule1_dummy_11 { L.Tk__tok_UnusedRule1_dummy_11 }
-tok_UnusedRule2_dummy_10 { L.Tk__tok_UnusedRule2_dummy_10 }
-tok_WhileLoop_dummy_9 { L.Tk__tok_WhileLoop_dummy_9 }
-tok__symbol__12 { L.Tk__tok__symbol__12 }
-tok__symbol__11 { L.Tk__tok__symbol__11 }
-tok_while_10 { L.Tk__tok_while_10 }
-tok_unused_13 { L.Tk__tok_unused_13 }
-tok_if_8 { L.Tk__tok_if_8 }
-tok_else_9 { L.Tk__tok_else_9 }
-tok__eql__0 { L.Tk__tok__eql__0 }
-tok__semi__1 { L.Tk__tok__semi__1 }
-tok__symbol__5 { L.Tk__tok__symbol__5 }
-tok__minus__3 { L.Tk__tok__minus__3 }
-tok__plus__2 { L.Tk__tok__plus__2 }
-tok__star__4 { L.Tk__tok__star__4 }
-tok__rparen__7 { L.Tk__tok__rparen__7 }
-tok__lparen__6 { L.Tk__tok__lparen__6 }
-number { L.Tk__number $$ }
-identifier { L.Tk__identifier $$ }
-qq_UnusedRule2 { L.Tk__qq_UnusedRule2 $$ }
-qq_UnusedRule1 { L.Tk__qq_UnusedRule1 $$ }
-qq_Block { L.Tk__qq_Block $$ }
-qq_WhileLoop { L.Tk__qq_WhileLoop $$ }
-qq_IfStatement { L.Tk__qq_IfStatement $$ }
-qq_Factor { L.Tk__qq_Factor $$ }
-qq_Term { L.Tk__qq_Term $$ }
-qq_Expression { L.Tk__qq_Expression $$ }
-qq_Assignment { L.Tk__qq_Assignment $$ }
-qq_Statement { L.Tk__qq_Statement $$ }
-qq_Program { L.Tk__qq_Program $$ }
+rtk__eof { L.PosToken _ L.EndOfFile }
+tok_Assignment_dummy_18 { L.PosToken _ L.Tk__tok_Assignment_dummy_18 }
+tok_Block_dummy_17 { L.PosToken _ L.Tk__tok_Block_dummy_17 }
+tok_Expression_dummy_16 { L.PosToken _ L.Tk__tok_Expression_dummy_16 }
+tok_Factor_dummy_15 { L.PosToken _ L.Tk__tok_Factor_dummy_15 }
+tok_IfStatement_dummy_14 { L.PosToken _ L.Tk__tok_IfStatement_dummy_14 }
+tok_Program_dummy_19 { L.PosToken _ L.Tk__tok_Program_dummy_19 }
+tok_Statement_dummy_13 { L.PosToken _ L.Tk__tok_Statement_dummy_13 }
+tok_Term_dummy_12 { L.PosToken _ L.Tk__tok_Term_dummy_12 }
+tok_UnusedRule1_dummy_11 { L.PosToken _ L.Tk__tok_UnusedRule1_dummy_11 }
+tok_UnusedRule2_dummy_10 { L.PosToken _ L.Tk__tok_UnusedRule2_dummy_10 }
+tok_WhileLoop_dummy_9 { L.PosToken _ L.Tk__tok_WhileLoop_dummy_9 }
+tok__symbol__12 { L.PosToken _ L.Tk__tok__symbol__12 }
+tok__symbol__11 { L.PosToken _ L.Tk__tok__symbol__11 }
+tok_while_10 { L.PosToken _ L.Tk__tok_while_10 }
+tok_unused_13 { L.PosToken _ L.Tk__tok_unused_13 }
+tok_if_8 { L.PosToken _ L.Tk__tok_if_8 }
+tok_else_9 { L.PosToken _ L.Tk__tok_else_9 }
+tok__eql__0 { L.PosToken _ L.Tk__tok__eql__0 }
+tok__semi__1 { L.PosToken _ L.Tk__tok__semi__1 }
+tok__symbol__5 { L.PosToken _ L.Tk__tok__symbol__5 }
+tok__minus__3 { L.PosToken _ L.Tk__tok__minus__3 }
+tok__plus__2 { L.PosToken _ L.Tk__tok__plus__2 }
+tok__star__4 { L.PosToken _ L.Tk__tok__star__4 }
+tok__rparen__7 { L.PosToken _ L.Tk__tok__rparen__7 }
+tok__lparen__6 { L.PosToken _ L.Tk__tok__lparen__6 }
+number { L.PosToken _ (L.Tk__number $$) }
+identifier { L.PosToken _ (L.Tk__identifier $$) }
+qq_UnusedRule2 { L.PosToken _ (L.Tk__qq_UnusedRule2 $$) }
+qq_UnusedRule1 { L.PosToken _ (L.Tk__qq_UnusedRule1 $$) }
+qq_Block { L.PosToken _ (L.Tk__qq_Block $$) }
+qq_WhileLoop { L.PosToken _ (L.Tk__qq_WhileLoop $$) }
+qq_IfStatement { L.PosToken _ (L.Tk__qq_IfStatement $$) }
+qq_Factor { L.PosToken _ (L.Tk__qq_Factor $$) }
+qq_Term { L.PosToken _ (L.Tk__qq_Term $$) }
+qq_Expression { L.PosToken _ (L.Tk__qq_Expression $$) }
+qq_Assignment { L.PosToken _ (L.Tk__qq_Assignment $$) }
+qq_Statement { L.PosToken _ (L.Tk__qq_Statement $$) }
+qq_Program { L.PosToken _ (L.Tk__qq_Program $$) }
 
 %%
+
+DebugTest__top : Program rtk__eof { $1 }
 
 Program : tok_Program_dummy_19 Program tok_Program_dummy_19 { Ctr__Program__0 (reverse $2) } |
           tok_Assignment_dummy_18 Assignment tok_Assignment_dummy_18 { Ctr__Program__1 $2 } |
@@ -132,6 +135,53 @@ WhileLoop : qq_WhileLoop { Anti_WhileLoop $1 } |
 
 
 {
+parseError :: [L.PosToken] -> a
+parseError [] = errorWithoutStackTrace "Parse error: unexpected end of input"
+parseError (L.PosToken (L.AlexPn _ line col) tok : _) =
+    errorWithoutStackTrace $ "Parse error at line " ++ show line ++ ", column " ++ show col ++ ": unexpected " ++ showRtkToken tok
+
+-- Render a token the way it appears in the source, for error messages
+showRtkToken :: L.Token -> String
+showRtkToken L.EndOfFile = "end of input"
+showRtkToken L.Tk__tok_Assignment_dummy_18 = "'tok_Assignment_dummy_18'"
+showRtkToken L.Tk__tok_Block_dummy_17 = "'tok_Block_dummy_17'"
+showRtkToken L.Tk__tok_Expression_dummy_16 = "'tok_Expression_dummy_16'"
+showRtkToken L.Tk__tok_Factor_dummy_15 = "'tok_Factor_dummy_15'"
+showRtkToken L.Tk__tok_IfStatement_dummy_14 = "'tok_IfStatement_dummy_14'"
+showRtkToken L.Tk__tok_Program_dummy_19 = "'tok_Program_dummy_19'"
+showRtkToken L.Tk__tok_Statement_dummy_13 = "'tok_Statement_dummy_13'"
+showRtkToken L.Tk__tok_Term_dummy_12 = "'tok_Term_dummy_12'"
+showRtkToken L.Tk__tok_UnusedRule1_dummy_11 = "'tok_UnusedRule1_dummy_11'"
+showRtkToken L.Tk__tok_UnusedRule2_dummy_10 = "'tok_UnusedRule2_dummy_10'"
+showRtkToken L.Tk__tok_WhileLoop_dummy_9 = "'tok_WhileLoop_dummy_9'"
+showRtkToken L.Tk__tok__symbol__12 = "'}'"
+showRtkToken L.Tk__tok__symbol__11 = "'{'"
+showRtkToken L.Tk__tok_while_10 = "'while'"
+showRtkToken L.Tk__tok_unused_13 = "'unused'"
+showRtkToken L.Tk__tok_if_8 = "'if'"
+showRtkToken L.Tk__tok_else_9 = "'else'"
+showRtkToken L.Tk__tok__eql__0 = "'='"
+showRtkToken L.Tk__tok__semi__1 = "';'"
+showRtkToken L.Tk__tok__symbol__5 = "'/'"
+showRtkToken L.Tk__tok__minus__3 = "'-'"
+showRtkToken L.Tk__tok__plus__2 = "'+'"
+showRtkToken L.Tk__tok__star__4 = "'*'"
+showRtkToken L.Tk__tok__rparen__7 = "')'"
+showRtkToken L.Tk__tok__lparen__6 = "'('"
+showRtkToken (L.Tk__number v) = "number " ++ show v
+showRtkToken (L.Tk__identifier v) = "identifier " ++ show v
+showRtkToken (L.Tk__qq_UnusedRule2 v) = "qq_UnusedRule2 " ++ show v
+showRtkToken (L.Tk__qq_UnusedRule1 v) = "qq_UnusedRule1 " ++ show v
+showRtkToken (L.Tk__qq_Block v) = "qq_Block " ++ show v
+showRtkToken (L.Tk__qq_WhileLoop v) = "qq_WhileLoop " ++ show v
+showRtkToken (L.Tk__qq_IfStatement v) = "qq_IfStatement " ++ show v
+showRtkToken (L.Tk__qq_Factor v) = "qq_Factor " ++ show v
+showRtkToken (L.Tk__qq_Term v) = "qq_Term " ++ show v
+showRtkToken (L.Tk__qq_Expression v) = "qq_Expression " ++ show v
+showRtkToken (L.Tk__qq_Assignment v) = "qq_Assignment " ++ show v
+showRtkToken (L.Tk__qq_Statement v) = "qq_Statement " ++ show v
+showRtkToken (L.Tk__qq_Program v) = "qq_Program " ++ show v
+
 data Program = Ctr__Program__0 Program |
                Ctr__Program__1 Assignment |
                Ctr__Program__2 Block |

--- a/test/golden/grammar/GrammarLexer.x
+++ b/test/golden/grammar/GrammarLexer.x
@@ -1,5 +1,5 @@
 {
-module GrammarLexer(alexScanTokens, Token(..))
+module GrammarLexer(alexScanTokens, Token(..), PosToken(..), AlexPosn(..))
 where
 
 import Data.List
@@ -106,25 +106,37 @@ data Token = EndOfFile |
              Tk__qq_Grammar String
              deriving (Show)
 
-alexEOF = return EndOfFile
-alexScanTokens :: String -> [Token]
-alexScanTokens str = 
+-- A token together with the source position where it starts
+data PosToken = PosToken { ptPos :: AlexPosn, ptToken :: Token }
+                deriving (Show)
+
+alexEOF = do
+  (pos, _, _, _) <- alexGetInput
+  return $ PosToken pos EndOfFile
+
+-- The returned list always ends with an EndOfFile token that carries the
+-- position of the end of input, so parse errors at end of input can be
+-- reported with a position too
+alexScanTokens :: String -> [PosToken]
+alexScanTokens str =
                case alexScanTokens1 str of
                   Right toks -> toks
-                  Left err -> error err
+                  Left err -> errorWithoutStackTrace err
 
 alexScanTokens1 str = runAlex str $ do
   let loop toks = do tok <- alexMonadScan
                      case tok of
-                       EndOfFile -> return $ reverse toks
-                       _ -> let toks' = tok : toks 
+                       PosToken _ EndOfFile -> return $ reverse (tok : toks)
+                       _ -> let toks' = tok : toks
                             in toks' `seq` loop toks'
   loop []
-simple1 :: (String -> Token) -> AlexInput -> Int -> Alex Token
-simple1 t (_, _, _, str) len = return $ t (take len str)
 
-simple t input len = return t
+simple1 :: (String -> Token) -> AlexInput -> Int -> Alex PosToken
+simple1 t (pos, _, _, str) len = return $ PosToken pos (t (take len str))
 
-rtkError ((AlexPn _ line column), _, _, str) len = alexError $ "lexical error at " ++ (show line) ++ " line, " ++ (show column) ++ " column" ++ ". Following chars :" ++ (take 10 str)
+simple :: Token -> AlexInput -> Int -> Alex PosToken
+simple t (pos, _, _, _) len = return $ PosToken pos t
+
+rtkError ((AlexPn _ line column), _, _, str) len = alexError $ "lexical error at line " ++ (show line) ++ ", column " ++ (show column) ++ ". Following chars: " ++ (take 10 str)
 
 }

--- a/test/golden/grammar/GrammarParser.y
+++ b/test/golden/grammar/GrammarParser.y
@@ -2,60 +2,63 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 module GrammarParser where
 import qualified Data.Generics as Gen
-import qualified GrammarLexer as L (Token(..), alexScanTokens)
+import qualified GrammarLexer as L (Token(..), PosToken(..), AlexPosn(..), alexScanTokens)
 }
 
 %name parseGrammar
-%tokentype { L.Token }
-%error { \ rest -> error $ "Parse error " ++ (show rest) }
+%tokentype { L.PosToken }
+%error { parseError }
 
 %token
 
-tok_Clause_dummy_14 { L.Tk__tok_Clause_dummy_14 }
-tok_Grammar_dummy_15 { L.Tk__tok_Grammar_dummy_15 }
-tok_IdList_dummy_13 { L.Tk__tok_IdList_dummy_13 }
-tok_ImportsOpt_dummy_12 { L.Tk__tok_ImportsOpt_dummy_12 }
-tok_Name_dummy_11 { L.Tk__tok_Name_dummy_11 }
-tok_OptDelim_dummy_10 { L.Tk__tok_OptDelim_dummy_10 }
-tok_Option_dummy_9 { L.Tk__tok_Option_dummy_9 }
-tok_OptionList_dummy_8 { L.Tk__tok_OptionList_dummy_8 }
-tok_Rule_dummy_7 { L.Tk__tok_Rule_dummy_7 }
-tok_RuleList_dummy_6 { L.Tk__tok_RuleList_dummy_6 }
-tok_StrLit_dummy_5 { L.Tk__tok_StrLit_dummy_5 }
-tok__tilde__16 { L.Tk__tok__tilde__16 }
-tok__pipe__11 { L.Tk__tok__pipe__11 }
-tok_imports_2 { L.Tk__tok_imports_2 }
-tok_grammar_0 { L.Tk__tok_grammar_0 }
-tok__symbol_symmacro_9 { L.Tk__tok__symbol_symmacro_9 }
-tok__symbol_shortcuts_6 { L.Tk__tok__symbol_shortcuts_6 }
-tok__symbol__15 { L.Tk__tok__symbol__15 }
-tok__eql__3 { L.Tk__tok__eql__3 }
-tok__semi__1 { L.Tk__tok__semi__1 }
-tok__colon__4 { L.Tk__tok__colon__4 }
-tok__dot__5 { L.Tk__tok__dot__5 }
-tok__coma__10 { L.Tk__tok__coma__10 }
-tok__plus__14 { L.Tk__tok__plus__14 }
-tok__star__13 { L.Tk__tok__star__13 }
-tok__rparen__8 { L.Tk__tok__rparen__8 }
-tok__lparen__7 { L.Tk__tok__lparen__7 }
-tok__exclamation__12 { L.Tk__tok__exclamation__12 }
-regexplit { L.Tk__regexplit $$ }
-bigstr { L.Tk__bigstr $$ }
-str { L.Tk__str $$ }
-id { L.Tk__id $$ }
-qq_Name { L.Tk__qq_Name $$ }
-qq_StrLit { L.Tk__qq_StrLit $$ }
-qq_OptDelim { L.Tk__qq_OptDelim $$ }
-qq_Clause { L.Tk__qq_Clause $$ }
-qq_IdList { L.Tk__qq_IdList $$ }
-qq_Option { L.Tk__qq_Option $$ }
-qq_OptionList { L.Tk__qq_OptionList $$ }
-qq_Rule { L.Tk__qq_Rule $$ }
-qq_RuleList { L.Tk__qq_RuleList $$ }
-qq_ImportsOpt { L.Tk__qq_ImportsOpt $$ }
-qq_Grammar { L.Tk__qq_Grammar $$ }
+rtk__eof { L.PosToken _ L.EndOfFile }
+tok_Clause_dummy_14 { L.PosToken _ L.Tk__tok_Clause_dummy_14 }
+tok_Grammar_dummy_15 { L.PosToken _ L.Tk__tok_Grammar_dummy_15 }
+tok_IdList_dummy_13 { L.PosToken _ L.Tk__tok_IdList_dummy_13 }
+tok_ImportsOpt_dummy_12 { L.PosToken _ L.Tk__tok_ImportsOpt_dummy_12 }
+tok_Name_dummy_11 { L.PosToken _ L.Tk__tok_Name_dummy_11 }
+tok_OptDelim_dummy_10 { L.PosToken _ L.Tk__tok_OptDelim_dummy_10 }
+tok_Option_dummy_9 { L.PosToken _ L.Tk__tok_Option_dummy_9 }
+tok_OptionList_dummy_8 { L.PosToken _ L.Tk__tok_OptionList_dummy_8 }
+tok_Rule_dummy_7 { L.PosToken _ L.Tk__tok_Rule_dummy_7 }
+tok_RuleList_dummy_6 { L.PosToken _ L.Tk__tok_RuleList_dummy_6 }
+tok_StrLit_dummy_5 { L.PosToken _ L.Tk__tok_StrLit_dummy_5 }
+tok__tilde__16 { L.PosToken _ L.Tk__tok__tilde__16 }
+tok__pipe__11 { L.PosToken _ L.Tk__tok__pipe__11 }
+tok_imports_2 { L.PosToken _ L.Tk__tok_imports_2 }
+tok_grammar_0 { L.PosToken _ L.Tk__tok_grammar_0 }
+tok__symbol_symmacro_9 { L.PosToken _ L.Tk__tok__symbol_symmacro_9 }
+tok__symbol_shortcuts_6 { L.PosToken _ L.Tk__tok__symbol_shortcuts_6 }
+tok__symbol__15 { L.PosToken _ L.Tk__tok__symbol__15 }
+tok__eql__3 { L.PosToken _ L.Tk__tok__eql__3 }
+tok__semi__1 { L.PosToken _ L.Tk__tok__semi__1 }
+tok__colon__4 { L.PosToken _ L.Tk__tok__colon__4 }
+tok__dot__5 { L.PosToken _ L.Tk__tok__dot__5 }
+tok__coma__10 { L.PosToken _ L.Tk__tok__coma__10 }
+tok__plus__14 { L.PosToken _ L.Tk__tok__plus__14 }
+tok__star__13 { L.PosToken _ L.Tk__tok__star__13 }
+tok__rparen__8 { L.PosToken _ L.Tk__tok__rparen__8 }
+tok__lparen__7 { L.PosToken _ L.Tk__tok__lparen__7 }
+tok__exclamation__12 { L.PosToken _ L.Tk__tok__exclamation__12 }
+regexplit { L.PosToken _ (L.Tk__regexplit $$) }
+bigstr { L.PosToken _ (L.Tk__bigstr $$) }
+str { L.PosToken _ (L.Tk__str $$) }
+id { L.PosToken _ (L.Tk__id $$) }
+qq_Name { L.PosToken _ (L.Tk__qq_Name $$) }
+qq_StrLit { L.PosToken _ (L.Tk__qq_StrLit $$) }
+qq_OptDelim { L.PosToken _ (L.Tk__qq_OptDelim $$) }
+qq_Clause { L.PosToken _ (L.Tk__qq_Clause $$) }
+qq_IdList { L.PosToken _ (L.Tk__qq_IdList $$) }
+qq_Option { L.PosToken _ (L.Tk__qq_Option $$) }
+qq_OptionList { L.PosToken _ (L.Tk__qq_OptionList $$) }
+qq_Rule { L.PosToken _ (L.Tk__qq_Rule $$) }
+qq_RuleList { L.PosToken _ (L.Tk__qq_RuleList $$) }
+qq_ImportsOpt { L.PosToken _ (L.Tk__qq_ImportsOpt $$) }
+qq_Grammar { L.PosToken _ (L.Tk__qq_Grammar $$) }
 
 %%
+
+Grammar__top : Grammar rtk__eof { $1 }
 
 Grammar : tok_Grammar_dummy_15 Grammar tok_Grammar_dummy_15 { Ctr__Grammar__0 $2 } |
           tok_Clause_dummy_14 Clause tok_Clause_dummy_14 { Ctr__Grammar__1 $2 } |
@@ -148,6 +151,58 @@ StrLit : qq_StrLit { Anti_StrLit $1 } |
 
 
 {
+parseError :: [L.PosToken] -> a
+parseError [] = errorWithoutStackTrace "Parse error: unexpected end of input"
+parseError (L.PosToken (L.AlexPn _ line col) tok : _) =
+    errorWithoutStackTrace $ "Parse error at line " ++ show line ++ ", column " ++ show col ++ ": unexpected " ++ showRtkToken tok
+
+-- Render a token the way it appears in the source, for error messages
+showRtkToken :: L.Token -> String
+showRtkToken L.EndOfFile = "end of input"
+showRtkToken L.Tk__tok_Clause_dummy_14 = "'tok_Clause_dummy_14'"
+showRtkToken L.Tk__tok_Grammar_dummy_15 = "'tok_Grammar_dummy_15'"
+showRtkToken L.Tk__tok_IdList_dummy_13 = "'tok_IdList_dummy_13'"
+showRtkToken L.Tk__tok_ImportsOpt_dummy_12 = "'tok_ImportsOpt_dummy_12'"
+showRtkToken L.Tk__tok_Name_dummy_11 = "'tok_Name_dummy_11'"
+showRtkToken L.Tk__tok_OptDelim_dummy_10 = "'tok_OptDelim_dummy_10'"
+showRtkToken L.Tk__tok_Option_dummy_9 = "'tok_Option_dummy_9'"
+showRtkToken L.Tk__tok_OptionList_dummy_8 = "'tok_OptionList_dummy_8'"
+showRtkToken L.Tk__tok_Rule_dummy_7 = "'tok_Rule_dummy_7'"
+showRtkToken L.Tk__tok_RuleList_dummy_6 = "'tok_RuleList_dummy_6'"
+showRtkToken L.Tk__tok_StrLit_dummy_5 = "'tok_StrLit_dummy_5'"
+showRtkToken L.Tk__tok__tilde__16 = "'~'"
+showRtkToken L.Tk__tok__pipe__11 = "'|'"
+showRtkToken L.Tk__tok_imports_2 = "'imports'"
+showRtkToken L.Tk__tok_grammar_0 = "'grammar'"
+showRtkToken L.Tk__tok__symbol_symmacro_9 = "'@symmacro'"
+showRtkToken L.Tk__tok__symbol_shortcuts_6 = "'@shortcuts'"
+showRtkToken L.Tk__tok__symbol__15 = "'?'"
+showRtkToken L.Tk__tok__eql__3 = "'='"
+showRtkToken L.Tk__tok__semi__1 = "';'"
+showRtkToken L.Tk__tok__colon__4 = "':'"
+showRtkToken L.Tk__tok__dot__5 = "'.'"
+showRtkToken L.Tk__tok__coma__10 = "','"
+showRtkToken L.Tk__tok__plus__14 = "'+'"
+showRtkToken L.Tk__tok__star__13 = "'*'"
+showRtkToken L.Tk__tok__rparen__8 = "')'"
+showRtkToken L.Tk__tok__lparen__7 = "'('"
+showRtkToken L.Tk__tok__exclamation__12 = "'!'"
+showRtkToken (L.Tk__regexplit v) = "regexplit " ++ show v
+showRtkToken (L.Tk__bigstr v) = "bigstr " ++ show v
+showRtkToken (L.Tk__str v) = "str " ++ show v
+showRtkToken (L.Tk__id v) = "id " ++ show v
+showRtkToken (L.Tk__qq_Name v) = "qq_Name " ++ show v
+showRtkToken (L.Tk__qq_StrLit v) = "qq_StrLit " ++ show v
+showRtkToken (L.Tk__qq_OptDelim v) = "qq_OptDelim " ++ show v
+showRtkToken (L.Tk__qq_Clause v) = "qq_Clause " ++ show v
+showRtkToken (L.Tk__qq_IdList v) = "qq_IdList " ++ show v
+showRtkToken (L.Tk__qq_Option v) = "qq_Option " ++ show v
+showRtkToken (L.Tk__qq_OptionList v) = "qq_OptionList " ++ show v
+showRtkToken (L.Tk__qq_Rule v) = "qq_Rule " ++ show v
+showRtkToken (L.Tk__qq_RuleList v) = "qq_RuleList " ++ show v
+showRtkToken (L.Tk__qq_ImportsOpt v) = "qq_ImportsOpt " ++ show v
+showRtkToken (L.Tk__qq_Grammar v) = "qq_Grammar " ++ show v
+
 data Grammar = Ctr__Grammar__0 Grammar |
                Ctr__Grammar__1 Clause |
                Ctr__Grammar__2 IdList |

--- a/test/golden/java-simple/JavaSimpleLexer.x
+++ b/test/golden/java-simple/JavaSimpleLexer.x
@@ -1,5 +1,5 @@
 {
-module JavaSimpleLexer(alexScanTokens, Token(..))
+module JavaSimpleLexer(alexScanTokens, Token(..), PosToken(..), AlexPosn(..))
 where
 
  }
@@ -65,25 +65,37 @@ data Token = EndOfFile |
              Tk__qq_JavaSimple String
              deriving (Show)
 
-alexEOF = return EndOfFile
-alexScanTokens :: String -> [Token]
-alexScanTokens str = 
+-- A token together with the source position where it starts
+data PosToken = PosToken { ptPos :: AlexPosn, ptToken :: Token }
+                deriving (Show)
+
+alexEOF = do
+  (pos, _, _, _) <- alexGetInput
+  return $ PosToken pos EndOfFile
+
+-- The returned list always ends with an EndOfFile token that carries the
+-- position of the end of input, so parse errors at end of input can be
+-- reported with a position too
+alexScanTokens :: String -> [PosToken]
+alexScanTokens str =
                case alexScanTokens1 str of
                   Right toks -> toks
-                  Left err -> error err
+                  Left err -> errorWithoutStackTrace err
 
 alexScanTokens1 str = runAlex str $ do
   let loop toks = do tok <- alexMonadScan
                      case tok of
-                       EndOfFile -> return $ reverse toks
-                       _ -> let toks' = tok : toks 
+                       PosToken _ EndOfFile -> return $ reverse (tok : toks)
+                       _ -> let toks' = tok : toks
                             in toks' `seq` loop toks'
   loop []
-simple1 :: (String -> Token) -> AlexInput -> Int -> Alex Token
-simple1 t (_, _, _, str) len = return $ t (take len str)
 
-simple t input len = return t
+simple1 :: (String -> Token) -> AlexInput -> Int -> Alex PosToken
+simple1 t (pos, _, _, str) len = return $ PosToken pos (t (take len str))
 
-rtkError ((AlexPn _ line column), _, _, str) len = alexError $ "lexical error at " ++ (show line) ++ " line, " ++ (show column) ++ " column" ++ ". Following chars :" ++ (take 10 str)
+simple :: Token -> AlexInput -> Int -> Alex PosToken
+simple t (pos, _, _, _) len = return $ PosToken pos t
+
+rtkError ((AlexPn _ line column), _, _, str) len = alexError $ "lexical error at line " ++ (show line) ++ ", column " ++ (show column) ++ ". Following chars: " ++ (take 10 str)
 
 }

--- a/test/golden/java-simple/JavaSimpleParser.y
+++ b/test/golden/java-simple/JavaSimpleParser.y
@@ -2,43 +2,46 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 module JavaSimpleParser where
 import qualified Data.Generics as Gen
-import qualified JavaSimpleLexer as L (Token(..), alexScanTokens)
+import qualified JavaSimpleLexer as L (Token(..), PosToken(..), AlexPosn(..), alexScanTokens)
 }
 
 %name parseJavaSimple
-%tokentype { L.Token }
-%error { \ rest -> error $ "Parse error " ++ (show rest) }
+%tokentype { L.PosToken }
+%error { parseError }
 
 %token
 
-tok_ClassDeclaration_dummy_10 { L.Tk__tok_ClassDeclaration_dummy_10 }
-tok_CompilationUnit_dummy_9 { L.Tk__tok_CompilationUnit_dummy_9 }
-tok_CompoundName_dummy_8 { L.Tk__tok_CompoundName_dummy_8 }
-tok_Field_dummy_7 { L.Tk__tok_Field_dummy_7 }
-tok_FieldList_dummy_6 { L.Tk__tok_FieldList_dummy_6 }
-tok_JavaSimple_dummy_11 { L.Tk__tok_JavaSimple_dummy_11 }
-tok_Package_dummy_5 { L.Tk__tok_Package_dummy_5 }
-tok_Type_dummy_4 { L.Tk__tok_Type_dummy_4 }
-tok__symbol__5 { L.Tk__tok__symbol__5 }
-tok__symbol__4 { L.Tk__tok__symbol__4 }
-tok_public_2 { L.Tk__tok_public_2 }
-tok_package_0 { L.Tk__tok_package_0 }
-tok_int_6 { L.Tk__tok_int_6 }
-tok_class_3 { L.Tk__tok_class_3 }
-tok_String_7 { L.Tk__tok_String_7 }
-tok__semi__1 { L.Tk__tok__semi__1 }
-tok__dot__8 { L.Tk__tok__dot__8 }
-id { L.Tk__id $$ }
-qq_CompoundName { L.Tk__qq_CompoundName $$ }
-qq_Type { L.Tk__qq_Type $$ }
-qq_Field { L.Tk__qq_Field $$ }
-qq_FieldList { L.Tk__qq_FieldList $$ }
-qq_ClassDeclaration { L.Tk__qq_ClassDeclaration $$ }
-qq_Package { L.Tk__qq_Package $$ }
-qq_CompilationUnit { L.Tk__qq_CompilationUnit $$ }
-qq_JavaSimple { L.Tk__qq_JavaSimple $$ }
+rtk__eof { L.PosToken _ L.EndOfFile }
+tok_ClassDeclaration_dummy_10 { L.PosToken _ L.Tk__tok_ClassDeclaration_dummy_10 }
+tok_CompilationUnit_dummy_9 { L.PosToken _ L.Tk__tok_CompilationUnit_dummy_9 }
+tok_CompoundName_dummy_8 { L.PosToken _ L.Tk__tok_CompoundName_dummy_8 }
+tok_Field_dummy_7 { L.PosToken _ L.Tk__tok_Field_dummy_7 }
+tok_FieldList_dummy_6 { L.PosToken _ L.Tk__tok_FieldList_dummy_6 }
+tok_JavaSimple_dummy_11 { L.PosToken _ L.Tk__tok_JavaSimple_dummy_11 }
+tok_Package_dummy_5 { L.PosToken _ L.Tk__tok_Package_dummy_5 }
+tok_Type_dummy_4 { L.PosToken _ L.Tk__tok_Type_dummy_4 }
+tok__symbol__5 { L.PosToken _ L.Tk__tok__symbol__5 }
+tok__symbol__4 { L.PosToken _ L.Tk__tok__symbol__4 }
+tok_public_2 { L.PosToken _ L.Tk__tok_public_2 }
+tok_package_0 { L.PosToken _ L.Tk__tok_package_0 }
+tok_int_6 { L.PosToken _ L.Tk__tok_int_6 }
+tok_class_3 { L.PosToken _ L.Tk__tok_class_3 }
+tok_String_7 { L.PosToken _ L.Tk__tok_String_7 }
+tok__semi__1 { L.PosToken _ L.Tk__tok__semi__1 }
+tok__dot__8 { L.PosToken _ L.Tk__tok__dot__8 }
+id { L.PosToken _ (L.Tk__id $$) }
+qq_CompoundName { L.PosToken _ (L.Tk__qq_CompoundName $$) }
+qq_Type { L.PosToken _ (L.Tk__qq_Type $$) }
+qq_Field { L.PosToken _ (L.Tk__qq_Field $$) }
+qq_FieldList { L.PosToken _ (L.Tk__qq_FieldList $$) }
+qq_ClassDeclaration { L.PosToken _ (L.Tk__qq_ClassDeclaration $$) }
+qq_Package { L.PosToken _ (L.Tk__qq_Package $$) }
+qq_CompilationUnit { L.PosToken _ (L.Tk__qq_CompilationUnit $$) }
+qq_JavaSimple { L.PosToken _ (L.Tk__qq_JavaSimple $$) }
 
 %%
+
+JavaSimple__top : JavaSimple rtk__eof { $1 }
 
 JavaSimple : tok_JavaSimple_dummy_11 JavaSimple tok_JavaSimple_dummy_11 { Ctr__JavaSimple__0 $2 } |
              tok_ClassDeclaration_dummy_10 ClassDeclaration tok_ClassDeclaration_dummy_10 { Ctr__JavaSimple__1 $2 } |
@@ -90,6 +93,41 @@ Type : qq_Type { Anti_Type $1 } |
 
 
 {
+parseError :: [L.PosToken] -> a
+parseError [] = errorWithoutStackTrace "Parse error: unexpected end of input"
+parseError (L.PosToken (L.AlexPn _ line col) tok : _) =
+    errorWithoutStackTrace $ "Parse error at line " ++ show line ++ ", column " ++ show col ++ ": unexpected " ++ showRtkToken tok
+
+-- Render a token the way it appears in the source, for error messages
+showRtkToken :: L.Token -> String
+showRtkToken L.EndOfFile = "end of input"
+showRtkToken L.Tk__tok_ClassDeclaration_dummy_10 = "'tok_ClassDeclaration_dummy_10'"
+showRtkToken L.Tk__tok_CompilationUnit_dummy_9 = "'tok_CompilationUnit_dummy_9'"
+showRtkToken L.Tk__tok_CompoundName_dummy_8 = "'tok_CompoundName_dummy_8'"
+showRtkToken L.Tk__tok_Field_dummy_7 = "'tok_Field_dummy_7'"
+showRtkToken L.Tk__tok_FieldList_dummy_6 = "'tok_FieldList_dummy_6'"
+showRtkToken L.Tk__tok_JavaSimple_dummy_11 = "'tok_JavaSimple_dummy_11'"
+showRtkToken L.Tk__tok_Package_dummy_5 = "'tok_Package_dummy_5'"
+showRtkToken L.Tk__tok_Type_dummy_4 = "'tok_Type_dummy_4'"
+showRtkToken L.Tk__tok__symbol__5 = "'}'"
+showRtkToken L.Tk__tok__symbol__4 = "'{'"
+showRtkToken L.Tk__tok_public_2 = "'public'"
+showRtkToken L.Tk__tok_package_0 = "'package'"
+showRtkToken L.Tk__tok_int_6 = "'int'"
+showRtkToken L.Tk__tok_class_3 = "'class'"
+showRtkToken L.Tk__tok_String_7 = "'String'"
+showRtkToken L.Tk__tok__semi__1 = "';'"
+showRtkToken L.Tk__tok__dot__8 = "'.'"
+showRtkToken (L.Tk__id v) = "id " ++ show v
+showRtkToken (L.Tk__qq_CompoundName v) = "qq_CompoundName " ++ show v
+showRtkToken (L.Tk__qq_Type v) = "qq_Type " ++ show v
+showRtkToken (L.Tk__qq_Field v) = "qq_Field " ++ show v
+showRtkToken (L.Tk__qq_FieldList v) = "qq_FieldList " ++ show v
+showRtkToken (L.Tk__qq_ClassDeclaration v) = "qq_ClassDeclaration " ++ show v
+showRtkToken (L.Tk__qq_Package v) = "qq_Package " ++ show v
+showRtkToken (L.Tk__qq_CompilationUnit v) = "qq_CompilationUnit " ++ show v
+showRtkToken (L.Tk__qq_JavaSimple v) = "qq_JavaSimple " ++ show v
+
 data JavaSimple = Ctr__JavaSimple__0 JavaSimple |
                   Ctr__JavaSimple__1 ClassDeclaration |
                   Ctr__JavaSimple__2 CompilationUnit |

--- a/test/golden/java/JavaLexer.x
+++ b/test/golden/java/JavaLexer.x
@@ -1,5 +1,5 @@
 {
-module JavaLexer(alexScanTokens, Token(..))
+module JavaLexer(alexScanTokens, Token(..), PosToken(..), AlexPosn(..))
 where
 
  }
@@ -539,25 +539,37 @@ data Token = EndOfFile |
              Tk__qq_Java String
              deriving (Show)
 
-alexEOF = return EndOfFile
-alexScanTokens :: String -> [Token]
-alexScanTokens str = 
+-- A token together with the source position where it starts
+data PosToken = PosToken { ptPos :: AlexPosn, ptToken :: Token }
+                deriving (Show)
+
+alexEOF = do
+  (pos, _, _, _) <- alexGetInput
+  return $ PosToken pos EndOfFile
+
+-- The returned list always ends with an EndOfFile token that carries the
+-- position of the end of input, so parse errors at end of input can be
+-- reported with a position too
+alexScanTokens :: String -> [PosToken]
+alexScanTokens str =
                case alexScanTokens1 str of
                   Right toks -> toks
-                  Left err -> error err
+                  Left err -> errorWithoutStackTrace err
 
 alexScanTokens1 str = runAlex str $ do
   let loop toks = do tok <- alexMonadScan
                      case tok of
-                       EndOfFile -> return $ reverse toks
-                       _ -> let toks' = tok : toks 
+                       PosToken _ EndOfFile -> return $ reverse (tok : toks)
+                       _ -> let toks' = tok : toks
                             in toks' `seq` loop toks'
   loop []
-simple1 :: (String -> Token) -> AlexInput -> Int -> Alex Token
-simple1 t (_, _, _, str) len = return $ t (take len str)
 
-simple t input len = return t
+simple1 :: (String -> Token) -> AlexInput -> Int -> Alex PosToken
+simple1 t (pos, _, _, str) len = return $ PosToken pos (t (take len str))
 
-rtkError ((AlexPn _ line column), _, _, str) len = alexError $ "lexical error at " ++ (show line) ++ " line, " ++ (show column) ++ " column" ++ ". Following chars :" ++ (take 10 str)
+simple :: Token -> AlexInput -> Int -> Alex PosToken
+simple t (pos, _, _, _) len = return $ PosToken pos t
+
+rtkError ((AlexPn _ line column), _, _, str) len = alexError $ "lexical error at line " ++ (show line) ++ ", column " ++ (show column) ++ ". Following chars: " ++ (take 10 str)
 
 }

--- a/test/golden/java/JavaParser.y
+++ b/test/golden/java/JavaParser.y
@@ -2,278 +2,281 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 module JavaParser where
 import qualified Data.Generics as Gen
-import qualified JavaLexer as L (Token(..), alexScanTokens)
+import qualified JavaLexer as L (Token(..), PosToken(..), AlexPosn(..), alexScanTokens)
 }
 
 %name parseJava
-%tokentype { L.Token }
-%error { \ rest -> error $ "Parse error " ++ (show rest) }
+%tokentype { L.PosToken }
+%error { parseError }
 
 %token
 
-tok_AdditiveOp_dummy_171 { L.Tk__tok_AdditiveOp_dummy_171 }
-tok_Annotation_dummy_170 { L.Tk__tok_Annotation_dummy_170 }
-tok_AnnotationArguments_dummy_169 { L.Tk__tok_AnnotationArguments_dummy_169 }
-tok_AnnotationDeclaration_dummy_168 { L.Tk__tok_AnnotationDeclaration_dummy_168 }
-tok_AnnotationElement_dummy_167 { L.Tk__tok_AnnotationElement_dummy_167 }
-tok_AnnotationList_dummy_166 { L.Tk__tok_AnnotationList_dummy_166 }
-tok_AnnotationTypeElement_dummy_165 { L.Tk__tok_AnnotationTypeElement_dummy_165 }
-tok_AnnotationTypeElementList_dummy_164 { L.Tk__tok_AnnotationTypeElementList_dummy_164 }
-tok_Arglist_dummy_163 { L.Tk__tok_Arglist_dummy_163 }
-tok_AssignmentOp_dummy_162 { L.Tk__tok_AssignmentOp_dummy_162 }
-tok_CatchList_dummy_161 { L.Tk__tok_CatchList_dummy_161 }
-tok_ClassDeclaration_dummy_160 { L.Tk__tok_ClassDeclaration_dummy_160 }
-tok_CompilationUnit_dummy_159 { L.Tk__tok_CompilationUnit_dummy_159 }
-tok_CompoundName_dummy_158 { L.Tk__tok_CompoundName_dummy_158 }
-tok_CreationExpression_dummy_157 { L.Tk__tok_CreationExpression_dummy_157 }
-tok_DoStatement_dummy_156 { L.Tk__tok_DoStatement_dummy_156 }
-tok_DocComment_dummy_155 { L.Tk__tok_DocComment_dummy_155 }
-tok_EnumConstant_dummy_154 { L.Tk__tok_EnumConstant_dummy_154 }
-tok_EnumConstantList_dummy_153 { L.Tk__tok_EnumConstantList_dummy_153 }
-tok_EnumDeclaration_dummy_152 { L.Tk__tok_EnumDeclaration_dummy_152 }
-tok_EqualityOp_dummy_151 { L.Tk__tok_EqualityOp_dummy_151 }
-tok_Expression_dummy_150 { L.Tk__tok_Expression_dummy_150 }
-tok_ExtendsList_dummy_149 { L.Tk__tok_ExtendsList_dummy_149 }
-tok_FieldDeclaration_dummy_148 { L.Tk__tok_FieldDeclaration_dummy_148 }
-tok_FieldDeclarationList_dummy_147 { L.Tk__tok_FieldDeclarationList_dummy_147 }
-tok_ForStatement_dummy_146 { L.Tk__tok_ForStatement_dummy_146 }
-tok_IfStatement_dummy_145 { L.Tk__tok_IfStatement_dummy_145 }
-tok_ImplementsList_dummy_144 { L.Tk__tok_ImplementsList_dummy_144 }
-tok_ImportList_dummy_143 { L.Tk__tok_ImportList_dummy_143 }
-tok_ImportStatement_dummy_142 { L.Tk__tok_ImportStatement_dummy_142 }
-tok_InterfaceDeclaration_dummy_141 { L.Tk__tok_InterfaceDeclaration_dummy_141 }
-tok_Java_dummy_172 { L.Tk__tok_Java_dummy_172 }
-tok_Literal_dummy_140 { L.Tk__tok_Literal_dummy_140 }
-tok_MemberAfterFirstId_dummy_139 { L.Tk__tok_MemberAfterFirstId_dummy_139 }
-tok_MemberDeclaration_dummy_138 { L.Tk__tok_MemberDeclaration_dummy_138 }
-tok_MemberRest_dummy_137 { L.Tk__tok_MemberRest_dummy_137 }
-tok_Modifier_dummy_136 { L.Tk__tok_Modifier_dummy_136 }
-tok_ModifierList_dummy_135 { L.Tk__tok_ModifierList_dummy_135 }
-tok_MoreTypeSpecifier_dummy_134 { L.Tk__tok_MoreTypeSpecifier_dummy_134 }
-tok_MoreVariableDeclarators_dummy_133 { L.Tk__tok_MoreVariableDeclarators_dummy_133 }
-tok_MultiplicativeOp_dummy_132 { L.Tk__tok_MultiplicativeOp_dummy_132 }
-tok_NestedTypeDeclaration_dummy_131 { L.Tk__tok_NestedTypeDeclaration_dummy_131 }
-tok_OptDocComment_dummy_130 { L.Tk__tok_OptDocComment_dummy_130 }
-tok_OptElsePart_dummy_129 { L.Tk__tok_OptElsePart_dummy_129 }
-tok_OptExpression_dummy_128 { L.Tk__tok_OptExpression_dummy_128 }
-tok_OptFinally_dummy_127 { L.Tk__tok_OptFinally_dummy_127 }
-tok_OptId_dummy_126 { L.Tk__tok_OptId_dummy_126 }
-tok_OptVariableInitializer_dummy_125 { L.Tk__tok_OptVariableInitializer_dummy_125 }
-tok_Package_dummy_124 { L.Tk__tok_Package_dummy_124 }
-tok_Parameter_dummy_123 { L.Tk__tok_Parameter_dummy_123 }
-tok_ParameterList_dummy_122 { L.Tk__tok_ParameterList_dummy_122 }
-tok_PostfixOp_dummy_121 { L.Tk__tok_PostfixOp_dummy_121 }
-tok_PrefixOp_dummy_120 { L.Tk__tok_PrefixOp_dummy_120 }
-tok_PrimitiveTypeKeyword_dummy_119 { L.Tk__tok_PrimitiveTypeKeyword_dummy_119 }
-tok_RelationalOp_dummy_118 { L.Tk__tok_RelationalOp_dummy_118 }
-tok_ShiftOp_dummy_117 { L.Tk__tok_ShiftOp_dummy_117 }
-tok_SquareBracketsList_dummy_116 { L.Tk__tok_SquareBracketsList_dummy_116 }
-tok_Statement_dummy_115 { L.Tk__tok_Statement_dummy_115 }
-tok_StatementBlock_dummy_114 { L.Tk__tok_StatementBlock_dummy_114 }
-tok_StatementList_dummy_113 { L.Tk__tok_StatementList_dummy_113 }
-tok_StatementWithoutIf_dummy_112 { L.Tk__tok_StatementWithoutIf_dummy_112 }
-tok_StaticInitializer_dummy_111 { L.Tk__tok_StaticInitializer_dummy_111 }
-tok_SwitchCaseList_dummy_110 { L.Tk__tok_SwitchCaseList_dummy_110 }
-tok_SwitchStatement_dummy_109 { L.Tk__tok_SwitchStatement_dummy_109 }
-tok_TryStatement_dummy_108 { L.Tk__tok_TryStatement_dummy_108 }
-tok_Type_dummy_107 { L.Tk__tok_Type_dummy_107 }
-tok_TypeArgument_dummy_106 { L.Tk__tok_TypeArgument_dummy_106 }
-tok_TypeArguments_dummy_105 { L.Tk__tok_TypeArguments_dummy_105 }
-tok_TypeDeclaration_dummy_104 { L.Tk__tok_TypeDeclaration_dummy_104 }
-tok_TypeParameter_dummy_103 { L.Tk__tok_TypeParameter_dummy_103 }
-tok_TypeParameters_dummy_102 { L.Tk__tok_TypeParameters_dummy_102 }
-tok_TypeSpecifier_dummy_101 { L.Tk__tok_TypeSpecifier_dummy_101 }
-tok_VariableDeclaration_dummy_100 { L.Tk__tok_VariableDeclaration_dummy_100 }
-tok_VariableDeclarator_dummy_99 { L.Tk__tok_VariableDeclarator_dummy_99 }
-tok_VariableDeclaratorList_dummy_98 { L.Tk__tok_VariableDeclaratorList_dummy_98 }
-tok_VariableInitializer_dummy_97 { L.Tk__tok_VariableInitializer_dummy_97 }
-tok_VariableInitializerList_dummy_96 { L.Tk__tok_VariableInitializerList_dummy_96 }
-tok_WhileStatement_dummy_95 { L.Tk__tok_WhileStatement_dummy_95 }
-tok_WildcardType_dummy_94 { L.Tk__tok_WildcardType_dummy_94 }
-tok__tilde__78 { L.Tk__tok__tilde__78 }
-tok__symbol__14 { L.Tk__tok__symbol__14 }
-tok__pipe__pipe__57 { L.Tk__tok__pipe__pipe__57 }
-tok__pipe__eql__49 { L.Tk__tok__pipe__eql__49 }
-tok__pipe__59 { L.Tk__tok__pipe__59 }
-tok__symbol__13 { L.Tk__tok__symbol__13 }
-tok_while_38 { L.Tk__tok_while_38 }
-tok_void_28 { L.Tk__tok_void_28 }
-tok_try_42 { L.Tk__tok_try_42 }
-tok_true_83 { L.Tk__tok_true_83 }
-tok_transient_94 { L.Tk__tok_transient_94 }
-tok_throw_31 { L.Tk__tok_throw_31 }
-tok_threadsafe_93 { L.Tk__tok_threadsafe_93 }
-tok_this_80 { L.Tk__tok_this_80 }
-tok_synchronized_30 { L.Tk__tok_synchronized_30 }
-tok_switch_44 { L.Tk__tok_switch_44 }
-tok_super_81 { L.Tk__tok_super_81 }
-tok_static_89 { L.Tk__tok_static_89 }
-tok_short_23 { L.Tk__tok_short_23 }
-tok_return_29 { L.Tk__tok_return_29 }
-tok_public_86 { L.Tk__tok_public_86 }
-tok_protected_88 { L.Tk__tok_protected_88 }
-tok_private_87 { L.Tk__tok_private_87 }
-tok_package_0 { L.Tk__tok_package_0 }
-tok_null_85 { L.Tk__tok_null_85 }
-tok_new_82 { L.Tk__tok_new_82 }
-tok_native_91 { L.Tk__tok_native_91 }
-tok_long_26 { L.Tk__tok_long_26 }
-tok_interface_15 { L.Tk__tok_interface_15 }
-tok_int_24 { L.Tk__tok_int_24 }
-tok_instanceof_68 { L.Tk__tok_instanceof_68 }
-tok_import_2 { L.Tk__tok_import_2 }
-tok_implements_11 { L.Tk__tok_implements_11 }
-tok_if_36 { L.Tk__tok_if_36 }
-tok_for_39 { L.Tk__tok_for_39 }
-tok_float_25 { L.Tk__tok_float_25 }
-tok_finally_41 { L.Tk__tok_finally_41 }
-tok_final_90 { L.Tk__tok_final_90 }
-tok_false_84 { L.Tk__tok_false_84 }
-tok_extends_10 { L.Tk__tok_extends_10 }
-tok_enum_17 { L.Tk__tok_enum_17 }
-tok_else_35 { L.Tk__tok_else_35 }
-tok_double_27 { L.Tk__tok_double_27 }
-tok_do_37 { L.Tk__tok_do_37 }
-tok_default_16 { L.Tk__tok_default_16 }
-tok_continue_34 { L.Tk__tok_continue_34 }
-tok_class_12 { L.Tk__tok_class_12 }
-tok_char_22 { L.Tk__tok_char_22 }
-tok_catch_40 { L.Tk__tok_catch_40 }
-tok_case_43 { L.Tk__tok_case_43 }
-tok_byte_21 { L.Tk__tok_byte_21 }
-tok_break_33 { L.Tk__tok_break_33 }
-tok_boolean_20 { L.Tk__tok_boolean_20 }
-tok_abstract_92 { L.Tk__tok_abstract_92 }
-tok__symbol__eql__51 { L.Tk__tok__symbol__eql__51 }
-tok__symbol__60 { L.Tk__tok__symbol__60 }
-tok__sq_bkt_r__19 { L.Tk__tok__sq_bkt_r__19 }
-tok__sq_bkt_l__18 { L.Tk__tok__sq_bkt_l__18 }
-tok__symbol__5 { L.Tk__tok__symbol__5 }
-tok__symbol__56 { L.Tk__tok__symbol__56 }
-tok__symbol__symbol__symbol__eql__55 { L.Tk__tok__symbol__symbol__symbol__eql__55 }
-tok__symbol__symbol__symbol__71 { L.Tk__tok__symbol__symbol__symbol__71 }
-tok__symbol__symbol__eql__54 { L.Tk__tok__symbol__symbol__eql__54 }
-tok__symbol__symbol__69 { L.Tk__tok__symbol__symbol__69 }
-tok__symbol__eql__67 { L.Tk__tok__symbol__eql__67 }
-tok__symbol__65 { L.Tk__tok__symbol__65 }
-tok__eql__eql__62 { L.Tk__tok__eql__eql__62 }
-tok__eql__9 { L.Tk__tok__eql__9 }
-tok__symbol__eql__66 { L.Tk__tok__symbol__eql__66 }
-tok__symbol__symbol__eql__53 { L.Tk__tok__symbol__symbol__eql__53 }
-tok__symbol__symbol__70 { L.Tk__tok__symbol__symbol__70 }
-tok__symbol__64 { L.Tk__tok__symbol__64 }
-tok__semi__1 { L.Tk__tok__semi__1 }
-tok__colon__32 { L.Tk__tok__colon__32 }
-tok__symbol__eql__48 { L.Tk__tok__symbol__eql__48 }
-tok__symbol__74 { L.Tk__tok__symbol__74 }
-tok__dot__3 { L.Tk__tok__dot__3 }
-tok__minus__eql__46 { L.Tk__tok__minus__eql__46 }
-tok__minus__minus__77 { L.Tk__tok__minus__minus__77 }
-tok__minus__73 { L.Tk__tok__minus__73 }
-tok__coma__8 { L.Tk__tok__coma__8 }
-tok__plus__eql__45 { L.Tk__tok__plus__eql__45 }
-tok__plus__plus__76 { L.Tk__tok__plus__plus__76 }
-tok__plus__72 { L.Tk__tok__plus__72 }
-tok__star__eql__47 { L.Tk__tok__star__eql__47 }
-tok__star__4 { L.Tk__tok__star__4 }
-tok__rparen__7 { L.Tk__tok__rparen__7 }
-tok__lparen__6 { L.Tk__tok__lparen__6 }
-tok__symbol__eql__50 { L.Tk__tok__symbol__eql__50 }
-tok__symbol__symbol__58 { L.Tk__tok__symbol__symbol__58 }
-tok__symbol__61 { L.Tk__tok__symbol__61 }
-tok__symbol__eql__52 { L.Tk__tok__symbol__eql__52 }
-tok__symbol__75 { L.Tk__tok__symbol__75 }
-tok__exclamation__eql__63 { L.Tk__tok__exclamation__eql__63 }
-tok__exclamation__79 { L.Tk__tok__exclamation__79 }
-doccomment { L.Tk__doccomment $$ }
-id { L.Tk__id $$ }
-string { L.Tk__string $$ }
-char { L.Tk__char $$ }
-floatTypeSuffix { L.Tk__floatTypeSuffix $$ }
-exponentPart { L.Tk__exponentPart $$ }
-floatLiteral { L.Tk__floatLiteral $$ }
-integerLiteral { L.Tk__integerLiteral $$ }
-qq_CompoundName { L.Tk__qq_CompoundName $$ }
-qq_Modifier { L.Tk__qq_Modifier $$ }
-qq_TypeSpecifier { L.Tk__qq_TypeSpecifier $$ }
-qq_Type { L.Tk__qq_Type $$ }
-qq_TypeParameter { L.Tk__qq_TypeParameter $$ }
-qq_TypeParameters { L.Tk__qq_TypeParameters $$ }
-qq_WildcardType { L.Tk__qq_WildcardType $$ }
-qq_TypeArgument { L.Tk__qq_TypeArgument $$ }
-qq_TypeArguments { L.Tk__qq_TypeArguments $$ }
-qq_Arglist { L.Tk__qq_Arglist $$ }
-qq_Literal { L.Tk__qq_Literal $$ }
-qq_CreationExpression { L.Tk__qq_CreationExpression $$ }
-qq_PostfixOp { L.Tk__qq_PostfixOp $$ }
-qq_PrefixOp { L.Tk__qq_PrefixOp $$ }
-qq_MultiplicativeOp { L.Tk__qq_MultiplicativeOp $$ }
-qq_AdditiveOp { L.Tk__qq_AdditiveOp $$ }
-qq_ShiftOp { L.Tk__qq_ShiftOp $$ }
-qq_RelationalOp { L.Tk__qq_RelationalOp $$ }
-qq_EqualityOp { L.Tk__qq_EqualityOp $$ }
-qq_AssignmentOp { L.Tk__qq_AssignmentOp $$ }
-qq_Expression { L.Tk__qq_Expression $$ }
-qq_SwitchStatement { L.Tk__qq_SwitchStatement $$ }
-qq_SwitchCaseList { L.Tk__qq_SwitchCaseList $$ }
-qq_TryStatement { L.Tk__qq_TryStatement $$ }
-qq_OptFinally { L.Tk__qq_OptFinally $$ }
-qq_CatchList { L.Tk__qq_CatchList $$ }
-qq_ForStatement { L.Tk__qq_ForStatement $$ }
-qq_WhileStatement { L.Tk__qq_WhileStatement $$ }
-qq_DoStatement { L.Tk__qq_DoStatement $$ }
-qq_IfStatement { L.Tk__qq_IfStatement $$ }
-qq_OptElsePart { L.Tk__qq_OptElsePart $$ }
-qq_StatementWithoutIf { L.Tk__qq_StatementWithoutIf $$ }
-qq_Statement { L.Tk__qq_Statement $$ }
-qq_OptId { L.Tk__qq_OptId $$ }
-qq_OptExpression { L.Tk__qq_OptExpression $$ }
-qq_StatementList { L.Tk__qq_StatementList $$ }
-qq_Parameter { L.Tk__qq_Parameter $$ }
-qq_ParameterList { L.Tk__qq_ParameterList $$ }
-qq_StaticInitializer { L.Tk__qq_StaticInitializer $$ }
-qq_VariableInitializer { L.Tk__qq_VariableInitializer $$ }
-qq_VariableInitializerList { L.Tk__qq_VariableInitializerList $$ }
-qq_VariableDeclarator { L.Tk__qq_VariableDeclarator $$ }
-qq_OptVariableInitializer { L.Tk__qq_OptVariableInitializer $$ }
-qq_VariableDeclaration { L.Tk__qq_VariableDeclaration $$ }
-qq_VariableDeclaratorList { L.Tk__qq_VariableDeclaratorList $$ }
-qq_StatementBlock { L.Tk__qq_StatementBlock $$ }
-qq_MoreVariableDeclarators { L.Tk__qq_MoreVariableDeclarators $$ }
-qq_MemberRest { L.Tk__qq_MemberRest $$ }
-qq_MoreTypeSpecifier { L.Tk__qq_MoreTypeSpecifier $$ }
-qq_MemberAfterFirstId { L.Tk__qq_MemberAfterFirstId $$ }
-qq_PrimitiveTypeKeyword { L.Tk__qq_PrimitiveTypeKeyword $$ }
-qq_MemberDeclaration { L.Tk__qq_MemberDeclaration $$ }
-qq_SquareBracketsList { L.Tk__qq_SquareBracketsList $$ }
-qq_FieldDeclaration { L.Tk__qq_FieldDeclaration $$ }
-qq_NestedTypeDeclaration { L.Tk__qq_NestedTypeDeclaration $$ }
-qq_EnumDeclaration { L.Tk__qq_EnumDeclaration $$ }
-qq_EnumConstantList { L.Tk__qq_EnumConstantList $$ }
-qq_EnumConstant { L.Tk__qq_EnumConstant $$ }
-qq_AnnotationTypeElement { L.Tk__qq_AnnotationTypeElement $$ }
-qq_AnnotationTypeElementList { L.Tk__qq_AnnotationTypeElementList $$ }
-qq_AnnotationDeclaration { L.Tk__qq_AnnotationDeclaration $$ }
-qq_InterfaceDeclaration { L.Tk__qq_InterfaceDeclaration $$ }
-qq_ClassDeclaration { L.Tk__qq_ClassDeclaration $$ }
-qq_FieldDeclarationList { L.Tk__qq_FieldDeclarationList $$ }
-qq_ImplementsList { L.Tk__qq_ImplementsList $$ }
-qq_ExtendsList { L.Tk__qq_ExtendsList $$ }
-qq_ModifierList { L.Tk__qq_ModifierList $$ }
-qq_AnnotationList { L.Tk__qq_AnnotationList $$ }
-qq_AnnotationElement { L.Tk__qq_AnnotationElement $$ }
-qq_AnnotationArguments { L.Tk__qq_AnnotationArguments $$ }
-qq_Annotation { L.Tk__qq_Annotation $$ }
-qq_DocComment { L.Tk__qq_DocComment $$ }
-qq_ImportStatement { L.Tk__qq_ImportStatement $$ }
-qq_Package { L.Tk__qq_Package $$ }
-qq_CompilationUnit { L.Tk__qq_CompilationUnit $$ }
-qq_ImportList { L.Tk__qq_ImportList $$ }
-qq_TypeDeclaration { L.Tk__qq_TypeDeclaration $$ }
-qq_OptDocComment { L.Tk__qq_OptDocComment $$ }
-qq_Java { L.Tk__qq_Java $$ }
+rtk__eof { L.PosToken _ L.EndOfFile }
+tok_AdditiveOp_dummy_171 { L.PosToken _ L.Tk__tok_AdditiveOp_dummy_171 }
+tok_Annotation_dummy_170 { L.PosToken _ L.Tk__tok_Annotation_dummy_170 }
+tok_AnnotationArguments_dummy_169 { L.PosToken _ L.Tk__tok_AnnotationArguments_dummy_169 }
+tok_AnnotationDeclaration_dummy_168 { L.PosToken _ L.Tk__tok_AnnotationDeclaration_dummy_168 }
+tok_AnnotationElement_dummy_167 { L.PosToken _ L.Tk__tok_AnnotationElement_dummy_167 }
+tok_AnnotationList_dummy_166 { L.PosToken _ L.Tk__tok_AnnotationList_dummy_166 }
+tok_AnnotationTypeElement_dummy_165 { L.PosToken _ L.Tk__tok_AnnotationTypeElement_dummy_165 }
+tok_AnnotationTypeElementList_dummy_164 { L.PosToken _ L.Tk__tok_AnnotationTypeElementList_dummy_164 }
+tok_Arglist_dummy_163 { L.PosToken _ L.Tk__tok_Arglist_dummy_163 }
+tok_AssignmentOp_dummy_162 { L.PosToken _ L.Tk__tok_AssignmentOp_dummy_162 }
+tok_CatchList_dummy_161 { L.PosToken _ L.Tk__tok_CatchList_dummy_161 }
+tok_ClassDeclaration_dummy_160 { L.PosToken _ L.Tk__tok_ClassDeclaration_dummy_160 }
+tok_CompilationUnit_dummy_159 { L.PosToken _ L.Tk__tok_CompilationUnit_dummy_159 }
+tok_CompoundName_dummy_158 { L.PosToken _ L.Tk__tok_CompoundName_dummy_158 }
+tok_CreationExpression_dummy_157 { L.PosToken _ L.Tk__tok_CreationExpression_dummy_157 }
+tok_DoStatement_dummy_156 { L.PosToken _ L.Tk__tok_DoStatement_dummy_156 }
+tok_DocComment_dummy_155 { L.PosToken _ L.Tk__tok_DocComment_dummy_155 }
+tok_EnumConstant_dummy_154 { L.PosToken _ L.Tk__tok_EnumConstant_dummy_154 }
+tok_EnumConstantList_dummy_153 { L.PosToken _ L.Tk__tok_EnumConstantList_dummy_153 }
+tok_EnumDeclaration_dummy_152 { L.PosToken _ L.Tk__tok_EnumDeclaration_dummy_152 }
+tok_EqualityOp_dummy_151 { L.PosToken _ L.Tk__tok_EqualityOp_dummy_151 }
+tok_Expression_dummy_150 { L.PosToken _ L.Tk__tok_Expression_dummy_150 }
+tok_ExtendsList_dummy_149 { L.PosToken _ L.Tk__tok_ExtendsList_dummy_149 }
+tok_FieldDeclaration_dummy_148 { L.PosToken _ L.Tk__tok_FieldDeclaration_dummy_148 }
+tok_FieldDeclarationList_dummy_147 { L.PosToken _ L.Tk__tok_FieldDeclarationList_dummy_147 }
+tok_ForStatement_dummy_146 { L.PosToken _ L.Tk__tok_ForStatement_dummy_146 }
+tok_IfStatement_dummy_145 { L.PosToken _ L.Tk__tok_IfStatement_dummy_145 }
+tok_ImplementsList_dummy_144 { L.PosToken _ L.Tk__tok_ImplementsList_dummy_144 }
+tok_ImportList_dummy_143 { L.PosToken _ L.Tk__tok_ImportList_dummy_143 }
+tok_ImportStatement_dummy_142 { L.PosToken _ L.Tk__tok_ImportStatement_dummy_142 }
+tok_InterfaceDeclaration_dummy_141 { L.PosToken _ L.Tk__tok_InterfaceDeclaration_dummy_141 }
+tok_Java_dummy_172 { L.PosToken _ L.Tk__tok_Java_dummy_172 }
+tok_Literal_dummy_140 { L.PosToken _ L.Tk__tok_Literal_dummy_140 }
+tok_MemberAfterFirstId_dummy_139 { L.PosToken _ L.Tk__tok_MemberAfterFirstId_dummy_139 }
+tok_MemberDeclaration_dummy_138 { L.PosToken _ L.Tk__tok_MemberDeclaration_dummy_138 }
+tok_MemberRest_dummy_137 { L.PosToken _ L.Tk__tok_MemberRest_dummy_137 }
+tok_Modifier_dummy_136 { L.PosToken _ L.Tk__tok_Modifier_dummy_136 }
+tok_ModifierList_dummy_135 { L.PosToken _ L.Tk__tok_ModifierList_dummy_135 }
+tok_MoreTypeSpecifier_dummy_134 { L.PosToken _ L.Tk__tok_MoreTypeSpecifier_dummy_134 }
+tok_MoreVariableDeclarators_dummy_133 { L.PosToken _ L.Tk__tok_MoreVariableDeclarators_dummy_133 }
+tok_MultiplicativeOp_dummy_132 { L.PosToken _ L.Tk__tok_MultiplicativeOp_dummy_132 }
+tok_NestedTypeDeclaration_dummy_131 { L.PosToken _ L.Tk__tok_NestedTypeDeclaration_dummy_131 }
+tok_OptDocComment_dummy_130 { L.PosToken _ L.Tk__tok_OptDocComment_dummy_130 }
+tok_OptElsePart_dummy_129 { L.PosToken _ L.Tk__tok_OptElsePart_dummy_129 }
+tok_OptExpression_dummy_128 { L.PosToken _ L.Tk__tok_OptExpression_dummy_128 }
+tok_OptFinally_dummy_127 { L.PosToken _ L.Tk__tok_OptFinally_dummy_127 }
+tok_OptId_dummy_126 { L.PosToken _ L.Tk__tok_OptId_dummy_126 }
+tok_OptVariableInitializer_dummy_125 { L.PosToken _ L.Tk__tok_OptVariableInitializer_dummy_125 }
+tok_Package_dummy_124 { L.PosToken _ L.Tk__tok_Package_dummy_124 }
+tok_Parameter_dummy_123 { L.PosToken _ L.Tk__tok_Parameter_dummy_123 }
+tok_ParameterList_dummy_122 { L.PosToken _ L.Tk__tok_ParameterList_dummy_122 }
+tok_PostfixOp_dummy_121 { L.PosToken _ L.Tk__tok_PostfixOp_dummy_121 }
+tok_PrefixOp_dummy_120 { L.PosToken _ L.Tk__tok_PrefixOp_dummy_120 }
+tok_PrimitiveTypeKeyword_dummy_119 { L.PosToken _ L.Tk__tok_PrimitiveTypeKeyword_dummy_119 }
+tok_RelationalOp_dummy_118 { L.PosToken _ L.Tk__tok_RelationalOp_dummy_118 }
+tok_ShiftOp_dummy_117 { L.PosToken _ L.Tk__tok_ShiftOp_dummy_117 }
+tok_SquareBracketsList_dummy_116 { L.PosToken _ L.Tk__tok_SquareBracketsList_dummy_116 }
+tok_Statement_dummy_115 { L.PosToken _ L.Tk__tok_Statement_dummy_115 }
+tok_StatementBlock_dummy_114 { L.PosToken _ L.Tk__tok_StatementBlock_dummy_114 }
+tok_StatementList_dummy_113 { L.PosToken _ L.Tk__tok_StatementList_dummy_113 }
+tok_StatementWithoutIf_dummy_112 { L.PosToken _ L.Tk__tok_StatementWithoutIf_dummy_112 }
+tok_StaticInitializer_dummy_111 { L.PosToken _ L.Tk__tok_StaticInitializer_dummy_111 }
+tok_SwitchCaseList_dummy_110 { L.PosToken _ L.Tk__tok_SwitchCaseList_dummy_110 }
+tok_SwitchStatement_dummy_109 { L.PosToken _ L.Tk__tok_SwitchStatement_dummy_109 }
+tok_TryStatement_dummy_108 { L.PosToken _ L.Tk__tok_TryStatement_dummy_108 }
+tok_Type_dummy_107 { L.PosToken _ L.Tk__tok_Type_dummy_107 }
+tok_TypeArgument_dummy_106 { L.PosToken _ L.Tk__tok_TypeArgument_dummy_106 }
+tok_TypeArguments_dummy_105 { L.PosToken _ L.Tk__tok_TypeArguments_dummy_105 }
+tok_TypeDeclaration_dummy_104 { L.PosToken _ L.Tk__tok_TypeDeclaration_dummy_104 }
+tok_TypeParameter_dummy_103 { L.PosToken _ L.Tk__tok_TypeParameter_dummy_103 }
+tok_TypeParameters_dummy_102 { L.PosToken _ L.Tk__tok_TypeParameters_dummy_102 }
+tok_TypeSpecifier_dummy_101 { L.PosToken _ L.Tk__tok_TypeSpecifier_dummy_101 }
+tok_VariableDeclaration_dummy_100 { L.PosToken _ L.Tk__tok_VariableDeclaration_dummy_100 }
+tok_VariableDeclarator_dummy_99 { L.PosToken _ L.Tk__tok_VariableDeclarator_dummy_99 }
+tok_VariableDeclaratorList_dummy_98 { L.PosToken _ L.Tk__tok_VariableDeclaratorList_dummy_98 }
+tok_VariableInitializer_dummy_97 { L.PosToken _ L.Tk__tok_VariableInitializer_dummy_97 }
+tok_VariableInitializerList_dummy_96 { L.PosToken _ L.Tk__tok_VariableInitializerList_dummy_96 }
+tok_WhileStatement_dummy_95 { L.PosToken _ L.Tk__tok_WhileStatement_dummy_95 }
+tok_WildcardType_dummy_94 { L.PosToken _ L.Tk__tok_WildcardType_dummy_94 }
+tok__tilde__78 { L.PosToken _ L.Tk__tok__tilde__78 }
+tok__symbol__14 { L.PosToken _ L.Tk__tok__symbol__14 }
+tok__pipe__pipe__57 { L.PosToken _ L.Tk__tok__pipe__pipe__57 }
+tok__pipe__eql__49 { L.PosToken _ L.Tk__tok__pipe__eql__49 }
+tok__pipe__59 { L.PosToken _ L.Tk__tok__pipe__59 }
+tok__symbol__13 { L.PosToken _ L.Tk__tok__symbol__13 }
+tok_while_38 { L.PosToken _ L.Tk__tok_while_38 }
+tok_void_28 { L.PosToken _ L.Tk__tok_void_28 }
+tok_try_42 { L.PosToken _ L.Tk__tok_try_42 }
+tok_true_83 { L.PosToken _ L.Tk__tok_true_83 }
+tok_transient_94 { L.PosToken _ L.Tk__tok_transient_94 }
+tok_throw_31 { L.PosToken _ L.Tk__tok_throw_31 }
+tok_threadsafe_93 { L.PosToken _ L.Tk__tok_threadsafe_93 }
+tok_this_80 { L.PosToken _ L.Tk__tok_this_80 }
+tok_synchronized_30 { L.PosToken _ L.Tk__tok_synchronized_30 }
+tok_switch_44 { L.PosToken _ L.Tk__tok_switch_44 }
+tok_super_81 { L.PosToken _ L.Tk__tok_super_81 }
+tok_static_89 { L.PosToken _ L.Tk__tok_static_89 }
+tok_short_23 { L.PosToken _ L.Tk__tok_short_23 }
+tok_return_29 { L.PosToken _ L.Tk__tok_return_29 }
+tok_public_86 { L.PosToken _ L.Tk__tok_public_86 }
+tok_protected_88 { L.PosToken _ L.Tk__tok_protected_88 }
+tok_private_87 { L.PosToken _ L.Tk__tok_private_87 }
+tok_package_0 { L.PosToken _ L.Tk__tok_package_0 }
+tok_null_85 { L.PosToken _ L.Tk__tok_null_85 }
+tok_new_82 { L.PosToken _ L.Tk__tok_new_82 }
+tok_native_91 { L.PosToken _ L.Tk__tok_native_91 }
+tok_long_26 { L.PosToken _ L.Tk__tok_long_26 }
+tok_interface_15 { L.PosToken _ L.Tk__tok_interface_15 }
+tok_int_24 { L.PosToken _ L.Tk__tok_int_24 }
+tok_instanceof_68 { L.PosToken _ L.Tk__tok_instanceof_68 }
+tok_import_2 { L.PosToken _ L.Tk__tok_import_2 }
+tok_implements_11 { L.PosToken _ L.Tk__tok_implements_11 }
+tok_if_36 { L.PosToken _ L.Tk__tok_if_36 }
+tok_for_39 { L.PosToken _ L.Tk__tok_for_39 }
+tok_float_25 { L.PosToken _ L.Tk__tok_float_25 }
+tok_finally_41 { L.PosToken _ L.Tk__tok_finally_41 }
+tok_final_90 { L.PosToken _ L.Tk__tok_final_90 }
+tok_false_84 { L.PosToken _ L.Tk__tok_false_84 }
+tok_extends_10 { L.PosToken _ L.Tk__tok_extends_10 }
+tok_enum_17 { L.PosToken _ L.Tk__tok_enum_17 }
+tok_else_35 { L.PosToken _ L.Tk__tok_else_35 }
+tok_double_27 { L.PosToken _ L.Tk__tok_double_27 }
+tok_do_37 { L.PosToken _ L.Tk__tok_do_37 }
+tok_default_16 { L.PosToken _ L.Tk__tok_default_16 }
+tok_continue_34 { L.PosToken _ L.Tk__tok_continue_34 }
+tok_class_12 { L.PosToken _ L.Tk__tok_class_12 }
+tok_char_22 { L.PosToken _ L.Tk__tok_char_22 }
+tok_catch_40 { L.PosToken _ L.Tk__tok_catch_40 }
+tok_case_43 { L.PosToken _ L.Tk__tok_case_43 }
+tok_byte_21 { L.PosToken _ L.Tk__tok_byte_21 }
+tok_break_33 { L.PosToken _ L.Tk__tok_break_33 }
+tok_boolean_20 { L.PosToken _ L.Tk__tok_boolean_20 }
+tok_abstract_92 { L.PosToken _ L.Tk__tok_abstract_92 }
+tok__symbol__eql__51 { L.PosToken _ L.Tk__tok__symbol__eql__51 }
+tok__symbol__60 { L.PosToken _ L.Tk__tok__symbol__60 }
+tok__sq_bkt_r__19 { L.PosToken _ L.Tk__tok__sq_bkt_r__19 }
+tok__sq_bkt_l__18 { L.PosToken _ L.Tk__tok__sq_bkt_l__18 }
+tok__symbol__5 { L.PosToken _ L.Tk__tok__symbol__5 }
+tok__symbol__56 { L.PosToken _ L.Tk__tok__symbol__56 }
+tok__symbol__symbol__symbol__eql__55 { L.PosToken _ L.Tk__tok__symbol__symbol__symbol__eql__55 }
+tok__symbol__symbol__symbol__71 { L.PosToken _ L.Tk__tok__symbol__symbol__symbol__71 }
+tok__symbol__symbol__eql__54 { L.PosToken _ L.Tk__tok__symbol__symbol__eql__54 }
+tok__symbol__symbol__69 { L.PosToken _ L.Tk__tok__symbol__symbol__69 }
+tok__symbol__eql__67 { L.PosToken _ L.Tk__tok__symbol__eql__67 }
+tok__symbol__65 { L.PosToken _ L.Tk__tok__symbol__65 }
+tok__eql__eql__62 { L.PosToken _ L.Tk__tok__eql__eql__62 }
+tok__eql__9 { L.PosToken _ L.Tk__tok__eql__9 }
+tok__symbol__eql__66 { L.PosToken _ L.Tk__tok__symbol__eql__66 }
+tok__symbol__symbol__eql__53 { L.PosToken _ L.Tk__tok__symbol__symbol__eql__53 }
+tok__symbol__symbol__70 { L.PosToken _ L.Tk__tok__symbol__symbol__70 }
+tok__symbol__64 { L.PosToken _ L.Tk__tok__symbol__64 }
+tok__semi__1 { L.PosToken _ L.Tk__tok__semi__1 }
+tok__colon__32 { L.PosToken _ L.Tk__tok__colon__32 }
+tok__symbol__eql__48 { L.PosToken _ L.Tk__tok__symbol__eql__48 }
+tok__symbol__74 { L.PosToken _ L.Tk__tok__symbol__74 }
+tok__dot__3 { L.PosToken _ L.Tk__tok__dot__3 }
+tok__minus__eql__46 { L.PosToken _ L.Tk__tok__minus__eql__46 }
+tok__minus__minus__77 { L.PosToken _ L.Tk__tok__minus__minus__77 }
+tok__minus__73 { L.PosToken _ L.Tk__tok__minus__73 }
+tok__coma__8 { L.PosToken _ L.Tk__tok__coma__8 }
+tok__plus__eql__45 { L.PosToken _ L.Tk__tok__plus__eql__45 }
+tok__plus__plus__76 { L.PosToken _ L.Tk__tok__plus__plus__76 }
+tok__plus__72 { L.PosToken _ L.Tk__tok__plus__72 }
+tok__star__eql__47 { L.PosToken _ L.Tk__tok__star__eql__47 }
+tok__star__4 { L.PosToken _ L.Tk__tok__star__4 }
+tok__rparen__7 { L.PosToken _ L.Tk__tok__rparen__7 }
+tok__lparen__6 { L.PosToken _ L.Tk__tok__lparen__6 }
+tok__symbol__eql__50 { L.PosToken _ L.Tk__tok__symbol__eql__50 }
+tok__symbol__symbol__58 { L.PosToken _ L.Tk__tok__symbol__symbol__58 }
+tok__symbol__61 { L.PosToken _ L.Tk__tok__symbol__61 }
+tok__symbol__eql__52 { L.PosToken _ L.Tk__tok__symbol__eql__52 }
+tok__symbol__75 { L.PosToken _ L.Tk__tok__symbol__75 }
+tok__exclamation__eql__63 { L.PosToken _ L.Tk__tok__exclamation__eql__63 }
+tok__exclamation__79 { L.PosToken _ L.Tk__tok__exclamation__79 }
+doccomment { L.PosToken _ (L.Tk__doccomment $$) }
+id { L.PosToken _ (L.Tk__id $$) }
+string { L.PosToken _ (L.Tk__string $$) }
+char { L.PosToken _ (L.Tk__char $$) }
+floatTypeSuffix { L.PosToken _ (L.Tk__floatTypeSuffix $$) }
+exponentPart { L.PosToken _ (L.Tk__exponentPart $$) }
+floatLiteral { L.PosToken _ (L.Tk__floatLiteral $$) }
+integerLiteral { L.PosToken _ (L.Tk__integerLiteral $$) }
+qq_CompoundName { L.PosToken _ (L.Tk__qq_CompoundName $$) }
+qq_Modifier { L.PosToken _ (L.Tk__qq_Modifier $$) }
+qq_TypeSpecifier { L.PosToken _ (L.Tk__qq_TypeSpecifier $$) }
+qq_Type { L.PosToken _ (L.Tk__qq_Type $$) }
+qq_TypeParameter { L.PosToken _ (L.Tk__qq_TypeParameter $$) }
+qq_TypeParameters { L.PosToken _ (L.Tk__qq_TypeParameters $$) }
+qq_WildcardType { L.PosToken _ (L.Tk__qq_WildcardType $$) }
+qq_TypeArgument { L.PosToken _ (L.Tk__qq_TypeArgument $$) }
+qq_TypeArguments { L.PosToken _ (L.Tk__qq_TypeArguments $$) }
+qq_Arglist { L.PosToken _ (L.Tk__qq_Arglist $$) }
+qq_Literal { L.PosToken _ (L.Tk__qq_Literal $$) }
+qq_CreationExpression { L.PosToken _ (L.Tk__qq_CreationExpression $$) }
+qq_PostfixOp { L.PosToken _ (L.Tk__qq_PostfixOp $$) }
+qq_PrefixOp { L.PosToken _ (L.Tk__qq_PrefixOp $$) }
+qq_MultiplicativeOp { L.PosToken _ (L.Tk__qq_MultiplicativeOp $$) }
+qq_AdditiveOp { L.PosToken _ (L.Tk__qq_AdditiveOp $$) }
+qq_ShiftOp { L.PosToken _ (L.Tk__qq_ShiftOp $$) }
+qq_RelationalOp { L.PosToken _ (L.Tk__qq_RelationalOp $$) }
+qq_EqualityOp { L.PosToken _ (L.Tk__qq_EqualityOp $$) }
+qq_AssignmentOp { L.PosToken _ (L.Tk__qq_AssignmentOp $$) }
+qq_Expression { L.PosToken _ (L.Tk__qq_Expression $$) }
+qq_SwitchStatement { L.PosToken _ (L.Tk__qq_SwitchStatement $$) }
+qq_SwitchCaseList { L.PosToken _ (L.Tk__qq_SwitchCaseList $$) }
+qq_TryStatement { L.PosToken _ (L.Tk__qq_TryStatement $$) }
+qq_OptFinally { L.PosToken _ (L.Tk__qq_OptFinally $$) }
+qq_CatchList { L.PosToken _ (L.Tk__qq_CatchList $$) }
+qq_ForStatement { L.PosToken _ (L.Tk__qq_ForStatement $$) }
+qq_WhileStatement { L.PosToken _ (L.Tk__qq_WhileStatement $$) }
+qq_DoStatement { L.PosToken _ (L.Tk__qq_DoStatement $$) }
+qq_IfStatement { L.PosToken _ (L.Tk__qq_IfStatement $$) }
+qq_OptElsePart { L.PosToken _ (L.Tk__qq_OptElsePart $$) }
+qq_StatementWithoutIf { L.PosToken _ (L.Tk__qq_StatementWithoutIf $$) }
+qq_Statement { L.PosToken _ (L.Tk__qq_Statement $$) }
+qq_OptId { L.PosToken _ (L.Tk__qq_OptId $$) }
+qq_OptExpression { L.PosToken _ (L.Tk__qq_OptExpression $$) }
+qq_StatementList { L.PosToken _ (L.Tk__qq_StatementList $$) }
+qq_Parameter { L.PosToken _ (L.Tk__qq_Parameter $$) }
+qq_ParameterList { L.PosToken _ (L.Tk__qq_ParameterList $$) }
+qq_StaticInitializer { L.PosToken _ (L.Tk__qq_StaticInitializer $$) }
+qq_VariableInitializer { L.PosToken _ (L.Tk__qq_VariableInitializer $$) }
+qq_VariableInitializerList { L.PosToken _ (L.Tk__qq_VariableInitializerList $$) }
+qq_VariableDeclarator { L.PosToken _ (L.Tk__qq_VariableDeclarator $$) }
+qq_OptVariableInitializer { L.PosToken _ (L.Tk__qq_OptVariableInitializer $$) }
+qq_VariableDeclaration { L.PosToken _ (L.Tk__qq_VariableDeclaration $$) }
+qq_VariableDeclaratorList { L.PosToken _ (L.Tk__qq_VariableDeclaratorList $$) }
+qq_StatementBlock { L.PosToken _ (L.Tk__qq_StatementBlock $$) }
+qq_MoreVariableDeclarators { L.PosToken _ (L.Tk__qq_MoreVariableDeclarators $$) }
+qq_MemberRest { L.PosToken _ (L.Tk__qq_MemberRest $$) }
+qq_MoreTypeSpecifier { L.PosToken _ (L.Tk__qq_MoreTypeSpecifier $$) }
+qq_MemberAfterFirstId { L.PosToken _ (L.Tk__qq_MemberAfterFirstId $$) }
+qq_PrimitiveTypeKeyword { L.PosToken _ (L.Tk__qq_PrimitiveTypeKeyword $$) }
+qq_MemberDeclaration { L.PosToken _ (L.Tk__qq_MemberDeclaration $$) }
+qq_SquareBracketsList { L.PosToken _ (L.Tk__qq_SquareBracketsList $$) }
+qq_FieldDeclaration { L.PosToken _ (L.Tk__qq_FieldDeclaration $$) }
+qq_NestedTypeDeclaration { L.PosToken _ (L.Tk__qq_NestedTypeDeclaration $$) }
+qq_EnumDeclaration { L.PosToken _ (L.Tk__qq_EnumDeclaration $$) }
+qq_EnumConstantList { L.PosToken _ (L.Tk__qq_EnumConstantList $$) }
+qq_EnumConstant { L.PosToken _ (L.Tk__qq_EnumConstant $$) }
+qq_AnnotationTypeElement { L.PosToken _ (L.Tk__qq_AnnotationTypeElement $$) }
+qq_AnnotationTypeElementList { L.PosToken _ (L.Tk__qq_AnnotationTypeElementList $$) }
+qq_AnnotationDeclaration { L.PosToken _ (L.Tk__qq_AnnotationDeclaration $$) }
+qq_InterfaceDeclaration { L.PosToken _ (L.Tk__qq_InterfaceDeclaration $$) }
+qq_ClassDeclaration { L.PosToken _ (L.Tk__qq_ClassDeclaration $$) }
+qq_FieldDeclarationList { L.PosToken _ (L.Tk__qq_FieldDeclarationList $$) }
+qq_ImplementsList { L.PosToken _ (L.Tk__qq_ImplementsList $$) }
+qq_ExtendsList { L.PosToken _ (L.Tk__qq_ExtendsList $$) }
+qq_ModifierList { L.PosToken _ (L.Tk__qq_ModifierList $$) }
+qq_AnnotationList { L.PosToken _ (L.Tk__qq_AnnotationList $$) }
+qq_AnnotationElement { L.PosToken _ (L.Tk__qq_AnnotationElement $$) }
+qq_AnnotationArguments { L.PosToken _ (L.Tk__qq_AnnotationArguments $$) }
+qq_Annotation { L.PosToken _ (L.Tk__qq_Annotation $$) }
+qq_DocComment { L.PosToken _ (L.Tk__qq_DocComment $$) }
+qq_ImportStatement { L.PosToken _ (L.Tk__qq_ImportStatement $$) }
+qq_Package { L.PosToken _ (L.Tk__qq_Package $$) }
+qq_CompilationUnit { L.PosToken _ (L.Tk__qq_CompilationUnit $$) }
+qq_ImportList { L.PosToken _ (L.Tk__qq_ImportList $$) }
+qq_TypeDeclaration { L.PosToken _ (L.Tk__qq_TypeDeclaration $$) }
+qq_OptDocComment { L.PosToken _ (L.Tk__qq_OptDocComment $$) }
+qq_Java { L.PosToken _ (L.Tk__qq_Java $$) }
 
 %%
+
+Java__top : Java rtk__eof { $1 }
 
 Java : tok_Java_dummy_172 Java tok_Java_dummy_172 { Ctr__Java__0 $2 } |
        tok_AdditiveOp_dummy_171 AdditiveOp tok_AdditiveOp_dummy_171 { Ctr__Java__1 $2 } |
@@ -1011,6 +1014,276 @@ WildcardType : qq_WildcardType { Anti_WildcardType $1 } |
 
 
 {
+parseError :: [L.PosToken] -> a
+parseError [] = errorWithoutStackTrace "Parse error: unexpected end of input"
+parseError (L.PosToken (L.AlexPn _ line col) tok : _) =
+    errorWithoutStackTrace $ "Parse error at line " ++ show line ++ ", column " ++ show col ++ ": unexpected " ++ showRtkToken tok
+
+-- Render a token the way it appears in the source, for error messages
+showRtkToken :: L.Token -> String
+showRtkToken L.EndOfFile = "end of input"
+showRtkToken L.Tk__tok_AdditiveOp_dummy_171 = "'tok_AdditiveOp_dummy_171'"
+showRtkToken L.Tk__tok_Annotation_dummy_170 = "'tok_Annotation_dummy_170'"
+showRtkToken L.Tk__tok_AnnotationArguments_dummy_169 = "'tok_AnnotationArguments_dummy_169'"
+showRtkToken L.Tk__tok_AnnotationDeclaration_dummy_168 = "'tok_AnnotationDeclaration_dummy_168'"
+showRtkToken L.Tk__tok_AnnotationElement_dummy_167 = "'tok_AnnotationElement_dummy_167'"
+showRtkToken L.Tk__tok_AnnotationList_dummy_166 = "'tok_AnnotationList_dummy_166'"
+showRtkToken L.Tk__tok_AnnotationTypeElement_dummy_165 = "'tok_AnnotationTypeElement_dummy_165'"
+showRtkToken L.Tk__tok_AnnotationTypeElementList_dummy_164 = "'tok_AnnotationTypeElementList_dummy_164'"
+showRtkToken L.Tk__tok_Arglist_dummy_163 = "'tok_Arglist_dummy_163'"
+showRtkToken L.Tk__tok_AssignmentOp_dummy_162 = "'tok_AssignmentOp_dummy_162'"
+showRtkToken L.Tk__tok_CatchList_dummy_161 = "'tok_CatchList_dummy_161'"
+showRtkToken L.Tk__tok_ClassDeclaration_dummy_160 = "'tok_ClassDeclaration_dummy_160'"
+showRtkToken L.Tk__tok_CompilationUnit_dummy_159 = "'tok_CompilationUnit_dummy_159'"
+showRtkToken L.Tk__tok_CompoundName_dummy_158 = "'tok_CompoundName_dummy_158'"
+showRtkToken L.Tk__tok_CreationExpression_dummy_157 = "'tok_CreationExpression_dummy_157'"
+showRtkToken L.Tk__tok_DoStatement_dummy_156 = "'tok_DoStatement_dummy_156'"
+showRtkToken L.Tk__tok_DocComment_dummy_155 = "'tok_DocComment_dummy_155'"
+showRtkToken L.Tk__tok_EnumConstant_dummy_154 = "'tok_EnumConstant_dummy_154'"
+showRtkToken L.Tk__tok_EnumConstantList_dummy_153 = "'tok_EnumConstantList_dummy_153'"
+showRtkToken L.Tk__tok_EnumDeclaration_dummy_152 = "'tok_EnumDeclaration_dummy_152'"
+showRtkToken L.Tk__tok_EqualityOp_dummy_151 = "'tok_EqualityOp_dummy_151'"
+showRtkToken L.Tk__tok_Expression_dummy_150 = "'tok_Expression_dummy_150'"
+showRtkToken L.Tk__tok_ExtendsList_dummy_149 = "'tok_ExtendsList_dummy_149'"
+showRtkToken L.Tk__tok_FieldDeclaration_dummy_148 = "'tok_FieldDeclaration_dummy_148'"
+showRtkToken L.Tk__tok_FieldDeclarationList_dummy_147 = "'tok_FieldDeclarationList_dummy_147'"
+showRtkToken L.Tk__tok_ForStatement_dummy_146 = "'tok_ForStatement_dummy_146'"
+showRtkToken L.Tk__tok_IfStatement_dummy_145 = "'tok_IfStatement_dummy_145'"
+showRtkToken L.Tk__tok_ImplementsList_dummy_144 = "'tok_ImplementsList_dummy_144'"
+showRtkToken L.Tk__tok_ImportList_dummy_143 = "'tok_ImportList_dummy_143'"
+showRtkToken L.Tk__tok_ImportStatement_dummy_142 = "'tok_ImportStatement_dummy_142'"
+showRtkToken L.Tk__tok_InterfaceDeclaration_dummy_141 = "'tok_InterfaceDeclaration_dummy_141'"
+showRtkToken L.Tk__tok_Java_dummy_172 = "'tok_Java_dummy_172'"
+showRtkToken L.Tk__tok_Literal_dummy_140 = "'tok_Literal_dummy_140'"
+showRtkToken L.Tk__tok_MemberAfterFirstId_dummy_139 = "'tok_MemberAfterFirstId_dummy_139'"
+showRtkToken L.Tk__tok_MemberDeclaration_dummy_138 = "'tok_MemberDeclaration_dummy_138'"
+showRtkToken L.Tk__tok_MemberRest_dummy_137 = "'tok_MemberRest_dummy_137'"
+showRtkToken L.Tk__tok_Modifier_dummy_136 = "'tok_Modifier_dummy_136'"
+showRtkToken L.Tk__tok_ModifierList_dummy_135 = "'tok_ModifierList_dummy_135'"
+showRtkToken L.Tk__tok_MoreTypeSpecifier_dummy_134 = "'tok_MoreTypeSpecifier_dummy_134'"
+showRtkToken L.Tk__tok_MoreVariableDeclarators_dummy_133 = "'tok_MoreVariableDeclarators_dummy_133'"
+showRtkToken L.Tk__tok_MultiplicativeOp_dummy_132 = "'tok_MultiplicativeOp_dummy_132'"
+showRtkToken L.Tk__tok_NestedTypeDeclaration_dummy_131 = "'tok_NestedTypeDeclaration_dummy_131'"
+showRtkToken L.Tk__tok_OptDocComment_dummy_130 = "'tok_OptDocComment_dummy_130'"
+showRtkToken L.Tk__tok_OptElsePart_dummy_129 = "'tok_OptElsePart_dummy_129'"
+showRtkToken L.Tk__tok_OptExpression_dummy_128 = "'tok_OptExpression_dummy_128'"
+showRtkToken L.Tk__tok_OptFinally_dummy_127 = "'tok_OptFinally_dummy_127'"
+showRtkToken L.Tk__tok_OptId_dummy_126 = "'tok_OptId_dummy_126'"
+showRtkToken L.Tk__tok_OptVariableInitializer_dummy_125 = "'tok_OptVariableInitializer_dummy_125'"
+showRtkToken L.Tk__tok_Package_dummy_124 = "'tok_Package_dummy_124'"
+showRtkToken L.Tk__tok_Parameter_dummy_123 = "'tok_Parameter_dummy_123'"
+showRtkToken L.Tk__tok_ParameterList_dummy_122 = "'tok_ParameterList_dummy_122'"
+showRtkToken L.Tk__tok_PostfixOp_dummy_121 = "'tok_PostfixOp_dummy_121'"
+showRtkToken L.Tk__tok_PrefixOp_dummy_120 = "'tok_PrefixOp_dummy_120'"
+showRtkToken L.Tk__tok_PrimitiveTypeKeyword_dummy_119 = "'tok_PrimitiveTypeKeyword_dummy_119'"
+showRtkToken L.Tk__tok_RelationalOp_dummy_118 = "'tok_RelationalOp_dummy_118'"
+showRtkToken L.Tk__tok_ShiftOp_dummy_117 = "'tok_ShiftOp_dummy_117'"
+showRtkToken L.Tk__tok_SquareBracketsList_dummy_116 = "'tok_SquareBracketsList_dummy_116'"
+showRtkToken L.Tk__tok_Statement_dummy_115 = "'tok_Statement_dummy_115'"
+showRtkToken L.Tk__tok_StatementBlock_dummy_114 = "'tok_StatementBlock_dummy_114'"
+showRtkToken L.Tk__tok_StatementList_dummy_113 = "'tok_StatementList_dummy_113'"
+showRtkToken L.Tk__tok_StatementWithoutIf_dummy_112 = "'tok_StatementWithoutIf_dummy_112'"
+showRtkToken L.Tk__tok_StaticInitializer_dummy_111 = "'tok_StaticInitializer_dummy_111'"
+showRtkToken L.Tk__tok_SwitchCaseList_dummy_110 = "'tok_SwitchCaseList_dummy_110'"
+showRtkToken L.Tk__tok_SwitchStatement_dummy_109 = "'tok_SwitchStatement_dummy_109'"
+showRtkToken L.Tk__tok_TryStatement_dummy_108 = "'tok_TryStatement_dummy_108'"
+showRtkToken L.Tk__tok_Type_dummy_107 = "'tok_Type_dummy_107'"
+showRtkToken L.Tk__tok_TypeArgument_dummy_106 = "'tok_TypeArgument_dummy_106'"
+showRtkToken L.Tk__tok_TypeArguments_dummy_105 = "'tok_TypeArguments_dummy_105'"
+showRtkToken L.Tk__tok_TypeDeclaration_dummy_104 = "'tok_TypeDeclaration_dummy_104'"
+showRtkToken L.Tk__tok_TypeParameter_dummy_103 = "'tok_TypeParameter_dummy_103'"
+showRtkToken L.Tk__tok_TypeParameters_dummy_102 = "'tok_TypeParameters_dummy_102'"
+showRtkToken L.Tk__tok_TypeSpecifier_dummy_101 = "'tok_TypeSpecifier_dummy_101'"
+showRtkToken L.Tk__tok_VariableDeclaration_dummy_100 = "'tok_VariableDeclaration_dummy_100'"
+showRtkToken L.Tk__tok_VariableDeclarator_dummy_99 = "'tok_VariableDeclarator_dummy_99'"
+showRtkToken L.Tk__tok_VariableDeclaratorList_dummy_98 = "'tok_VariableDeclaratorList_dummy_98'"
+showRtkToken L.Tk__tok_VariableInitializer_dummy_97 = "'tok_VariableInitializer_dummy_97'"
+showRtkToken L.Tk__tok_VariableInitializerList_dummy_96 = "'tok_VariableInitializerList_dummy_96'"
+showRtkToken L.Tk__tok_WhileStatement_dummy_95 = "'tok_WhileStatement_dummy_95'"
+showRtkToken L.Tk__tok_WildcardType_dummy_94 = "'tok_WildcardType_dummy_94'"
+showRtkToken L.Tk__tok__tilde__78 = "'~'"
+showRtkToken L.Tk__tok__symbol__14 = "'}'"
+showRtkToken L.Tk__tok__pipe__pipe__57 = "'||'"
+showRtkToken L.Tk__tok__pipe__eql__49 = "'|='"
+showRtkToken L.Tk__tok__pipe__59 = "'|'"
+showRtkToken L.Tk__tok__symbol__13 = "'{'"
+showRtkToken L.Tk__tok_while_38 = "'while'"
+showRtkToken L.Tk__tok_void_28 = "'void'"
+showRtkToken L.Tk__tok_try_42 = "'try'"
+showRtkToken L.Tk__tok_true_83 = "'true'"
+showRtkToken L.Tk__tok_transient_94 = "'transient'"
+showRtkToken L.Tk__tok_throw_31 = "'throw'"
+showRtkToken L.Tk__tok_threadsafe_93 = "'threadsafe'"
+showRtkToken L.Tk__tok_this_80 = "'this'"
+showRtkToken L.Tk__tok_synchronized_30 = "'synchronized'"
+showRtkToken L.Tk__tok_switch_44 = "'switch'"
+showRtkToken L.Tk__tok_super_81 = "'super'"
+showRtkToken L.Tk__tok_static_89 = "'static'"
+showRtkToken L.Tk__tok_short_23 = "'short'"
+showRtkToken L.Tk__tok_return_29 = "'return'"
+showRtkToken L.Tk__tok_public_86 = "'public'"
+showRtkToken L.Tk__tok_protected_88 = "'protected'"
+showRtkToken L.Tk__tok_private_87 = "'private'"
+showRtkToken L.Tk__tok_package_0 = "'package'"
+showRtkToken L.Tk__tok_null_85 = "'null'"
+showRtkToken L.Tk__tok_new_82 = "'new'"
+showRtkToken L.Tk__tok_native_91 = "'native'"
+showRtkToken L.Tk__tok_long_26 = "'long'"
+showRtkToken L.Tk__tok_interface_15 = "'interface'"
+showRtkToken L.Tk__tok_int_24 = "'int'"
+showRtkToken L.Tk__tok_instanceof_68 = "'instanceof'"
+showRtkToken L.Tk__tok_import_2 = "'import'"
+showRtkToken L.Tk__tok_implements_11 = "'implements'"
+showRtkToken L.Tk__tok_if_36 = "'if'"
+showRtkToken L.Tk__tok_for_39 = "'for'"
+showRtkToken L.Tk__tok_float_25 = "'float'"
+showRtkToken L.Tk__tok_finally_41 = "'finally'"
+showRtkToken L.Tk__tok_final_90 = "'final'"
+showRtkToken L.Tk__tok_false_84 = "'false'"
+showRtkToken L.Tk__tok_extends_10 = "'extends'"
+showRtkToken L.Tk__tok_enum_17 = "'enum'"
+showRtkToken L.Tk__tok_else_35 = "'else'"
+showRtkToken L.Tk__tok_double_27 = "'double'"
+showRtkToken L.Tk__tok_do_37 = "'do'"
+showRtkToken L.Tk__tok_default_16 = "'default'"
+showRtkToken L.Tk__tok_continue_34 = "'continue'"
+showRtkToken L.Tk__tok_class_12 = "'class'"
+showRtkToken L.Tk__tok_char_22 = "'char'"
+showRtkToken L.Tk__tok_catch_40 = "'catch'"
+showRtkToken L.Tk__tok_case_43 = "'case'"
+showRtkToken L.Tk__tok_byte_21 = "'byte'"
+showRtkToken L.Tk__tok_break_33 = "'break'"
+showRtkToken L.Tk__tok_boolean_20 = "'boolean'"
+showRtkToken L.Tk__tok_abstract_92 = "'abstract'"
+showRtkToken L.Tk__tok__symbol__eql__51 = "'^='"
+showRtkToken L.Tk__tok__symbol__60 = "'^'"
+showRtkToken L.Tk__tok__sq_bkt_r__19 = "']'"
+showRtkToken L.Tk__tok__sq_bkt_l__18 = "'['"
+showRtkToken L.Tk__tok__symbol__5 = "'@'"
+showRtkToken L.Tk__tok__symbol__56 = "'?'"
+showRtkToken L.Tk__tok__symbol__symbol__symbol__eql__55 = "'>>>='"
+showRtkToken L.Tk__tok__symbol__symbol__symbol__71 = "'>>>'"
+showRtkToken L.Tk__tok__symbol__symbol__eql__54 = "'>>='"
+showRtkToken L.Tk__tok__symbol__symbol__69 = "'>>'"
+showRtkToken L.Tk__tok__symbol__eql__67 = "'>='"
+showRtkToken L.Tk__tok__symbol__65 = "'>'"
+showRtkToken L.Tk__tok__eql__eql__62 = "'=='"
+showRtkToken L.Tk__tok__eql__9 = "'='"
+showRtkToken L.Tk__tok__symbol__eql__66 = "'<='"
+showRtkToken L.Tk__tok__symbol__symbol__eql__53 = "'<<='"
+showRtkToken L.Tk__tok__symbol__symbol__70 = "'<<'"
+showRtkToken L.Tk__tok__symbol__64 = "'<'"
+showRtkToken L.Tk__tok__semi__1 = "';'"
+showRtkToken L.Tk__tok__colon__32 = "':'"
+showRtkToken L.Tk__tok__symbol__eql__48 = "'/='"
+showRtkToken L.Tk__tok__symbol__74 = "'/'"
+showRtkToken L.Tk__tok__dot__3 = "'.'"
+showRtkToken L.Tk__tok__minus__eql__46 = "'-='"
+showRtkToken L.Tk__tok__minus__minus__77 = "'--'"
+showRtkToken L.Tk__tok__minus__73 = "'-'"
+showRtkToken L.Tk__tok__coma__8 = "','"
+showRtkToken L.Tk__tok__plus__eql__45 = "'+='"
+showRtkToken L.Tk__tok__plus__plus__76 = "'++'"
+showRtkToken L.Tk__tok__plus__72 = "'+'"
+showRtkToken L.Tk__tok__star__eql__47 = "'*='"
+showRtkToken L.Tk__tok__star__4 = "'*'"
+showRtkToken L.Tk__tok__rparen__7 = "')'"
+showRtkToken L.Tk__tok__lparen__6 = "'('"
+showRtkToken L.Tk__tok__symbol__eql__50 = "'&='"
+showRtkToken L.Tk__tok__symbol__symbol__58 = "'&&'"
+showRtkToken L.Tk__tok__symbol__61 = "'&'"
+showRtkToken L.Tk__tok__symbol__eql__52 = "'%='"
+showRtkToken L.Tk__tok__symbol__75 = "'%'"
+showRtkToken L.Tk__tok__exclamation__eql__63 = "'!='"
+showRtkToken L.Tk__tok__exclamation__79 = "'!'"
+showRtkToken (L.Tk__doccomment v) = "doccomment " ++ show v
+showRtkToken (L.Tk__id v) = "id " ++ show v
+showRtkToken (L.Tk__string v) = "string " ++ show v
+showRtkToken (L.Tk__char v) = "char " ++ show v
+showRtkToken (L.Tk__floatTypeSuffix v) = "floatTypeSuffix " ++ show v
+showRtkToken (L.Tk__exponentPart v) = "exponentPart " ++ show v
+showRtkToken (L.Tk__floatLiteral v) = "floatLiteral " ++ show v
+showRtkToken (L.Tk__integerLiteral v) = "integerLiteral " ++ show v
+showRtkToken (L.Tk__qq_CompoundName v) = "qq_CompoundName " ++ show v
+showRtkToken (L.Tk__qq_Modifier v) = "qq_Modifier " ++ show v
+showRtkToken (L.Tk__qq_TypeSpecifier v) = "qq_TypeSpecifier " ++ show v
+showRtkToken (L.Tk__qq_Type v) = "qq_Type " ++ show v
+showRtkToken (L.Tk__qq_TypeParameter v) = "qq_TypeParameter " ++ show v
+showRtkToken (L.Tk__qq_TypeParameters v) = "qq_TypeParameters " ++ show v
+showRtkToken (L.Tk__qq_WildcardType v) = "qq_WildcardType " ++ show v
+showRtkToken (L.Tk__qq_TypeArgument v) = "qq_TypeArgument " ++ show v
+showRtkToken (L.Tk__qq_TypeArguments v) = "qq_TypeArguments " ++ show v
+showRtkToken (L.Tk__qq_Arglist v) = "qq_Arglist " ++ show v
+showRtkToken (L.Tk__qq_Literal v) = "qq_Literal " ++ show v
+showRtkToken (L.Tk__qq_CreationExpression v) = "qq_CreationExpression " ++ show v
+showRtkToken (L.Tk__qq_PostfixOp v) = "qq_PostfixOp " ++ show v
+showRtkToken (L.Tk__qq_PrefixOp v) = "qq_PrefixOp " ++ show v
+showRtkToken (L.Tk__qq_MultiplicativeOp v) = "qq_MultiplicativeOp " ++ show v
+showRtkToken (L.Tk__qq_AdditiveOp v) = "qq_AdditiveOp " ++ show v
+showRtkToken (L.Tk__qq_ShiftOp v) = "qq_ShiftOp " ++ show v
+showRtkToken (L.Tk__qq_RelationalOp v) = "qq_RelationalOp " ++ show v
+showRtkToken (L.Tk__qq_EqualityOp v) = "qq_EqualityOp " ++ show v
+showRtkToken (L.Tk__qq_AssignmentOp v) = "qq_AssignmentOp " ++ show v
+showRtkToken (L.Tk__qq_Expression v) = "qq_Expression " ++ show v
+showRtkToken (L.Tk__qq_SwitchStatement v) = "qq_SwitchStatement " ++ show v
+showRtkToken (L.Tk__qq_SwitchCaseList v) = "qq_SwitchCaseList " ++ show v
+showRtkToken (L.Tk__qq_TryStatement v) = "qq_TryStatement " ++ show v
+showRtkToken (L.Tk__qq_OptFinally v) = "qq_OptFinally " ++ show v
+showRtkToken (L.Tk__qq_CatchList v) = "qq_CatchList " ++ show v
+showRtkToken (L.Tk__qq_ForStatement v) = "qq_ForStatement " ++ show v
+showRtkToken (L.Tk__qq_WhileStatement v) = "qq_WhileStatement " ++ show v
+showRtkToken (L.Tk__qq_DoStatement v) = "qq_DoStatement " ++ show v
+showRtkToken (L.Tk__qq_IfStatement v) = "qq_IfStatement " ++ show v
+showRtkToken (L.Tk__qq_OptElsePart v) = "qq_OptElsePart " ++ show v
+showRtkToken (L.Tk__qq_StatementWithoutIf v) = "qq_StatementWithoutIf " ++ show v
+showRtkToken (L.Tk__qq_Statement v) = "qq_Statement " ++ show v
+showRtkToken (L.Tk__qq_OptId v) = "qq_OptId " ++ show v
+showRtkToken (L.Tk__qq_OptExpression v) = "qq_OptExpression " ++ show v
+showRtkToken (L.Tk__qq_StatementList v) = "qq_StatementList " ++ show v
+showRtkToken (L.Tk__qq_Parameter v) = "qq_Parameter " ++ show v
+showRtkToken (L.Tk__qq_ParameterList v) = "qq_ParameterList " ++ show v
+showRtkToken (L.Tk__qq_StaticInitializer v) = "qq_StaticInitializer " ++ show v
+showRtkToken (L.Tk__qq_VariableInitializer v) = "qq_VariableInitializer " ++ show v
+showRtkToken (L.Tk__qq_VariableInitializerList v) = "qq_VariableInitializerList " ++ show v
+showRtkToken (L.Tk__qq_VariableDeclarator v) = "qq_VariableDeclarator " ++ show v
+showRtkToken (L.Tk__qq_OptVariableInitializer v) = "qq_OptVariableInitializer " ++ show v
+showRtkToken (L.Tk__qq_VariableDeclaration v) = "qq_VariableDeclaration " ++ show v
+showRtkToken (L.Tk__qq_VariableDeclaratorList v) = "qq_VariableDeclaratorList " ++ show v
+showRtkToken (L.Tk__qq_StatementBlock v) = "qq_StatementBlock " ++ show v
+showRtkToken (L.Tk__qq_MoreVariableDeclarators v) = "qq_MoreVariableDeclarators " ++ show v
+showRtkToken (L.Tk__qq_MemberRest v) = "qq_MemberRest " ++ show v
+showRtkToken (L.Tk__qq_MoreTypeSpecifier v) = "qq_MoreTypeSpecifier " ++ show v
+showRtkToken (L.Tk__qq_MemberAfterFirstId v) = "qq_MemberAfterFirstId " ++ show v
+showRtkToken (L.Tk__qq_PrimitiveTypeKeyword v) = "qq_PrimitiveTypeKeyword " ++ show v
+showRtkToken (L.Tk__qq_MemberDeclaration v) = "qq_MemberDeclaration " ++ show v
+showRtkToken (L.Tk__qq_SquareBracketsList v) = "qq_SquareBracketsList " ++ show v
+showRtkToken (L.Tk__qq_FieldDeclaration v) = "qq_FieldDeclaration " ++ show v
+showRtkToken (L.Tk__qq_NestedTypeDeclaration v) = "qq_NestedTypeDeclaration " ++ show v
+showRtkToken (L.Tk__qq_EnumDeclaration v) = "qq_EnumDeclaration " ++ show v
+showRtkToken (L.Tk__qq_EnumConstantList v) = "qq_EnumConstantList " ++ show v
+showRtkToken (L.Tk__qq_EnumConstant v) = "qq_EnumConstant " ++ show v
+showRtkToken (L.Tk__qq_AnnotationTypeElement v) = "qq_AnnotationTypeElement " ++ show v
+showRtkToken (L.Tk__qq_AnnotationTypeElementList v) = "qq_AnnotationTypeElementList " ++ show v
+showRtkToken (L.Tk__qq_AnnotationDeclaration v) = "qq_AnnotationDeclaration " ++ show v
+showRtkToken (L.Tk__qq_InterfaceDeclaration v) = "qq_InterfaceDeclaration " ++ show v
+showRtkToken (L.Tk__qq_ClassDeclaration v) = "qq_ClassDeclaration " ++ show v
+showRtkToken (L.Tk__qq_FieldDeclarationList v) = "qq_FieldDeclarationList " ++ show v
+showRtkToken (L.Tk__qq_ImplementsList v) = "qq_ImplementsList " ++ show v
+showRtkToken (L.Tk__qq_ExtendsList v) = "qq_ExtendsList " ++ show v
+showRtkToken (L.Tk__qq_ModifierList v) = "qq_ModifierList " ++ show v
+showRtkToken (L.Tk__qq_AnnotationList v) = "qq_AnnotationList " ++ show v
+showRtkToken (L.Tk__qq_AnnotationElement v) = "qq_AnnotationElement " ++ show v
+showRtkToken (L.Tk__qq_AnnotationArguments v) = "qq_AnnotationArguments " ++ show v
+showRtkToken (L.Tk__qq_Annotation v) = "qq_Annotation " ++ show v
+showRtkToken (L.Tk__qq_DocComment v) = "qq_DocComment " ++ show v
+showRtkToken (L.Tk__qq_ImportStatement v) = "qq_ImportStatement " ++ show v
+showRtkToken (L.Tk__qq_Package v) = "qq_Package " ++ show v
+showRtkToken (L.Tk__qq_CompilationUnit v) = "qq_CompilationUnit " ++ show v
+showRtkToken (L.Tk__qq_ImportList v) = "qq_ImportList " ++ show v
+showRtkToken (L.Tk__qq_TypeDeclaration v) = "qq_TypeDeclaration " ++ show v
+showRtkToken (L.Tk__qq_OptDocComment v) = "qq_OptDocComment " ++ show v
+showRtkToken (L.Tk__qq_Java v) = "qq_Java " ++ show v
+
 data Java = Ctr__Java__0 Java |
             Ctr__Java__1 AdditiveOp |
             Ctr__Java__2 Annotation |

--- a/test/golden/p/PLexer.x
+++ b/test/golden/p/PLexer.x
@@ -1,5 +1,5 @@
 {
-module PLexer(alexScanTokens, Token(..))
+module PLexer(alexScanTokens, Token(..), PosToken(..), AlexPosn(..))
 where
 
  }
@@ -67,25 +67,37 @@ data Token = EndOfFile |
              Tk__qq_P String
              deriving (Show)
 
-alexEOF = return EndOfFile
-alexScanTokens :: String -> [Token]
-alexScanTokens str = 
+-- A token together with the source position where it starts
+data PosToken = PosToken { ptPos :: AlexPosn, ptToken :: Token }
+                deriving (Show)
+
+alexEOF = do
+  (pos, _, _, _) <- alexGetInput
+  return $ PosToken pos EndOfFile
+
+-- The returned list always ends with an EndOfFile token that carries the
+-- position of the end of input, so parse errors at end of input can be
+-- reported with a position too
+alexScanTokens :: String -> [PosToken]
+alexScanTokens str =
                case alexScanTokens1 str of
                   Right toks -> toks
-                  Left err -> error err
+                  Left err -> errorWithoutStackTrace err
 
 alexScanTokens1 str = runAlex str $ do
   let loop toks = do tok <- alexMonadScan
                      case tok of
-                       EndOfFile -> return $ reverse toks
-                       _ -> let toks' = tok : toks 
+                       PosToken _ EndOfFile -> return $ reverse (tok : toks)
+                       _ -> let toks' = tok : toks
                             in toks' `seq` loop toks'
   loop []
-simple1 :: (String -> Token) -> AlexInput -> Int -> Alex Token
-simple1 t (_, _, _, str) len = return $ t (take len str)
 
-simple t input len = return t
+simple1 :: (String -> Token) -> AlexInput -> Int -> Alex PosToken
+simple1 t (pos, _, _, str) len = return $ PosToken pos (t (take len str))
 
-rtkError ((AlexPn _ line column), _, _, str) len = alexError $ "lexical error at " ++ (show line) ++ " line, " ++ (show column) ++ " column" ++ ". Following chars :" ++ (take 10 str)
+simple :: Token -> AlexInput -> Int -> Alex PosToken
+simple t (pos, _, _, _) len = return $ PosToken pos t
+
+rtkError ((AlexPn _ line column), _, _, str) len = alexError $ "lexical error at line " ++ (show line) ++ ", column " ++ (show column) ++ ". Following chars: " ++ (take 10 str)
 
 }

--- a/test/golden/p/PParser.y
+++ b/test/golden/p/PParser.y
@@ -2,44 +2,47 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 module PParser where
 import qualified Data.Generics as Gen
-import qualified PLexer as L (Token(..), alexScanTokens)
+import qualified PLexer as L (Token(..), PosToken(..), AlexPosn(..), alexScanTokens)
 }
 
 %name parseP
-%tokentype { L.Token }
-%error { \ rest -> error $ "Parse error " ++ (show rest) }
+%tokentype { L.PosToken }
+%error { parseError }
 
 %token
 
-tok_E_dummy_3 { L.Tk__tok_E_dummy_3 }
-tok_Id_dummy_2 { L.Tk__tok_Id_dummy_2 }
-tok_Op1_dummy_1 { L.Tk__tok_Op1_dummy_1 }
-tok_Op2_dummy_0 { L.Tk__tok_Op2_dummy_0 }
-tok_P_dummy_4 { L.Tk__tok_P_dummy_4 }
-tok_xor_14 { L.Tk__tok_xor_14 }
-tok_shr4_10 { L.Tk__tok_shr4_10 }
-tok_shr16_11 { L.Tk__tok_shr16_11 }
-tok_shr1_9 { L.Tk__tok_shr1_9 }
-tok_shl1_8 { L.Tk__tok_shl1_8 }
-tok_plus_15 { L.Tk__tok_plus_15 }
-tok_or_13 { L.Tk__tok_or_13 }
-tok_not_7 { L.Tk__tok_not_7 }
-tok_lambda_1 { L.Tk__tok_lambda_1 }
-tok_if0_5 { L.Tk__tok_if0_5 }
-tok_fold_6 { L.Tk__tok_fold_6 }
-tok_and_12 { L.Tk__tok_and_12 }
-tok_1_4 { L.Tk__tok_1_4 }
-tok_0_3 { L.Tk__tok_0_3 }
-tok__rparen__2 { L.Tk__tok__rparen__2 }
-tok__lparen__0 { L.Tk__tok__lparen__0 }
-id { L.Tk__id $$ }
-qq_Id { L.Tk__qq_Id $$ }
-qq_Op2 { L.Tk__qq_Op2 $$ }
-qq_Op1 { L.Tk__qq_Op1 $$ }
-qq_E { L.Tk__qq_E $$ }
-qq_P { L.Tk__qq_P $$ }
+rtk__eof { L.PosToken _ L.EndOfFile }
+tok_E_dummy_3 { L.PosToken _ L.Tk__tok_E_dummy_3 }
+tok_Id_dummy_2 { L.PosToken _ L.Tk__tok_Id_dummy_2 }
+tok_Op1_dummy_1 { L.PosToken _ L.Tk__tok_Op1_dummy_1 }
+tok_Op2_dummy_0 { L.PosToken _ L.Tk__tok_Op2_dummy_0 }
+tok_P_dummy_4 { L.PosToken _ L.Tk__tok_P_dummy_4 }
+tok_xor_14 { L.PosToken _ L.Tk__tok_xor_14 }
+tok_shr4_10 { L.PosToken _ L.Tk__tok_shr4_10 }
+tok_shr16_11 { L.PosToken _ L.Tk__tok_shr16_11 }
+tok_shr1_9 { L.PosToken _ L.Tk__tok_shr1_9 }
+tok_shl1_8 { L.PosToken _ L.Tk__tok_shl1_8 }
+tok_plus_15 { L.PosToken _ L.Tk__tok_plus_15 }
+tok_or_13 { L.PosToken _ L.Tk__tok_or_13 }
+tok_not_7 { L.PosToken _ L.Tk__tok_not_7 }
+tok_lambda_1 { L.PosToken _ L.Tk__tok_lambda_1 }
+tok_if0_5 { L.PosToken _ L.Tk__tok_if0_5 }
+tok_fold_6 { L.PosToken _ L.Tk__tok_fold_6 }
+tok_and_12 { L.PosToken _ L.Tk__tok_and_12 }
+tok_1_4 { L.PosToken _ L.Tk__tok_1_4 }
+tok_0_3 { L.PosToken _ L.Tk__tok_0_3 }
+tok__rparen__2 { L.PosToken _ L.Tk__tok__rparen__2 }
+tok__lparen__0 { L.PosToken _ L.Tk__tok__lparen__0 }
+id { L.PosToken _ (L.Tk__id $$) }
+qq_Id { L.PosToken _ (L.Tk__qq_Id $$) }
+qq_Op2 { L.PosToken _ (L.Tk__qq_Op2 $$) }
+qq_Op1 { L.PosToken _ (L.Tk__qq_Op1 $$) }
+qq_E { L.PosToken _ (L.Tk__qq_E $$) }
+qq_P { L.PosToken _ (L.Tk__qq_P $$) }
 
 %%
+
+P__top : P rtk__eof { $1 }
 
 P : tok_P_dummy_4 P tok_P_dummy_4 { Ctr__P__0 $2 } |
     tok_E_dummy_3 E tok_E_dummy_3 { Ctr__P__1 $2 } |
@@ -77,6 +80,42 @@ Op2 : qq_Op2 { Anti_Op2 $1 } |
 
 
 {
+parseError :: [L.PosToken] -> a
+parseError [] = errorWithoutStackTrace "Parse error: unexpected end of input"
+parseError (L.PosToken (L.AlexPn _ line col) tok : _) =
+    errorWithoutStackTrace $ "Parse error at line " ++ show line ++ ", column " ++ show col ++ ": unexpected " ++ showRtkToken tok
+
+-- Render a token the way it appears in the source, for error messages
+showRtkToken :: L.Token -> String
+showRtkToken L.EndOfFile = "end of input"
+showRtkToken L.Tk__tok_E_dummy_3 = "'tok_E_dummy_3'"
+showRtkToken L.Tk__tok_Id_dummy_2 = "'tok_Id_dummy_2'"
+showRtkToken L.Tk__tok_Op1_dummy_1 = "'tok_Op1_dummy_1'"
+showRtkToken L.Tk__tok_Op2_dummy_0 = "'tok_Op2_dummy_0'"
+showRtkToken L.Tk__tok_P_dummy_4 = "'tok_P_dummy_4'"
+showRtkToken L.Tk__tok_xor_14 = "'xor'"
+showRtkToken L.Tk__tok_shr4_10 = "'shr4'"
+showRtkToken L.Tk__tok_shr16_11 = "'shr16'"
+showRtkToken L.Tk__tok_shr1_9 = "'shr1'"
+showRtkToken L.Tk__tok_shl1_8 = "'shl1'"
+showRtkToken L.Tk__tok_plus_15 = "'plus'"
+showRtkToken L.Tk__tok_or_13 = "'or'"
+showRtkToken L.Tk__tok_not_7 = "'not'"
+showRtkToken L.Tk__tok_lambda_1 = "'lambda'"
+showRtkToken L.Tk__tok_if0_5 = "'if0'"
+showRtkToken L.Tk__tok_fold_6 = "'fold'"
+showRtkToken L.Tk__tok_and_12 = "'and'"
+showRtkToken L.Tk__tok_1_4 = "'1'"
+showRtkToken L.Tk__tok_0_3 = "'0'"
+showRtkToken L.Tk__tok__rparen__2 = "')'"
+showRtkToken L.Tk__tok__lparen__0 = "'('"
+showRtkToken (L.Tk__id v) = "id " ++ show v
+showRtkToken (L.Tk__qq_Id v) = "qq_Id " ++ show v
+showRtkToken (L.Tk__qq_Op2 v) = "qq_Op2 " ++ show v
+showRtkToken (L.Tk__qq_Op1 v) = "qq_Op1 " ++ show v
+showRtkToken (L.Tk__qq_E v) = "qq_E " ++ show v
+showRtkToken (L.Tk__qq_P v) = "qq_P " ++ show v
+
 data P = Ctr__P__0 P |
          Ctr__P__1 E |
          Ctr__P__2 Id |

--- a/test/golden/sandbox/SandboxLexer.x
+++ b/test/golden/sandbox/SandboxLexer.x
@@ -1,5 +1,5 @@
 {
-module SandboxLexer(alexScanTokens, Token(..))
+module SandboxLexer(alexScanTokens, Token(..), PosToken(..), AlexPosn(..))
 where
 
  }
@@ -21,25 +21,37 @@ data Token = EndOfFile |
              Tk__qq_Sandbox String
              deriving (Show)
 
-alexEOF = return EndOfFile
-alexScanTokens :: String -> [Token]
-alexScanTokens str = 
+-- A token together with the source position where it starts
+data PosToken = PosToken { ptPos :: AlexPosn, ptToken :: Token }
+                deriving (Show)
+
+alexEOF = do
+  (pos, _, _, _) <- alexGetInput
+  return $ PosToken pos EndOfFile
+
+-- The returned list always ends with an EndOfFile token that carries the
+-- position of the end of input, so parse errors at end of input can be
+-- reported with a position too
+alexScanTokens :: String -> [PosToken]
+alexScanTokens str =
                case alexScanTokens1 str of
                   Right toks -> toks
-                  Left err -> error err
+                  Left err -> errorWithoutStackTrace err
 
 alexScanTokens1 str = runAlex str $ do
   let loop toks = do tok <- alexMonadScan
                      case tok of
-                       EndOfFile -> return $ reverse toks
-                       _ -> let toks' = tok : toks 
+                       PosToken _ EndOfFile -> return $ reverse (tok : toks)
+                       _ -> let toks' = tok : toks
                             in toks' `seq` loop toks'
   loop []
-simple1 :: (String -> Token) -> AlexInput -> Int -> Alex Token
-simple1 t (_, _, _, str) len = return $ t (take len str)
 
-simple t input len = return t
+simple1 :: (String -> Token) -> AlexInput -> Int -> Alex PosToken
+simple1 t (pos, _, _, str) len = return $ PosToken pos (t (take len str))
 
-rtkError ((AlexPn _ line column), _, _, str) len = alexError $ "lexical error at " ++ (show line) ++ " line, " ++ (show column) ++ " column" ++ ". Following chars :" ++ (take 10 str)
+simple :: Token -> AlexInput -> Int -> Alex PosToken
+simple t (pos, _, _, _) len = return $ PosToken pos t
+
+rtkError ((AlexPn _ line column), _, _, str) len = alexError $ "lexical error at line " ++ (show line) ++ ", column " ++ (show column) ++ ". Following chars: " ++ (take 10 str)
 
 }

--- a/test/golden/sandbox/SandboxParser.y
+++ b/test/golden/sandbox/SandboxParser.y
@@ -2,20 +2,23 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 module SandboxParser where
 import qualified Data.Generics as Gen
-import qualified SandboxLexer as L (Token(..), alexScanTokens)
+import qualified SandboxLexer as L (Token(..), PosToken(..), AlexPosn(..), alexScanTokens)
 }
 
 %name parseSandbox
-%tokentype { L.Token }
-%error { \ rest -> error $ "Parse error " ++ (show rest) }
+%tokentype { L.PosToken }
+%error { parseError }
 
 %token
 
-tok_Sandbox_dummy_0 { L.Tk__tok_Sandbox_dummy_0 }
-doccomment { L.Tk__doccomment $$ }
-qq_Sandbox { L.Tk__qq_Sandbox $$ }
+rtk__eof { L.PosToken _ L.EndOfFile }
+tok_Sandbox_dummy_0 { L.PosToken _ L.Tk__tok_Sandbox_dummy_0 }
+doccomment { L.PosToken _ (L.Tk__doccomment $$) }
+qq_Sandbox { L.PosToken _ (L.Tk__qq_Sandbox $$) }
 
 %%
+
+Sandbox__top : Sandbox rtk__eof { $1 }
 
 Sandbox : tok_Sandbox_dummy_0 Sandbox tok_Sandbox_dummy_0 { Ctr__Sandbox__0 $2 }
 
@@ -24,6 +27,18 @@ Sandbox : qq_Sandbox { Anti_Sandbox $1 } |
 
 
 {
+parseError :: [L.PosToken] -> a
+parseError [] = errorWithoutStackTrace "Parse error: unexpected end of input"
+parseError (L.PosToken (L.AlexPn _ line col) tok : _) =
+    errorWithoutStackTrace $ "Parse error at line " ++ show line ++ ", column " ++ show col ++ ": unexpected " ++ showRtkToken tok
+
+-- Render a token the way it appears in the source, for error messages
+showRtkToken :: L.Token -> String
+showRtkToken L.EndOfFile = "end of input"
+showRtkToken L.Tk__tok_Sandbox_dummy_0 = "'tok_Sandbox_dummy_0'"
+showRtkToken (L.Tk__doccomment v) = "doccomment " ++ show v
+showRtkToken (L.Tk__qq_Sandbox v) = "qq_Sandbox " ++ show v
+
 data Sandbox = Ctr__Sandbox__0 Sandbox |
                Anti_Sandbox String |
                Ctr__Sandbox__1 String

--- a/test/golden/t1/T1Lexer.x
+++ b/test/golden/t1/T1Lexer.x
@@ -1,5 +1,5 @@
 {
-module T1Lexer(alexScanTokens, Token(..))
+module T1Lexer(alexScanTokens, Token(..), PosToken(..), AlexPosn(..))
 where
 
  }
@@ -62,25 +62,37 @@ data Token = EndOfFile |
              Tk__qq_A String
              deriving (Show)
 
-alexEOF = return EndOfFile
-alexScanTokens :: String -> [Token]
-alexScanTokens str = 
+-- A token together with the source position where it starts
+data PosToken = PosToken { ptPos :: AlexPosn, ptToken :: Token }
+                deriving (Show)
+
+alexEOF = do
+  (pos, _, _, _) <- alexGetInput
+  return $ PosToken pos EndOfFile
+
+-- The returned list always ends with an EndOfFile token that carries the
+-- position of the end of input, so parse errors at end of input can be
+-- reported with a position too
+alexScanTokens :: String -> [PosToken]
+alexScanTokens str =
                case alexScanTokens1 str of
                   Right toks -> toks
-                  Left err -> error err
+                  Left err -> errorWithoutStackTrace err
 
 alexScanTokens1 str = runAlex str $ do
   let loop toks = do tok <- alexMonadScan
                      case tok of
-                       EndOfFile -> return $ reverse toks
-                       _ -> let toks' = tok : toks 
+                       PosToken _ EndOfFile -> return $ reverse (tok : toks)
+                       _ -> let toks' = tok : toks
                             in toks' `seq` loop toks'
   loop []
-simple1 :: (String -> Token) -> AlexInput -> Int -> Alex Token
-simple1 t (_, _, _, str) len = return $ t (take len str)
 
-simple t input len = return t
+simple1 :: (String -> Token) -> AlexInput -> Int -> Alex PosToken
+simple1 t (pos, _, _, str) len = return $ PosToken pos (t (take len str))
 
-rtkError ((AlexPn _ line column), _, _, str) len = alexError $ "lexical error at " ++ (show line) ++ " line, " ++ (show column) ++ " column" ++ ". Following chars :" ++ (take 10 str)
+simple :: Token -> AlexInput -> Int -> Alex PosToken
+simple t (pos, _, _, _) len = return $ PosToken pos t
+
+rtkError ((AlexPn _ line column), _, _, str) len = alexError $ "lexical error at line " ++ (show line) ++ ", column " ++ (show column) ++ ". Following chars: " ++ (take 10 str)
 
 }

--- a/test/golden/t1/T1Parser.y
+++ b/test/golden/t1/T1Parser.y
@@ -2,42 +2,45 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 module T1Parser where
 import qualified Data.Generics as Gen
-import qualified T1Lexer as L (Token(..), alexScanTokens)
+import qualified T1Lexer as L (Token(..), PosToken(..), AlexPosn(..), alexScanTokens)
 }
 
 %name parseT1
-%tokentype { L.Token }
-%error { \ rest -> error $ "Parse error " ++ (show rest) }
+%tokentype { L.PosToken }
+%error { parseError }
 
 %token
 
-tok_A_dummy_19 { L.Tk__tok_A_dummy_19 }
-tok_B_dummy_18 { L.Tk__tok_B_dummy_18 }
-tok_C_dummy_17 { L.Tk__tok_C_dummy_17 }
-tok_D_dummy_16 { L.Tk__tok_D_dummy_16 }
-tok_E_dummy_15 { L.Tk__tok_E_dummy_15 }
-tok_F1_dummy_14 { L.Tk__tok_F1_dummy_14 }
-tok_F2_dummy_13 { L.Tk__tok_F2_dummy_13 }
-tok_F3_dummy_12 { L.Tk__tok_F3_dummy_12 }
-tok_F4_dummy_11 { L.Tk__tok_F4_dummy_11 }
-tok_F5_dummy_10 { L.Tk__tok_F5_dummy_10 }
-tok_G_dummy_9 { L.Tk__tok_G_dummy_9 }
-tok_b_1 { L.Tk__tok_b_1 }
-tok_a_0 { L.Tk__tok_a_0 }
-tok__coma__2 { L.Tk__tok__coma__2 }
-qq_G { L.Tk__qq_G $$ }
-qq_F5 { L.Tk__qq_F5 $$ }
-qq_F4 { L.Tk__qq_F4 $$ }
-qq_F3 { L.Tk__qq_F3 $$ }
-qq_F2 { L.Tk__qq_F2 $$ }
-qq_F1 { L.Tk__qq_F1 $$ }
-qq_E { L.Tk__qq_E $$ }
-qq_D { L.Tk__qq_D $$ }
-qq_C { L.Tk__qq_C $$ }
-qq_B { L.Tk__qq_B $$ }
-qq_A { L.Tk__qq_A $$ }
+rtk__eof { L.PosToken _ L.EndOfFile }
+tok_A_dummy_19 { L.PosToken _ L.Tk__tok_A_dummy_19 }
+tok_B_dummy_18 { L.PosToken _ L.Tk__tok_B_dummy_18 }
+tok_C_dummy_17 { L.PosToken _ L.Tk__tok_C_dummy_17 }
+tok_D_dummy_16 { L.PosToken _ L.Tk__tok_D_dummy_16 }
+tok_E_dummy_15 { L.PosToken _ L.Tk__tok_E_dummy_15 }
+tok_F1_dummy_14 { L.PosToken _ L.Tk__tok_F1_dummy_14 }
+tok_F2_dummy_13 { L.PosToken _ L.Tk__tok_F2_dummy_13 }
+tok_F3_dummy_12 { L.PosToken _ L.Tk__tok_F3_dummy_12 }
+tok_F4_dummy_11 { L.PosToken _ L.Tk__tok_F4_dummy_11 }
+tok_F5_dummy_10 { L.PosToken _ L.Tk__tok_F5_dummy_10 }
+tok_G_dummy_9 { L.PosToken _ L.Tk__tok_G_dummy_9 }
+tok_b_1 { L.PosToken _ L.Tk__tok_b_1 }
+tok_a_0 { L.PosToken _ L.Tk__tok_a_0 }
+tok__coma__2 { L.PosToken _ L.Tk__tok__coma__2 }
+qq_G { L.PosToken _ (L.Tk__qq_G $$) }
+qq_F5 { L.PosToken _ (L.Tk__qq_F5 $$) }
+qq_F4 { L.PosToken _ (L.Tk__qq_F4 $$) }
+qq_F3 { L.PosToken _ (L.Tk__qq_F3 $$) }
+qq_F2 { L.PosToken _ (L.Tk__qq_F2 $$) }
+qq_F1 { L.PosToken _ (L.Tk__qq_F1 $$) }
+qq_E { L.PosToken _ (L.Tk__qq_E $$) }
+qq_D { L.PosToken _ (L.Tk__qq_D $$) }
+qq_C { L.PosToken _ (L.Tk__qq_C $$) }
+qq_B { L.PosToken _ (L.Tk__qq_B $$) }
+qq_A { L.PosToken _ (L.Tk__qq_A $$) }
 
 %%
+
+T1__top : A rtk__eof { $1 }
 
 A : tok_A_dummy_19 A tok_A_dummy_19 { Ctr__A__0 $2 } |
     tok_B_dummy_18 B tok_B_dummy_18 { Ctr__A__1 $2 } |
@@ -115,6 +118,40 @@ Rule_8 : D E { Ctr__Rule_8__0 $1 $2 }
 
 
 {
+parseError :: [L.PosToken] -> a
+parseError [] = errorWithoutStackTrace "Parse error: unexpected end of input"
+parseError (L.PosToken (L.AlexPn _ line col) tok : _) =
+    errorWithoutStackTrace $ "Parse error at line " ++ show line ++ ", column " ++ show col ++ ": unexpected " ++ showRtkToken tok
+
+-- Render a token the way it appears in the source, for error messages
+showRtkToken :: L.Token -> String
+showRtkToken L.EndOfFile = "end of input"
+showRtkToken L.Tk__tok_A_dummy_19 = "'tok_A_dummy_19'"
+showRtkToken L.Tk__tok_B_dummy_18 = "'tok_B_dummy_18'"
+showRtkToken L.Tk__tok_C_dummy_17 = "'tok_C_dummy_17'"
+showRtkToken L.Tk__tok_D_dummy_16 = "'tok_D_dummy_16'"
+showRtkToken L.Tk__tok_E_dummy_15 = "'tok_E_dummy_15'"
+showRtkToken L.Tk__tok_F1_dummy_14 = "'tok_F1_dummy_14'"
+showRtkToken L.Tk__tok_F2_dummy_13 = "'tok_F2_dummy_13'"
+showRtkToken L.Tk__tok_F3_dummy_12 = "'tok_F3_dummy_12'"
+showRtkToken L.Tk__tok_F4_dummy_11 = "'tok_F4_dummy_11'"
+showRtkToken L.Tk__tok_F5_dummy_10 = "'tok_F5_dummy_10'"
+showRtkToken L.Tk__tok_G_dummy_9 = "'tok_G_dummy_9'"
+showRtkToken L.Tk__tok_b_1 = "'b'"
+showRtkToken L.Tk__tok_a_0 = "'a'"
+showRtkToken L.Tk__tok__coma__2 = "','"
+showRtkToken (L.Tk__qq_G v) = "qq_G " ++ show v
+showRtkToken (L.Tk__qq_F5 v) = "qq_F5 " ++ show v
+showRtkToken (L.Tk__qq_F4 v) = "qq_F4 " ++ show v
+showRtkToken (L.Tk__qq_F3 v) = "qq_F3 " ++ show v
+showRtkToken (L.Tk__qq_F2 v) = "qq_F2 " ++ show v
+showRtkToken (L.Tk__qq_F1 v) = "qq_F1 " ++ show v
+showRtkToken (L.Tk__qq_E v) = "qq_E " ++ show v
+showRtkToken (L.Tk__qq_D v) = "qq_D " ++ show v
+showRtkToken (L.Tk__qq_C v) = "qq_C " ++ show v
+showRtkToken (L.Tk__qq_B v) = "qq_B " ++ show v
+showRtkToken (L.Tk__qq_A v) = "qq_A " ++ show v
+
 data A = Ctr__A__0 A |
          Ctr__A__1 B |
          Ctr__A__2 C |


### PR DESCRIPTION
Thread source positions through the whole pipeline so that grammar
authors get errors that point at their source instead of bare
constructor dumps:

- Lexer.x and generated lexers (GenX) return PosToken values pairing
  each token with its AlexPosn. The token stream ends with an explicit
  EndOfFile token carrying the end-of-input position; the parsers
  consume it instead of relying on happy's internal end-of-input
  placeholder, which gives unexpected-EOF errors a real position and
  avoids an "Internal Happy parser panic" that GHC optimizations could
  otherwise surface with happy 2.x.
- Parse errors report line, column and a human-readable token
  description, both in the hand-written Parser.y and in all generated
  parsers (GenY, via a generated showRtkToken that renders keyword
  tokens as their source literal). Previously generated parsers only
  dumped the remaining token list with no location.
- IRule records the position of its defining identifier, and
  normalization errors (Normalize) name the offending rule and its
  position, e.g. "Grammar error in rule 'Foo' (at line 2, column 1)".
  The lifted-clause-in-sequence check moved from code generation into
  normalization where that context is still known. Lexer-spec
  translation errors (GenX) name the lexical rule.
- fromJust crashes replaced with descriptive errors. A grammar whose
  first rule is lexical, or has a data-type annotation different from
  the rule name, now reports a proper error instead of crashing with
  "fromJust: Nothing". An untranslatable macro clause now aborts
  generation instead of writing the error text into the generated
  lexer.
- User-facing errors use errorWithoutStackTrace, so messages are not
  followed by a GHC call stack.
- New regression tests in test/UnitTests.hs for parse-error positions
  (including at end of input), rule context in normalization errors,
  the first-rule check and position preservation in token processing;
  the token-processing tests are adapted to the PosToken stream.
- Golden snapshots under test/golden/ refreshed via make accept-golden
  for the intended generator changes (QQ output is unchanged).

https://claude.ai/code/session_01EubzZoEYiR5GmPqAMcj1Lq