### PR TITLE
Fix Java implements clause to support multiple interfaces

### DIFF
--- a/makefile
+++ b/makefile
@@ -114,7 +114,7 @@ $(foreach grammar,$(GRAMMARS),$(eval $(call make-grammar-rule,$(grammar))))
 # ============================================================================
 
 # Generic rule to copy main files
-test-out/%-main.hs: test-grammars/%-main.hs
+test-out/%-main.hs: test-grammars/%-main.hs | test-out
 	$(CP) test-grammars/$*-main.hs test-out
 
 # Generic test rule - requires main file and test data to be defined
@@ -162,6 +162,7 @@ $(eval $(call make-shared-test-rule,java-field-this,java,Java,test-grammars/java
 $(eval $(call make-shared-test-rule,java-simple-assignment,java,Java,test-grammars/java/test-simple-assignment.java))
 $(eval $(call make-shared-test-rule,java-compound-assignment,java,Java,test-grammars/java/test-compound-assignment.java))
 $(eval $(call make-shared-test-rule,java-set-value,java,Java,test-grammars/java/test-set-value.java))
+$(eval $(call make-shared-test-rule,java-implements,java,Java,test-grammars/java/test-implements.java))
 
 # JavaDoc comment tests (blank line + {@link Class#method()} regression tests)
 $(eval $(call make-shared-test-rule,java-javadoc-blank-link,java,Java,test-grammars/java/javadoc/test-blank-then-link.java))
@@ -182,7 +183,7 @@ accept-lex-java: test-out/java-main
 	ACCEPT=1 ./test-java-lexical.sh
 
 # Run all Java tests
-test-all-java: test-java test-java-simple test-java-minimal test-java-field test-java-field-public test-java-package test-java-string test-java-complex test-java-full test-java-generics test-java-enum test-java-annotations test-java-empty-method test-java-simple-return test-java-return-field test-java-very-simple test-java-parameter-only test-java-field-this test-java-simple-assignment test-java-compound-assignment test-java-set-value test-java-javadoc-blank-link test-java-javadoc-minimal-hash test-java-javadoc-minimal-fail test-java-javadoc-link-tag test-java-javadoc-just-hash
+test-all-java: test-java test-java-simple test-java-minimal test-java-field test-java-field-public test-java-package test-java-string test-java-complex test-java-full test-java-generics test-java-enum test-java-annotations test-java-empty-method test-java-simple-return test-java-return-field test-java-very-simple test-java-parameter-only test-java-field-this test-java-simple-assignment test-java-compound-assignment test-java-set-value test-java-implements test-java-javadoc-blank-link test-java-javadoc-minimal-hash test-java-javadoc-minimal-fail test-java-javadoc-link-tag test-java-javadoc-just-hash
 	@echo ""
 	@echo "=== All Java tests completed successfully! ==="
 

--- a/test-grammars/java.pg
+++ b/test-grammars/java.pg
@@ -37,7 +37,7 @@ AnnotationList = Annotation* ;
 ModifierList = (Modifier | Annotation)* ;
 
 ExtendsList = ('extends' CompoundName (',' CompoundName)*)? ;
-ImplementsList = 'implements' CompoundName + ',';
+ImplementsList = 'implements' CompoundName + ~',';
 FieldDeclarationList = FieldDeclaration *;
 
 ClassDeclaration  =

--- a/test-grammars/java/test-implements.java
+++ b/test-grammars/java/test-implements.java
@@ -1,0 +1,7 @@
+class Multiple extends Base implements Comparable, Serializable, Cloneable {
+    int y;
+
+    enum Status implements Describable {
+        OPEN, CLOSED
+    }
+}

--- a/test-suites/commons-lang-parser-blacklist-tests.txt
+++ b/test-suites/commons-lang-parser-blacklist-tests.txt
@@ -5,7 +5,7 @@
 # - Anonymous inner classes
 # - Enhanced for-each with colon
 #
-# Total: 253 files blacklisted, 14 files passing
+# Total: 251 files blacklisted, 16 files passing
 # As grammar support is added, remove files from this list
 
 org/apache/commons/lang3/AbstractLangTest.java
@@ -201,11 +201,9 @@ org/apache/commons/lang3/reflect/PackageBean.java
 org/apache/commons/lang3/reflect/PublicSubBean.java
 org/apache/commons/lang3/reflect/TypeLiteralTest.java
 org/apache/commons/lang3/reflect/TypeUtilsTest.java
-org/apache/commons/lang3/reflect/testbed/Ambig.java
 org/apache/commons/lang3/reflect/testbed/Annotated.java
 org/apache/commons/lang3/reflect/testbed/GenericParent.java
 org/apache/commons/lang3/reflect/testbed/PackageBeanOtherPackage.java
-org/apache/commons/lang3/reflect/testbed/Parent.java
 org/apache/commons/lang3/reflect/testbed/PrivatelyShadowedChild.java
 org/apache/commons/lang3/reflect/testbed/PublicSubBeanOtherPackage.java
 org/apache/commons/lang3/reflect/testbed/StringParameterizedChild.java

--- a/test/golden/java/JavaParser.y
+++ b/test/golden/java/JavaParser.y
@@ -545,7 +545,7 @@ IfStatement : qq_IfStatement { Anti_IfStatement $1 } |
               tok_if_36 tok__lparen__6 Expression tok__rparen__7 StatementWithoutIf OptElsePart { Ctr__IfStatement__0 $3 $5 $6 }
 
 ImplementsList : qq_ImplementsList { Anti_ImplementsList $1 } |
-                 tok_implements_11 Rule_23 tok__coma__8 { Ctr__ImplementsList__0 (reverse $2) }
+                 tok_implements_11 Rule_23 { Ctr__ImplementsList__0 (reverse $2) }
 
 ImportList : {- empty -} { [] } |
              ImportList ListElem_ImportList3 { $2 : $1 }
@@ -717,7 +717,7 @@ Rule_21 : {- empty -} { [] } |
 Rule_22 : tok__coma__8 CompoundName { Ctr__Rule_22__0 $2 }
 
 Rule_23 : CompoundName { [$1] } |
-          Rule_23 CompoundName { $2 : $1 }
+          Rule_23 tok__coma__8 CompoundName { $3 : $1 }
 
 Rule_25 : { Ctr__Rule_25__0 } |
           ExtendsList { Ctr__Rule_25__1 $1 }


### PR DESCRIPTION
## Summary

Fix the Java grammar so the `implements` clause parses at all. `ImplementsList` used the stale separated-list syntax `'implements' CompoundName + ','`, which the current grammar language parses as a **plus-list with no separator followed by a mandatory literal comma**. As a result `class A implements B {` (and every other use of `implements`, including enums) could never parse. The correct syntax is `+ ~','`, where `~` introduces the list separator (as used in grammar.pg and t1.pg).

No curated test covered `implements`, so this only surfaced when running the commons-lang corpus without blacklists (85 of 526 files use `implements`).

## Changes

- **test-grammars/java.pg**: `ImplementsList = 'implements' CompoundName + ~','` — comma is now the list separator instead of a stray sequence element
- **test/golden/java/JavaParser.y**: regenerated; `Rule_23` becomes a comma-separated list and `ImplementsList` drops the trailing-comma token (only these two productions change)
- **test-grammars/java/test-implements.java**: new curated test — class with `extends` + multi-interface `implements`, plus a nested enum with `implements` — wired into `test-all-java` so the clause stays covered
- **makefile**: give the `test-out/%-main.hs` copy rule the `test-out` directory as an order-only prerequisite; on a fresh checkout the rule ran before the directory target existed and `cp` created a *file* named `test-out`, breaking generation
- **test-suites/commons-lang-parser-blacklist-tests.txt**: unblacklist `reflect/testbed/Ambig.java` and `Parent.java`, which now parse (253 → 251 blacklisted, 14 → 16 passing)

## Verification

- `make test` (unit 103 + golden 25), `make test-all-java` (27 tests incl. the new one), `make test-lex-java`, `make test-java-qq` — all pass
- happy conflict counts on the generated parser are unchanged (the fix is conflict-neutral)
- commons-lang suites: lex-only still 526/526; blacklisted parse suites green with the two files re-enabled

https://claude.ai/code/session_01BfJ1B1z2bSrx5evCfNZUhM