### PR TITLE
Refactor lexical rule handling to distinguish macro rules

### DIFF
--- a/GenAST.hs
+++ b/GenAST.hs
@@ -6,6 +6,7 @@ import Text.PrettyPrint
 import Grammar
 import qualified Data.Map as Map
 import qualified Data.List as List
+import Data.Maybe (mapMaybe)
 
 normalRulesNamed :: [SyntaxRuleGroup] -> [(ID, SyntaxTopClause)]
 normalRulesNamed groups = map (\g -> (getSDataTypeName g, combineClauses $ map getSClause $ getSRules g))
@@ -26,8 +27,14 @@ type RulesMap = Map.Map ID ID
 rulesMap :: NormalGrammar -> RulesMap
 rulesMap NormalGrammar{ getSyntaxRuleGroups = groups, getLexicalRules = lrules } = 
     Map.fromList $ concat 
-            (map (\ lr -> (getLRuleName lr, getLRuleDataType lr)) (removeSymmacros lrules) : 
+            (mapMaybe lexRuleEntry lrules :
              map (\ g -> map (\r -> (getSRuleName r, getSDataTypeName g)) $ getSRules g) groups)
+
+-- Macro rules are inlined into the lexer spec and carry no data type, so
+-- they contribute nothing to the rules map.
+lexRuleEntry :: LexicalRule -> Maybe (ID, ID)
+lexRuleEntry LexicalRule{ getLRuleName = name, getLRuleDataType = dt } = Just (name, dt)
+lexRuleEntry MacroRule{} = Nothing
 
 genAST :: NormalGrammar -> String
 genAST grammar = render $ vcat (map (genRule rules_map) (normalRulesNamed $ getSyntaxRuleGroups grammar))

--- a/GenQ.hs
+++ b/GenQ.hs
@@ -129,7 +129,9 @@ replaceAllPatterns str = init $ replaceAllPatterns1 (str ++ " ")
                                           _ -> ("", ""))
                                       (case rules of
                                          (firstRule:_) -> case getSRules firstRule of
-                                           (firstSRule:_) -> getAltOfSeq $ getSClause firstSRule
+                                           (firstSRule:_) -> case getSClause firstSRule of
+                                                               STAltOfSeq alts -> alts
+                                                               _ -> []
                                            [] -> []
                                          [] -> [])
           rulesWithoutProxies = filterProxyRules proxyRules rules

--- a/test/UnitTests.hs
+++ b/test/UnitTests.hs
@@ -404,8 +404,8 @@ invariants grammarKey g = TestList
     -- tokens that may be referenced from syntax rules: macro rules are inlined
     -- into the lexer spec and Ignore tokens are dropped from the token stream,
     -- so neither may appear in a parser rule
-    usableTokens = S.fromList [ getLRuleName lr | lr@LexicalRule{} <- getLexicalRules g
-                              , getLRuleDataType lr /= "Ignore" ]
+    usableTokens = S.fromList [ name | LexicalRule{getLRuleName = name, getLRuleDataType = dt} <- getLexicalRules g
+                              , dt /= "Ignore" ]
 
 --------------------------------------------------------------------------------
 -- Small helpers over the normalized grammar
@@ -450,7 +450,7 @@ ambiguousConstructors g =
         , not (isClauseSeqLifted cs) ]
     fieldTypes cs = [ M.findWithDefault ("?" ++ i) i typeOf | SSId i <- cs ]
     typeOf = M.fromList $
-        [ (getLRuleName lr, getLRuleDataType lr) | lr@LexicalRule{} <- getLexicalRules g ]
+        [ (name, dt) | LexicalRule{getLRuleName = name, getLRuleDataType = dt} <- getLexicalRules g ]
         ++ [ (getSRuleName r, getSDataTypeName grp)
            | grp <- getSyntaxRuleGroups g, r <- getSRules grp ]
 


### PR DESCRIPTION
## Summary

This change refactors how lexical rules are processed to properly distinguish between regular lexical rules and macro rules. Macro rules are inlined into the lexer specification and should not contribute entries to the rules map, while regular lexical rules should.

## Key Changes

- **GenAST.hs**: 
  - Added import of `Data.Maybe (mapMaybe)`
  - Replaced `removeSymmacros` call with a new `lexRuleEntry` function that uses `mapMaybe` to filter lexical rules
  - Added `lexRuleEntry` helper function that returns `Just (name, dt)` for `LexicalRule` and `Nothing` for `MacroRule`, with explanatory comment about macro rule inlining

- **test/UnitTests.hs**:
  - Simplified pattern matching in `usableTokens` to use record syntax instead of `@` pattern with redundant guard
  - Simplified pattern matching in `typeOf` map construction to use record syntax directly
  - Both changes improve code clarity without altering logic

- **GenQ.hs**:
  - Replaced direct call to `getAltOfSeq` with explicit pattern matching on `getSClause` result
  - Added case handling for `STAltOfSeq` constructor to extract alternatives, with fallback to empty list for other clause types
  - Improves type safety and handles edge cases more explicitly

## Implementation Details

The refactoring uses `mapMaybe` with a dedicated `lexRuleEntry` function instead of the previous `removeSymmacros` approach. This makes the distinction between macro rules and regular lexical rules explicit in the type system: macro rules contribute `Nothing` to the map, while lexical rules contribute `Just (name, datatype)`. This is clearer and more maintainable than filtering after the fact.

https://claude.ai/code/session_01Jr6EvkZTpzDukyV7Bu67SA