### PR TITLE
Error handling: return Either instead of throwing in generated code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Generated parsers, lexers and quasi-quoters report errors with `Either`
+  instead of throwing (the deferred "Stage G" of the diagnostics
+  migration): generated parsers use `%monad { Either String }`, so
+  `parse<Name> :: [PosToken] -> Either String <AST>` mirrors the shape of
+  the hand-written grammar parser; generated lexers expose
+  `scanTokens :: String -> Either String [PosToken]` (`alexScanTokens`
+  stays as a throwing compatibility wrapper); and the generated
+  quasi-quoters route lexer, parser and unknown-metavariable failures
+  through `fail` in `TH.Q`, so a bad quasi-quote is now a positioned GHC
+  compile error at the splice site instead of a runtime crash during
+  Template Haskell expansion. Generated code stays dependency-free
 - Duplicate rule definitions are rejected: defining the same rule name twice
   in a grammar is now a normalization error carrying both source positions
   (e.g. `g.pg:3:1: error: in rule 'Foo': rule 'Foo' is defined more than

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Duplicate rule definitions are rejected: defining the same rule name twice
+  in a grammar is now a normalization error carrying both source positions
+  (e.g. `g.pg:3:1: error: in rule 'Foo': rule 'Foo' is defined more than
+  once (first definition at line 2, column 1)`), instead of the definitions
+  being silently merged into one rule group with extra alternatives
+  (closes #20). `test-grammars/debug-test.pg`, the one grammar that relied
+  on this, now defines `IfStatement` once with `|` alternatives
 - A `$$` escape in quasi-quote bodies: `$$name` now produces the literal
   text `$name` instead of being rewritten as a metavariable (or rejected).
   Previously the generated quasi-quoter rewrote `$ident` everywhere in a

--- a/GenQ.hs
+++ b/GenQ.hs
@@ -48,30 +48,29 @@ qqShortcuts :: M.Map String String
 -- metavariable stands for one literal '$' (so $$$x is a literal '$'
 -- followed by the metavariable $x). A '$' not followed by an identifier is
 -- never rewritten and needs no escape.
-replaceAllPatterns1 :: String -> String
+replaceAllPatterns1 :: String -> Either String String
 replaceAllPatterns1 str = let (pre, match, post) = str =~ qqPattern :: (String, String, String)
                           in if match == ""
-                              then pre
+                              then Right pre
                               else let varName = init $ tail match
                                        addSym = last match
                                        escCount = length $ takeWhile (== '$') $ reverse pre
                                        keptPre = take (length pre - escCount) pre ++ replicate (div escCount 2) '$'
                                        ruleVariants = catMaybes $ map (\ prefix -> M.lookup prefix qqShortcuts) $ reverse $ inits varName
-                                       rule = case ruleVariants of
-                                                [] -> error $ unlines
-                                                        [ "Unknown metavariable $" ++ varName ++ " in quasi-quote:"
-                                                        , "no prefix of '" ++ varName ++ "' is a known shortcut. Known shortcuts:"
-                                                        , "  " ++ intercalate ", " (M.keys qqShortcuts)
-                                                        , "To include the literal text $" ++ varName ++ " in the quoted code"
-                                                        , "(e.g. inside a string literal), escape it as $$" ++ varName ++ "." ]
-                                                (rule : _) -> rule
                                    in if odd escCount
-                                       then keptPre ++ ('$' : varName) ++ (replaceAllPatterns1 $ addSym : post)
-                                       else keptPre ++ ('$' : rule ++ ":") ++ varName ++ (replaceAllPatterns1 $ addSym : post)
+                                       then (\rest -> keptPre ++ ('$' : varName) ++ rest) <$> (replaceAllPatterns1 $ addSym : post)
+                                       else case ruleVariants of
+                                              [] -> Left $ unlines
+                                                      [ "Unknown metavariable $" ++ varName ++ " in quasi-quote:"
+                                                      , "no prefix of '" ++ varName ++ "' is a known shortcut. Known shortcuts:"
+                                                      , "  " ++ intercalate ", " (M.keys qqShortcuts)
+                                                      , "To include the literal text $" ++ varName ++ " in the quoted code"
+                                                      , "(e.g. inside a string literal), escape it as $$" ++ varName ++ "." ]
+                                              (rule : _) -> (\rest -> keptPre ++ ('$' : rule ++ ":") ++ varName ++ rest) <$> (replaceAllPatterns1 $ addSym : post)
 
 -- Add ' ' at the end, so regex can match variable in the end of the string
-replaceAllPatterns :: String -> String
-replaceAllPatterns str = init $ replaceAllPatterns1 (str ++ " ")
+replaceAllPatterns :: String -> Either String String
+replaceAllPatterns str = init <$> replaceAllPatterns1 (str ++ " ")
 
 ?qqShortCutsMapDef
 
@@ -135,8 +134,11 @@ replaceAllPatterns str = init $ replaceAllPatterns1 (str ++ " ")
           qqFunProtoGen typ = [str|?(qqFunName typ) :: Data.Data a => String -> (?startRuleName -> a) -> String -> TH.?typ~Q|]
           dataToExpCall typ var = [str|  dataTo?typ~Q (?(antiExprsGen typ)) ?var|]
           qqFunImplGen typ = [str|?(qqFunName typ ) dummy func s = do
-  let s1 = replaceAllPatterns s
-      expr = func $ parse?name $ alexScanTokens (dummy ++ " " ++ s1 ++ " " ++ dummy)
+  s1 <- either fail return (replaceAllPatterns s)
+  ast <- case scanTokens (dummy ++ " " ++ s1 ++ " " ++ dummy) >>= parse?name of
+           Left err -> fail err
+           Right a -> return a
+  let expr = func ast
 |] ++ dataToExpCall typ "expr"
           qqFunType = qqFunName "Type" ++ " s = return TH.ListT"
           qqFunDecs = qqFunName "Decs" ++ " s = return []"

--- a/GenX.hs
+++ b/GenX.hs
@@ -67,7 +67,7 @@ genX (NormalGrammar { getNGrammarName = name, getLexicalRules = tokens, getNImpo
     where macroIds = getMacroIds tokens
           symMacroIds = getSymMacroIds tokens
           adt = genTokenADT $ removeSymmacros tokens
-          header = vcat [text "{", ((text "module" <+> text name) <> text "Lexer(alexScanTokens, Token(..), PosToken(..), AlexPosn(..))"), text "where", text imports, text " }",
+          header = vcat [text "{", ((text "module" <+> text name) <> text "Lexer(scanTokens, alexScanTokens, Token(..), PosToken(..), AlexPosn(..))"), text "where", text imports, text " }",
                          text "%wrapper \"monad\""]
           funs_text = [str|
 -- A token together with the source position where it starts
@@ -78,22 +78,26 @@ alexEOF = do
   (pos, _, _, _) <- alexGetInput
   return $ PosToken pos EndOfFile
 
--- The returned list always ends with an EndOfFile token that carries the
--- position of the end of input, so parse errors at end of input can be
--- reported with a position too
-alexScanTokens :: String -> [PosToken]
-alexScanTokens str =
-               case alexScanTokens1 str of
-                  Right toks -> toks
-                  Left err -> errorWithoutStackTrace err
-
-alexScanTokens1 str = runAlex str $ do
+-- Lex the input into a token stream, returning the positioned error message
+-- on a lexical error. The returned list always ends with an EndOfFile token
+-- that carries the position of the end of input, so parse errors at end of
+-- input can be reported with a position too
+scanTokens :: String -> Either String [PosToken]
+scanTokens str = runAlex str $ do
   let loop toks = do tok <- alexMonadScan
                      case tok of
                        PosToken _ EndOfFile -> return $ reverse (tok : toks)
                        _ -> let toks' = tok : toks
                             in toks' `seq` loop toks'
   loop []
+
+-- Thin compatibility wrapper: callers that have not switched to 'scanTokens'
+-- get the error message thrown instead
+alexScanTokens :: String -> [PosToken]
+alexScanTokens str =
+               case scanTokens str of
+                  Right toks -> toks
+                  Left err -> errorWithoutStackTrace err
 
 simple1 :: (String -> Token) -> AlexInput -> Int -> Alex PosToken
 simple1 t (pos, _, _, str) len = return $ PosToken pos (t (take len str))

--- a/GenY.hs
+++ b/GenY.hs
@@ -16,6 +16,7 @@ genY g@(NormalGrammar name srules lex_rules _ _ _ _) = do
                    nl,
                    text "%name parse" <> text name,
                    text "%tokentype { L.PosToken }",
+                   text "%monad { Either String }",
                    text "%error { parseError }",
                    nl,
                    text "%token",
@@ -47,10 +48,10 @@ genY g@(NormalGrammar name srules lex_rules _ _ _ _) = do
                    \import qualified Data.Generics as Gen\n\
                    \import qualified " ++ name ++  "Lexer as L (Token(..), PosToken(..), AlexPosn(..), alexScanTokens)\n\
                    \}"
-          parseErrorDefs = "parseError :: [L.PosToken] -> a\n\
-                           \parseError [] = errorWithoutStackTrace \"Parse error: unexpected end of input\"\n\
+          parseErrorDefs = "parseError :: [L.PosToken] -> Either String a\n\
+                           \parseError [] = Left \"Parse error: unexpected end of input\"\n\
                            \parseError (L.PosToken (L.AlexPn _ line col) tok : _) =\n\
-                           \    errorWithoutStackTrace $ \"Parse error at line \" ++ show line ++ \", column \" ++ show col ++ \": unexpected \" ++ showRtkToken tok\n"
+                           \    Left $ \"Parse error at line \" ++ show line ++ \", column \" ++ show col ++ \": unexpected \" ++ showRtkToken tok\n"
           showTokenDefs = render $ vcat (text "-- Render a token the way it appears in the source, for error messages"
                                          : text "showRtkToken :: L.Token -> String"
                                          : text "showRtkToken L.EndOfFile = \"end of input\""

--- a/Normalize.hs
+++ b/Normalize.hs
@@ -3,7 +3,7 @@ module Normalize(normalizeTopLevelClauses, fillConstructorNames)
     where
 
 import Parser
-import Diagnostics (Diagnostic(..))
+import Diagnostics (Diagnostic(..), showSourcePos)
 import Grammar (isNotIgnored)
 import Data.Generics
 import Data.Maybe
@@ -304,9 +304,30 @@ buildRuleToTypeMap grammar = M.fromList $ map ruleMapping $ getIRules grammar
   where
     ruleMapping r = (getIRuleName r, maybe (getIRuleName r) id (getIDataTypeName r))
 
+-- A rule name may be defined only once: addRule would otherwise silently
+-- merge the definitions into one rule group, turning an (almost certainly
+-- accidental) duplicate into extra alternatives (issue #20). Checked on the
+-- input rules, so the synthesized start wrapper added later by addStartGroup
+-- - which legitimately reuses the start rule's name - is exempt.
+checkDuplicateRuleNames :: [IRule] -> Normalization ()
+checkDuplicateRuleNames = go M.empty
+  where
+    go _ [] = return ()
+    go seen (r : rest) =
+      case M.lookup (getIRuleName r) seen of
+        Nothing -> go (M.insert (getIRuleName r) r seen) rest
+        Just firstDef -> do
+          currentRule .= Just r
+          normError $ "rule '" ++ getIRuleName r ++ "' is defined more than once"
+                      ++ firstDefinedAt firstDef
+    firstDefinedAt r = case getIRulePos r of
+      Just pos -> " (first definition at " ++ showSourcePos pos ++ ")"
+      Nothing  -> ""
+
 doNM :: InitialGrammar -> Normalization ()
 doNM grammar = do
   let grammar0 = everywhereBut (False `mkQ` (isLexicalRule . getIRuleName)) (mkT removeOpts) grammar
+  checkDuplicateRuleNames $ getIRules grammar0
   mapM_ (\r -> do currentRule .= Just r
                   normalizeRule r)
         $ getIRules grammar0

--- a/test-grammars/debug-test.pg
+++ b/test-grammars/debug-test.pg
@@ -17,8 +17,8 @@ Expression = Term (('+' | '-') Term)*;
 Term = Factor (('*' | '/') Factor)*;
 Factor = identifier | number | '(' Expression ')';
 
-IfStatement = 'if' '(' Expression ')' Statement;
-IfStatement = 'if' '(' Expression ')' Statement 'else' Statement;
+IfStatement = 'if' '(' Expression ')' Statement
+            | 'if' '(' Expression ')' Statement 'else' Statement;
 
 WhileLoop = 'while' '(' Expression ')' Statement;
 

--- a/test-grammars/grammar-main.hs
+++ b/test-grammars/grammar-main.hs
@@ -18,7 +18,7 @@ getGrammarFileName = do
 main = do
     file <- getGrammarFileName
     content <- readFile file
-    let grm = parseGrammar . alexScanTokens $ content
+    let grm = either errorWithoutStackTrace id $ scanTokens content >>= parseGrammar
     let [grammar|grammar $StrLit:str ; $importsOpt|] = [grammar|grammar 'test' ;|]
     let [rule|Rule = $cl1 | $clause2 | $clause3 | $clause4 ;|] = [rule| Rule = id '=' Clause ';' 
                                                                       | id ':' id '=' Clause ';'

--- a/test-grammars/haskell-main.hs
+++ b/test-grammars/haskell-main.hs
@@ -19,7 +19,7 @@ main = do
     file <- getGrammarFileName
     content <- readFile file
     let lexems = alexScanTokens content
-    let prg = parseHaskell . alexScanTokens $ content
+    let prg = either errorWithoutStackTrace id $ scanTokens content >>= parseHaskell
     putStrLn $ show lexems
     --putStrLn $ show prg
     return 0

--- a/test-grammars/java-main.hs
+++ b/test-grammars/java-main.hs
@@ -43,8 +43,9 @@ main = do
                     exitSuccess
 
                 FullParse -> do
-                    -- Perform full parse
-                    let ast = parseJava . alexScanTokens $ content
+                    -- Perform full parse; lexer and parser report errors as Left
+                    let ast = either errorWithoutStackTrace id $
+                                scanTokens content >>= parseJava
                     putStrLn "=== Parsed Java AST ==="
                     putStrLn $ ppShow ast
                     putStrLn "\n=== Parse successful! ==="

--- a/test-grammars/java-simple-main.hs
+++ b/test-grammars/java-simple-main.hs
@@ -21,7 +21,7 @@ main = do
     putStrLn $ "First 10 tokens: " ++ show (take 10 tokens)
     
     putStrLn "\n=== Parsing ==="
-    let ast = parseJavaSimple tokens
+    let ast = either errorWithoutStackTrace id $ parseJavaSimple tokens
     putStrLn $ "AST: " ++ ppShow ast
     
     putStrLn "\n=== Java QuasiQuoter Demo ==="

--- a/test-grammars/p-main.hs
+++ b/test-grammars/p-main.hs
@@ -24,7 +24,9 @@ evalP :: P -> Int -> Int
 evalP [p|(lambda ($id) $e)|] i = evalE $ subst id e i
 
 main = do
-    let _p = parseP $ alexScanTokens "(lambda (x) (fold x 0 (lambda (y z) (or y z))))"
+    -- Prelude.id: PQQ also exports an 'id' quasi-quoter for the Id type
+    let _p = either errorWithoutStackTrace Prelude.id $
+               scanTokens "(lambda (x) (fold x 0 (lambda (y z) (or y z))))" >>= parseP
     let [p|(lambda ($id) $e)|] = _p
     putStrLn $ show $ subst (Ctr__Id__0 "x") e 0x1122334455667788
     return ()

--- a/test/UnitTests.hs
+++ b/test/UnitTests.hs
@@ -207,6 +207,15 @@ errorHandlingTests = TestList
             assertEqual "position of 'Foo'" (Just (SourcePos 2 1)) (diagPos d)
             assertBool ("unexpected message: " ++ diagMessage d) $
                 "lifted" `isInfixOf` diagMessage d && "*" `isInfixOf` diagMessage d
+    , TestLabel "duplicate rule definitions are rejected" $ TestCase $
+        -- the error points at the second definition and names the first
+        expectDiagnostic "a duplicate rule"
+            (normalizeGrammarSource "grammar 'Dup';\nFoo = 'a';\nFoo = 'b';\n") $ \d -> do
+            assertEqual "context names the rule" (Just "in rule 'Foo'") (diagContext d)
+            assertEqual "position of the second definition" (Just (SourcePos 3 1)) (diagPos d)
+            assertBool ("unexpected message: " ++ diagMessage d) $
+                "defined more than once" `isInfixOf` diagMessage d
+                && "line 2, column 1" `isInfixOf` diagMessage d
     , TestLabel "a reference to an unknown rule is rejected during generation" $ TestCase $
         expectDiagnostic "an unknown rule reference"
             (normalizeGrammarSource "grammar 'X';\nFoo = Nope;\n" >>= artifactsFor) $ \d -> do
@@ -399,13 +408,6 @@ invariantTestsFor pgFile = do
             "normalization failed for " ++ pgFile ++ ":\n" ++ show (err :: SomeException)
         Right g -> invariants (takeBaseName pgFile) g
 
--- | Rule names that a grammar deliberately defines more than once.
--- debug-test.pg defines IfStatement twice to exercise the debug options; it is
--- only used for rtk's own diagnostics and is never fed to happy.
-knownDuplicateRuleNames :: String -> [ID]
-knownDuplicateRuleNames "debug-test" = ["IfStatement"]
-knownDuplicateRuleNames _ = []
-
 -- | References to rules that a grammar is known to leave undefined.
 -- Currently empty: every grammar in test-grammars/ resolves all its
 -- references. Pin a grammar here only to keep the invariant active for the
@@ -419,8 +421,7 @@ invariants grammarKey g = TestList
         -- the synthesized start wrapper legitimately shares the start rule's name
         assertEqual "duplicate rule names" [] $
             duplicates (map getSRuleName (allRules g))
-                `removeAll` (maybeToList (getStartRuleName info)
-                             ++ knownDuplicateRuleNames grammarKey)
+                `removeAll` maybeToList (getStartRuleName info)
     , TestLabel "rule group types are unique" $ TestCase $
         assertEqual "duplicate group types" [] $
             duplicates (map getSDataTypeName (getSyntaxRuleGroups g))

--- a/test/golden/debug-test/DebugTestLexer.x
+++ b/test/golden/debug-test/DebugTestLexer.x
@@ -1,5 +1,5 @@
 {
-module DebugTestLexer(alexScanTokens, Token(..), PosToken(..), AlexPosn(..))
+module DebugTestLexer(scanTokens, alexScanTokens, Token(..), PosToken(..), AlexPosn(..))
 where
 
  }
@@ -96,22 +96,26 @@ alexEOF = do
   (pos, _, _, _) <- alexGetInput
   return $ PosToken pos EndOfFile
 
--- The returned list always ends with an EndOfFile token that carries the
--- position of the end of input, so parse errors at end of input can be
--- reported with a position too
-alexScanTokens :: String -> [PosToken]
-alexScanTokens str =
-               case alexScanTokens1 str of
-                  Right toks -> toks
-                  Left err -> errorWithoutStackTrace err
-
-alexScanTokens1 str = runAlex str $ do
+-- Lex the input into a token stream, returning the positioned error message
+-- on a lexical error. The returned list always ends with an EndOfFile token
+-- that carries the position of the end of input, so parse errors at end of
+-- input can be reported with a position too
+scanTokens :: String -> Either String [PosToken]
+scanTokens str = runAlex str $ do
   let loop toks = do tok <- alexMonadScan
                      case tok of
                        PosToken _ EndOfFile -> return $ reverse (tok : toks)
                        _ -> let toks' = tok : toks
                             in toks' `seq` loop toks'
   loop []
+
+-- Thin compatibility wrapper: callers that have not switched to 'scanTokens'
+-- get the error message thrown instead
+alexScanTokens :: String -> [PosToken]
+alexScanTokens str =
+               case scanTokens str of
+                  Right toks -> toks
+                  Left err -> errorWithoutStackTrace err
 
 simple1 :: (String -> Token) -> AlexInput -> Int -> Alex PosToken
 simple1 t (pos, _, _, str) len = return $ PosToken pos (t (take len str))

--- a/test/golden/debug-test/DebugTestParser.y
+++ b/test/golden/debug-test/DebugTestParser.y
@@ -85,10 +85,8 @@ Factor : qq_Factor { Anti_Factor $1 } |
          tok__lparen__6 Expression tok__rparen__7 { Ctr__Factor__2 $2 }
 
 IfStatement : qq_IfStatement { Anti_IfStatement $1 } |
-              tok_if_8 tok__lparen__6 Expression tok__rparen__7 Statement tok_else_9 Statement { Ctr__IfStatement__0 $3 $5 $7 }
-
-IfStatement : qq_IfStatement { Anti_IfStatement $1 } |
-              tok_if_8 tok__lparen__6 Expression tok__rparen__7 Statement { Ctr__IfStatement__1 $3 $5 }
+              tok_if_8 tok__lparen__6 Expression tok__rparen__7 Statement { Ctr__IfStatement__0 $3 $5 } |
+              tok_if_8 tok__lparen__6 Expression tok__rparen__7 Statement tok_else_9 Statement { Ctr__IfStatement__1 $3 $5 $7 }
 
 Rule_1 : {- empty -} { [] } |
          Rule_1 Rule_2 { $2 : $1 }
@@ -209,8 +207,8 @@ data Factor = Anti_Factor String |
               Ctr__Factor__2 Expression
               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 data IfStatement = Anti_IfStatement String |
-                   Ctr__IfStatement__0 Expression Statement Statement |
-                   Ctr__IfStatement__1 Expression Statement
+                   Ctr__IfStatement__0 Expression Statement |
+                   Ctr__IfStatement__1 Expression Statement Statement
                    deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 type Rule_1 = [Rule_2]
 data Rule_2 = Ctr__Rule_2__0 Rule_3 Term

--- a/test/golden/debug-test/DebugTestParser.y
+++ b/test/golden/debug-test/DebugTestParser.y
@@ -7,6 +7,7 @@ import qualified DebugTestLexer as L (Token(..), PosToken(..), AlexPosn(..), ale
 
 %name parseDebugTest
 %tokentype { L.PosToken }
+%monad { Either String }
 %error { parseError }
 
 %token
@@ -133,10 +134,10 @@ WhileLoop : qq_WhileLoop { Anti_WhileLoop $1 } |
 
 
 {
-parseError :: [L.PosToken] -> a
-parseError [] = errorWithoutStackTrace "Parse error: unexpected end of input"
+parseError :: [L.PosToken] -> Either String a
+parseError [] = Left "Parse error: unexpected end of input"
 parseError (L.PosToken (L.AlexPn _ line col) tok : _) =
-    errorWithoutStackTrace $ "Parse error at line " ++ show line ++ ", column " ++ show col ++ ": unexpected " ++ showRtkToken tok
+    Left $ "Parse error at line " ++ show line ++ ", column " ++ show col ++ ": unexpected " ++ showRtkToken tok
 
 -- Render a token the way it appears in the source, for error messages
 showRtkToken :: L.Token -> String

--- a/test/golden/debug-test/DebugTestQQ.hs
+++ b/test/golden/debug-test/DebugTestQQ.hs
@@ -25,42 +25,47 @@ qqShortcuts :: M.Map String String
 -- metavariable stands for one literal '$' (so $$$x is a literal '$'
 -- followed by the metavariable $x). A '$' not followed by an identifier is
 -- never rewritten and needs no escape.
-replaceAllPatterns1 :: String -> String
+replaceAllPatterns1 :: String -> Either String String
 replaceAllPatterns1 str = let (pre, match, post) = str =~ qqPattern :: (String, String, String)
                           in if match == ""
-                              then pre
+                              then Right pre
                               else let varName = init $ tail match
                                        addSym = last match
                                        escCount = length $ takeWhile (== '$') $ reverse pre
                                        keptPre = take (length pre - escCount) pre ++ replicate (div escCount 2) '$'
                                        ruleVariants = catMaybes $ map (\ prefix -> M.lookup prefix qqShortcuts) $ reverse $ inits varName
-                                       rule = case ruleVariants of
-                                                [] -> error $ unlines
-                                                        [ "Unknown metavariable $" ++ varName ++ " in quasi-quote:"
-                                                        , "no prefix of '" ++ varName ++ "' is a known shortcut. Known shortcuts:"
-                                                        , "  " ++ intercalate ", " (M.keys qqShortcuts)
-                                                        , "To include the literal text $" ++ varName ++ " in the quoted code"
-                                                        , "(e.g. inside a string literal), escape it as $$" ++ varName ++ "." ]
-                                                (rule : _) -> rule
                                    in if odd escCount
-                                       then keptPre ++ ('$' : varName) ++ (replaceAllPatterns1 $ addSym : post)
-                                       else keptPre ++ ('$' : rule ++ ":") ++ varName ++ (replaceAllPatterns1 $ addSym : post)
+                                       then (\rest -> keptPre ++ ('$' : varName) ++ rest) <$> (replaceAllPatterns1 $ addSym : post)
+                                       else case ruleVariants of
+                                              [] -> Left $ unlines
+                                                      [ "Unknown metavariable $" ++ varName ++ " in quasi-quote:"
+                                                      , "no prefix of '" ++ varName ++ "' is a known shortcut. Known shortcuts:"
+                                                      , "  " ++ intercalate ", " (M.keys qqShortcuts)
+                                                      , "To include the literal text $" ++ varName ++ " in the quoted code"
+                                                      , "(e.g. inside a string literal), escape it as $$" ++ varName ++ "." ]
+                                              (rule : _) -> (\rest -> keptPre ++ ('$' : rule ++ ":") ++ varName ++ rest) <$> (replaceAllPatterns1 $ addSym : post)
 
 -- Add ' ' at the end, so regex can match variable in the end of the string
-replaceAllPatterns :: String -> String
-replaceAllPatterns str = init $ replaceAllPatterns1 (str ++ " ")
+replaceAllPatterns :: String -> Either String String
+replaceAllPatterns str = init <$> replaceAllPatterns1 (str ++ " ")
 
 qqShortcuts = M.fromList [ ("program","Program"),("assignment","Assignment"),("block","Block"),("expression","Expression"),("factor","Factor"),("ifStatement","IfStatement"),("statement","Statement"),("term","Term"),("unusedRule1","UnusedRule1"),("unusedRule2","UnusedRule2"),("whileLoop","WhileLoop")]
 
 quoteDebugTestExp :: Data.Data a => String -> (Program -> a) -> String -> TH.ExpQ
 quoteDebugTestExp dummy func s = do
-  let s1 = replaceAllPatterns s
-      expr = func $ parseDebugTest $ alexScanTokens (dummy ++ " " ++ s1 ++ " " ++ dummy)
+  s1 <- either fail return (replaceAllPatterns s)
+  ast <- case scanTokens (dummy ++ " " ++ s1 ++ " " ++ dummy) >>= parseDebugTest of
+           Left err -> fail err
+           Right a -> return a
+  let expr = func ast
   dataToExpQ (const Nothing `Generics.extQ` antiStatementExp `Generics.extQ` antiAssignmentExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiTermExp `Generics.extQ` antiFactorExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiWhileLoopExp `Generics.extQ` antiBlockExp `Generics.extQ` antiUnusedRule1Exp) expr
 quoteDebugTestPat :: Data.Data a => String -> (Program -> a) -> String -> TH.PatQ
 quoteDebugTestPat dummy func s = do
-  let s1 = replaceAllPatterns s
-      expr = func $ parseDebugTest $ alexScanTokens (dummy ++ " " ++ s1 ++ " " ++ dummy)
+  s1 <- either fail return (replaceAllPatterns s)
+  ast <- case scanTokens (dummy ++ " " ++ s1 ++ " " ++ dummy) >>= parseDebugTest of
+           Left err -> fail err
+           Right a -> return a
+  let expr = func ast
   dataToPatQ (const Nothing `Generics.extQ` antiStatementPat `Generics.extQ` antiAssignmentPat `Generics.extQ` antiExpressionPat `Generics.extQ` antiTermPat `Generics.extQ` antiFactorPat `Generics.extQ` antiIfStatementPat `Generics.extQ` antiWhileLoopPat `Generics.extQ` antiBlockPat `Generics.extQ` antiUnusedRule1Pat) expr
 
 antiUnusedRule1Exp :: UnusedRule1 -> Maybe (TH.Q TH.Exp )

--- a/test/golden/grammar/GrammarLexer.x
+++ b/test/golden/grammar/GrammarLexer.x
@@ -1,5 +1,5 @@
 {
-module GrammarLexer(alexScanTokens, Token(..), PosToken(..), AlexPosn(..))
+module GrammarLexer(scanTokens, alexScanTokens, Token(..), PosToken(..), AlexPosn(..))
 where
 
 import Data.List
@@ -114,22 +114,26 @@ alexEOF = do
   (pos, _, _, _) <- alexGetInput
   return $ PosToken pos EndOfFile
 
--- The returned list always ends with an EndOfFile token that carries the
--- position of the end of input, so parse errors at end of input can be
--- reported with a position too
-alexScanTokens :: String -> [PosToken]
-alexScanTokens str =
-               case alexScanTokens1 str of
-                  Right toks -> toks
-                  Left err -> errorWithoutStackTrace err
-
-alexScanTokens1 str = runAlex str $ do
+-- Lex the input into a token stream, returning the positioned error message
+-- on a lexical error. The returned list always ends with an EndOfFile token
+-- that carries the position of the end of input, so parse errors at end of
+-- input can be reported with a position too
+scanTokens :: String -> Either String [PosToken]
+scanTokens str = runAlex str $ do
   let loop toks = do tok <- alexMonadScan
                      case tok of
                        PosToken _ EndOfFile -> return $ reverse (tok : toks)
                        _ -> let toks' = tok : toks
                             in toks' `seq` loop toks'
   loop []
+
+-- Thin compatibility wrapper: callers that have not switched to 'scanTokens'
+-- get the error message thrown instead
+alexScanTokens :: String -> [PosToken]
+alexScanTokens str =
+               case scanTokens str of
+                  Right toks -> toks
+                  Left err -> errorWithoutStackTrace err
 
 simple1 :: (String -> Token) -> AlexInput -> Int -> Alex PosToken
 simple1 t (pos, _, _, str) len = return $ PosToken pos (t (take len str))

--- a/test/golden/grammar/GrammarParser.y
+++ b/test/golden/grammar/GrammarParser.y
@@ -7,6 +7,7 @@ import qualified GrammarLexer as L (Token(..), PosToken(..), AlexPosn(..), alexS
 
 %name parseGrammar
 %tokentype { L.PosToken }
+%monad { Either String }
 %error { parseError }
 
 %token
@@ -151,10 +152,10 @@ StrLit : qq_StrLit { Anti_StrLit $1 } |
 
 
 {
-parseError :: [L.PosToken] -> a
-parseError [] = errorWithoutStackTrace "Parse error: unexpected end of input"
+parseError :: [L.PosToken] -> Either String a
+parseError [] = Left "Parse error: unexpected end of input"
 parseError (L.PosToken (L.AlexPn _ line col) tok : _) =
-    errorWithoutStackTrace $ "Parse error at line " ++ show line ++ ", column " ++ show col ++ ": unexpected " ++ showRtkToken tok
+    Left $ "Parse error at line " ++ show line ++ ", column " ++ show col ++ ": unexpected " ++ showRtkToken tok
 
 -- Render a token the way it appears in the source, for error messages
 showRtkToken :: L.Token -> String

--- a/test/golden/grammar/GrammarQQ.hs
+++ b/test/golden/grammar/GrammarQQ.hs
@@ -25,42 +25,47 @@ qqShortcuts :: M.Map String String
 -- metavariable stands for one literal '$' (so $$$x is a literal '$'
 -- followed by the metavariable $x). A '$' not followed by an identifier is
 -- never rewritten and needs no escape.
-replaceAllPatterns1 :: String -> String
+replaceAllPatterns1 :: String -> Either String String
 replaceAllPatterns1 str = let (pre, match, post) = str =~ qqPattern :: (String, String, String)
                           in if match == ""
-                              then pre
+                              then Right pre
                               else let varName = init $ tail match
                                        addSym = last match
                                        escCount = length $ takeWhile (== '$') $ reverse pre
                                        keptPre = take (length pre - escCount) pre ++ replicate (div escCount 2) '$'
                                        ruleVariants = catMaybes $ map (\ prefix -> M.lookup prefix qqShortcuts) $ reverse $ inits varName
-                                       rule = case ruleVariants of
-                                                [] -> error $ unlines
-                                                        [ "Unknown metavariable $" ++ varName ++ " in quasi-quote:"
-                                                        , "no prefix of '" ++ varName ++ "' is a known shortcut. Known shortcuts:"
-                                                        , "  " ++ intercalate ", " (M.keys qqShortcuts)
-                                                        , "To include the literal text $" ++ varName ++ " in the quoted code"
-                                                        , "(e.g. inside a string literal), escape it as $$" ++ varName ++ "." ]
-                                                (rule : _) -> rule
                                    in if odd escCount
-                                       then keptPre ++ ('$' : varName) ++ (replaceAllPatterns1 $ addSym : post)
-                                       else keptPre ++ ('$' : rule ++ ":") ++ varName ++ (replaceAllPatterns1 $ addSym : post)
+                                       then (\rest -> keptPre ++ ('$' : varName) ++ rest) <$> (replaceAllPatterns1 $ addSym : post)
+                                       else case ruleVariants of
+                                              [] -> Left $ unlines
+                                                      [ "Unknown metavariable $" ++ varName ++ " in quasi-quote:"
+                                                      , "no prefix of '" ++ varName ++ "' is a known shortcut. Known shortcuts:"
+                                                      , "  " ++ intercalate ", " (M.keys qqShortcuts)
+                                                      , "To include the literal text $" ++ varName ++ " in the quoted code"
+                                                      , "(e.g. inside a string literal), escape it as $$" ++ varName ++ "." ]
+                                              (rule : _) -> (\rest -> keptPre ++ ('$' : rule ++ ":") ++ varName ++ rest) <$> (replaceAllPatterns1 $ addSym : post)
 
 -- Add ' ' at the end, so regex can match variable in the end of the string
-replaceAllPatterns :: String -> String
-replaceAllPatterns str = init $ replaceAllPatterns1 (str ++ " ")
+replaceAllPatterns :: String -> Either String String
+replaceAllPatterns str = init <$> replaceAllPatterns1 (str ++ " ")
 
 qqShortcuts = M.fromList [ ("grammar","Grammar"),("clause","Clause"),("idList","IdList"),("importsOpt","ImportsOpt"),("name","Name"),("optDelim","OptDelim"),("option","Option"),("optionList","OptionList"),("rule","Rule"),("ruleList","RuleList"),("strLit","StrLit"),("cl","Clause"),("r","Rule")]
 
 quoteGrammarExp :: Data.Data a => String -> (Grammar -> a) -> String -> TH.ExpQ
 quoteGrammarExp dummy func s = do
-  let s1 = replaceAllPatterns s
-      expr = func $ parseGrammar $ alexScanTokens (dummy ++ " " ++ s1 ++ " " ++ dummy)
+  s1 <- either fail return (replaceAllPatterns s)
+  ast <- case scanTokens (dummy ++ " " ++ s1 ++ " " ++ dummy) >>= parseGrammar of
+           Left err -> fail err
+           Right a -> return a
+  let expr = func ast
   dataToExpQ (const Nothing `Generics.extQ` antiGrammarExp `Generics.extQ` antiImportsOptExp `Generics.extQ` antiRuleExp `Generics.extQ` antiOptionExp `Generics.extQ` antiNameExp `Generics.extQ` antiClauseExp `Generics.extQ` antiOptDelimExp `Generics.extQ` antiStrLitExp) expr
 quoteGrammarPat :: Data.Data a => String -> (Grammar -> a) -> String -> TH.PatQ
 quoteGrammarPat dummy func s = do
-  let s1 = replaceAllPatterns s
-      expr = func $ parseGrammar $ alexScanTokens (dummy ++ " " ++ s1 ++ " " ++ dummy)
+  s1 <- either fail return (replaceAllPatterns s)
+  ast <- case scanTokens (dummy ++ " " ++ s1 ++ " " ++ dummy) >>= parseGrammar of
+           Left err -> fail err
+           Right a -> return a
+  let expr = func ast
   dataToPatQ (const Nothing `Generics.extQ` antiGrammarPat `Generics.extQ` antiImportsOptPat `Generics.extQ` antiRulePat `Generics.extQ` antiOptionPat `Generics.extQ` antiNamePat `Generics.extQ` antiClausePat `Generics.extQ` antiOptDelimPat `Generics.extQ` antiStrLitPat) expr
 
 antiStrLitExp :: StrLit -> Maybe (TH.Q TH.Exp )

--- a/test/golden/haskell/HaskellLexer.x
+++ b/test/golden/haskell/HaskellLexer.x
@@ -1,5 +1,5 @@
 {
-module HaskellLexer(alexScanTokens, Token(..), PosToken(..), AlexPosn(..))
+module HaskellLexer(scanTokens, alexScanTokens, Token(..), PosToken(..), AlexPosn(..))
 where
 
  }
@@ -372,22 +372,26 @@ alexEOF = do
   (pos, _, _, _) <- alexGetInput
   return $ PosToken pos EndOfFile
 
--- The returned list always ends with an EndOfFile token that carries the
--- position of the end of input, so parse errors at end of input can be
--- reported with a position too
-alexScanTokens :: String -> [PosToken]
-alexScanTokens str =
-               case alexScanTokens1 str of
-                  Right toks -> toks
-                  Left err -> errorWithoutStackTrace err
-
-alexScanTokens1 str = runAlex str $ do
+-- Lex the input into a token stream, returning the positioned error message
+-- on a lexical error. The returned list always ends with an EndOfFile token
+-- that carries the position of the end of input, so parse errors at end of
+-- input can be reported with a position too
+scanTokens :: String -> Either String [PosToken]
+scanTokens str = runAlex str $ do
   let loop toks = do tok <- alexMonadScan
                      case tok of
                        PosToken _ EndOfFile -> return $ reverse (tok : toks)
                        _ -> let toks' = tok : toks
                             in toks' `seq` loop toks'
   loop []
+
+-- Thin compatibility wrapper: callers that have not switched to 'scanTokens'
+-- get the error message thrown instead
+alexScanTokens :: String -> [PosToken]
+alexScanTokens str =
+               case scanTokens str of
+                  Right toks -> toks
+                  Left err -> errorWithoutStackTrace err
 
 simple1 :: (String -> Token) -> AlexInput -> Int -> Alex PosToken
 simple1 t (pos, _, _, str) len = return $ PosToken pos (t (take len str))

--- a/test/golden/haskell/HaskellParser.y
+++ b/test/golden/haskell/HaskellParser.y
@@ -7,6 +7,7 @@ import qualified HaskellLexer as L (Token(..), PosToken(..), AlexPosn(..), alexS
 
 %name parseHaskell
 %tokentype { L.PosToken }
+%monad { Either String }
 %error { parseError }
 
 %token
@@ -643,10 +644,10 @@ Vars : qq_Vars { Anti_Vars $1 } |
 
 
 {
-parseError :: [L.PosToken] -> a
-parseError [] = errorWithoutStackTrace "Parse error: unexpected end of input"
+parseError :: [L.PosToken] -> Either String a
+parseError [] = Left "Parse error: unexpected end of input"
 parseError (L.PosToken (L.AlexPn _ line col) tok : _) =
-    errorWithoutStackTrace $ "Parse error at line " ++ show line ++ ", column " ++ show col ++ ": unexpected " ++ showRtkToken tok
+    Left $ "Parse error at line " ++ show line ++ ", column " ++ show col ++ ": unexpected " ++ showRtkToken tok
 
 -- Render a token the way it appears in the source, for error messages
 showRtkToken :: L.Token -> String

--- a/test/golden/haskell/HaskellQQ.hs
+++ b/test/golden/haskell/HaskellQQ.hs
@@ -25,42 +25,47 @@ qqShortcuts :: M.Map String String
 -- metavariable stands for one literal '$' (so $$$x is a literal '$'
 -- followed by the metavariable $x). A '$' not followed by an identifier is
 -- never rewritten and needs no escape.
-replaceAllPatterns1 :: String -> String
+replaceAllPatterns1 :: String -> Either String String
 replaceAllPatterns1 str = let (pre, match, post) = str =~ qqPattern :: (String, String, String)
                           in if match == ""
-                              then pre
+                              then Right pre
                               else let varName = init $ tail match
                                        addSym = last match
                                        escCount = length $ takeWhile (== '$') $ reverse pre
                                        keptPre = take (length pre - escCount) pre ++ replicate (div escCount 2) '$'
                                        ruleVariants = catMaybes $ map (\ prefix -> M.lookup prefix qqShortcuts) $ reverse $ inits varName
-                                       rule = case ruleVariants of
-                                                [] -> error $ unlines
-                                                        [ "Unknown metavariable $" ++ varName ++ " in quasi-quote:"
-                                                        , "no prefix of '" ++ varName ++ "' is a known shortcut. Known shortcuts:"
-                                                        , "  " ++ intercalate ", " (M.keys qqShortcuts)
-                                                        , "To include the literal text $" ++ varName ++ " in the quoted code"
-                                                        , "(e.g. inside a string literal), escape it as $$" ++ varName ++ "." ]
-                                                (rule : _) -> rule
                                    in if odd escCount
-                                       then keptPre ++ ('$' : varName) ++ (replaceAllPatterns1 $ addSym : post)
-                                       else keptPre ++ ('$' : rule ++ ":") ++ varName ++ (replaceAllPatterns1 $ addSym : post)
+                                       then (\rest -> keptPre ++ ('$' : varName) ++ rest) <$> (replaceAllPatterns1 $ addSym : post)
+                                       else case ruleVariants of
+                                              [] -> Left $ unlines
+                                                      [ "Unknown metavariable $" ++ varName ++ " in quasi-quote:"
+                                                      , "no prefix of '" ++ varName ++ "' is a known shortcut. Known shortcuts:"
+                                                      , "  " ++ intercalate ", " (M.keys qqShortcuts)
+                                                      , "To include the literal text $" ++ varName ++ " in the quoted code"
+                                                      , "(e.g. inside a string literal), escape it as $$" ++ varName ++ "." ]
+                                              (rule : _) -> (\rest -> keptPre ++ ('$' : rule ++ ":") ++ varName ++ rest) <$> (replaceAllPatterns1 $ addSym : post)
 
 -- Add ' ' at the end, so regex can match variable in the end of the string
-replaceAllPatterns :: String -> String
-replaceAllPatterns str = init $ replaceAllPatterns1 (str ++ " ")
+replaceAllPatterns :: String -> Either String String
+replaceAllPatterns str = init <$> replaceAllPatterns1 (str ++ " ")
 
 qqShortcuts = M.fromList [ ("haskell","Haskell"),("aType","AType"),("aTypeList","ATypeList"),("bType","BType"),("body","Body"),("cName","CName"),("cNameList","CNameList"),("class","Class"),("classList","ClassList"),("con","Con"),("constr","Constr"),("constrs","Constrs"),("context","Context"),("dClass","DClass"),("dClassList","DClassList"),("decl","Decl"),("declList","DeclList"),("decls","Decls"),("deriving","Deriving"),("exp","Exp"),("expI","ExpI"),("export","Export"),("exportsList","ExportsList"),("exportsOpt","ExportsOpt"),("fieldDecl","FieldDecl"),("fieldDeclList","FieldDeclList"),("fixity","Fixity"),("funLhs","FunLhs"),("gTyCon","GTyCon"),("gd","Gd"),("gdRhs","GdRhs"),("genDecl","GenDecl"),("impDecl","ImpDecl"),("impDeclList","ImpDeclList"),("import","Import"),("importList","ImportList"),("modId","ModId"),("modIdList","ModIdList"),("module","Module"),("op","Op"),("ops","Ops"),("optContext","OptContext"),("optDeriving","OptDeriving"),("optExpTypeSignature","OptExpTypeSignature"),("optGdRhs","OptGdRhs"),("optImpSpec","OptImpSpec"),("optInteger","OptInteger"),("optQualified","OptQualified"),("optQualifiedAs","OptQualifiedAs"),("optWhere","OptWhere"),("pat","Pat"),("qOp","QOp"),("qTyCls","QTyCls"),("qTyCon","QTyCon"),("qVar","QVar"),("qVarId","QVarId"),("qVarList","QVarList"),("rhs","Rhs"),("simpleType","SimpleType"),("topDecl","TopDecl"),("topDecls","TopDecls"),("tyCls","TyCls"),("tyCon","TyCon"),("tyVar","TyVar"),("tyVars","TyVars"),("type","Type"),("typeList","TypeList"),("var","Var"),("vars","Vars")]
 
 quoteHaskellExp :: Data.Data a => String -> (Haskell -> a) -> String -> TH.ExpQ
 quoteHaskellExp dummy func s = do
-  let s1 = replaceAllPatterns s
-      expr = func $ parseHaskell $ alexScanTokens (dummy ++ " " ++ s1 ++ " " ++ dummy)
+  s1 <- either fail return (replaceAllPatterns s)
+  ast <- case scanTokens (dummy ++ " " ++ s1 ++ " " ++ dummy) >>= parseHaskell of
+           Left err -> fail err
+           Right a -> return a
+  let expr = func ast
   dataToExpQ (const Nothing `Generics.extQ` antiHaskellExp `Generics.extQ` antiModuleExp `Generics.extQ` antiExportsOptExp `Generics.extQ` antiExportsListExp `Generics.extQ` antiExportExp `Generics.extQ` antiBodyExp `Generics.extQ` antiImpDeclListExp `Generics.extQ` antiImportListExp `Generics.extQ` antiVarExp `Generics.extQ` antiConExp `Generics.extQ` antiRule_13Exp `Generics.extQ` antiQVarIdExp `Generics.extQ` antiQVarExp `Generics.extQ` antiQTyClsExp `Generics.extQ` antiQTyConExp `Generics.extQ` antiCNameExp `Generics.extQ` antiCNameListExp `Generics.extQ` antiQVarListExp `Generics.extQ` antiImportExp `Generics.extQ` antiOptQualifiedExp `Generics.extQ` antiOptQualifiedAsExp `Generics.extQ` antiOptImpSpecExp `Generics.extQ` antiImpDeclExp `Generics.extQ` antiTopDeclsExp `Generics.extQ` antiTopDeclExp `Generics.extQ` antiDeclExp `Generics.extQ` antiOptContextExp `Generics.extQ` antiGenDeclExp `Generics.extQ` antiOptIntegerExp `Generics.extQ` antiOpsExp `Generics.extQ` antiFixityExp `Generics.extQ` antiFunLhsExp `Generics.extQ` antiPatExp `Generics.extQ` antiOptWhereExp `Generics.extQ` antiDeclListExp `Generics.extQ` antiDeclsExp `Generics.extQ` antiRhsExp `Generics.extQ` antiOptGdRhsExp `Generics.extQ` antiGdExp `Generics.extQ` antiOptExpTypeSignatureExp `Generics.extQ` antiExpExp `Generics.extQ` antiExpIExp `Generics.extQ` antiGdRhsExp `Generics.extQ` antiConstrsExp `Generics.extQ` antiConstrExp `Generics.extQ` antiFieldDeclListExp `Generics.extQ` antiFieldDeclExp `Generics.extQ` antiVarsExp `Generics.extQ` antiOptDerivingExp `Generics.extQ` antiDerivingExp `Generics.extQ` antiDClassListExp `Generics.extQ` antiDClassExp `Generics.extQ` antiContextExp `Generics.extQ` antiClassListExp `Generics.extQ` antiClassExp `Generics.extQ` antiTypeExp `Generics.extQ` antiBTypeExp `Generics.extQ` antiATypeExp `Generics.extQ` antiGTyConExp `Generics.extQ` antiTypeListExp `Generics.extQ` antiSimpleTypeExp `Generics.extQ` antiTyVarExp `Generics.extQ` antiTyConExp `Generics.extQ` antiModIdExp `Generics.extQ` antiTyClsExp `Generics.extQ` antiOpExp `Generics.extQ` antiQOpExp) expr
 quoteHaskellPat :: Data.Data a => String -> (Haskell -> a) -> String -> TH.PatQ
 quoteHaskellPat dummy func s = do
-  let s1 = replaceAllPatterns s
-      expr = func $ parseHaskell $ alexScanTokens (dummy ++ " " ++ s1 ++ " " ++ dummy)
+  s1 <- either fail return (replaceAllPatterns s)
+  ast <- case scanTokens (dummy ++ " " ++ s1 ++ " " ++ dummy) >>= parseHaskell of
+           Left err -> fail err
+           Right a -> return a
+  let expr = func ast
   dataToPatQ (const Nothing `Generics.extQ` antiHaskellPat `Generics.extQ` antiModulePat `Generics.extQ` antiExportsOptPat `Generics.extQ` antiExportsListPat `Generics.extQ` antiExportPat `Generics.extQ` antiBodyPat `Generics.extQ` antiImpDeclListPat `Generics.extQ` antiImportListPat `Generics.extQ` antiVarPat `Generics.extQ` antiConPat `Generics.extQ` antiRule_13Pat `Generics.extQ` antiQVarIdPat `Generics.extQ` antiQVarPat `Generics.extQ` antiQTyClsPat `Generics.extQ` antiQTyConPat `Generics.extQ` antiCNamePat `Generics.extQ` antiCNameListPat `Generics.extQ` antiQVarListPat `Generics.extQ` antiImportPat `Generics.extQ` antiOptQualifiedPat `Generics.extQ` antiOptQualifiedAsPat `Generics.extQ` antiOptImpSpecPat `Generics.extQ` antiImpDeclPat `Generics.extQ` antiTopDeclsPat `Generics.extQ` antiTopDeclPat `Generics.extQ` antiDeclPat `Generics.extQ` antiOptContextPat `Generics.extQ` antiGenDeclPat `Generics.extQ` antiOptIntegerPat `Generics.extQ` antiOpsPat `Generics.extQ` antiFixityPat `Generics.extQ` antiFunLhsPat `Generics.extQ` antiPatPat `Generics.extQ` antiOptWherePat `Generics.extQ` antiDeclListPat `Generics.extQ` antiDeclsPat `Generics.extQ` antiRhsPat `Generics.extQ` antiOptGdRhsPat `Generics.extQ` antiGdPat `Generics.extQ` antiOptExpTypeSignaturePat `Generics.extQ` antiExpPat `Generics.extQ` antiExpIPat `Generics.extQ` antiGdRhsPat `Generics.extQ` antiConstrsPat `Generics.extQ` antiConstrPat `Generics.extQ` antiFieldDeclListPat `Generics.extQ` antiFieldDeclPat `Generics.extQ` antiVarsPat `Generics.extQ` antiOptDerivingPat `Generics.extQ` antiDerivingPat `Generics.extQ` antiDClassListPat `Generics.extQ` antiDClassPat `Generics.extQ` antiContextPat `Generics.extQ` antiClassListPat `Generics.extQ` antiClassPat `Generics.extQ` antiTypePat `Generics.extQ` antiBTypePat `Generics.extQ` antiATypePat `Generics.extQ` antiGTyConPat `Generics.extQ` antiTypeListPat `Generics.extQ` antiSimpleTypePat `Generics.extQ` antiTyVarPat `Generics.extQ` antiTyConPat `Generics.extQ` antiModIdPat `Generics.extQ` antiTyClsPat `Generics.extQ` antiOpPat `Generics.extQ` antiQOpPat) expr
 
 antiQOpExp :: QOp -> Maybe (TH.Q TH.Exp )

--- a/test/golden/java-simple/JavaSimpleLexer.x
+++ b/test/golden/java-simple/JavaSimpleLexer.x
@@ -1,5 +1,5 @@
 {
-module JavaSimpleLexer(alexScanTokens, Token(..), PosToken(..), AlexPosn(..))
+module JavaSimpleLexer(scanTokens, alexScanTokens, Token(..), PosToken(..), AlexPosn(..))
 where
 
  }
@@ -73,22 +73,26 @@ alexEOF = do
   (pos, _, _, _) <- alexGetInput
   return $ PosToken pos EndOfFile
 
--- The returned list always ends with an EndOfFile token that carries the
--- position of the end of input, so parse errors at end of input can be
--- reported with a position too
-alexScanTokens :: String -> [PosToken]
-alexScanTokens str =
-               case alexScanTokens1 str of
-                  Right toks -> toks
-                  Left err -> errorWithoutStackTrace err
-
-alexScanTokens1 str = runAlex str $ do
+-- Lex the input into a token stream, returning the positioned error message
+-- on a lexical error. The returned list always ends with an EndOfFile token
+-- that carries the position of the end of input, so parse errors at end of
+-- input can be reported with a position too
+scanTokens :: String -> Either String [PosToken]
+scanTokens str = runAlex str $ do
   let loop toks = do tok <- alexMonadScan
                      case tok of
                        PosToken _ EndOfFile -> return $ reverse (tok : toks)
                        _ -> let toks' = tok : toks
                             in toks' `seq` loop toks'
   loop []
+
+-- Thin compatibility wrapper: callers that have not switched to 'scanTokens'
+-- get the error message thrown instead
+alexScanTokens :: String -> [PosToken]
+alexScanTokens str =
+               case scanTokens str of
+                  Right toks -> toks
+                  Left err -> errorWithoutStackTrace err
 
 simple1 :: (String -> Token) -> AlexInput -> Int -> Alex PosToken
 simple1 t (pos, _, _, str) len = return $ PosToken pos (t (take len str))

--- a/test/golden/java-simple/JavaSimpleParser.y
+++ b/test/golden/java-simple/JavaSimpleParser.y
@@ -7,6 +7,7 @@ import qualified JavaSimpleLexer as L (Token(..), PosToken(..), AlexPosn(..), al
 
 %name parseJavaSimple
 %tokentype { L.PosToken }
+%monad { Either String }
 %error { parseError }
 
 %token
@@ -93,10 +94,10 @@ Type : qq_Type { Anti_Type $1 } |
 
 
 {
-parseError :: [L.PosToken] -> a
-parseError [] = errorWithoutStackTrace "Parse error: unexpected end of input"
+parseError :: [L.PosToken] -> Either String a
+parseError [] = Left "Parse error: unexpected end of input"
 parseError (L.PosToken (L.AlexPn _ line col) tok : _) =
-    errorWithoutStackTrace $ "Parse error at line " ++ show line ++ ", column " ++ show col ++ ": unexpected " ++ showRtkToken tok
+    Left $ "Parse error at line " ++ show line ++ ", column " ++ show col ++ ": unexpected " ++ showRtkToken tok
 
 -- Render a token the way it appears in the source, for error messages
 showRtkToken :: L.Token -> String

--- a/test/golden/java-simple/JavaSimpleQQ.hs
+++ b/test/golden/java-simple/JavaSimpleQQ.hs
@@ -25,42 +25,47 @@ qqShortcuts :: M.Map String String
 -- metavariable stands for one literal '$' (so $$$x is a literal '$'
 -- followed by the metavariable $x). A '$' not followed by an identifier is
 -- never rewritten and needs no escape.
-replaceAllPatterns1 :: String -> String
+replaceAllPatterns1 :: String -> Either String String
 replaceAllPatterns1 str = let (pre, match, post) = str =~ qqPattern :: (String, String, String)
                           in if match == ""
-                              then pre
+                              then Right pre
                               else let varName = init $ tail match
                                        addSym = last match
                                        escCount = length $ takeWhile (== '$') $ reverse pre
                                        keptPre = take (length pre - escCount) pre ++ replicate (div escCount 2) '$'
                                        ruleVariants = catMaybes $ map (\ prefix -> M.lookup prefix qqShortcuts) $ reverse $ inits varName
-                                       rule = case ruleVariants of
-                                                [] -> error $ unlines
-                                                        [ "Unknown metavariable $" ++ varName ++ " in quasi-quote:"
-                                                        , "no prefix of '" ++ varName ++ "' is a known shortcut. Known shortcuts:"
-                                                        , "  " ++ intercalate ", " (M.keys qqShortcuts)
-                                                        , "To include the literal text $" ++ varName ++ " in the quoted code"
-                                                        , "(e.g. inside a string literal), escape it as $$" ++ varName ++ "." ]
-                                                (rule : _) -> rule
                                    in if odd escCount
-                                       then keptPre ++ ('$' : varName) ++ (replaceAllPatterns1 $ addSym : post)
-                                       else keptPre ++ ('$' : rule ++ ":") ++ varName ++ (replaceAllPatterns1 $ addSym : post)
+                                       then (\rest -> keptPre ++ ('$' : varName) ++ rest) <$> (replaceAllPatterns1 $ addSym : post)
+                                       else case ruleVariants of
+                                              [] -> Left $ unlines
+                                                      [ "Unknown metavariable $" ++ varName ++ " in quasi-quote:"
+                                                      , "no prefix of '" ++ varName ++ "' is a known shortcut. Known shortcuts:"
+                                                      , "  " ++ intercalate ", " (M.keys qqShortcuts)
+                                                      , "To include the literal text $" ++ varName ++ " in the quoted code"
+                                                      , "(e.g. inside a string literal), escape it as $$" ++ varName ++ "." ]
+                                              (rule : _) -> (\rest -> keptPre ++ ('$' : rule ++ ":") ++ varName ++ rest) <$> (replaceAllPatterns1 $ addSym : post)
 
 -- Add ' ' at the end, so regex can match variable in the end of the string
-replaceAllPatterns :: String -> String
-replaceAllPatterns str = init $ replaceAllPatterns1 (str ++ " ")
+replaceAllPatterns :: String -> Either String String
+replaceAllPatterns str = init <$> replaceAllPatterns1 (str ++ " ")
 
 qqShortcuts = M.fromList [ ("javaSimple","JavaSimple"),("classDeclaration","ClassDeclaration"),("compilationUnit","CompilationUnit"),("compoundName","CompoundName"),("field","Field"),("fieldList","FieldList"),("package","Package"),("type","Type")]
 
 quoteJavaSimpleExp :: Data.Data a => String -> (JavaSimple -> a) -> String -> TH.ExpQ
 quoteJavaSimpleExp dummy func s = do
-  let s1 = replaceAllPatterns s
-      expr = func $ parseJavaSimple $ alexScanTokens (dummy ++ " " ++ s1 ++ " " ++ dummy)
+  s1 <- either fail return (replaceAllPatterns s)
+  ast <- case scanTokens (dummy ++ " " ++ s1 ++ " " ++ dummy) >>= parseJavaSimple of
+           Left err -> fail err
+           Right a -> return a
+  let expr = func ast
   dataToExpQ (const Nothing `Generics.extQ` antiJavaSimpleExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiFieldExp `Generics.extQ` antiTypeExp `Generics.extQ` antiCompoundNameExp) expr
 quoteJavaSimplePat :: Data.Data a => String -> (JavaSimple -> a) -> String -> TH.PatQ
 quoteJavaSimplePat dummy func s = do
-  let s1 = replaceAllPatterns s
-      expr = func $ parseJavaSimple $ alexScanTokens (dummy ++ " " ++ s1 ++ " " ++ dummy)
+  s1 <- either fail return (replaceAllPatterns s)
+  ast <- case scanTokens (dummy ++ " " ++ s1 ++ " " ++ dummy) >>= parseJavaSimple of
+           Left err -> fail err
+           Right a -> return a
+  let expr = func ast
   dataToPatQ (const Nothing `Generics.extQ` antiJavaSimplePat `Generics.extQ` antiCompilationUnitPat `Generics.extQ` antiPackagePat `Generics.extQ` antiClassDeclarationPat `Generics.extQ` antiFieldPat `Generics.extQ` antiTypePat `Generics.extQ` antiCompoundNamePat) expr
 
 antiCompoundNameExp :: CompoundName -> Maybe (TH.Q TH.Exp )

--- a/test/golden/java/JavaLexer.x
+++ b/test/golden/java/JavaLexer.x
@@ -1,5 +1,5 @@
 {
-module JavaLexer(alexScanTokens, Token(..), PosToken(..), AlexPosn(..))
+module JavaLexer(scanTokens, alexScanTokens, Token(..), PosToken(..), AlexPosn(..))
 where
 
  }
@@ -547,22 +547,26 @@ alexEOF = do
   (pos, _, _, _) <- alexGetInput
   return $ PosToken pos EndOfFile
 
--- The returned list always ends with an EndOfFile token that carries the
--- position of the end of input, so parse errors at end of input can be
--- reported with a position too
-alexScanTokens :: String -> [PosToken]
-alexScanTokens str =
-               case alexScanTokens1 str of
-                  Right toks -> toks
-                  Left err -> errorWithoutStackTrace err
-
-alexScanTokens1 str = runAlex str $ do
+-- Lex the input into a token stream, returning the positioned error message
+-- on a lexical error. The returned list always ends with an EndOfFile token
+-- that carries the position of the end of input, so parse errors at end of
+-- input can be reported with a position too
+scanTokens :: String -> Either String [PosToken]
+scanTokens str = runAlex str $ do
   let loop toks = do tok <- alexMonadScan
                      case tok of
                        PosToken _ EndOfFile -> return $ reverse (tok : toks)
                        _ -> let toks' = tok : toks
                             in toks' `seq` loop toks'
   loop []
+
+-- Thin compatibility wrapper: callers that have not switched to 'scanTokens'
+-- get the error message thrown instead
+alexScanTokens :: String -> [PosToken]
+alexScanTokens str =
+               case scanTokens str of
+                  Right toks -> toks
+                  Left err -> errorWithoutStackTrace err
 
 simple1 :: (String -> Token) -> AlexInput -> Int -> Alex PosToken
 simple1 t (pos, _, _, str) len = return $ PosToken pos (t (take len str))

--- a/test/golden/java/JavaParser.y
+++ b/test/golden/java/JavaParser.y
@@ -7,6 +7,7 @@ import qualified JavaLexer as L (Token(..), PosToken(..), AlexPosn(..), alexScan
 
 %name parseJava
 %tokentype { L.PosToken }
+%monad { Either String }
 %error { parseError }
 
 %token
@@ -1014,10 +1015,10 @@ WildcardType : qq_WildcardType { Anti_WildcardType $1 } |
 
 
 {
-parseError :: [L.PosToken] -> a
-parseError [] = errorWithoutStackTrace "Parse error: unexpected end of input"
+parseError :: [L.PosToken] -> Either String a
+parseError [] = Left "Parse error: unexpected end of input"
 parseError (L.PosToken (L.AlexPn _ line col) tok : _) =
-    errorWithoutStackTrace $ "Parse error at line " ++ show line ++ ", column " ++ show col ++ ": unexpected " ++ showRtkToken tok
+    Left $ "Parse error at line " ++ show line ++ ", column " ++ show col ++ ": unexpected " ++ showRtkToken tok
 
 -- Render a token the way it appears in the source, for error messages
 showRtkToken :: L.Token -> String

--- a/test/golden/java/JavaQQ.hs
+++ b/test/golden/java/JavaQQ.hs
@@ -25,42 +25,47 @@ qqShortcuts :: M.Map String String
 -- metavariable stands for one literal '$' (so $$$x is a literal '$'
 -- followed by the metavariable $x). A '$' not followed by an identifier is
 -- never rewritten and needs no escape.
-replaceAllPatterns1 :: String -> String
+replaceAllPatterns1 :: String -> Either String String
 replaceAllPatterns1 str = let (pre, match, post) = str =~ qqPattern :: (String, String, String)
                           in if match == ""
-                              then pre
+                              then Right pre
                               else let varName = init $ tail match
                                        addSym = last match
                                        escCount = length $ takeWhile (== '$') $ reverse pre
                                        keptPre = take (length pre - escCount) pre ++ replicate (div escCount 2) '$'
                                        ruleVariants = catMaybes $ map (\ prefix -> M.lookup prefix qqShortcuts) $ reverse $ inits varName
-                                       rule = case ruleVariants of
-                                                [] -> error $ unlines
-                                                        [ "Unknown metavariable $" ++ varName ++ " in quasi-quote:"
-                                                        , "no prefix of '" ++ varName ++ "' is a known shortcut. Known shortcuts:"
-                                                        , "  " ++ intercalate ", " (M.keys qqShortcuts)
-                                                        , "To include the literal text $" ++ varName ++ " in the quoted code"
-                                                        , "(e.g. inside a string literal), escape it as $$" ++ varName ++ "." ]
-                                                (rule : _) -> rule
                                    in if odd escCount
-                                       then keptPre ++ ('$' : varName) ++ (replaceAllPatterns1 $ addSym : post)
-                                       else keptPre ++ ('$' : rule ++ ":") ++ varName ++ (replaceAllPatterns1 $ addSym : post)
+                                       then (\rest -> keptPre ++ ('$' : varName) ++ rest) <$> (replaceAllPatterns1 $ addSym : post)
+                                       else case ruleVariants of
+                                              [] -> Left $ unlines
+                                                      [ "Unknown metavariable $" ++ varName ++ " in quasi-quote:"
+                                                      , "no prefix of '" ++ varName ++ "' is a known shortcut. Known shortcuts:"
+                                                      , "  " ++ intercalate ", " (M.keys qqShortcuts)
+                                                      , "To include the literal text $" ++ varName ++ " in the quoted code"
+                                                      , "(e.g. inside a string literal), escape it as $$" ++ varName ++ "." ]
+                                              (rule : _) -> (\rest -> keptPre ++ ('$' : rule ++ ":") ++ varName ++ rest) <$> (replaceAllPatterns1 $ addSym : post)
 
 -- Add ' ' at the end, so regex can match variable in the end of the string
-replaceAllPatterns :: String -> String
-replaceAllPatterns str = init $ replaceAllPatterns1 (str ++ " ")
+replaceAllPatterns :: String -> Either String String
+replaceAllPatterns str = init <$> replaceAllPatterns1 (str ++ " ")
 
 qqShortcuts = M.fromList [ ("java","Java"),("additiveOp","AdditiveOp"),("annotation","Annotation"),("annotationArguments","AnnotationArguments"),("annotationDeclaration","AnnotationDeclaration"),("annotationElement","AnnotationElement"),("annotationList","AnnotationList"),("annotationTypeElement","AnnotationTypeElement"),("annotationTypeElementList","AnnotationTypeElementList"),("arglist","Arglist"),("assignmentOp","AssignmentOp"),("catchList","CatchList"),("classDeclaration","ClassDeclaration"),("compilationUnit","CompilationUnit"),("compoundName","CompoundName"),("creationExpression","CreationExpression"),("doStatement","DoStatement"),("docComment","DocComment"),("enumConstant","EnumConstant"),("enumConstantList","EnumConstantList"),("enumDeclaration","EnumDeclaration"),("equalityOp","EqualityOp"),("expression","Expression"),("extendsList","ExtendsList"),("fieldDeclaration","FieldDeclaration"),("fieldDeclarationList","FieldDeclarationList"),("forStatement","ForStatement"),("ifStatement","IfStatement"),("implementsList","ImplementsList"),("importList","ImportList"),("importStatement","ImportStatement"),("interfaceDeclaration","InterfaceDeclaration"),("literal","Literal"),("memberAfterFirstId","MemberAfterFirstId"),("memberDeclaration","MemberDeclaration"),("memberRest","MemberRest"),("modifier","Modifier"),("modifierList","ModifierList"),("moreTypeSpecifier","MoreTypeSpecifier"),("moreVariableDeclarators","MoreVariableDeclarators"),("multiplicativeOp","MultiplicativeOp"),("nestedTypeDeclaration","NestedTypeDeclaration"),("optDocComment","OptDocComment"),("optElsePart","OptElsePart"),("optExpression","OptExpression"),("optFinally","OptFinally"),("optId","OptId"),("optVariableInitializer","OptVariableInitializer"),("package","Package"),("parameter","Parameter"),("parameterList","ParameterList"),("postfixOp","PostfixOp"),("prefixOp","PrefixOp"),("primitiveTypeKeyword","PrimitiveTypeKeyword"),("relationalOp","RelationalOp"),("shiftOp","ShiftOp"),("squareBracketsList","SquareBracketsList"),("statement","Statement"),("statementBlock","StatementBlock"),("statementList","StatementList"),("statementWithoutIf","StatementWithoutIf"),("staticInitializer","StaticInitializer"),("switchCaseList","SwitchCaseList"),("switchStatement","SwitchStatement"),("tryStatement","TryStatement"),("type","Type"),("typeArgument","TypeArgument"),("typeArguments","TypeArguments"),("typeDeclaration","TypeDeclaration"),("typeParameter","TypeParameter"),("typeParameters","TypeParameters"),("typeSpecifier","TypeSpecifier"),("variableDeclaration","VariableDeclaration"),("variableDeclarator","VariableDeclarator"),("variableDeclaratorList","VariableDeclaratorList"),("variableInitializer","VariableInitializer"),("variableInitializerList","VariableInitializerList"),("whileStatement","WhileStatement"),("wildcardType","WildcardType")]
 
 quoteJavaExp :: Data.Data a => String -> (Java -> a) -> String -> TH.ExpQ
 quoteJavaExp dummy func s = do
-  let s1 = replaceAllPatterns s
-      expr = func $ parseJava $ alexScanTokens (dummy ++ " " ++ s1 ++ " " ++ dummy)
+  s1 <- either fail return (replaceAllPatterns s)
+  ast <- case scanTokens (dummy ++ " " ++ s1 ++ " " ++ dummy) >>= parseJava of
+           Left err -> fail err
+           Right a -> return a
+  let expr = func ast
   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiRule_2Exp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_18Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiNestedTypeDeclarationExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_49Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiStatementWithoutIfExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_65Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_68Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) expr
 quoteJavaPat :: Data.Data a => String -> (Java -> a) -> String -> TH.PatQ
 quoteJavaPat dummy func s = do
-  let s1 = replaceAllPatterns s
-      expr = func $ parseJava $ alexScanTokens (dummy ++ " " ++ s1 ++ " " ++ dummy)
+  s1 <- either fail return (replaceAllPatterns s)
+  ast <- case scanTokens (dummy ++ " " ++ s1 ++ " " ++ dummy) >>= parseJava of
+           Left err -> fail err
+           Right a -> return a
+  let expr = func ast
   dataToPatQ (const Nothing `Generics.extQ` antiJavaPat `Generics.extQ` antiOptDocCommentPat `Generics.extQ` antiTypeDeclarationPat `Generics.extQ` antiRule_2Pat `Generics.extQ` antiCompilationUnitPat `Generics.extQ` antiPackagePat `Generics.extQ` antiImportStatementPat `Generics.extQ` antiDocCommentPat `Generics.extQ` antiAnnotationPat `Generics.extQ` antiAnnotationArgumentsPat `Generics.extQ` antiAnnotationElementPat `Generics.extQ` antiRule_18Pat `Generics.extQ` antiExtendsListPat `Generics.extQ` antiImplementsListPat `Generics.extQ` antiFieldDeclarationPat `Generics.extQ` antiClassDeclarationPat `Generics.extQ` antiInterfaceDeclarationPat `Generics.extQ` antiAnnotationDeclarationPat `Generics.extQ` antiAnnotationTypeElementPat `Generics.extQ` antiEnumConstantPat `Generics.extQ` antiEnumConstantListPat `Generics.extQ` antiEnumDeclarationPat `Generics.extQ` antiNestedTypeDeclarationPat `Generics.extQ` antiRule_44Pat `Generics.extQ` antiMemberDeclarationPat `Generics.extQ` antiPrimitiveTypeKeywordPat `Generics.extQ` antiMemberAfterFirstIdPat `Generics.extQ` antiMoreTypeSpecifierPat `Generics.extQ` antiMemberRestPat `Generics.extQ` antiRule_49Pat `Generics.extQ` antiStatementBlockPat `Generics.extQ` antiVariableDeclaratorListPat `Generics.extQ` antiVariableDeclarationPat `Generics.extQ` antiOptVariableInitializerPat `Generics.extQ` antiVariableDeclaratorPat `Generics.extQ` antiVariableInitializerListPat `Generics.extQ` antiVariableInitializerPat `Generics.extQ` antiStaticInitializerPat `Generics.extQ` antiParameterListPat `Generics.extQ` antiParameterPat `Generics.extQ` antiStatementPat `Generics.extQ` antiOptExpressionPat `Generics.extQ` antiOptIdPat `Generics.extQ` antiStatementWithoutIfPat `Generics.extQ` antiOptElsePartPat `Generics.extQ` antiIfStatementPat `Generics.extQ` antiDoStatementPat `Generics.extQ` antiWhileStatementPat `Generics.extQ` antiForStatementPat `Generics.extQ` antiRule_65Pat `Generics.extQ` antiOptFinallyPat `Generics.extQ` antiTryStatementPat `Generics.extQ` antiRule_68Pat `Generics.extQ` antiSwitchStatementPat `Generics.extQ` antiExpressionPat `Generics.extQ` antiAssignmentOpPat `Generics.extQ` antiEqualityOpPat `Generics.extQ` antiRelationalOpPat `Generics.extQ` antiShiftOpPat `Generics.extQ` antiAdditiveOpPat `Generics.extQ` antiMultiplicativeOpPat `Generics.extQ` antiPrefixOpPat `Generics.extQ` antiPostfixOpPat `Generics.extQ` antiCreationExpressionPat `Generics.extQ` antiLiteralPat `Generics.extQ` antiArglistPat `Generics.extQ` antiTypeArgumentsPat `Generics.extQ` antiTypeArgumentPat `Generics.extQ` antiWildcardTypePat `Generics.extQ` antiTypeParametersPat `Generics.extQ` antiTypeParameterPat `Generics.extQ` antiTypePat `Generics.extQ` antiTypeSpecifierPat `Generics.extQ` antiModifierPat `Generics.extQ` antiCompoundNamePat) expr
 
 antiCompoundNameExp :: CompoundName -> Maybe (TH.Q TH.Exp )

--- a/test/golden/p/PLexer.x
+++ b/test/golden/p/PLexer.x
@@ -1,5 +1,5 @@
 {
-module PLexer(alexScanTokens, Token(..), PosToken(..), AlexPosn(..))
+module PLexer(scanTokens, alexScanTokens, Token(..), PosToken(..), AlexPosn(..))
 where
 
  }
@@ -75,22 +75,26 @@ alexEOF = do
   (pos, _, _, _) <- alexGetInput
   return $ PosToken pos EndOfFile
 
--- The returned list always ends with an EndOfFile token that carries the
--- position of the end of input, so parse errors at end of input can be
--- reported with a position too
-alexScanTokens :: String -> [PosToken]
-alexScanTokens str =
-               case alexScanTokens1 str of
-                  Right toks -> toks
-                  Left err -> errorWithoutStackTrace err
-
-alexScanTokens1 str = runAlex str $ do
+-- Lex the input into a token stream, returning the positioned error message
+-- on a lexical error. The returned list always ends with an EndOfFile token
+-- that carries the position of the end of input, so parse errors at end of
+-- input can be reported with a position too
+scanTokens :: String -> Either String [PosToken]
+scanTokens str = runAlex str $ do
   let loop toks = do tok <- alexMonadScan
                      case tok of
                        PosToken _ EndOfFile -> return $ reverse (tok : toks)
                        _ -> let toks' = tok : toks
                             in toks' `seq` loop toks'
   loop []
+
+-- Thin compatibility wrapper: callers that have not switched to 'scanTokens'
+-- get the error message thrown instead
+alexScanTokens :: String -> [PosToken]
+alexScanTokens str =
+               case scanTokens str of
+                  Right toks -> toks
+                  Left err -> errorWithoutStackTrace err
 
 simple1 :: (String -> Token) -> AlexInput -> Int -> Alex PosToken
 simple1 t (pos, _, _, str) len = return $ PosToken pos (t (take len str))

--- a/test/golden/p/PParser.y
+++ b/test/golden/p/PParser.y
@@ -7,6 +7,7 @@ import qualified PLexer as L (Token(..), PosToken(..), AlexPosn(..), alexScanTok
 
 %name parseP
 %tokentype { L.PosToken }
+%monad { Either String }
 %error { parseError }
 
 %token
@@ -80,10 +81,10 @@ Op2 : qq_Op2 { Anti_Op2 $1 } |
 
 
 {
-parseError :: [L.PosToken] -> a
-parseError [] = errorWithoutStackTrace "Parse error: unexpected end of input"
+parseError :: [L.PosToken] -> Either String a
+parseError [] = Left "Parse error: unexpected end of input"
 parseError (L.PosToken (L.AlexPn _ line col) tok : _) =
-    errorWithoutStackTrace $ "Parse error at line " ++ show line ++ ", column " ++ show col ++ ": unexpected " ++ showRtkToken tok
+    Left $ "Parse error at line " ++ show line ++ ", column " ++ show col ++ ": unexpected " ++ showRtkToken tok
 
 -- Render a token the way it appears in the source, for error messages
 showRtkToken :: L.Token -> String

--- a/test/golden/p/PQQ.hs
+++ b/test/golden/p/PQQ.hs
@@ -25,42 +25,47 @@ qqShortcuts :: M.Map String String
 -- metavariable stands for one literal '$' (so $$$x is a literal '$'
 -- followed by the metavariable $x). A '$' not followed by an identifier is
 -- never rewritten and needs no escape.
-replaceAllPatterns1 :: String -> String
+replaceAllPatterns1 :: String -> Either String String
 replaceAllPatterns1 str = let (pre, match, post) = str =~ qqPattern :: (String, String, String)
                           in if match == ""
-                              then pre
+                              then Right pre
                               else let varName = init $ tail match
                                        addSym = last match
                                        escCount = length $ takeWhile (== '$') $ reverse pre
                                        keptPre = take (length pre - escCount) pre ++ replicate (div escCount 2) '$'
                                        ruleVariants = catMaybes $ map (\ prefix -> M.lookup prefix qqShortcuts) $ reverse $ inits varName
-                                       rule = case ruleVariants of
-                                                [] -> error $ unlines
-                                                        [ "Unknown metavariable $" ++ varName ++ " in quasi-quote:"
-                                                        , "no prefix of '" ++ varName ++ "' is a known shortcut. Known shortcuts:"
-                                                        , "  " ++ intercalate ", " (M.keys qqShortcuts)
-                                                        , "To include the literal text $" ++ varName ++ " in the quoted code"
-                                                        , "(e.g. inside a string literal), escape it as $$" ++ varName ++ "." ]
-                                                (rule : _) -> rule
                                    in if odd escCount
-                                       then keptPre ++ ('$' : varName) ++ (replaceAllPatterns1 $ addSym : post)
-                                       else keptPre ++ ('$' : rule ++ ":") ++ varName ++ (replaceAllPatterns1 $ addSym : post)
+                                       then (\rest -> keptPre ++ ('$' : varName) ++ rest) <$> (replaceAllPatterns1 $ addSym : post)
+                                       else case ruleVariants of
+                                              [] -> Left $ unlines
+                                                      [ "Unknown metavariable $" ++ varName ++ " in quasi-quote:"
+                                                      , "no prefix of '" ++ varName ++ "' is a known shortcut. Known shortcuts:"
+                                                      , "  " ++ intercalate ", " (M.keys qqShortcuts)
+                                                      , "To include the literal text $" ++ varName ++ " in the quoted code"
+                                                      , "(e.g. inside a string literal), escape it as $$" ++ varName ++ "." ]
+                                              (rule : _) -> (\rest -> keptPre ++ ('$' : rule ++ ":") ++ varName ++ rest) <$> (replaceAllPatterns1 $ addSym : post)
 
 -- Add ' ' at the end, so regex can match variable in the end of the string
-replaceAllPatterns :: String -> String
-replaceAllPatterns str = init $ replaceAllPatterns1 (str ++ " ")
+replaceAllPatterns :: String -> Either String String
+replaceAllPatterns str = init <$> replaceAllPatterns1 (str ++ " ")
 
 qqShortcuts = M.fromList [ ("p","P"),("e","E"),("id","Id"),("op1","Op1"),("op2","Op2")]
 
 quotePExp :: Data.Data a => String -> (P -> a) -> String -> TH.ExpQ
 quotePExp dummy func s = do
-  let s1 = replaceAllPatterns s
-      expr = func $ parseP $ alexScanTokens (dummy ++ " " ++ s1 ++ " " ++ dummy)
+  s1 <- either fail return (replaceAllPatterns s)
+  ast <- case scanTokens (dummy ++ " " ++ s1 ++ " " ++ dummy) >>= parseP of
+           Left err -> fail err
+           Right a -> return a
+  let expr = func ast
   dataToExpQ (const Nothing `Generics.extQ` antiPExp `Generics.extQ` antiEExp `Generics.extQ` antiOp1Exp `Generics.extQ` antiOp2Exp `Generics.extQ` antiIdExp) expr
 quotePPat :: Data.Data a => String -> (P -> a) -> String -> TH.PatQ
 quotePPat dummy func s = do
-  let s1 = replaceAllPatterns s
-      expr = func $ parseP $ alexScanTokens (dummy ++ " " ++ s1 ++ " " ++ dummy)
+  s1 <- either fail return (replaceAllPatterns s)
+  ast <- case scanTokens (dummy ++ " " ++ s1 ++ " " ++ dummy) >>= parseP of
+           Left err -> fail err
+           Right a -> return a
+  let expr = func ast
   dataToPatQ (const Nothing `Generics.extQ` antiPPat `Generics.extQ` antiEPat `Generics.extQ` antiOp1Pat `Generics.extQ` antiOp2Pat `Generics.extQ` antiIdPat) expr
 
 antiIdExp :: Id -> Maybe (TH.Q TH.Exp )

--- a/test/golden/sandbox/SandboxLexer.x
+++ b/test/golden/sandbox/SandboxLexer.x
@@ -1,5 +1,5 @@
 {
-module SandboxLexer(alexScanTokens, Token(..), PosToken(..), AlexPosn(..))
+module SandboxLexer(scanTokens, alexScanTokens, Token(..), PosToken(..), AlexPosn(..))
 where
 
  }
@@ -29,22 +29,26 @@ alexEOF = do
   (pos, _, _, _) <- alexGetInput
   return $ PosToken pos EndOfFile
 
--- The returned list always ends with an EndOfFile token that carries the
--- position of the end of input, so parse errors at end of input can be
--- reported with a position too
-alexScanTokens :: String -> [PosToken]
-alexScanTokens str =
-               case alexScanTokens1 str of
-                  Right toks -> toks
-                  Left err -> errorWithoutStackTrace err
-
-alexScanTokens1 str = runAlex str $ do
+-- Lex the input into a token stream, returning the positioned error message
+-- on a lexical error. The returned list always ends with an EndOfFile token
+-- that carries the position of the end of input, so parse errors at end of
+-- input can be reported with a position too
+scanTokens :: String -> Either String [PosToken]
+scanTokens str = runAlex str $ do
   let loop toks = do tok <- alexMonadScan
                      case tok of
                        PosToken _ EndOfFile -> return $ reverse (tok : toks)
                        _ -> let toks' = tok : toks
                             in toks' `seq` loop toks'
   loop []
+
+-- Thin compatibility wrapper: callers that have not switched to 'scanTokens'
+-- get the error message thrown instead
+alexScanTokens :: String -> [PosToken]
+alexScanTokens str =
+               case scanTokens str of
+                  Right toks -> toks
+                  Left err -> errorWithoutStackTrace err
 
 simple1 :: (String -> Token) -> AlexInput -> Int -> Alex PosToken
 simple1 t (pos, _, _, str) len = return $ PosToken pos (t (take len str))

--- a/test/golden/sandbox/SandboxParser.y
+++ b/test/golden/sandbox/SandboxParser.y
@@ -7,6 +7,7 @@ import qualified SandboxLexer as L (Token(..), PosToken(..), AlexPosn(..), alexS
 
 %name parseSandbox
 %tokentype { L.PosToken }
+%monad { Either String }
 %error { parseError }
 
 %token
@@ -27,10 +28,10 @@ Sandbox : qq_Sandbox { Anti_Sandbox $1 } |
 
 
 {
-parseError :: [L.PosToken] -> a
-parseError [] = errorWithoutStackTrace "Parse error: unexpected end of input"
+parseError :: [L.PosToken] -> Either String a
+parseError [] = Left "Parse error: unexpected end of input"
 parseError (L.PosToken (L.AlexPn _ line col) tok : _) =
-    errorWithoutStackTrace $ "Parse error at line " ++ show line ++ ", column " ++ show col ++ ": unexpected " ++ showRtkToken tok
+    Left $ "Parse error at line " ++ show line ++ ", column " ++ show col ++ ": unexpected " ++ showRtkToken tok
 
 -- Render a token the way it appears in the source, for error messages
 showRtkToken :: L.Token -> String

--- a/test/golden/sandbox/SandboxQQ.hs
+++ b/test/golden/sandbox/SandboxQQ.hs
@@ -25,42 +25,47 @@ qqShortcuts :: M.Map String String
 -- metavariable stands for one literal '$' (so $$$x is a literal '$'
 -- followed by the metavariable $x). A '$' not followed by an identifier is
 -- never rewritten and needs no escape.
-replaceAllPatterns1 :: String -> String
+replaceAllPatterns1 :: String -> Either String String
 replaceAllPatterns1 str = let (pre, match, post) = str =~ qqPattern :: (String, String, String)
                           in if match == ""
-                              then pre
+                              then Right pre
                               else let varName = init $ tail match
                                        addSym = last match
                                        escCount = length $ takeWhile (== '$') $ reverse pre
                                        keptPre = take (length pre - escCount) pre ++ replicate (div escCount 2) '$'
                                        ruleVariants = catMaybes $ map (\ prefix -> M.lookup prefix qqShortcuts) $ reverse $ inits varName
-                                       rule = case ruleVariants of
-                                                [] -> error $ unlines
-                                                        [ "Unknown metavariable $" ++ varName ++ " in quasi-quote:"
-                                                        , "no prefix of '" ++ varName ++ "' is a known shortcut. Known shortcuts:"
-                                                        , "  " ++ intercalate ", " (M.keys qqShortcuts)
-                                                        , "To include the literal text $" ++ varName ++ " in the quoted code"
-                                                        , "(e.g. inside a string literal), escape it as $$" ++ varName ++ "." ]
-                                                (rule : _) -> rule
                                    in if odd escCount
-                                       then keptPre ++ ('$' : varName) ++ (replaceAllPatterns1 $ addSym : post)
-                                       else keptPre ++ ('$' : rule ++ ":") ++ varName ++ (replaceAllPatterns1 $ addSym : post)
+                                       then (\rest -> keptPre ++ ('$' : varName) ++ rest) <$> (replaceAllPatterns1 $ addSym : post)
+                                       else case ruleVariants of
+                                              [] -> Left $ unlines
+                                                      [ "Unknown metavariable $" ++ varName ++ " in quasi-quote:"
+                                                      , "no prefix of '" ++ varName ++ "' is a known shortcut. Known shortcuts:"
+                                                      , "  " ++ intercalate ", " (M.keys qqShortcuts)
+                                                      , "To include the literal text $" ++ varName ++ " in the quoted code"
+                                                      , "(e.g. inside a string literal), escape it as $$" ++ varName ++ "." ]
+                                              (rule : _) -> (\rest -> keptPre ++ ('$' : rule ++ ":") ++ varName ++ rest) <$> (replaceAllPatterns1 $ addSym : post)
 
 -- Add ' ' at the end, so regex can match variable in the end of the string
-replaceAllPatterns :: String -> String
-replaceAllPatterns str = init $ replaceAllPatterns1 (str ++ " ")
+replaceAllPatterns :: String -> Either String String
+replaceAllPatterns str = init <$> replaceAllPatterns1 (str ++ " ")
 
 qqShortcuts = M.fromList [ ("sandbox","Sandbox")]
 
 quoteSandboxExp :: Data.Data a => String -> (Sandbox -> a) -> String -> TH.ExpQ
 quoteSandboxExp dummy func s = do
-  let s1 = replaceAllPatterns s
-      expr = func $ parseSandbox $ alexScanTokens (dummy ++ " " ++ s1 ++ " " ++ dummy)
+  s1 <- either fail return (replaceAllPatterns s)
+  ast <- case scanTokens (dummy ++ " " ++ s1 ++ " " ++ dummy) >>= parseSandbox of
+           Left err -> fail err
+           Right a -> return a
+  let expr = func ast
   dataToExpQ (const Nothing `Generics.extQ` antiSandboxExp) expr
 quoteSandboxPat :: Data.Data a => String -> (Sandbox -> a) -> String -> TH.PatQ
 quoteSandboxPat dummy func s = do
-  let s1 = replaceAllPatterns s
-      expr = func $ parseSandbox $ alexScanTokens (dummy ++ " " ++ s1 ++ " " ++ dummy)
+  s1 <- either fail return (replaceAllPatterns s)
+  ast <- case scanTokens (dummy ++ " " ++ s1 ++ " " ++ dummy) >>= parseSandbox of
+           Left err -> fail err
+           Right a -> return a
+  let expr = func ast
   dataToPatQ (const Nothing `Generics.extQ` antiSandboxPat) expr
 
 antiSandboxExp :: Sandbox -> Maybe (TH.Q TH.Exp )

--- a/test/golden/t1/T1Lexer.x
+++ b/test/golden/t1/T1Lexer.x
@@ -1,5 +1,5 @@
 {
-module T1Lexer(alexScanTokens, Token(..), PosToken(..), AlexPosn(..))
+module T1Lexer(scanTokens, alexScanTokens, Token(..), PosToken(..), AlexPosn(..))
 where
 
  }
@@ -70,22 +70,26 @@ alexEOF = do
   (pos, _, _, _) <- alexGetInput
   return $ PosToken pos EndOfFile
 
--- The returned list always ends with an EndOfFile token that carries the
--- position of the end of input, so parse errors at end of input can be
--- reported with a position too
-alexScanTokens :: String -> [PosToken]
-alexScanTokens str =
-               case alexScanTokens1 str of
-                  Right toks -> toks
-                  Left err -> errorWithoutStackTrace err
-
-alexScanTokens1 str = runAlex str $ do
+-- Lex the input into a token stream, returning the positioned error message
+-- on a lexical error. The returned list always ends with an EndOfFile token
+-- that carries the position of the end of input, so parse errors at end of
+-- input can be reported with a position too
+scanTokens :: String -> Either String [PosToken]
+scanTokens str = runAlex str $ do
   let loop toks = do tok <- alexMonadScan
                      case tok of
                        PosToken _ EndOfFile -> return $ reverse (tok : toks)
                        _ -> let toks' = tok : toks
                             in toks' `seq` loop toks'
   loop []
+
+-- Thin compatibility wrapper: callers that have not switched to 'scanTokens'
+-- get the error message thrown instead
+alexScanTokens :: String -> [PosToken]
+alexScanTokens str =
+               case scanTokens str of
+                  Right toks -> toks
+                  Left err -> errorWithoutStackTrace err
 
 simple1 :: (String -> Token) -> AlexInput -> Int -> Alex PosToken
 simple1 t (pos, _, _, str) len = return $ PosToken pos (t (take len str))

--- a/test/golden/t1/T1Parser.y
+++ b/test/golden/t1/T1Parser.y
@@ -7,6 +7,7 @@ import qualified T1Lexer as L (Token(..), PosToken(..), AlexPosn(..), alexScanTo
 
 %name parseT1
 %tokentype { L.PosToken }
+%monad { Either String }
 %error { parseError }
 
 %token
@@ -118,10 +119,10 @@ Rule_8 : D E { Ctr__Rule_8__0 $1 $2 }
 
 
 {
-parseError :: [L.PosToken] -> a
-parseError [] = errorWithoutStackTrace "Parse error: unexpected end of input"
+parseError :: [L.PosToken] -> Either String a
+parseError [] = Left "Parse error: unexpected end of input"
 parseError (L.PosToken (L.AlexPn _ line col) tok : _) =
-    errorWithoutStackTrace $ "Parse error at line " ++ show line ++ ", column " ++ show col ++ ": unexpected " ++ showRtkToken tok
+    Left $ "Parse error at line " ++ show line ++ ", column " ++ show col ++ ": unexpected " ++ showRtkToken tok
 
 -- Render a token the way it appears in the source, for error messages
 showRtkToken :: L.Token -> String

--- a/test/golden/t1/T1QQ.hs
+++ b/test/golden/t1/T1QQ.hs
@@ -25,42 +25,47 @@ qqShortcuts :: M.Map String String
 -- metavariable stands for one literal '$' (so $$$x is a literal '$'
 -- followed by the metavariable $x). A '$' not followed by an identifier is
 -- never rewritten and needs no escape.
-replaceAllPatterns1 :: String -> String
+replaceAllPatterns1 :: String -> Either String String
 replaceAllPatterns1 str = let (pre, match, post) = str =~ qqPattern :: (String, String, String)
                           in if match == ""
-                              then pre
+                              then Right pre
                               else let varName = init $ tail match
                                        addSym = last match
                                        escCount = length $ takeWhile (== '$') $ reverse pre
                                        keptPre = take (length pre - escCount) pre ++ replicate (div escCount 2) '$'
                                        ruleVariants = catMaybes $ map (\ prefix -> M.lookup prefix qqShortcuts) $ reverse $ inits varName
-                                       rule = case ruleVariants of
-                                                [] -> error $ unlines
-                                                        [ "Unknown metavariable $" ++ varName ++ " in quasi-quote:"
-                                                        , "no prefix of '" ++ varName ++ "' is a known shortcut. Known shortcuts:"
-                                                        , "  " ++ intercalate ", " (M.keys qqShortcuts)
-                                                        , "To include the literal text $" ++ varName ++ " in the quoted code"
-                                                        , "(e.g. inside a string literal), escape it as $$" ++ varName ++ "." ]
-                                                (rule : _) -> rule
                                    in if odd escCount
-                                       then keptPre ++ ('$' : varName) ++ (replaceAllPatterns1 $ addSym : post)
-                                       else keptPre ++ ('$' : rule ++ ":") ++ varName ++ (replaceAllPatterns1 $ addSym : post)
+                                       then (\rest -> keptPre ++ ('$' : varName) ++ rest) <$> (replaceAllPatterns1 $ addSym : post)
+                                       else case ruleVariants of
+                                              [] -> Left $ unlines
+                                                      [ "Unknown metavariable $" ++ varName ++ " in quasi-quote:"
+                                                      , "no prefix of '" ++ varName ++ "' is a known shortcut. Known shortcuts:"
+                                                      , "  " ++ intercalate ", " (M.keys qqShortcuts)
+                                                      , "To include the literal text $" ++ varName ++ " in the quoted code"
+                                                      , "(e.g. inside a string literal), escape it as $$" ++ varName ++ "." ]
+                                              (rule : _) -> (\rest -> keptPre ++ ('$' : rule ++ ":") ++ varName ++ rest) <$> (replaceAllPatterns1 $ addSym : post)
 
 -- Add ' ' at the end, so regex can match variable in the end of the string
-replaceAllPatterns :: String -> String
-replaceAllPatterns str = init $ replaceAllPatterns1 (str ++ " ")
+replaceAllPatterns :: String -> Either String String
+replaceAllPatterns str = init <$> replaceAllPatterns1 (str ++ " ")
 
 qqShortcuts = M.fromList [ ("a","A"),("b","B"),("c","C"),("d","D"),("e","E"),("f1","F1"),("f2","F2"),("f3","F3"),("f4","F4"),("f5","F5"),("g","G")]
 
 quoteT1Exp :: Data.Data a => String -> (A -> a) -> String -> TH.ExpQ
 quoteT1Exp dummy func s = do
-  let s1 = replaceAllPatterns s
-      expr = func $ parseT1 $ alexScanTokens (dummy ++ " " ++ s1 ++ " " ++ dummy)
+  s1 <- either fail return (replaceAllPatterns s)
+  ast <- case scanTokens (dummy ++ " " ++ s1 ++ " " ++ dummy) >>= parseT1 of
+           Left err -> fail err
+           Right a -> return a
+  let expr = func ast
   dataToExpQ (const Nothing `Generics.extQ` antiAExp `Generics.extQ` antiBExp `Generics.extQ` antiDExp `Generics.extQ` antiEExp `Generics.extQ` antiF4Exp `Generics.extQ` antiGExp) expr
 quoteT1Pat :: Data.Data a => String -> (A -> a) -> String -> TH.PatQ
 quoteT1Pat dummy func s = do
-  let s1 = replaceAllPatterns s
-      expr = func $ parseT1 $ alexScanTokens (dummy ++ " " ++ s1 ++ " " ++ dummy)
+  s1 <- either fail return (replaceAllPatterns s)
+  ast <- case scanTokens (dummy ++ " " ++ s1 ++ " " ++ dummy) >>= parseT1 of
+           Left err -> fail err
+           Right a -> return a
+  let expr = func ast
   dataToPatQ (const Nothing `Generics.extQ` antiAPat `Generics.extQ` antiBPat `Generics.extQ` antiDPat `Generics.extQ` antiEPat `Generics.extQ` antiF4Pat `Generics.extQ` antiGPat) expr
 
 antiGExp :: G -> Maybe (TH.Q TH.Exp )


### PR DESCRIPTION
## Summary

This PR migrates generated parsers, lexers, and quasi-quoters from throwing exceptions to returning `Either` for error handling, completing the "Stage G" of the diagnostics migration. Generated code now reports errors as values rather than exceptions, enabling better error recovery and positioning.

## Key Changes

### Lexer Generation (GenX.hs, *.x files)
- New `scanTokens :: String -> Either String [PosToken]` function returns lexical errors as `Left String`
- `alexScanTokens` retained as a compatibility wrapper that throws on error
- Module exports updated to include `scanTokens` first
- Updated test-grammars main files to use the new error-returning interface

### Parser Generation (GenY.hs, *.y files)
- Added `%monad { Either String }` directive to Happy parser specs
- `parseError` now returns `Either String a` instead of throwing
- Parser automatically propagates errors through the Either monad
- All generated parser files updated with the monad directive

### Quasi-Quoter Generation (GenQ.hs, *.hs files)
- `replaceAllPatterns1` changed from `String -> String` to `String -> Either String String`
- Unknown metavariable errors now return `Left` instead of calling `error`
- Lexer and parser errors propagated through `Either` and routed to `fail` in `TH.Q`
- Bad quasi-quotes now produce positioned GHC compile errors at splice site instead of runtime crashes

### Normalization (Normalize.hs)
- Added `checkDuplicateRuleNames` function to detect and reject duplicate rule definitions
- Duplicate rules now produce a normalization error with both source positions
- Error message includes the position of the first definition for reference
- Checked on input rules before synthesized start wrapper is added

### Testing
- Added unit test for duplicate rule detection with position reporting
- Updated test-grammars main files to handle `Either` return types
- Golden tests updated to reflect new parser monad directive
- All existing tests pass with new error handling

## Implementation Details

- Generated code remains **dependency-free** (no new imports required)
- Error messages preserve source position information for better diagnostics
- Backward compatibility maintained via `alexScanTokens` wrapper
- Quasi-quoter errors integrated with Template Haskell's error reporting system
- Duplicate rule detection happens during normalization, before code generation

https://claude.ai/code/session_01RCYf192PYs4XY9k8syv96F