### PR TITLE
Add $$ escape for literal $ in quasi-quote bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- A `$$` escape in quasi-quote bodies: `$$name` now produces the literal
+  text `$name` instead of being rewritten as a metavariable (or rejected).
+  Previously the generated quasi-quoter rewrote `$ident` everywhere in a
+  quote body — including inside the quoted language's own string literals —
+  mangling programs. Each `$$` pair directly before a metavariable stands
+  for one literal `$` (so `$$$x` is a literal `$` followed by the
+  metavariable `$x`). The unknown-metavariable error now names the
+  offending `$name`, lists the known shortcuts and points at the `$$`
+  escape (see `docs/why-qq-limitations.md`)
 - Hackage packaging hygiene: PVP version bounds on all dependencies and on
   the `alex`/`happy` build tools, `Tested-With` now lists GHC 9.4.7 and
   9.6.4 (the versions actually exercised locally and in CI), and the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   printed an error
 
 ### Fixed
+- `'\f'` and `'\v'` escapes in grammar string and `[...]` regex literals now
+  reach the generated lexer as bare Alex escapes; previously token
+  post-processing (`unBackQuote`) stripped them to the literal letters
+  `f`/`v` even though `GenX.isAlexEscape` was ready to emit them, so the two
+  escape sets disagreed. The preserved set (`\n \t \r \f \v`) is now pinned
+  to `isAlexEscape` by a unit test
 - `test-grammars/haskell.pg` is self-consistent again: minimal `Pat` and
   `QOp` rules were added for the previously dangling references, so RTK
   generation no longer aborts on it (progress on issue #30; the grammar is

--- a/GenQ.hs
+++ b/GenQ.hs
@@ -41,17 +41,33 @@ qqPattern = "\\$[A-Za-z_][A-Za-z_0-9]*[^A-Za-z_0-9:]"
 
 qqShortcuts :: M.Map String String
 
+-- A $name metavariable is rewritten to $Type:name using the qqShortcuts
+-- table below. The rewrite is purely textual, so it would also fire inside
+-- the quoted language's own string literals: write $$name there to escape
+-- it and get the literal text $name. Each '$$' pair directly before a
+-- metavariable stands for one literal '$' (so $$$x is a literal '$'
+-- followed by the metavariable $x). A '$' not followed by an identifier is
+-- never rewritten and needs no escape.
 replaceAllPatterns1 :: String -> String
 replaceAllPatterns1 str = let (pre, match, post) = str =~ qqPattern :: (String, String, String)
                           in if match == ""
                               then pre
                               else let varName = init $ tail match
                                        addSym = last match
+                                       escCount = length $ takeWhile (== '$') $ reverse pre
+                                       keptPre = take (length pre - escCount) pre ++ replicate (div escCount 2) '$'
                                        ruleVariants = catMaybes $ map (\ prefix -> M.lookup prefix qqShortcuts) $ reverse $ inits varName
                                        rule = case ruleVariants of
-                                                [] -> error $ "Unknown shortcut for " ++ varName
+                                                [] -> error $ unlines
+                                                        [ "Unknown metavariable $" ++ varName ++ " in quasi-quote:"
+                                                        , "no prefix of '" ++ varName ++ "' is a known shortcut. Known shortcuts:"
+                                                        , "  " ++ intercalate ", " (M.keys qqShortcuts)
+                                                        , "To include the literal text $" ++ varName ++ " in the quoted code"
+                                                        , "(e.g. inside a string literal), escape it as $$" ++ varName ++ "." ]
                                                 (rule : _) -> rule
-                                   in pre ++ ('$' : rule ++ ":") ++ varName ++ (replaceAllPatterns1 $ addSym : post)
+                                   in if odd escCount
+                                       then keptPre ++ ('$' : varName) ++ (replaceAllPatterns1 $ addSym : post)
+                                       else keptPre ++ ('$' : rule ++ ":") ++ varName ++ (replaceAllPatterns1 $ addSym : post)
 
 -- Add ' ' at the end, so regex can match variable in the end of the string
 replaceAllPatterns :: String -> String

--- a/GenX.hs
+++ b/GenX.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE QuasiQuotes #-}
-module GenX (genX)
+module GenX (genX, isAlexEscape)
     where
 
 import Parser
@@ -176,6 +176,8 @@ translateClauseForMacro rname cl = lexErr rname $ "cannot translate clause to a 
 -- Detect Alex escape sequences that should be output as bare escapes, not quoted strings.
 -- In Alex: "\n" = literal backslash+n, but \n = newline character.
 -- When grammar has '\n', we want to generate \n (the escape), not "\n" (literal).
+-- This set must stay identical to the escapes TokenProcessing.unBackQuote
+-- preserves, or escapes get silently stripped before they reach this point.
 isAlexEscape :: String -> Bool
 isAlexEscape "\\n" = True   -- newline
 isAlexEscape "\\t" = True   -- tab

--- a/TokenProcessing.hs
+++ b/TokenProcessing.hs
@@ -21,12 +21,15 @@ processEscapesTok (RegExpLit s) = RegExpLit (unBackQuote s)
 processEscapesTok tok = tok
 
 -- | Handle backslash escape sequences
--- Preserves \\n, \\t, \\r as-is (for grammar rules)
+-- Preserves \\n, \\t, \\r, \\f, \\v as-is (for grammar rules); this must stay
+-- exactly the set that GenX.isAlexEscape emits bare into the generated lexer
 -- Removes backslash from other escaped characters
 unBackQuote :: String -> String
 unBackQuote ('\\':'n':xs) = '\\':'n' : unBackQuote xs
 unBackQuote ('\\':'t':xs) = '\\':'t' : unBackQuote xs
 unBackQuote ('\\':'r':xs) = '\\':'r' : unBackQuote xs
+unBackQuote ('\\':'f':xs) = '\\':'f' : unBackQuote xs
+unBackQuote ('\\':'v':xs) = '\\':'v' : unBackQuote xs
 unBackQuote ('\\':c:xs) = c : unBackQuote xs
 unBackQuote (c:xs) = c : unBackQuote xs
 unBackQuote [] = []

--- a/docs/why-qq-limitations.md
+++ b/docs/why-qq-limitations.md
@@ -45,7 +45,9 @@ From `GenQ.hs`:
          ruleVariants = catMaybes $ map (\ prefix -> M.lookup prefix qqShortcuts)
                                         $ reverse $ inits varName
          rule = case ruleVariants of
-                  [] -> error $ "Unknown shortcut for " ++ varName
+                  [] -> error ...  -- unknown metavariable: the error names it,
+                                   -- lists the known shortcuts and suggests the
+                                   -- $$ escape (see below)
                   (rule : _) -> rule
      in pre ++ ('$' : rule ++ ":") ++ varName ++ ...
    ```
@@ -62,6 +64,39 @@ The Java grammar's parser expects specific token sequences. When quasi-quotation
 - After substitution: `$Expression:expression1 + $Expression:expression2`
 - Tokens generated: `[..., Tk__tok__plus__72, Tk__qq_Expression188 "expression2", ...]`
 - Parser sees unexpected token sequence and fails
+
+## Literal `$` in Quoted Text: the `$$` Escape
+
+`replaceAllPatterns` is purely textual — it knows nothing about the quoted
+language's lexical structure. Every `$name` in the quote body is rewritten
+(or rejected with the unknown-metavariable error), **including occurrences
+inside the quoted language's own string literals**, and in languages where
+`$` is a legal identifier character (like Java) real identifiers can look
+like metavariables.
+
+To include the literal text `$name` in quoted code, escape it as `$$name`:
+
+```haskell
+-- the Java string contains a literal "$total"; no rewrite happens
+let e = [expression| "price: $$total" |]
+```
+
+The rules:
+
+- `$$name` produces the literal text `$name` (no metavariable rewrite).
+- Each `$$` pair directly before a metavariable stands for one literal `$`,
+  so `$$$x` is a literal `$` followed by the metavariable `$x`.
+- A `$` that is *not* followed by an identifier character is never rewritten
+  and needs no escape (`"cost: $"` is fine as-is).
+- A `$name` whose name has no known shortcut prefix aborts quote expansion
+  with an error that names the metavariable, lists the known shortcuts, and
+  points at the `$$` escape.
+
+Why not skip rewriting inside string literals automatically? String syntax
+is per-language: the preprocessor would need to know how each quoted
+grammar tokenizes strings (quoting style, escape rules, nesting), and any
+built-in heuristic would silently do the wrong thing for some grammars. The
+explicit `$$` escape is unambiguous in every grammar.
 
 ## Why It Works for P Language
 

--- a/test-grammars/java-qq-test.hs
+++ b/test-grammars/java-qq-test.hs
@@ -5,6 +5,7 @@
 
 import qualified JavaQQ as J
 import qualified JavaParser as JP
+import Data.List (isInfixOf)
 import Text.Show.Pretty (ppShow)
 
 main :: IO ()
@@ -19,6 +20,8 @@ main = do
     testSplicing
     putStrLn ""
     testPatternMatching
+    putStrLn ""
+    testDollarEscape
     putStrLn ""
 
     putStrLn "=========================================================="
@@ -211,6 +214,42 @@ testPatternMatching = do
     putStrLn ""
 
     putStrLn "Pattern matching tests: ALL PASSED ✅"
+
+-- ========== PART 4: Literal '$' ($$ escape) Tests ==========
+testDollarEscape :: IO ()
+testDollarEscape = do
+    putStrLn "========== PART 4: Literal '$' ($$ escape) Tests =========="
+    putStrLn ""
+    putStrLn "$$name in a quote body escapes metavariable rewriting and"
+    putStrLn "produces the literal text $name - needed for '$' inside the"
+    putStrLn "quoted language's string literals."
+    putStrLn ""
+
+    putStrLn "--- Test: $$ inside a quoted Java string literal ---"
+    let priceExpr = [J.expression| "price: $$total" |]
+    expectInAST "string literal round-trips with a literal $total"
+                "price: $total" (ppShow priceExpr)
+
+    putStrLn "--- Test: $$ escape next to a real splice ---"
+    let x = [J.expression| x |]
+    let mixed = [J.expression| $Expression:x + "cost: $$amount" |]
+    expectInAST "string keeps the literal $amount while $Expression:x splices"
+                "cost: $amount" (ppShow mixed)
+
+    putStrLn ""
+    putStrLn "Dollar-escape tests: ALL PASSED ✅"
+
+-- Unlike the informational checks above, a wrong AST here must fail the
+-- test binary (and with it `make test-java-qq`), so mismatches are fatal.
+expectInAST :: String -> String -> String -> IO ()
+expectInAST what needle shown
+    | not (needle `isInfixOf` shown) =
+        error $ "FAILED: " ++ what ++ ": expected " ++ show needle
+              ++ " in the AST:\n" ++ shown
+    | "$$" `isInfixOf` shown =
+        error $ "FAILED: " ++ what ++ ": the $$ escape was not collapsed"
+              ++ " to a single $ in the AST:\n" ++ shown
+    | otherwise = putStrLn $ "✅ " ++ what
 
 {-
 TEST SUMMARY:

--- a/test/UnitTests.hs
+++ b/test/UnitTests.hs
@@ -19,6 +19,7 @@ import System.FilePath (takeBaseName)
 import Test.HUnit
 
 import Diagnostics (Diagnostic (..), SourcePos (..), renderDiagnostic)
+import GenX (isAlexEscape)
 import Grammar (isClauseSeqLifted)
 import Lexer (AlexPosn (..), PosToken (..), Token (..))
 import Normalize (fillConstructorNames, normalizeTopLevelClauses)
@@ -78,8 +79,14 @@ tokenProcessingTests :: Test
 tokenProcessingTests = TestList
     [ TestLabel "unBackQuote strips escaping backslashes" $ TestCase $
         assertEqual "" "a'b" (unBackQuote "a\\'b")
-    , TestLabel "unBackQuote keeps \\n \\t \\r escapes" $ TestCase $
-        assertEqual "" "\\n\\t\\r" (unBackQuote "\\n\\t\\r")
+    , TestLabel "unBackQuote keeps \\n \\t \\r \\f \\v escapes" $ TestCase $
+        assertEqual "" "\\n\\t\\r\\f\\v" (unBackQuote "\\n\\t\\r\\f\\v")
+    , TestLabel "preserved escapes are exactly the ones GenX emits bare" $ TestCase $
+        mapM_ (\c -> do
+            let esc = ['\\', c]
+            assertEqual ("unBackQuote preserves " ++ esc) esc (unBackQuote esc)
+            assertBool ("GenX.isAlexEscape recognizes " ++ esc) (isAlexEscape esc))
+          "ntrfv"
     , TestLabel "unBackQuote unescapes backslash itself" $ TestCase $
         assertEqual "" "\\" (unBackQuote "\\\\")
     , TestLabel "catBigstrs joins adjacent big strings" $ TestCase $
@@ -92,7 +99,23 @@ tokenProcessingTests = TestList
     , TestLabel "processTokens combines both steps" $ TestCase $
         assertEqual "" (map at [StrLit "'", BigStr "a\nb"])
                        (processTokens (map at [StrLit "\\'", BigStr "a", BigStr "b"]))
+    , TestLabel "a '\\f' keyword survives to the generated lexer" testFormFeedReachesLexer
     ]
+
+-- | End-to-end: a '\f' keyword must reach the generated Alex spec as the bare
+-- \f escape (neither stripped to a literal 'f' nor quoted as "\f", which Alex
+-- would read as backslash + 'f').
+testFormFeedReachesLexer :: Test
+testFormFeedReachesLexer = TestCase $
+    case normalizeGrammarSource "grammar 'Esc';\nS = '\\f' ;\n" >>= artifactsFor of
+        Left d -> assertFailure $ "generation failed: " ++ show d
+        Right artifacts -> case lookup "EscLexer.x" artifacts of
+            Nothing -> assertFailure "no EscLexer.x artifact generated"
+            Just lexerSpec -> do
+                assertBool "lexer spec contains the bare \\f escape"
+                    ("\\f" `isInfixOf` lexerSpec)
+                assertBool "\\f is not emitted as a quoted string literal"
+                    (not ("\"\\f\"" `isInfixOf` lexerSpec))
 
 -- | Wrap a token at a dummy position; token processing ignores positions.
 at :: Token -> PosToken

--- a/test/golden/debug-test/DebugTestQQ.hs
+++ b/test/golden/debug-test/DebugTestQQ.hs
@@ -18,17 +18,33 @@ qqPattern = "\\$[A-Za-z_][A-Za-z_0-9]*[^A-Za-z_0-9:]"
 
 qqShortcuts :: M.Map String String
 
+-- A $name metavariable is rewritten to $Type:name using the qqShortcuts
+-- table below. The rewrite is purely textual, so it would also fire inside
+-- the quoted language's own string literals: write $$name there to escape
+-- it and get the literal text $name. Each '$$' pair directly before a
+-- metavariable stands for one literal '$' (so $$$x is a literal '$'
+-- followed by the metavariable $x). A '$' not followed by an identifier is
+-- never rewritten and needs no escape.
 replaceAllPatterns1 :: String -> String
 replaceAllPatterns1 str = let (pre, match, post) = str =~ qqPattern :: (String, String, String)
                           in if match == ""
                               then pre
                               else let varName = init $ tail match
                                        addSym = last match
+                                       escCount = length $ takeWhile (== '$') $ reverse pre
+                                       keptPre = take (length pre - escCount) pre ++ replicate (div escCount 2) '$'
                                        ruleVariants = catMaybes $ map (\ prefix -> M.lookup prefix qqShortcuts) $ reverse $ inits varName
                                        rule = case ruleVariants of
-                                                [] -> error $ "Unknown shortcut for " ++ varName
+                                                [] -> error $ unlines
+                                                        [ "Unknown metavariable $" ++ varName ++ " in quasi-quote:"
+                                                        , "no prefix of '" ++ varName ++ "' is a known shortcut. Known shortcuts:"
+                                                        , "  " ++ intercalate ", " (M.keys qqShortcuts)
+                                                        , "To include the literal text $" ++ varName ++ " in the quoted code"
+                                                        , "(e.g. inside a string literal), escape it as $$" ++ varName ++ "." ]
                                                 (rule : _) -> rule
-                                   in pre ++ ('$' : rule ++ ":") ++ varName ++ (replaceAllPatterns1 $ addSym : post)
+                                   in if odd escCount
+                                       then keptPre ++ ('$' : varName) ++ (replaceAllPatterns1 $ addSym : post)
+                                       else keptPre ++ ('$' : rule ++ ":") ++ varName ++ (replaceAllPatterns1 $ addSym : post)
 
 -- Add ' ' at the end, so regex can match variable in the end of the string
 replaceAllPatterns :: String -> String

--- a/test/golden/grammar/GrammarQQ.hs
+++ b/test/golden/grammar/GrammarQQ.hs
@@ -18,17 +18,33 @@ qqPattern = "\\$[A-Za-z_][A-Za-z_0-9]*[^A-Za-z_0-9:]"
 
 qqShortcuts :: M.Map String String
 
+-- A $name metavariable is rewritten to $Type:name using the qqShortcuts
+-- table below. The rewrite is purely textual, so it would also fire inside
+-- the quoted language's own string literals: write $$name there to escape
+-- it and get the literal text $name. Each '$$' pair directly before a
+-- metavariable stands for one literal '$' (so $$$x is a literal '$'
+-- followed by the metavariable $x). A '$' not followed by an identifier is
+-- never rewritten and needs no escape.
 replaceAllPatterns1 :: String -> String
 replaceAllPatterns1 str = let (pre, match, post) = str =~ qqPattern :: (String, String, String)
                           in if match == ""
                               then pre
                               else let varName = init $ tail match
                                        addSym = last match
+                                       escCount = length $ takeWhile (== '$') $ reverse pre
+                                       keptPre = take (length pre - escCount) pre ++ replicate (div escCount 2) '$'
                                        ruleVariants = catMaybes $ map (\ prefix -> M.lookup prefix qqShortcuts) $ reverse $ inits varName
                                        rule = case ruleVariants of
-                                                [] -> error $ "Unknown shortcut for " ++ varName
+                                                [] -> error $ unlines
+                                                        [ "Unknown metavariable $" ++ varName ++ " in quasi-quote:"
+                                                        , "no prefix of '" ++ varName ++ "' is a known shortcut. Known shortcuts:"
+                                                        , "  " ++ intercalate ", " (M.keys qqShortcuts)
+                                                        , "To include the literal text $" ++ varName ++ " in the quoted code"
+                                                        , "(e.g. inside a string literal), escape it as $$" ++ varName ++ "." ]
                                                 (rule : _) -> rule
-                                   in pre ++ ('$' : rule ++ ":") ++ varName ++ (replaceAllPatterns1 $ addSym : post)
+                                   in if odd escCount
+                                       then keptPre ++ ('$' : varName) ++ (replaceAllPatterns1 $ addSym : post)
+                                       else keptPre ++ ('$' : rule ++ ":") ++ varName ++ (replaceAllPatterns1 $ addSym : post)
 
 -- Add ' ' at the end, so regex can match variable in the end of the string
 replaceAllPatterns :: String -> String

--- a/test/golden/haskell/HaskellQQ.hs
+++ b/test/golden/haskell/HaskellQQ.hs
@@ -18,17 +18,33 @@ qqPattern = "\\$[A-Za-z_][A-Za-z_0-9]*[^A-Za-z_0-9:]"
 
 qqShortcuts :: M.Map String String
 
+-- A $name metavariable is rewritten to $Type:name using the qqShortcuts
+-- table below. The rewrite is purely textual, so it would also fire inside
+-- the quoted language's own string literals: write $$name there to escape
+-- it and get the literal text $name. Each '$$' pair directly before a
+-- metavariable stands for one literal '$' (so $$$x is a literal '$'
+-- followed by the metavariable $x). A '$' not followed by an identifier is
+-- never rewritten and needs no escape.
 replaceAllPatterns1 :: String -> String
 replaceAllPatterns1 str = let (pre, match, post) = str =~ qqPattern :: (String, String, String)
                           in if match == ""
                               then pre
                               else let varName = init $ tail match
                                        addSym = last match
+                                       escCount = length $ takeWhile (== '$') $ reverse pre
+                                       keptPre = take (length pre - escCount) pre ++ replicate (div escCount 2) '$'
                                        ruleVariants = catMaybes $ map (\ prefix -> M.lookup prefix qqShortcuts) $ reverse $ inits varName
                                        rule = case ruleVariants of
-                                                [] -> error $ "Unknown shortcut for " ++ varName
+                                                [] -> error $ unlines
+                                                        [ "Unknown metavariable $" ++ varName ++ " in quasi-quote:"
+                                                        , "no prefix of '" ++ varName ++ "' is a known shortcut. Known shortcuts:"
+                                                        , "  " ++ intercalate ", " (M.keys qqShortcuts)
+                                                        , "To include the literal text $" ++ varName ++ " in the quoted code"
+                                                        , "(e.g. inside a string literal), escape it as $$" ++ varName ++ "." ]
                                                 (rule : _) -> rule
-                                   in pre ++ ('$' : rule ++ ":") ++ varName ++ (replaceAllPatterns1 $ addSym : post)
+                                   in if odd escCount
+                                       then keptPre ++ ('$' : varName) ++ (replaceAllPatterns1 $ addSym : post)
+                                       else keptPre ++ ('$' : rule ++ ":") ++ varName ++ (replaceAllPatterns1 $ addSym : post)
 
 -- Add ' ' at the end, so regex can match variable in the end of the string
 replaceAllPatterns :: String -> String

--- a/test/golden/java-simple/JavaSimpleQQ.hs
+++ b/test/golden/java-simple/JavaSimpleQQ.hs
@@ -18,17 +18,33 @@ qqPattern = "\\$[A-Za-z_][A-Za-z_0-9]*[^A-Za-z_0-9:]"
 
 qqShortcuts :: M.Map String String
 
+-- A $name metavariable is rewritten to $Type:name using the qqShortcuts
+-- table below. The rewrite is purely textual, so it would also fire inside
+-- the quoted language's own string literals: write $$name there to escape
+-- it and get the literal text $name. Each '$$' pair directly before a
+-- metavariable stands for one literal '$' (so $$$x is a literal '$'
+-- followed by the metavariable $x). A '$' not followed by an identifier is
+-- never rewritten and needs no escape.
 replaceAllPatterns1 :: String -> String
 replaceAllPatterns1 str = let (pre, match, post) = str =~ qqPattern :: (String, String, String)
                           in if match == ""
                               then pre
                               else let varName = init $ tail match
                                        addSym = last match
+                                       escCount = length $ takeWhile (== '$') $ reverse pre
+                                       keptPre = take (length pre - escCount) pre ++ replicate (div escCount 2) '$'
                                        ruleVariants = catMaybes $ map (\ prefix -> M.lookup prefix qqShortcuts) $ reverse $ inits varName
                                        rule = case ruleVariants of
-                                                [] -> error $ "Unknown shortcut for " ++ varName
+                                                [] -> error $ unlines
+                                                        [ "Unknown metavariable $" ++ varName ++ " in quasi-quote:"
+                                                        , "no prefix of '" ++ varName ++ "' is a known shortcut. Known shortcuts:"
+                                                        , "  " ++ intercalate ", " (M.keys qqShortcuts)
+                                                        , "To include the literal text $" ++ varName ++ " in the quoted code"
+                                                        , "(e.g. inside a string literal), escape it as $$" ++ varName ++ "." ]
                                                 (rule : _) -> rule
-                                   in pre ++ ('$' : rule ++ ":") ++ varName ++ (replaceAllPatterns1 $ addSym : post)
+                                   in if odd escCount
+                                       then keptPre ++ ('$' : varName) ++ (replaceAllPatterns1 $ addSym : post)
+                                       else keptPre ++ ('$' : rule ++ ":") ++ varName ++ (replaceAllPatterns1 $ addSym : post)
 
 -- Add ' ' at the end, so regex can match variable in the end of the string
 replaceAllPatterns :: String -> String

--- a/test/golden/java/JavaQQ.hs
+++ b/test/golden/java/JavaQQ.hs
@@ -18,17 +18,33 @@ qqPattern = "\\$[A-Za-z_][A-Za-z_0-9]*[^A-Za-z_0-9:]"
 
 qqShortcuts :: M.Map String String
 
+-- A $name metavariable is rewritten to $Type:name using the qqShortcuts
+-- table below. The rewrite is purely textual, so it would also fire inside
+-- the quoted language's own string literals: write $$name there to escape
+-- it and get the literal text $name. Each '$$' pair directly before a
+-- metavariable stands for one literal '$' (so $$$x is a literal '$'
+-- followed by the metavariable $x). A '$' not followed by an identifier is
+-- never rewritten and needs no escape.
 replaceAllPatterns1 :: String -> String
 replaceAllPatterns1 str = let (pre, match, post) = str =~ qqPattern :: (String, String, String)
                           in if match == ""
                               then pre
                               else let varName = init $ tail match
                                        addSym = last match
+                                       escCount = length $ takeWhile (== '$') $ reverse pre
+                                       keptPre = take (length pre - escCount) pre ++ replicate (div escCount 2) '$'
                                        ruleVariants = catMaybes $ map (\ prefix -> M.lookup prefix qqShortcuts) $ reverse $ inits varName
                                        rule = case ruleVariants of
-                                                [] -> error $ "Unknown shortcut for " ++ varName
+                                                [] -> error $ unlines
+                                                        [ "Unknown metavariable $" ++ varName ++ " in quasi-quote:"
+                                                        , "no prefix of '" ++ varName ++ "' is a known shortcut. Known shortcuts:"
+                                                        , "  " ++ intercalate ", " (M.keys qqShortcuts)
+                                                        , "To include the literal text $" ++ varName ++ " in the quoted code"
+                                                        , "(e.g. inside a string literal), escape it as $$" ++ varName ++ "." ]
                                                 (rule : _) -> rule
-                                   in pre ++ ('$' : rule ++ ":") ++ varName ++ (replaceAllPatterns1 $ addSym : post)
+                                   in if odd escCount
+                                       then keptPre ++ ('$' : varName) ++ (replaceAllPatterns1 $ addSym : post)
+                                       else keptPre ++ ('$' : rule ++ ":") ++ varName ++ (replaceAllPatterns1 $ addSym : post)
 
 -- Add ' ' at the end, so regex can match variable in the end of the string
 replaceAllPatterns :: String -> String

--- a/test/golden/p/PQQ.hs
+++ b/test/golden/p/PQQ.hs
@@ -18,17 +18,33 @@ qqPattern = "\\$[A-Za-z_][A-Za-z_0-9]*[^A-Za-z_0-9:]"
 
 qqShortcuts :: M.Map String String
 
+-- A $name metavariable is rewritten to $Type:name using the qqShortcuts
+-- table below. The rewrite is purely textual, so it would also fire inside
+-- the quoted language's own string literals: write $$name there to escape
+-- it and get the literal text $name. Each '$$' pair directly before a
+-- metavariable stands for one literal '$' (so $$$x is a literal '$'
+-- followed by the metavariable $x). A '$' not followed by an identifier is
+-- never rewritten and needs no escape.
 replaceAllPatterns1 :: String -> String
 replaceAllPatterns1 str = let (pre, match, post) = str =~ qqPattern :: (String, String, String)
                           in if match == ""
                               then pre
                               else let varName = init $ tail match
                                        addSym = last match
+                                       escCount = length $ takeWhile (== '$') $ reverse pre
+                                       keptPre = take (length pre - escCount) pre ++ replicate (div escCount 2) '$'
                                        ruleVariants = catMaybes $ map (\ prefix -> M.lookup prefix qqShortcuts) $ reverse $ inits varName
                                        rule = case ruleVariants of
-                                                [] -> error $ "Unknown shortcut for " ++ varName
+                                                [] -> error $ unlines
+                                                        [ "Unknown metavariable $" ++ varName ++ " in quasi-quote:"
+                                                        , "no prefix of '" ++ varName ++ "' is a known shortcut. Known shortcuts:"
+                                                        , "  " ++ intercalate ", " (M.keys qqShortcuts)
+                                                        , "To include the literal text $" ++ varName ++ " in the quoted code"
+                                                        , "(e.g. inside a string literal), escape it as $$" ++ varName ++ "." ]
                                                 (rule : _) -> rule
-                                   in pre ++ ('$' : rule ++ ":") ++ varName ++ (replaceAllPatterns1 $ addSym : post)
+                                   in if odd escCount
+                                       then keptPre ++ ('$' : varName) ++ (replaceAllPatterns1 $ addSym : post)
+                                       else keptPre ++ ('$' : rule ++ ":") ++ varName ++ (replaceAllPatterns1 $ addSym : post)
 
 -- Add ' ' at the end, so regex can match variable in the end of the string
 replaceAllPatterns :: String -> String

--- a/test/golden/sandbox/SandboxQQ.hs
+++ b/test/golden/sandbox/SandboxQQ.hs
@@ -18,17 +18,33 @@ qqPattern = "\\$[A-Za-z_][A-Za-z_0-9]*[^A-Za-z_0-9:]"
 
 qqShortcuts :: M.Map String String
 
+-- A $name metavariable is rewritten to $Type:name using the qqShortcuts
+-- table below. The rewrite is purely textual, so it would also fire inside
+-- the quoted language's own string literals: write $$name there to escape
+-- it and get the literal text $name. Each '$$' pair directly before a
+-- metavariable stands for one literal '$' (so $$$x is a literal '$'
+-- followed by the metavariable $x). A '$' not followed by an identifier is
+-- never rewritten and needs no escape.
 replaceAllPatterns1 :: String -> String
 replaceAllPatterns1 str = let (pre, match, post) = str =~ qqPattern :: (String, String, String)
                           in if match == ""
                               then pre
                               else let varName = init $ tail match
                                        addSym = last match
+                                       escCount = length $ takeWhile (== '$') $ reverse pre
+                                       keptPre = take (length pre - escCount) pre ++ replicate (div escCount 2) '$'
                                        ruleVariants = catMaybes $ map (\ prefix -> M.lookup prefix qqShortcuts) $ reverse $ inits varName
                                        rule = case ruleVariants of
-                                                [] -> error $ "Unknown shortcut for " ++ varName
+                                                [] -> error $ unlines
+                                                        [ "Unknown metavariable $" ++ varName ++ " in quasi-quote:"
+                                                        , "no prefix of '" ++ varName ++ "' is a known shortcut. Known shortcuts:"
+                                                        , "  " ++ intercalate ", " (M.keys qqShortcuts)
+                                                        , "To include the literal text $" ++ varName ++ " in the quoted code"
+                                                        , "(e.g. inside a string literal), escape it as $$" ++ varName ++ "." ]
                                                 (rule : _) -> rule
-                                   in pre ++ ('$' : rule ++ ":") ++ varName ++ (replaceAllPatterns1 $ addSym : post)
+                                   in if odd escCount
+                                       then keptPre ++ ('$' : varName) ++ (replaceAllPatterns1 $ addSym : post)
+                                       else keptPre ++ ('$' : rule ++ ":") ++ varName ++ (replaceAllPatterns1 $ addSym : post)
 
 -- Add ' ' at the end, so regex can match variable in the end of the string
 replaceAllPatterns :: String -> String

--- a/test/golden/t1/T1QQ.hs
+++ b/test/golden/t1/T1QQ.hs
@@ -18,17 +18,33 @@ qqPattern = "\\$[A-Za-z_][A-Za-z_0-9]*[^A-Za-z_0-9:]"
 
 qqShortcuts :: M.Map String String
 
+-- A $name metavariable is rewritten to $Type:name using the qqShortcuts
+-- table below. The rewrite is purely textual, so it would also fire inside
+-- the quoted language's own string literals: write $$name there to escape
+-- it and get the literal text $name. Each '$$' pair directly before a
+-- metavariable stands for one literal '$' (so $$$x is a literal '$'
+-- followed by the metavariable $x). A '$' not followed by an identifier is
+-- never rewritten and needs no escape.
 replaceAllPatterns1 :: String -> String
 replaceAllPatterns1 str = let (pre, match, post) = str =~ qqPattern :: (String, String, String)
                           in if match == ""
                               then pre
                               else let varName = init $ tail match
                                        addSym = last match
+                                       escCount = length $ takeWhile (== '$') $ reverse pre
+                                       keptPre = take (length pre - escCount) pre ++ replicate (div escCount 2) '$'
                                        ruleVariants = catMaybes $ map (\ prefix -> M.lookup prefix qqShortcuts) $ reverse $ inits varName
                                        rule = case ruleVariants of
-                                                [] -> error $ "Unknown shortcut for " ++ varName
+                                                [] -> error $ unlines
+                                                        [ "Unknown metavariable $" ++ varName ++ " in quasi-quote:"
+                                                        , "no prefix of '" ++ varName ++ "' is a known shortcut. Known shortcuts:"
+                                                        , "  " ++ intercalate ", " (M.keys qqShortcuts)
+                                                        , "To include the literal text $" ++ varName ++ " in the quoted code"
+                                                        , "(e.g. inside a string literal), escape it as $$" ++ varName ++ "." ]
                                                 (rule : _) -> rule
-                                   in pre ++ ('$' : rule ++ ":") ++ varName ++ (replaceAllPatterns1 $ addSym : post)
+                                   in if odd escCount
+                                       then keptPre ++ ('$' : varName) ++ (replaceAllPatterns1 $ addSym : post)
+                                       else keptPre ++ ('$' : rule ++ ":") ++ varName ++ (replaceAllPatterns1 $ addSym : post)
 
 -- Add ' ' at the end, so regex can match variable in the end of the string
 replaceAllPatterns :: String -> String


### PR DESCRIPTION
## Summary

Implement a `$$` escape mechanism in quasi-quote bodies to allow literal `$` characters in quoted code. Previously, the quasi-quoter rewrote all `$ident` patterns everywhere in a quote body—including inside the quoted language's own string literals—which mangled programs that needed literal dollar signs. Now `$$name` produces the literal text `$name` instead of being rewritten as a metavariable.

## Key Changes

- **Quasi-quoter escape logic** (`GenQ.hs`): Modified `replaceAllPatterns1` to detect and handle `$$` escape sequences. Each `$$` pair directly before a metavariable stands for one literal `$` (so `$$$x` is a literal `$` followed by the metavariable `$x`). A `$` not followed by an identifier character is never rewritten and needs no escape.

- **Error messages**: Enhanced the unknown-metavariable error to name the offending `$name`, list all known shortcuts, and point users to the `$$` escape as a solution.

- **Documentation** (`docs/why-qq-limitations.md`): Added comprehensive section explaining the `$$` escape, its rules, and why automatic string-literal detection is not feasible.

- **Test coverage** (`test-grammars/java-qq-test.hs`): Added `testDollarEscape` test suite with two test cases:
  - `$$name` inside a quoted Java string literal produces literal `$name`
  - `$$` escape works correctly alongside real splices (e.g., `$Expression:x`)
  - New `expectInAST` helper validates that the escape was properly collapsed and no `$$` remains in the AST

- **Escape sequence consistency** (`TokenProcessing.hs`, `GenX.hs`, `test/UnitTests.hs`): Fixed a latent bug where `\f` (form feed) and `\v` (vertical tab) escapes in grammar string and regex literals were being stripped to literal `f`/`v` by `unBackQuote`, even though `GenX.isAlexEscape` was ready to emit them bare into the generated lexer. Updated `unBackQuote` to preserve both escapes, and added a unit test (`testFormFeedReachesLexer`) to ensure they reach the generated Alex spec as bare escapes, not quoted strings.

- **Generated quasi-quoters**: Updated all golden test quasi-quoter files to include the new escape logic and improved error messages.

- **Changelog**: Documented the new feature and the escape sequence fix.

## Implementation Details

The escape detection works by counting consecutive `$` characters before a metavariable match:
- If the count is odd, the last `$` is part of the escape sequence, so we output `(count-1)/2` literal `$` characters and the unescaped metavariable name
- If the count is even, we output `count/2` literal `$` characters and proceed with normal metavariable rewriting

This approach is unambiguous in every grammar and requires no language-specific knowledge of string syntax.

https://claude.ai/code/session_014PJY1KVqqzjG89UyKL4c9T