### PR TITLE
Add PVP version bounds and document RTK-generated code dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Hackage packaging hygiene: PVP version bounds on all dependencies and on
+  the `alex`/`happy` build tools, `Tested-With` now lists GHC 9.4.7 and
+  9.6.4 (the versions actually exercised locally and in CI), and the
+  packages required by RTK-generated code are documented in the README and
+  the cabal description
 - Source positions on tokens: the lexer now returns `PosToken` values
   (token plus line/column), both in the hand-written lexer and in all
   generated lexers

--- a/README.md
+++ b/README.md
@@ -34,7 +34,27 @@ Then compile with Alex and Happy:
 
 ```bash
 alex <Grammar>Lexer.x -o <Grammar>Lexer.hs
-happy <Grammar>Parser.y -o <Grammar>Parser.hs
+happy <Grammar>Parser.y --ghc -o <Grammar>Parser.hs
+```
+
+### Using the generated code
+
+The generated modules are compiled as part of *your* project, so your project
+must depend on the packages they use:
+
+- `array` — runtime support for the Alex lexer and the Happy parser tables
+- `syb` — the generated parser and quasi-quoter use `Data.Generics`
+- `containers` — the quasi-quoter keeps its shortcut table in a `Data.Map`
+- `template-haskell` — the quasi-quoter builds `Language.Haskell.TH` splices
+- `regex-posix` and `regex-base` — the quasi-quoter matches `$var` antiquotation
+  patterns with `Text.Regex.Posix`
+
+If you only use the lexer and parser (no quasi-quotation), `array` and `syb`
+are enough. A typical `build-depends` line for code that uses all three
+generated modules:
+
+```
+build-depends: base, array, syb, containers, template-haskell, regex-posix, regex-base
 ```
 
 ## Grammar Format

--- a/rtk.cabal
+++ b/rtk.cabal
@@ -5,6 +5,11 @@ Synopsis:            Parser and rewrite facility generator from grammar specific
 Description:         RTK (Rewrite ToolKit) generates Alex lexer and Happy parser
                      files from grammar specifications. It supports quasi-quotation
                      for embedding parsed syntax in Haskell code.
+                     .
+                     Projects that compile the generated modules need to depend on
+                     @array@ and @syb@ (lexer and parser), plus @containers@,
+                     @template-haskell@, @regex-posix@ and @regex-base@ for the
+                     generated quasi-quoter; see the README for details.
 License:             MIT
 License-File:        LICENSE
 Author:              prozak
@@ -13,7 +18,7 @@ Homepage:            https://github.com/prozak/rtk
 Bug-Reports:         https://github.com/prozak/rtk/issues
 Category:            Language, Development
 Build-Type:          Simple
-Tested-With:         GHC == 9.4.7
+Tested-With:         GHC == 9.4.7 || == 9.6.4
 
 Extra-Source-Files:
     CHANGELOG.md
@@ -48,15 +53,32 @@ Library
                      StringLiterals,
                      DebugOptions,
                      Debug
-  Build-Depends:     base >= 4.7 && < 5, array, syb, template-haskell, containers, mtl, pretty, pretty-show, MissingH, haskell-src-exts, haskell-src-meta, lens, optparse-applicative, time, ansi-terminal
-  Build-Tool-Depends: happy:happy, alex:alex
+  Build-Depends:
+                     base                 >= 4.17 && < 4.19,
+                     array                >= 0.5  && < 0.6,
+                     syb                  >= 0.7  && < 0.8,
+                     template-haskell     >= 2.19 && < 2.21,
+                     containers           >= 0.6  && < 0.7,
+                     mtl                  >= 2.2  && < 2.4,
+                     pretty               >= 1.1  && < 1.2,
+                     pretty-show          >= 1.10 && < 1.11,
+                     MissingH             >= 1.6  && < 1.7,
+                     haskell-src-exts     >= 1.23 && < 1.24,
+                     haskell-src-meta     >= 0.8  && < 0.9,
+                     lens                 >= 5.2  && < 5.4,
+                     optparse-applicative >= 0.18 && < 0.20,
+                     time                 >= 1.12 && < 1.13,
+                     ansi-terminal        >= 1.0  && < 1.2
+  -- CI pins the exact tool versions (alex-3.5.4.2, happy-2.2 in
+  -- .github/workflows/ci.yml); these ranges must stay compatible with them.
+  Build-Tool-Depends: happy:happy == 2.2.*, alex:alex == 3.5.*
   Default-Extensions:  DeriveDataTypeable, StandaloneDeriving
 
 Executable rtk
   Import:            warnings
   Main-is:           main.hs
   Hs-Source-Dirs:    app
-  Build-Depends:     base >= 4.7 && < 5, rtk
+  Build-Depends:     base >= 4.17 && < 4.19, rtk
   ghc-options:       -rtsopts
 
 -- In-process tests of the generation pipeline (lex/parse/normalize/generate).
@@ -68,7 +90,13 @@ Test-Suite unit
   Main-Is:           UnitTests.hs
   Hs-Source-Dirs:    test
   Other-Modules:     TestSupport
-  Build-Depends:     base >= 4.7 && < 5, rtk, HUnit, containers, directory, filepath
+  Build-Depends:
+                     base       >= 4.17 && < 4.19,
+                     rtk,
+                     HUnit      >= 1.6  && < 1.7,
+                     containers >= 0.6  && < 0.7,
+                     directory  >= 1.3  && < 1.4,
+                     filepath   >= 1.4  && < 1.6
 
 -- Golden tests: generated .x/.y/QQ.hs output for every grammar under
 -- test-grammars/ is compared against snapshots in test/golden/.
@@ -80,4 +108,9 @@ Test-Suite golden
   Main-Is:           GoldenTests.hs
   Hs-Source-Dirs:    test
   Other-Modules:     TestSupport
-  Build-Depends:     base >= 4.7 && < 5, rtk, HUnit, directory, filepath
+  Build-Depends:
+                     base       >= 4.17 && < 4.19,
+                     rtk,
+                     HUnit      >= 1.6  && < 1.7,
+                     directory  >= 1.3  && < 1.4,
+                     filepath   >= 1.4  && < 1.6


### PR DESCRIPTION
## Summary

This PR improves Hackage packaging hygiene by adding explicit PVP (Package Versioning Policy) version bounds to all dependencies, documenting the packages required by RTK-generated code, and updating the tested GHC versions.

## Key Changes

- **Version bounds**: Added specific PVP-compliant version ranges for all dependencies in the library, executables, and test suites
  - Base: `>= 4.17 && < 4.19` (GHC 9.4.7 and 9.6.4)
  - All other dependencies pinned to specific minor versions
  - Build tools (alex, happy) pinned to compatible versions with CI

- **Documentation**: Updated README with a new "Using the generated code" section explaining which packages are required by generated lexers, parsers, and quasi-quoters

- **Cabal metadata**: 
  - Expanded package description to list runtime dependencies
  - Updated `Tested-With` to include both GHC 9.4.7 and 9.6.4
  - Added comment explaining build tool version pinning strategy

- **CHANGELOG**: Documented these packaging improvements in the Unreleased section

## Implementation Details

The version bounds were carefully chosen to match the actual versions used in development and CI (as noted in `.github/workflows/ci.yml`). The README now clearly distinguishes between minimal dependencies (array + syb for lexer/parser only) and full dependencies (including containers, template-haskell, regex-posix, regex-base for quasi-quotation support).

This makes it easier for users to understand what their projects need to depend on when using RTK-generated code.

https://claude.ai/code/session_01TDF4kUQFuFGyof6gNmaoYZ