### PR TITLE
Pin alex 3.5.4.2 and happy 2.2 in the CI install step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,8 +76,12 @@ jobs:
     - name: Update Cabal package list
       run: cabal update
 
+    # Pin exact alex/happy versions so a new Hackage release can't change CI
+    # behavior without a repo change. Because the test-out cache key hashes
+    # this file, bumping these versions intentionally invalidates cached
+    # generated parsers and test binaries.
     - name: Install build tools (Alex and Happy)
-      run: cabal install alex happy --installdir=$HOME/.cabal/bin --overwrite-policy=always --install-method=copy
+      run: cabal install alex-3.5.4.2 happy-2.2 --installdir=$HOME/.cabal/bin --overwrite-policy=always --install-method=copy
 
     - name: Build project with linting (treat warnings as errors)
       run: |


### PR DESCRIPTION
## Summary

Follow-up to #87. CI installed alex/happy unpinned, so a new Hackage release could change CI behavior with no repo change — the same silent-drift failure mode #87 eliminated for GHC (which floated to 9.14 and broke). Unpinned tools also meant the `test-out` cache could serve stale generated parsers across a tool release, since tool versions appeared nowhere in the cache key.

This pins the exact versions the last green run resolved to:

```yaml
run: cabal install alex-3.5.4.2 happy-2.2 --installdir=$HOME/.cabal/bin --overwrite-policy=always --install-method=copy
```

Because the `test-out` cache key already hashes `ci.yml`, the pin also puts tool versions into the cache key for free: any future version bump automatically invalidates cached generated parsers. A comment in the workflow notes this.

Deliberately **not** included (separate decision, affects local dependency solving too): version bounds on `Build-Tool-Depends:` in `rtk.cabal`. The makefile resolves alex/happy from PATH, so the CI install pin is what actually governs test generation.

## Verification status — all checks complete ✅

- [x] Install step log lists exactly `alex-3.5.4.2` and `happy-2.2` — [run #241](https://github.com/prozak/rtk/actions/runs/27248722663): `alex-3.5.4.2` built and installed; happy satisfied from the cached cabal store under the exact `happy-2.2` constraint (10s install, as expected with the warm `~/.cabal/store` cache)
- [x] Full test suite green — run #241: all 9 test groups PASS
- [x] Second run on the same tree: `test-out` cache exact-hits and run stays green — [run #243](https://github.com/prozak/rtk/actions/runs/27249544836) (retriggered via close/reopen): log shows `Cache restored from key: v3-Linux-test-out-7d8c7a3e…` (the exact key run #241 saved after its expected miss on the new hash), timestamp refresh ran on the restored outputs, post step reports `Cache hit occurred on the primary key …, not saving cache`, and all 9 test groups PASS again (run completed ~1.5 min faster than #241)

https://claude.ai/code/session_01EY6wtAmHQkTyK3zqEY9sfR