### PR TITLE
Structured diagnostics: replace error() with Either Diagnostic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   9.6.4 (the versions actually exercised locally and in CI), and the
   packages required by RTK-generated code are documented in the README and
   the cabal description
+- Structured diagnostics: grammar errors are now `Diagnostic` values
+  (message plus optional source position and context) threaded through
+  `Either`, instead of being thrown with `error`. The grammar-processing
+  pipeline functions (`scanTokens`, `parse`, `normalizeTopLevelClauses`,
+  `genX`/`genY`/`genAST`/`genQ`) are total for user-caused failures
+- One-line GNU-style error reporting: `rtk` prints `FILE:LINE:COL: error:
+  MESSAGE` to stderr and exits 1 for a bad grammar, with no Haskell exception
+  or call stack (closes #23 and #31)
+- A lifted (`,`) clause under `*`/`+`/`?` (e.g. `Foo = ,Bar* ;`) is now
+  rejected with a clear error during normalization, instead of silently
+  generating broken code
+- A reference to an unknown rule now names both the unknown rule and the type
+  that references it
 - Source positions on tokens: the lexer now returns `PosToken` values
   (token plus line/column), both in the hand-written lexer and in all
   generated lexers

--- a/Diagnostics.hs
+++ b/Diagnostics.hs
@@ -1,0 +1,56 @@
+-- | Structured, user-facing diagnostics for the grammar-processing pipeline.
+--
+-- Errors caused by a bad grammar are represented as 'Diagnostic' values that
+-- are threaded through 'Either' instead of being thrown with 'error'. The
+-- pipeline stages (lexing, parsing, normalization, code generation) return
+-- @Either Diagnostic a@; the executable renders the diagnostic in GNU one-line
+-- style and exits, so RTK never shows a Haskell exception for a user mistake.
+--
+-- This module sits below the rest of the project (it imports nothing from it),
+-- so 'SourcePos' lives here and both the lexer and the parser can refer to it.
+module Diagnostics
+    ( SourcePos(..)
+    , showSourcePos
+    , Diagnostic(..)
+    , renderDiagnostic
+    ) where
+
+import Data.Data (Data, Typeable)
+
+-- | Position in the grammar source file (line and column, both 1-based).
+data SourcePos = SourcePos { srcLine :: Int, srcColumn :: Int }
+                 deriving (Eq, Ord, Show, Typeable, Data)
+
+showSourcePos :: SourcePos -> String
+showSourcePos (SourcePos line col) = "line " ++ show line ++ ", column " ++ show col
+
+-- | A user-facing diagnostic: an optional source position, optional context
+-- (such as the rule being processed) and the message itself.
+--
+-- The 'Data' instance lets @--profile-stages@ deep-force an @Either Diagnostic
+-- a@ result like any other pipeline value.
+data Diagnostic = Diagnostic
+  { diagPos     :: Maybe SourcePos
+  , diagContext :: Maybe String    -- ^ e.g. @"in rule 'Foo'"@
+  , diagMessage :: String
+  } deriving (Eq, Show, Data, Typeable)
+
+-- | Render a diagnostic in GNU one-line style:
+--
+-- >>> renderDiagnostic "g.pg" (Diagnostic (Just (SourcePos 2 1)) (Just "in rule 'Foo'") "message")
+-- "g.pg:2:1: error: in rule 'Foo': message"
+--
+-- The position is omitted when unknown and the context when absent:
+--
+-- >>> renderDiagnostic "g.pg" (Diagnostic Nothing Nothing "message")
+-- "g.pg: error: message"
+renderDiagnostic :: FilePath -> Diagnostic -> String
+renderDiagnostic file (Diagnostic mpos mctx msg) =
+    file ++ posPart ++ ": error: " ++ ctxPart ++ msg
+  where
+    posPart = case mpos of
+                Just (SourcePos line col) -> ":" ++ show line ++ ":" ++ show col
+                Nothing                   -> ""
+    ctxPart = case mctx of
+                Just ctx -> ctx ++ ": "
+                Nothing  -> ""

--- a/GenAST.hs
+++ b/GenAST.hs
@@ -2,6 +2,7 @@ module GenAST (genAST)
     where
 
 import Parser
+import Diagnostics (Diagnostic(..))
 import Text.PrettyPrint
 import Grammar
 import qualified Data.Map as Map
@@ -36,45 +37,56 @@ lexRuleEntry :: LexicalRule -> Maybe (ID, ID)
 lexRuleEntry LexicalRule{ getLRuleName = name, getLRuleDataType = dt } = Just (name, dt)
 lexRuleEntry MacroRule{} = Nothing
 
-genAST :: NormalGrammar -> String
-genAST grammar = render $ vcat (map (genRule rules_map) (normalRulesNamed $ getSyntaxRuleGroups grammar))
-    where rules_map = rulesMap grammar
+genAST :: NormalGrammar -> Either Diagnostic String
+genAST grammar = do
+    docs <- mapM (genRule rules_map) (normalRulesNamed $ getSyntaxRuleGroups grammar)
+    return $ render $ vcat docs
+  where rules_map = rulesMap grammar
 
-genRule :: RulesMap -> (ID, SyntaxTopClause) -> Doc
+genRule :: RulesMap -> (ID, SyntaxTopClause) -> Either Diagnostic Doc
 genRule rmap (type_name, clause) =
     case clause of
          s@(STMany _ _ _) -> genType rmap type_name [s]
          s@(STOpt _)      -> genType rmap type_name [s]
          (STAltOfSeq sequences)        -> genData rmap type_name sequences
 
-genType :: RulesMap -> String -> [SyntaxTopClause] -> Doc
-genType rmap name clauses = text "type" <+> text name <+> text "=" <+> (hsep $ map (genItem rmap) clauses)
+genType :: RulesMap -> String -> [SyntaxTopClause] -> Either Diagnostic Doc
+genType rmap name clauses = do
+    items <- mapM (genItem rmap name) clauses
+    return $ text "type" <+> text name <+> text "=" <+> hsep items
 
 needGenereateAlt :: STSeq -> Bool
 needGenereateAlt (STSeq _ seqs) = not $ isClauseSeqLifted seqs
 
-genData :: RulesMap -> String -> [STSeq] -> Doc
-genData rmap name sequences = text "data" <+> text name <+> text "=" <+> (joinAlts (map (genConstructor rmap) sequences') 
-                                                                          $$ text "deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)")
+genData :: RulesMap -> String -> [STSeq] -> Either Diagnostic Doc
+genData rmap name sequences = do
+    ctors <- mapM (genConstructor rmap name) sequences'
+    return $ text "data" <+> text name <+> text "=" <+> (joinAlts ctors
+                                                         $$ text "deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)")
     where sequences' = filter needGenereateAlt sequences
 
-genConstructor :: RulesMap -> STSeq -> Doc
-genConstructor rmap (STSeq constructor clauses) = text constructor <+> (hsep $ map (genSimpleItem rmap) clauses)
+genConstructor :: RulesMap -> String -> STSeq -> Either Diagnostic Doc
+genConstructor rmap refType (STSeq constructor clauses) = do
+    items <- mapM (genSimpleItem rmap refType) clauses
+    return $ text constructor <+> hsep items
 
-genItem :: RulesMap -> SyntaxTopClause -> Doc
-genItem rmap (STMany _ cl _) = brackets $ genSimpleItem rmap cl
-genItem rmap (STOpt cl) = parens $ text "Maybe" <+> genSimpleItem rmap cl
-genItem _ (STAltOfSeq _) = error "STAltOfSeq not supported in genItem"
+genItem :: RulesMap -> String -> SyntaxTopClause -> Either Diagnostic Doc
+genItem rmap refType (STMany _ cl _) = brackets <$> genSimpleItem rmap refType cl
+genItem rmap refType (STOpt cl) = (\d -> parens (text "Maybe" <+> d)) <$> genSimpleItem rmap refType cl
+genItem _ _ (STAltOfSeq _) = error "STAltOfSeq not supported in genItem"
 
-genSimpleItem :: RulesMap -> SyntaxSimpleClause -> Doc
-genSimpleItem rmap (SSId idName) = text $ findRuleDataTypeName rmap idName
-genSimpleItem _    (SSIgnore _) = empty
-genSimpleItem _    (SSLifted _) = error "lifted rules are not yet implemented"
+genSimpleItem :: RulesMap -> String -> SyntaxSimpleClause -> Either Diagnostic Doc
+genSimpleItem rmap refType (SSId idName) = text <$> findRuleDataTypeName rmap refType idName
+genSimpleItem _    _       (SSIgnore _) = Right empty
+genSimpleItem _    _       (SSLifted _) = error "lifted rules are not yet implemented"
 
-findRuleDataTypeName :: RulesMap -> ID -> ID
-findRuleDataTypeName rmap idName = case Map.lookup idName rmap of
-                                 Just r -> r
-                                 _      -> error $ "Reference to unknown rule " ++ idName
+-- A reference to an unknown rule is a user error (a typo'd rule name); name
+-- both the unknown rule and the type that references it.
+findRuleDataTypeName :: RulesMap -> String -> ID -> Either Diagnostic ID
+findRuleDataTypeName rmap refType idName = case Map.lookup idName rmap of
+                                 Just r -> Right r
+                                 _      -> Left $ Diagnostic Nothing (Just ("in type '" ++ refType ++ "'"))
+                                                  ("reference to unknown rule '" ++ idName ++ "'")
 
 joinAlts :: [Doc] -> Doc
 joinAlts alts = vcat $ punctuate (text " |") alts

--- a/GenQ.hs
+++ b/GenQ.hs
@@ -3,6 +3,7 @@ module GenQ (genQ)
     where
 
 import Parser
+import Diagnostics (Diagnostic)
 import qualified Data.Char as C
 import qualified Data.Map as M
 import Data.Maybe
@@ -17,8 +18,10 @@ sortNameToHaskellName "class" = "__class"
 sortNameToHaskellName "deriving" = "__deriving"
 sortNameToHaskellName s = s
 
-genQ :: NormalGrammar -> String
-genQ (NormalGrammar name rules _ antiRules shortcuts _ info) = [str|{-# LANGUAGE TemplateHaskell #-}
+-- genQ has no user-reachable error paths today (its remaining guards are
+-- internal invariants); the Either signature keeps it uniform with genX/genY.
+genQ :: NormalGrammar -> Either Diagnostic String
+genQ (NormalGrammar name rules _ antiRules shortcuts _ info) = Right [str|{-# LANGUAGE TemplateHaskell #-}
 module ?name~QQ
 where
 

--- a/GenX.hs
+++ b/GenX.hs
@@ -3,8 +3,10 @@ module GenX (genX)
     where
 
 import Parser
+import Diagnostics (Diagnostic(..))
 import Text.PrettyPrint hiding ((<>))
 import qualified Data.Set as S
+import Data.Maybe (catMaybes)
 import Grammar
 import StrQuote
 
@@ -33,21 +35,27 @@ getSymMacroIds lexRules = foldr (\lexRule result ->
                             S.empty
                             lexRules
 
-genMacroText :: S.Set String -> S.Set String -> [LexicalRule] -> Doc
-genMacroText sMacroIds macroIds tokens =
-    vcat $ foldl (\result  lrule ->
-                    case lrule of
-                      (LexicalRule {getLRuleName = name, getLClause = cl }) ->
-                        if name `S.member` macroIds
-                          then (text "@" <> text name) <+> text "=" <+> translateClause name sMacroIds cl : result
-                          else result
-                      (MacroRule {getLRuleName = name, getLClause = cl }) ->
-                          (text "$" <> text name) <+> text "=" <+> translateClauseForMacro name cl : result)
-             [] tokens
+-- The output lines are emitted in reverse token order, matching the original
+-- foldl; keep it so the generated lexer is byte-for-byte unchanged.
+genMacroText :: S.Set String -> S.Set String -> [LexicalRule] -> Either Diagnostic Doc
+genMacroText sMacroIds macroIds tokens = do
+    docs <- mapM lineFor tokens
+    return $ vcat $ reverse $ catMaybes docs
+  where
+    lineFor (LexicalRule {getLRuleName = name, getLClause = cl})
+      | name `S.member` macroIds = do
+          d <- translateClause name sMacroIds cl
+          return $ Just $ (text "@" <> text name) <+> text "=" <+> d
+      | otherwise = return Nothing
+    lineFor (MacroRule {getLRuleName = name, getLClause = cl}) = do
+          d <- translateClauseForMacro name cl
+          return $ Just $ (text "$" <> text name) <+> text "=" <+> d
 
-genX :: NormalGrammar -> String
-genX (NormalGrammar { getNGrammarName = name, getLexicalRules = tokens, getNImports = imports}) = 
-    render $ vcat [
+genX :: NormalGrammar -> Either Diagnostic String
+genX (NormalGrammar { getNGrammarName = name, getLexicalRules = tokens, getNImports = imports}) = do
+    tokensText <- genTokens symMacroIds $ removeSymmacros tokens
+    macroText <- genMacroText symMacroIds macroIds tokens
+    return $ render $ vcat [
                    header,
                    nl,
                    macroText,
@@ -58,8 +66,6 @@ genX (NormalGrammar { getNGrammarName = name, getLexicalRules = tokens, getNImpo
                   ]
     where macroIds = getMacroIds tokens
           symMacroIds = getSymMacroIds tokens
-          tokensText = genTokens symMacroIds $ removeSymmacros tokens
-          macroText = genMacroText symMacroIds macroIds tokens
           adt = genTokenADT $ removeSymmacros tokens
           header = vcat [text "{", ((text "module" <+> text name) <> text "Lexer(alexScanTokens, Token(..), PosToken(..), AlexPosn(..))"), text "where", text imports, text " }",
                          text "%wrapper \"monad\""]
@@ -111,12 +117,14 @@ genTokenADT lexical_rules = text "data" <+> text "Token" <+> text "=" <+> (joinA
                    _         -> token_name <+> text data_type
           makeToken (MacroRule _ _) = empty
 
-genTokens :: S.Set String -> [LexicalRule] -> Doc
-genTokens smacroIds lexical_rules =
-  text "tokens" <+> text ":-" <+> vcat (map makeToken lexical_rules ++ [text ". { rtkError }"])
-    where makeToken LexicalRule { getLRuleDataType = data_type, getLRuleFunc = func, getLRuleName = name, getLClause = cl } =
-              translateClause name smacroIds cl <+> makeProduction name data_type func
-          makeToken (MacroRule _ _) = empty
+genTokens :: S.Set String -> [LexicalRule] -> Either Diagnostic Doc
+genTokens smacroIds lexical_rules = do
+    toks <- mapM makeToken lexical_rules
+    return $ text "tokens" <+> text ":-" <+> vcat (toks ++ [text ". { rtkError }"])
+    where makeToken LexicalRule { getLRuleDataType = data_type, getLRuleFunc = func, getLRuleName = name, getLClause = cl } = do
+              cld <- translateClause name smacroIds cl
+              return $ cld <+> makeProduction name data_type func
+          makeToken (MacroRule _ _) = return empty
           makeProduction name data_type func =
             let token_name = text $ tokenName name in
               case data_type of
@@ -150,12 +158,20 @@ backquoteStrInBrackets s = concat (map (\chr -> if (case chr of
                                           else [chr] )
                                   s)
 
-translateClauseForMacro :: ID -> IClause -> Doc
-translateClauseForMacro _ (IStrLit s) = text s
-translateClauseForMacro _ (IRegExpLit re) = brackets $ text $ backquoteStrInBrackets re
-translateClauseForMacro rname (ISeq cls) = hsep $ punctuate (text " ") (map (translateClauseForMacro rname) cls)
-translateClauseForMacro rname (IAlt clauses) = hsep $ punctuate (text "|") (map (translateClauseForMacro rname) clauses)
-translateClauseForMacro rname cl = errorWithoutStackTrace $ "In lexical rule '" ++ rname ++ "': cannot translate clause to a lexer macro definition: " ++ showClause cl
+-- Report a lexical-rule generation error, naming the rule for context.
+lexErr :: ID -> String -> Either Diagnostic a
+lexErr rname msg = Left $ Diagnostic Nothing (Just ("in lexical rule '" ++ rname ++ "'")) msg
+
+translateClauseForMacro :: ID -> IClause -> Either Diagnostic Doc
+translateClauseForMacro _ (IStrLit s) = Right $ text s
+translateClauseForMacro _ (IRegExpLit re) = Right $ brackets $ text $ backquoteStrInBrackets re
+translateClauseForMacro rname (ISeq cls) = do
+    ds <- mapM (translateClauseForMacro rname) cls
+    return $ hsep $ punctuate (text " ") ds
+translateClauseForMacro rname (IAlt clauses) = do
+    ds <- mapM (translateClauseForMacro rname) clauses
+    return $ hsep $ punctuate (text "|") ds
+translateClauseForMacro rname cl = lexErr rname $ "cannot translate clause to a lexer macro definition: " ++ showClause cl
 
 -- Detect Alex escape sequences that should be output as bare escapes, not quoted strings.
 -- In Alex: "\n" = literal backslash+n, but \n = newline character.
@@ -168,25 +184,29 @@ isAlexEscape "\\f" = True   -- form feed
 isAlexEscape "\\v" = True   -- vertical tab
 isAlexEscape _ = False
 
-translateClause :: ID -> S.Set ID -> IClause -> Doc
+translateClause :: ID -> S.Set ID -> IClause -> Either Diagnostic Doc
 translateClause _ sMacroIds (IId name) | name `S.member` sMacroIds =
-  text "$" <> text name
+  Right $ text "$" <> text name
 translateClause _ _ (IId name) =
-  text "@" <> text name
+  Right $ text "@" <> text name
 translateClause _ _ (IStrLit s)
-  | isAlexEscape s = text s   -- output bare escape: \n, \t, etc.
-  | otherwise      = doubleQuotes $ text $ backquoteStr s
-translateClause _ _ (IDot)              = text "."
-translateClause _ _ (IRegExpLit re)     = brackets $ text $ backquoteStrInBrackets re
-translateClause rname sMacroIds (IStar cl Nothing)  = translateClause rname sMacroIds cl <> text "*"
+  | isAlexEscape s = Right $ text s   -- output bare escape: \n, \t, etc.
+  | otherwise      = Right $ doubleQuotes $ text $ backquoteStr s
+translateClause _ _ (IDot)              = Right $ text "."
+translateClause _ _ (IRegExpLit re)     = Right $ brackets $ text $ backquoteStrInBrackets re
+translateClause rname sMacroIds (IStar cl Nothing)  = (<> text "*") <$> translateClause rname sMacroIds cl
 -- a* ~x --> (a(x a)*)?
-translateClause rname _ (IStar _ (Just _)) = errorWithoutStackTrace $ "In lexical rule '" ++ rname ++ "': star (*) clauses with delimiters (~) are not supported in lexical rules"
-translateClause rname sMacroIds (IPlus cl Nothing)  = translateClause rname sMacroIds cl <> text "+"
-translateClause rname _ (IPlus _ (Just _)) = errorWithoutStackTrace $ "In lexical rule '" ++ rname ++ "': plus (+) clauses with delimiters (~) are not supported in lexical rules"
-translateClause rname sMacroIds (IAlt clauses)      = parens $ hsep $ punctuate (text "|") (map (translateClause rname sMacroIds) clauses)
-translateClause rname sMacroIds (ISeq clauses)    = hsep $ punctuate (text " ") (map (translateClause rname sMacroIds) clauses)
-translateClause rname sMacroIds (IOpt clause)       = translateClause rname sMacroIds clause <+> text "?"
-translateClause rname _ cl                 = errorWithoutStackTrace $ "In lexical rule '" ++ rname ++ "': cannot translate clause to lexer spec: " ++ showClause cl
+translateClause rname _ (IStar _ (Just _)) = lexErr rname "star (*) clauses with delimiters (~) are not supported in lexical rules"
+translateClause rname sMacroIds (IPlus cl Nothing)  = (<> text "+") <$> translateClause rname sMacroIds cl
+translateClause rname _ (IPlus _ (Just _)) = lexErr rname "plus (+) clauses with delimiters (~) are not supported in lexical rules"
+translateClause rname sMacroIds (IAlt clauses)      = do
+    ds <- mapM (translateClause rname sMacroIds) clauses
+    return $ parens $ hsep $ punctuate (text "|") ds
+translateClause rname sMacroIds (ISeq clauses)    = do
+    ds <- mapM (translateClause rname sMacroIds) clauses
+    return $ hsep $ punctuate (text " ") ds
+translateClause rname sMacroIds (IOpt clause)       = (<+> text "?") <$> translateClause rname sMacroIds clause
+translateClause rname _ cl                 = lexErr rname $ "cannot translate clause to lexer spec: " ++ showClause cl
 
 joinAlts :: [Doc] -> Doc
 joinAlts alts = vcat $ punctuate (text " |") (filter (not.isEmpty) alts)

--- a/GenY.hs
+++ b/GenY.hs
@@ -2,14 +2,16 @@ module GenY (genY)
     where
 
 import Parser
+import Diagnostics (Diagnostic)
 import Text.PrettyPrint hiding ((<>))
 import qualified Data.Set as Set
 import GenAST
 import Grammar
 
-genY :: NormalGrammar -> String
-genY g@(NormalGrammar name srules lex_rules _ _ _ _) =
-    render $ vcat [
+genY :: NormalGrammar -> Either Diagnostic String
+genY g@(NormalGrammar name srules lex_rules _ _ _ _) = do
+    ast <- genAST g
+    return $ render $ vcat [
                    text header,
                    nl,
                    text "%name parse" <> text name,
@@ -24,7 +26,7 @@ genY g@(NormalGrammar name srules lex_rules _ _ _ _) =
                    nl,
                    rulesDoc,
                    nl,
-                   text footer
+                   text (footer ast)
                   ]
     where normal_rules = normalRules srules
           listRuleSet = makeListRuleSet normal_rules
@@ -45,7 +47,6 @@ genY g@(NormalGrammar name srules lex_rules _ _ _ _) =
                    \import qualified Data.Generics as Gen\n\
                    \import qualified " ++ name ++  "Lexer as L (Token(..), PosToken(..), AlexPosn(..), alexScanTokens)\n\
                    \}"
-          ast = genAST g
           parseErrorDefs = "parseError :: [L.PosToken] -> a\n\
                            \parseError [] = errorWithoutStackTrace \"Parse error: unexpected end of input\"\n\
                            \parseError (L.PosToken (L.AlexPn _ line col) tok : _) =\n\
@@ -54,7 +55,7 @@ genY g@(NormalGrammar name srules lex_rules _ _ _ _) =
                                          : text "showRtkToken :: L.Token -> String"
                                          : text "showRtkToken L.EndOfFile = \"end of input\""
                                          : map genShowToken (removeSymmacros lex_rules))
-          footer = "{\n" ++ parseErrorDefs ++ "\n" ++ showTokenDefs ++ "\n\n" ++ ast ++ "\n}"
+          footer ast = "{\n" ++ parseErrorDefs ++ "\n" ++ showTokenDefs ++ "\n\n" ++ ast ++ "\n}"
 
 type ListRuleSet = Set.Set ID
 

--- a/Lexer.x
+++ b/Lexer.x
@@ -2,6 +2,7 @@
 module Lexer where
 
 import Data.Data (Data, Typeable)
+import Diagnostics (Diagnostic(..), SourcePos(..), renderDiagnostic)
 }
 
 %wrapper "monadUserState"
@@ -111,14 +112,34 @@ deriving instance Data AlexPosn
 data PosToken = PosToken { ptPos :: AlexPosn, ptToken :: Token }
                 deriving (Eq, Show, Typeable, Data)
 
--- The returned list always ends with an EndOfFile token that carries the
--- position of the end of input, so parse errors at end of input can be
--- reported with a position too
-alexScanTokens :: String -> [PosToken]
-alexScanTokens str =
+-- Lex the input into a token stream, returning a structured diagnostic on a
+-- lexical error. The returned list always ends with an EndOfFile token that
+-- carries the position of the end of input, so parse errors at end of input
+-- can be reported with a position too.
+scanTokens :: String -> Either Diagnostic [PosToken]
+scanTokens str =
                case alexScanTokens1 str of
-                  Right toks -> toks
-                  Left err -> errorWithoutStackTrace err
+                  Right toks -> Right toks
+                  Left err   -> Left (lexDiagnostic err)
+
+-- rtkError encodes the error position as "LINE:COL:message"; recover it here so
+-- the diagnostic carries a real SourcePos. Fall back to a position-less
+-- diagnostic if the encoding is absent (e.g. an internal alex error).
+lexDiagnostic :: String -> Diagnostic
+lexDiagnostic err =
+    case span (/= ':') err of
+        (l, ':' : rest1) | [(line, "")] <- reads l ->
+            case span (/= ':') rest1 of
+                (c, ':' : msg) | [(col, "")] <- reads c ->
+                    Diagnostic (Just (SourcePos line col)) Nothing msg
+                _ -> noPos
+        _ -> noPos
+  where noPos = Diagnostic Nothing Nothing err
+
+-- Thin wrapper kept during the migration to structured diagnostics: callers
+-- that have not yet switched to 'scanTokens' get the rendered message thrown.
+alexScanTokens :: String -> [PosToken]
+alexScanTokens str = either (errorWithoutStackTrace . renderDiagnostic "<input>") id (scanTokens str)
 
 alexScanTokens1 str = runAlex str $ do
   let loop toks = do tok <- alexMonadScan
@@ -132,7 +153,9 @@ alexEOF = do
   (pos, _, _, _) <- alexGetInput
   return $ PosToken pos EndOfFile
 
-rtkError ((AlexPn _ line column), _, _, str) _ = alexError $ "lexical error at line " ++ (show line) ++ ", column " ++ (show column) ++ ". Following chars: " ++ (take 10 str)
+-- Encode the position as "LINE:COL:message" so scanTokens can split it back
+-- out into a SourcePos for the diagnostic.
+rtkError ((AlexPn _ line column), _, _, str) _ = alexError $ (show line) ++ ":" ++ (show column) ++ ":lexical error. Following chars: " ++ (take 10 str)
 
 simple1 :: (String -> Token) -> AlexInput -> Int -> Alex PosToken
 simple1 t (pos, _, _, str) len = return $ PosToken pos (t (take len str))

--- a/Normalize.hs
+++ b/Normalize.hs
@@ -3,6 +3,7 @@ module Normalize(normalizeTopLevelClauses, fillConstructorNames)
     where
 
 import Parser
+import Diagnostics (Diagnostic(..))
 import Grammar (isNotIgnored)
 import Data.Generics
 import Data.Maybe
@@ -12,6 +13,7 @@ import qualified Data.Set as S
 import Control.Lens
 
 import Control.Monad.State.Strict hiding (lift)
+import Control.Monad.State.Strict (lift)
 
 -- In the normal form top level clause of the non-lexical rule can be the following:
 -- 1. simple_clause *
@@ -40,19 +42,20 @@ data NormalizationState = NormalizationState {
 
 $(makeLenses ''NormalizationState)
 
-type Normalization a = State NormalizationState a
+-- Normalization can fail with a structured Diagnostic, carried in the Either
+-- under the state transformer.
+type Normalization a = StateT NormalizationState (Either Diagnostic) a
 
--- Report a grammar error, attaching the rule (and its source position, when
--- known) that was being normalized when the problem was found
+-- Report a grammar error as a Diagnostic, attaching the rule being normalized
+-- (its name as context and its source position, when known) when the problem
+-- was found.
 normError :: String -> Normalization a
 normError msg = do
   ctx <- gets _currentRule
-  let loc = case ctx of
-              Just r -> "in rule '" ++ getIRuleName r ++ "'"
-                        ++ maybe "" (\p -> " (at " ++ showSourcePos p ++ ")") (getIRulePos r)
-                        ++ ": "
-              Nothing -> ""
-  errorWithoutStackTrace $ "Grammar error " ++ loc ++ msg
+  let diag = case ctx of
+               Just r  -> Diagnostic (getIRulePos r) (Just ("in rule '" ++ getIRuleName r ++ "'")) msg
+               Nothing -> Diagnostic Nothing Nothing msg
+  lift (Left diag)
 
 newNamePrefixed :: String -> Normalization String
 newNamePrefixed prefix = do
@@ -201,6 +204,13 @@ checkSimpleClause (IIgnore c1) = do
     _ -> normError $ "ignore (!) cannot be applied to: " ++ showClause c1
 checkSimpleClause c = extractClause c >>= return . SSId
 
+-- A repetition/option clause: cannot be the body of a lifted (,) clause.
+isRepetition :: IClause -> Bool
+isRepetition IStar{} = True
+isRepetition IPlus{} = True
+isRepetition IOpt{}  = True
+isRepetition _       = False
+
 checkNormalClause :: IClause -> Normalization SyntaxTopClause
 checkNormalClause (IStar c mc) = do
   c1 <- checkSimpleClause c
@@ -223,11 +233,20 @@ checkNormalClause (ISeq [c]) = do
 checkNormalClause tc@(ISeq _) = do
   c1 <- checkNormalClauseSeq tc
   return $ STAltOfSeq [c1]
-checkNormalClause (ILifted c) = do
-  c1 <- checkSimpleClause c
-  case c1 of
-    SSId idName -> return $ STAltOfSeq [STSeq "" [SSLifted idName]]
-    _ -> normError $ "lifted (,) cannot be applied to: " ++ showClause c
+-- A lifted (,) clause names the single rule whose value becomes this rule's
+-- value, so it must reference one rule, not a repetition. Lifting a list/plus
+-- (e.g. "Foo = ,Bar* ;") is not implemented: it would otherwise slip through to
+-- GenAST.genSimpleItem and die there ("lifted rules are not yet implemented").
+-- (IOpt is desugared by removeOpts before normalization, so only * and + reach
+-- here as repetitions.)
+checkNormalClause (ILifted c)
+  | isRepetition c =
+      normError "a lifted (,) clause is not supported under *, + or ?"
+  | otherwise = do
+      c1 <- checkSimpleClause c
+      case c1 of
+        SSId idName -> return $ STAltOfSeq [STSeq "" [SSLifted idName]]
+        _ -> normError $ "lifted (,) cannot be applied to: " ++ showClause c
 checkNormalClause (IIgnore c) = do
   c1 <- checkSimpleClause c
   case c1 of
@@ -350,24 +369,27 @@ addStartGroup ng@NormalGrammar { getSyntaxRuleGroups = rules, getLexicalRules = 
              getGrammarInfo = info { getNameCounter = counter, getRuleToStartInfo = ruleToStartInfo }}
       [] -> error "Grammar must have at least one rule group"
 
-normalizeTopLevelClauses :: InitialGrammar -> NormalGrammar
+normalizeTopLevelClauses :: InitialGrammar -> Either Diagnostic NormalGrammar
 normalizeTopLevelClauses grammar =
   case getIRules grammar of
-    [] -> errorWithoutStackTrace $ "Grammar '" ++ (getIGrammarName grammar) ++ "' contains no rules"
-    (firstIRule:_) ->
+    [] -> Left $ Diagnostic Nothing Nothing $
+                   "grammar '" ++ getIGrammarName grammar ++ "' contains no rules"
+    (firstIRule:_) -> do
       let firstID = maybe (getIRuleName firstIRule) Prelude.id (getIDataTypeName firstIRule)
           ruleTypeMap = buildRuleToTypeMap grammar
-          (_, NormalizationState nrs nls counter antiRules shortcuts proxyRules _ _ _ _) =
-            runState (doNM grammar) (NormalizationState M.empty [] 0 [] [] S.empty M.empty M.empty ruleTypeMap Nothing)
-          firstRuleGroupRules = fromMaybe firstRuleError $ M.lookup firstID nrs
-          firstRuleError = errorWithoutStackTrace $ "Grammar error: the first rule ('" ++ getIRuleName firstIRule
-                                   ++ "') must be a syntax rule (its name must start with an uppercase letter),"
-                                   ++ " because it defines the start symbol of the grammar"
-          nrs1 = M.delete firstID nrs
+      (_, NormalizationState nrs nls counter antiRules shortcuts proxyRules _ _ _ _) <-
+        runStateT (doNM grammar) (NormalizationState M.empty [] 0 [] [] S.empty M.empty M.empty ruleTypeMap Nothing)
+      firstRuleGroupRules <- case M.lookup firstID nrs of
+        Just rs -> Right rs
+        Nothing -> Left $ Diagnostic (getIRulePos firstIRule) Nothing $
+                            "the first rule ('" ++ getIRuleName firstIRule
+                            ++ "') must be a syntax rule (its name must start with an uppercase letter),"
+                            ++ " because it defines the start symbol of the grammar"
+      let nrs1 = M.delete firstID nrs
           firstGroup = SyntaxRuleGroup firstID firstRuleGroupRules
           otherGroups = map (\ (k,v) -> SyntaxRuleGroup k v) $ M.toList nrs1
           groups = firstGroup : otherGroups
-        in addStartGroup $ NormalGrammar (getIGrammarName grammar) groups nls antiRules shortcuts (getImports grammar) (GrammarInfo (Just firstID) M.empty counter proxyRules)
+      return $ addStartGroup $ NormalGrammar (getIGrammarName grammar) groups nls antiRules shortcuts (getImports grammar) (GrammarInfo (Just firstID) M.empty counter proxyRules)
 
 data FillNameState = FillNameState { nameCtr :: Int, nameBase :: String }
 type FillName a = State FillNameState a

--- a/Parser.y
+++ b/Parser.y
@@ -2,6 +2,7 @@
 module Parser where
 
 import qualified Lexer as L (Token(..), PosToken(..), AlexPosn(..), alexScanTokens)
+import Diagnostics (Diagnostic(..), SourcePos(..))
 import Data.Generics
 import Data.Data
 import Data.Char
@@ -13,6 +14,7 @@ import qualified Data.Set as S
 
 %name parse
 %tokentype  { L.PosToken }
+%monad      { Either Diagnostic }
 %error      { parseError }
 
 %token
@@ -102,16 +104,17 @@ OptDelim : {- empty -}          { Nothing }
 
 {
 
-parseError :: [L.PosToken] -> a
-parseError [] = errorWithoutStackTrace "Parse error: unexpected end of input. Expected a grammar definition."
+parseError :: [L.PosToken] -> Either Diagnostic a
+parseError [] = Left $ Diagnostic Nothing Nothing "unexpected end of input; expected a grammar definition"
 parseError (L.PosToken pos tok : rest) =
-    errorWithoutStackTrace $ "Parse error at " ++ showAlexPos pos ++ ": unexpected " ++ showToken tok ++ following
+    Left $ Diagnostic (Just (alexPosToSourcePos pos)) Nothing
+                      ("unexpected " ++ showToken tok ++ following)
   where following = case rest of
                       [] -> ""
                       _  -> ", followed by: " ++ intercalate ", " (map (showToken . L.ptToken) (take 4 rest))
 
-showAlexPos :: L.AlexPosn -> String
-showAlexPos (L.AlexPn _ line col) = "line " ++ show line ++ ", column " ++ show col
+alexPosToSourcePos :: L.AlexPosn -> SourcePos
+alexPosToSourcePos (L.AlexPn _ line col) = SourcePos line col
 
 -- Render a token the way it appears in the grammar source, for error messages
 showToken :: L.Token -> String
@@ -145,13 +148,6 @@ idStr t = error $ "Internal error: identifier token expected, but got: " ++ show
 
 idPos :: L.PosToken -> SourcePos
 idPos (L.PosToken (L.AlexPn _ line col) _) = SourcePos line col
-
--- Position in the grammar source file (line and column, both 1-based)
-data SourcePos = SourcePos { srcLine :: Int, srcColumn :: Int }
-                 deriving (Eq, Ord, Show, Typeable, Data)
-
-showSourcePos :: SourcePos -> String
-showSourcePos (SourcePos line col) = "line " ++ show line ++ ", column " ++ show col
 
 data InitialGrammar = InitialGrammar { getIGrammarName :: String, getImports :: String, getIRules :: [IRule] }
                  deriving (Eq, Show, Typeable, Data)

--- a/app/main.hs
+++ b/app/main.hs
@@ -1,5 +1,6 @@
 import Lexer
 import Parser
+import Diagnostics (Diagnostic, renderDiagnostic)
 import TokenProcessing
 import StringLiterals
 import Normalize
@@ -12,7 +13,8 @@ import Control.Monad (when)
 import Data.Data (Data)
 import Data.Maybe (catMaybes)
 import Control.Exception (evaluate)
-import System.Exit (exitSuccess)
+import System.IO (hPutStrLn, stderr)
+import System.Exit (exitSuccess, exitWith, ExitCode (ExitFailure))
 
 main :: IO ()
 main = do
@@ -23,7 +25,8 @@ main = do
     content <- readFile (grammarFile opts)
 
     -- Stage 1: Lexical Analysis
-    (rawTokens, maybeT1) <- runStage opts "Lexical Analysis" $ alexScanTokens content
+    (eRawTokens, maybeT1) <- runStage opts "Lexical Analysis" $ scanTokens content
+    rawTokens <- orDie opts eRawTokens
 
     -- Stage 1.5: Token Post-Processing
     -- Process escape sequences and concatenate multi-line strings
@@ -36,7 +39,8 @@ main = do
         exitAfterDebug
 
     -- Stage 2: Parsing
-    (grammar, maybeT2) <- runStage opts "Parsing" $ parse tokens
+    (eGrammar, maybeT2) <- runStage opts "Parsing" $ parse tokens
+    grammar <- orDie opts eGrammar
 
     when (debugParse opts) $
         D.printInitialGrammar opts grammar
@@ -54,7 +58,8 @@ main = do
         exitAfterDebug
 
     -- Stage 4: Clause Normalization
-    (grammar1, maybeT4) <- runStage opts "Clause Normalization" $ normalizeTopLevelClauses grammar0
+    (eGrammar1, maybeT4) <- runStage opts "Clause Normalization" $ normalizeTopLevelClauses grammar0
+    grammar1 <- orDie opts eGrammar1
 
     when (debugClauseNorm opts) $
         D.printNormalGrammar opts "CLAUSE NORMALIZATION OUTPUT" grammar1
@@ -107,11 +112,14 @@ main = do
     -- Stage 6: Code Generation
     let grammar_name = getNGrammarName grammar2
 
-    (y_content, maybeT6) <- runStage opts "Parser (Y) Generation" $ genY grammar2
+    (eY, maybeT6) <- runStage opts "Parser (Y) Generation" $ genY grammar2
+    y_content <- orDie opts eY
 
-    (x_content, maybeT7) <- runStage opts "Lexer (X) Generation" $ genX grammar2
+    (eX, maybeT7) <- runStage opts "Lexer (X) Generation" $ genX grammar2
+    x_content <- orDie opts eX
 
-    (q_content, maybeT8) <- runStage opts "QuasiQuoter (Q) Generation" $ genQ grammar2
+    (eQ, maybeT8) <- runStage opts "QuasiQuoter (Q) Generation" $ genQ grammar2
+    q_content <- orDie opts eQ
 
     -- Debug generated specs if requested
     when (debugParserSpec opts) $ do
@@ -126,8 +134,10 @@ main = do
         D.debugSection opts "GENERATED QUASIQUOTER CODE"
         putStrLn q_content
 
-    -- Write output files (unless we're only validating)
-    when (not (validateGrammar opts) || not (validateGrammar opts && not (any id [debugParserSpec opts, debugLexerSpec opts, debugQQSpec opts]))) $ do
+    -- Write output files (unless we're only validating). A spec dump still
+    -- writes the files; validation alone suppresses them.
+    let specDumpRequested = any id [debugParserSpec opts, debugLexerSpec opts, debugQQSpec opts]
+    when (not (validateGrammar opts) || specDumpRequested) $ do
         let dir = outputDir opts
         writeFile (dir ++ "/" ++ grammar_name ++ "Parser.y") y_content
         writeFile (dir ++ "/" ++ grammar_name ++ "Lexer.x") x_content
@@ -145,6 +155,14 @@ main = do
                         debugParserSpec opts, debugLexerSpec opts, debugQQSpec opts,
                         showStats opts, validateGrammar opts]) $ do
         putStrLn $ "Successfully generated files for " ++ grammar_name
+
+-- | Either surface a pipeline diagnostic on stderr and exit 1, or return the
+-- value. The grammar file name gives the diagnostic its GNU-style prefix.
+orDie :: DebugOptions -> Either Diagnostic a -> IO a
+orDie opts (Left d)  = do
+    hPutStrLn stderr (renderDiagnostic (grammarFile opts) d)
+    exitWith (ExitFailure 1)
+orDie _    (Right a) = return a
 
 -- | Run one pure pipeline stage. Under --profile-stages the result is forced
 -- to normal form inside the timed window, so the timing reflects the stage

--- a/rtk.cabal
+++ b/rtk.cabal
@@ -39,6 +39,7 @@ Common warnings
 Library
   Import:            warnings
   Exposed-Modules:
+                     Diagnostics,
                      Lexer,
                      Parser,
                      TokenProcessing,

--- a/test/GoldenTests.hs
+++ b/test/GoldenTests.hs
@@ -22,6 +22,7 @@ import System.Exit (exitFailure)
 import System.FilePath ((</>), takeBaseName)
 import Test.HUnit
 
+import Diagnostics (renderDiagnostic)
 import TestSupport
 
 goldenRoot :: FilePath
@@ -45,13 +46,15 @@ regenerateHint =
 generateArtifacts :: FilePath -> IO (Either String [(FilePath, String)])
 generateArtifacts pgFile = do
     source <- readFileUtf8 pgFile
-    result <- try $ do
-        let artifacts = artifactsFor (normalizeGrammarSource source)
-        mapM_ (\(_, content) -> evaluate (length content)) artifacts
-        return artifacts
+    result <- try $
+        case normalizeGrammarSource source >>= artifactsFor of
+            Left d          -> return (Left (renderDiagnostic pgFile d))
+            Right artifacts -> do
+                mapM_ (\(_, content) -> evaluate (length content)) artifacts
+                return (Right artifacts)
     return $ case result of
-        Left e          -> Left (show (e :: SomeException))
-        Right artifacts -> Right artifacts
+        Left e      -> Left (show (e :: SomeException))
+        Right inner -> inner
 
 -- | A short, readable summary of where two artifacts diverge.
 diffSummary :: String -> String -> String

--- a/test/TestSupport.hs
+++ b/test/TestSupport.hs
@@ -17,31 +17,38 @@ import System.Directory (listDirectory)
 import System.FilePath ((</>), takeExtension)
 import System.IO
 
+import Diagnostics (Diagnostic)
 import GenQ (genQ)
 import GenX (genX)
 import GenY (genY)
-import Lexer (alexScanTokens)
+import Lexer (scanTokens)
 import Normalize (fillConstructorNames, normalizeTopLevelClauses)
 import Parser
 import StringLiterals (normalizeStringLiterals)
 import TokenProcessing (processTokens)
 
 -- | Lexing, token post-processing and parsing of a grammar specification.
-parseGrammarSource :: String -> InitialGrammar
-parseGrammarSource = parse . processTokens . alexScanTokens
+parseGrammarSource :: String -> Either Diagnostic InitialGrammar
+parseGrammarSource src = scanTokens src >>= (parse . processTokens)
 
 -- | The full front-end pipeline, producing the normalized grammar that the
 -- code generators consume.
-normalizeGrammarSource :: String -> NormalGrammar
-normalizeGrammarSource =
-    fillConstructorNames . normalizeTopLevelClauses . normalizeStringLiterals . parseGrammarSource
+normalizeGrammarSource :: String -> Either Diagnostic NormalGrammar
+normalizeGrammarSource src = do
+    ig <- parseGrammarSource src
+    ng <- normalizeTopLevelClauses (normalizeStringLiterals ig)
+    return (fillConstructorNames ng)
 
 -- | The three files rtk writes for a grammar, as (file name, content) pairs.
-artifactsFor :: NormalGrammar -> [(FilePath, String)]
-artifactsFor g = [ (name ++ "Lexer.x",  genX g)
-                 , (name ++ "Parser.y", genY g)
-                 , (name ++ "QQ.hs",    genQ g)
-                 ]
+artifactsFor :: NormalGrammar -> Either Diagnostic [(FilePath, String)]
+artifactsFor g = do
+    x <- genX g
+    y <- genY g
+    q <- genQ g
+    return [ (name ++ "Lexer.x",  x)
+           , (name ++ "Parser.y", y)
+           , (name ++ "QQ.hs",    q)
+           ]
     where name = getNGrammarName g
 
 grammarsDir :: FilePath

--- a/test/UnitTests.hs
+++ b/test/UnitTests.hs
@@ -8,7 +8,7 @@
 --   * normalization invariants checked against every grammar in test-grammars/
 module Main (main) where
 
-import Control.Exception (ErrorCall (..), SomeException, catch, evaluate, try)
+import Control.Exception (SomeException, evaluate, try)
 import Control.Monad (when)
 import Data.List (find, group, isInfixOf, isPrefixOf, nub, sort)
 import qualified Data.Map as M
@@ -18,6 +18,7 @@ import System.Exit (exitFailure)
 import System.FilePath (takeBaseName)
 import Test.HUnit
 
+import Diagnostics (Diagnostic (..), SourcePos (..), renderDiagnostic)
 import Grammar (isClauseSeqLifted)
 import Lexer (AlexPosn (..), PosToken (..), Token (..))
 import Normalize (fillConstructorNames, normalizeTopLevelClauses)
@@ -35,15 +36,25 @@ main = do
     results <- runTestTT $ TestList $
         [ TestLabel "StrQuote" strQuoteTests
         , TestLabel "TokenProcessing" tokenProcessingTests
+        , TestLabel "diagnostics" diagnosticsTests
         , TestLabel "pipeline error handling" errorHandlingTests
         , TestLabel "normalization behavior" normalizationTests
         ] ++ perGrammar
     when (errors results + failures results /= 0) exitFailure
 
--- | Normalize without constructor-name filling, for tests that inspect the
--- intermediate form.
+-- | Normalize without constructor-name filling, returning the diagnostic on
+-- failure. Used by the error-handling tests.
+normalizeNoFillE :: String -> Either Diagnostic NormalGrammar
+normalizeNoFillE src = parseGrammarSource src >>= (normalizeTopLevelClauses . normalizeStringLiterals)
+
+-- | Partial unwrapping for the behavior tests, which all use valid grammars:
+-- a diagnostic here means the test grammar itself is wrong.
 normalizeNoFill :: String -> NormalGrammar
-normalizeNoFill = normalizeTopLevelClauses . normalizeStringLiterals . parseGrammarSource
+normalizeNoFill = either (error . ("unexpected diagnostic: " ++) . show) id . normalizeNoFillE
+
+-- | Parse a valid grammar, failing loudly on a diagnostic.
+parseOrDie :: String -> InitialGrammar
+parseOrDie = either (error . ("unexpected diagnostic: " ++) . show) id . parseGrammarSource
 
 --------------------------------------------------------------------------------
 -- StrQuote
@@ -91,62 +102,94 @@ at = PosToken (AlexPn 0 1 1)
 -- Pipeline error handling
 --------------------------------------------------------------------------------
 
-expectErrorCall :: a -> IO (Either String String)
-expectErrorCall value =
-    catch (evaluate value >> return (Left "no error thrown"))
-          (\(ErrorCall msg) -> return (Right msg))
+-- | Assert that an Either is Left and hand the diagnostic to a checker.
+expectDiagnostic :: String -> Either Diagnostic a -> (Diagnostic -> Assertion) -> Assertion
+expectDiagnostic _    (Left d)  check = check d
+expectDiagnostic what (Right _) _     = assertFailure $ "expected a diagnostic for " ++ what
+
+--------------------------------------------------------------------------------
+-- Diagnostics rendering
+--------------------------------------------------------------------------------
+
+diagnosticsTests :: Test
+diagnosticsTests = TestList
+    [ TestLabel "renderDiagnostic with position and context" $ TestCase $
+        assertEqual ""
+            "g.pg:2:1: error: in rule 'Foo': bad thing"
+            (renderDiagnostic "g.pg"
+                (Diagnostic (Just (SourcePos 2 1)) (Just "in rule 'Foo'") "bad thing"))
+    , TestLabel "renderDiagnostic with position, no context" $ TestCase $
+        assertEqual ""
+            "g.pg:2:1: error: bad thing"
+            (renderDiagnostic "g.pg" (Diagnostic (Just (SourcePos 2 1)) Nothing "bad thing"))
+    , TestLabel "renderDiagnostic without position or context" $ TestCase $
+        assertEqual ""
+            "g.pg: error: bad thing"
+            (renderDiagnostic "g.pg" (Diagnostic Nothing Nothing "bad thing"))
+    ]
+
+--------------------------------------------------------------------------------
+-- Pipeline error handling
+--------------------------------------------------------------------------------
 
 errorHandlingTests :: Test
 errorHandlingTests = TestList
-    [ TestLabel "grammar without rules is rejected" $ TestCase $ do
-        result <- expectErrorCall $ normalizeNoFill "grammar 'Empty';"
-        case result of
-            Left err -> assertFailure $ "expected an error about the empty grammar, got: " ++ err
-            Right msg -> assertBool ("unexpected message: " ++ msg) $
-                "contains no rules" `isInfixOf` msg && "Empty" `isInfixOf` msg
-    , TestLabel "empty input is a parse error" $ TestCase $ do
-        result <- expectErrorCall $ parseGrammarSource ""
-        case result of
-            Left err -> assertFailure $ "expected a parse error for empty input, got: " ++ err
-            Right msg -> assertBool ("unexpected message: " ++ msg) $
-                "Parse error" `isInfixOf` msg
-    , TestLabel "minimal valid grammar normalizes" $ TestCase $ do
-        result <- expectErrorCall $ forceGrammar $
-            normalizeGrammarSource "grammar 'Valid';\nRule = 'test' ;"
-        case result of
-            Left _ -> return ()
-            Right msg -> assertFailure $ "valid grammar should normalize, got error: " ++ msg
-    , TestLabel "parse errors report the offending position" $ TestCase $ do
+    [ TestLabel "grammar without rules is rejected" $ TestCase $
+        expectDiagnostic "an empty grammar" (normalizeNoFillE "grammar 'Empty';") $ \d -> do
+            assertBool ("unexpected message: " ++ diagMessage d) $
+                "contains no rules" `isInfixOf` diagMessage d
+                && "Empty" `isInfixOf` diagMessage d
+            assertEqual "no position" Nothing (diagPos d)
+    , TestLabel "empty input is a parse error" $ TestCase $
+        expectDiagnostic "empty input" (parseGrammarSource "") $ \d -> do
+            assertBool ("unexpected message: " ++ diagMessage d) $
+                "end of input" `isInfixOf` diagMessage d
+            assertEqual "position of end of input" (Just (SourcePos 1 1)) (diagPos d)
+    , TestLabel "minimal valid grammar normalizes" $ TestCase $
+        case normalizeGrammarSource "grammar 'Valid';\nRule = 'test' ;" of
+            Right _ -> return ()
+            Left d  -> assertFailure $ "valid grammar should normalize, got: " ++ show d
+    , TestLabel "parse errors report the offending position" $ TestCase $
         -- ';' missing after the grammar declaration: the parser should point
         -- at the identifier 'Foo' on line 2
-        result <- expectErrorCall $ parseGrammarSource "grammar 'Test'\nFoo = bar;\n"
-        case result of
-            Left err -> assertFailure $ "expected a parse error, got: " ++ err
-            Right msg -> assertBool ("unexpected message: " ++ msg) $
-                "line 2, column 1" `isInfixOf` msg && "identifier 'Foo'" `isInfixOf` msg
-    , TestLabel "errors at end of input carry a position" $ TestCase $ do
-        result <- expectErrorCall $ parseGrammarSource "grammar 'Test';\nFoo =\n"
-        case result of
-            Left err -> assertFailure $ "expected a parse error, got: " ++ err
-            Right msg -> assertBool ("unexpected message: " ++ msg) $
-                "line 3, column 1" `isInfixOf` msg && "end of input" `isInfixOf` msg
-    , TestLabel "a lexical first rule is rejected with an explanation" $ TestCase $ do
-        result <- expectErrorCall $ forceGrammar $
-            normalizeGrammarSource "grammar 'Test';\nfoo = [a-z];\n"
-        case result of
-            Left err -> assertFailure $ "expected an error about the first rule, got: " ++ err
-            Right msg -> assertBool ("unexpected message: " ++ msg) $
-                "must be a syntax rule" `isInfixOf` msg && "foo" `isInfixOf` msg
-    , TestLabel "normalization errors name the offending rule and position" $ TestCase $ do
+        expectDiagnostic "a missing ';'" (parseGrammarSource "grammar 'Test'\nFoo = bar;\n") $ \d -> do
+            assertEqual "position of 'Foo'" (Just (SourcePos 2 1)) (diagPos d)
+            assertBool ("unexpected message: " ++ diagMessage d) $
+                "identifier 'Foo'" `isInfixOf` diagMessage d
+    , TestLabel "errors at end of input carry a position" $ TestCase $
+        expectDiagnostic "a truncated rule" (parseGrammarSource "grammar 'Test';\nFoo =\n") $ \d -> do
+            assertEqual "position of end of input" (Just (SourcePos 3 1)) (diagPos d)
+            assertBool ("unexpected message: " ++ diagMessage d) $
+                "end of input" `isInfixOf` diagMessage d
+    , TestLabel "a lexical first rule is rejected with an explanation" $ TestCase $
+        expectDiagnostic "a lexical first rule"
+            (normalizeGrammarSource "grammar 'Test';\nfoo = [a-z];\n") $ \d -> do
+            assertBool ("unexpected message: " ++ diagMessage d) $
+                "must be a syntax rule" `isInfixOf` diagMessage d
+                && "foo" `isInfixOf` diagMessage d
+            assertEqual "position of 'foo'" (Just (SourcePos 2 1)) (diagPos d)
+    , TestLabel "normalization errors name the offending rule and position" $ TestCase $
         -- a lifted (,) clause mixed with other clauses is rejected; the error
         -- should point at rule 'Foo' on line 2
-        result <- expectErrorCall $ forceGrammar $
-            normalizeGrammarSource "grammar 'Test';\nFoo = ,Bar Baz;\nBar = 'b';\nBaz = 'z';\n"
-        case result of
-            Left err -> assertFailure $ "expected an error about the lifted clause, got: " ++ err
-            Right msg -> assertBool ("unexpected message: " ++ msg) $
-                "in rule 'Foo'" `isInfixOf` msg && "line 2" `isInfixOf` msg
-                && "lifted" `isInfixOf` msg
+        expectDiagnostic "a mixed lifted clause"
+            (normalizeGrammarSource "grammar 'Test';\nFoo = ,Bar Baz;\nBar = 'b';\nBaz = 'z';\n") $ \d -> do
+            assertEqual "context names the rule" (Just "in rule 'Foo'") (diagContext d)
+            assertEqual "position of 'Foo'" (Just (SourcePos 2 1)) (diagPos d)
+            assertBool ("unexpected message: " ++ diagMessage d) $
+                "lifted" `isInfixOf` diagMessage d
+    , TestLabel "a lifted clause under * is rejected" $ TestCase $
+        expectDiagnostic "a lifted clause under *"
+            (normalizeGrammarSource "grammar 'X';\nFoo = ,Bar * ;\nBar = 'b';\n") $ \d -> do
+            assertEqual "context names the rule" (Just "in rule 'Foo'") (diagContext d)
+            assertEqual "position of 'Foo'" (Just (SourcePos 2 1)) (diagPos d)
+            assertBool ("unexpected message: " ++ diagMessage d) $
+                "lifted" `isInfixOf` diagMessage d && "*" `isInfixOf` diagMessage d
+    , TestLabel "a reference to an unknown rule is rejected during generation" $ TestCase $
+        expectDiagnostic "an unknown rule reference"
+            (normalizeGrammarSource "grammar 'X';\nFoo = Nope;\n" >>= artifactsFor) $ \d -> do
+            assertEqual "context names the referencing type" (Just "in type 'Foo'") (diagContext d)
+            assertBool ("unexpected message: " ++ diagMessage d) $
+                "unknown rule" `isInfixOf` diagMessage d && "Nope" `isInfixOf` diagMessage d
     ]
 
 -- | Force the whole grammar value so lazy errors surface where we expect them.
@@ -171,7 +214,7 @@ normalizationTests = TestList
 
 testStringLiterals :: Test
 testStringLiterals = TestCase $ do
-    let g = normalizeStringLiterals $ parseGrammarSource $ unlines
+    let g = normalizeStringLiterals $ parseOrDie $ unlines
                 [ "grammar 'Lit';"
                 , "A = 'x' bb ;"
                 , "B = 'x' A ;"


### PR DESCRIPTION
## Summary

Replace ad-hoc error handling with structured diagnostics throughout the grammar-processing pipeline. Grammar errors are now represented as `Diagnostic` values (message plus optional source position and context) threaded through `Either`, instead of being thrown with `error()`. This enables one-line GNU-style error reporting to stderr and eliminates Haskell exception stack traces for user mistakes.

## Key Changes

- **New `Diagnostics` module**: Defines `SourcePos` and `Diagnostic` types with `renderDiagnostic` for GNU-style formatting (`FILE:LINE:COL: error: CONTEXT: MESSAGE`)

- **Pipeline functions now return `Either Diagnostic`**:
  - `Lexer.scanTokens` (new; `alexScanTokens` kept as compatibility wrapper)
  - `Parser.parse`
  - `Normalize.normalizeTopLevelClauses`
  - `GenX.genX`, `GenY.genY`, `GenAST.genAST`, `GenQ.genQ`

- **Error reporting improvements**:
  - Lexical errors now carry source positions (line:column)
  - Parse errors report position and context (e.g., "unexpected identifier 'Foo'")
  - Normalization errors name the offending rule and its position
  - Code generation errors name both the unknown rule and the type referencing it

- **New validation**: A lifted (`,`) clause under `*`/`+`/`?` (e.g., `Foo = ,Bar* ;`) is now rejected during normalization with a clear error, instead of silently generating broken code

- **Main executable**: Updated to handle `Either Diagnostic` results, rendering diagnostics to stderr and exiting with code 1 on grammar errors

- **Test suite**: Refactored error-handling tests to use structured diagnostics; added `diagnosticsTests` for `renderDiagnostic` formatting

- **Build**: Added `Diagnostics` to exposed modules in `rtk.cabal`

## Implementation Details

- `Normalize.hs` uses `StateT NormalizationState (Either Diagnostic)` to thread diagnostics through the normalization state machine
- Lexer error encoding: `rtkError` encodes position as `"LINE:COL:message"` so `scanTokens` can recover it into a `SourcePos`
- Parser error handling: `parseError` constructs `Diagnostic` with position from `AlexPosn` and context from lookahead tokens
- Code generators (`GenX`, `GenY`, `GenAST`) use applicative/monadic `Either` to propagate errors from nested calls
- Backward compatibility: `alexScanTokens` wraps `scanTokens` and throws the rendered diagnostic for callers not yet migrated

https://claude.ai/code/session_01SfxQzGbV3k8MQmXmx26y7g