### PR TITLE
Attach splice alternatives only at minimal attach points in shared-type groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   position (e.g. `Grammar error in rule 'Foo' (at line 2, column 1): ...`)
 - Lexer-generation errors name the lexical rule they occur in
 
+### Changed
+- The `$Type:var` splice alternative is now attached to a minimal set of
+  rules of a shared-type group instead of to every rule. The normalizer
+  builds the group's lift graph (rule A → rule B when B has an alternative
+  that is exactly the single nonterminal A, ignoring nullable clauses) and
+  greedily picks attach points whose unit-closure covers every rule the
+  grammar demands from some position; a splice token reduces at an attach
+  point and climbs the chain to the level its position requires. For
+  java.pg's 18-rule Expression chain the single attach point is
+  `PrimaryNoPostfix`, which removes the 806 reduce/reduce conflicts
+  (of 883) the per-rule alternatives used to cause, along with the three
+  "rule ... is unused" happy warnings, and makes the parse of a splice
+  independent of conflict-resolution accidents. Types declared by a
+  single rule are unaffected. A
+  group whose demanded rules cannot be covered from one attach point gets
+  several; if their closures overlap, the overlap can reintroduce
+  reduce/reduce conflicts between the splice reductions (inherent to such
+  grammars; normalization has no warning channel to report them)
+
 ### Removed
 - Unimplemented CLI options that were advertised in `--help` but had no
   effect: `--debug-rule`, `--compare-stages`, `--memory-stats`,

--- a/Normalize.hs
+++ b/Normalize.hs
@@ -37,6 +37,9 @@ data NormalizationState = NormalizationState {
                                               _qqLexRuleCache :: M.Map ID ID,
                                               _antiRuleCache :: M.Map ID ID,
                                               _ruleToTypeName :: M.Map ID ID,
+                                              -- type name -> rules that receive the $Type:var
+                                              -- splice alternative (see computeQQAttachPoints)
+                                              _qqAttachPoints :: M.Map ID (S.Set ID),
                                               _currentRule :: Maybe IRule
                                              }
 
@@ -149,11 +152,21 @@ addRuleWithQQ tdName ruleName clause = do
                 addRule tdName ruleName $ STMany opType (SSId newRule) mcl
     _ -> addRule tdName ruleName clause
   where qqAdd altseqs = do
+          -- The QQ machinery (lexical rule, anti rule) is created at the first
+          -- eligible rule of the type, as before; but the splice alternative
+          -- itself is only attached at the group's attach points (a minimal
+          -- set of rules from which every rule of a shared-type group is
+          -- reachable via unit productions, see computeQQAttachPoints).
+          -- Attaching it to every rule instead would add one reduce item per
+          -- rule for the same splice token, flooding the parser with
+          -- reduce/reduce conflicts.
           qqLexRule <- addQQLexRuleCached tdName     -- Use cached version
           constr <- addAntiRuleCached tdName False   -- Use cached version
-          -- For shared types, add anti-alternative to ALL rules (GenAST deduplicates constructors)
-          -- This ensures splicing works in all grammar contexts, not just the first rule
-          addRule tdName ruleName $ STAltOfSeq (STSeq constr [SSId qqLexRule] : altseqs)
+          attachMap <- use qqAttachPoints
+          let attachHere = S.member ruleName $ M.findWithDefault S.empty tdName attachMap
+          if attachHere
+            then addRule tdName ruleName $ STAltOfSeq (STSeq constr [SSId qqLexRule] : altseqs)
+            else addRule tdName ruleName clause
 
 addListProxyRule :: ID -> ID -> ID -> Normalization ID
 addListProxyRule tdName elemRuleName listName = do
@@ -324,6 +337,182 @@ checkDuplicateRuleNames = go M.empty
       Just pos -> " (first definition at " ++ showSourcePos pos ++ ")"
       Nothing  -> ""
 
+-- Decide, for every data type, which of its rules receive the $Type:var
+-- splice alternative ("attach points"). A type declared by a single rule
+-- keeps today's behavior: the rule itself is the attach point.
+--
+-- For a shared type (several rules declaring the same type, e.g. java.pg's
+-- 18-rule Expression precedence chain) attaching the alternative to every
+-- rule would make the splice token reducible to all of them at once: the
+-- parser gets one reduce item per rule in the same states and cannot know
+-- which rule to reduce the token to (in java.pg this used to cause 806 of
+-- the 883 reduce/reduce conflicts). Instead the alternative is attached to
+-- a minimal set of rules from which the rest of the group is reachable via
+-- unit productions:
+--
+--   * Build the intra-group "lift graph": an edge A -> B when rule B has an
+--     alternative consisting of exactly the single nonterminal A once
+--     nullable clauses are dropped (i.e. an A on the stack reduces to B by a
+--     unit production, possibly surrounded by empty reductions). For java.pg
+--     this is the chain PrimaryNoPostfix -> PostfixExpression -> ... ->
+--     Expression.
+--   * Collect the rules of the group some grammar position actually demands:
+--     every reference from any rule's alternatives counts, except the
+--     reference that forms a lift edge inside the group itself (a splice
+--     never needs to stop at that position: reducing further is the only
+--     thing the parser can do with it). The rule named after the type is
+--     always demanded, because the synthesized start rule references it.
+--   * Greedily pick attach points whose unit-closure covers all demanded
+--     rules. A precedence chain needs exactly one (its bottom rule). A group
+--     that genuinely needs several attach points gets several; if their
+--     closures overlap, the overlap reintroduces reduce/reduce conflicts
+--     between the splice reductions -- that is inherent to such a grammar,
+--     not to this placement (there is no warning channel in normalization,
+--     so such groups are not reported).
+--
+-- Only rules that addRuleWithQQ would accept the alternative for are attach
+-- point candidates (rules whose clause normalizes to plain alternatives with
+-- no leading lifted (,) clause). Two conservative fallbacks keep splicing at
+-- least as available as before: when no rule is named after the type, every
+-- rule of the group counts as demanded; and when the greedy cover cannot
+-- cover anything, every candidate becomes an attach point.
+computeQQAttachPoints :: InitialGrammar -> M.Map ID (S.Set ID)
+computeQQAttachPoints grammar = M.fromList $ map attachFor groups
+  where
+    synRules = [ r | r <- getIRules grammar, not (isLexicalRule (getIRuleName r)) ]
+    ruleTypeOf r = maybe (getIRuleName r) Prelude.id (getIDataTypeName r)
+    groupNames = L.nub $ map ruleTypeOf synRules
+    groups = [ (t, [ r | r <- synRules, ruleTypeOf r == t ]) | t <- groupNames ]
+    groupOfRule = M.fromList [ (getIRuleName r, ruleTypeOf r) | r <- synRules ]
+
+    -- Rule-level nullability, by fixpoint. Lexical rules (and unknown names)
+    -- never match the empty input.
+    clausesByName = M.fromListWith (flip (++)) [ (getIRuleName r, [getIClause r]) | r <- synRules ]
+    nullableRules = fixNullable S.empty
+    fixNullable env =
+      let env' = S.fromList [ n | (n, cls) <- M.toList clausesByName
+                                , any (clauseNullable env) cls ]
+      in if env' == env then env else fixNullable env'
+    clauseNullable env c = case c of
+      IId n        -> S.member n env
+      IStrLit _    -> False
+      IDot         -> False
+      IRegExpLit _ -> False
+      IStar _ _    -> True
+      IOpt _       -> True
+      IPlus c1 _   -> clauseNullable env c1
+      IAlt cs      -> any (clauseNullable env) cs
+      ISeq cs      -> all (clauseNullable env) cs
+      ILifted c1   -> clauseNullable env c1
+      IIgnore c1   -> clauseNullable env c1
+    isNullable = clauseNullable nullableRules
+
+    -- The alternatives a clause normalizes to, mirroring checkNormalClause:
+    -- singleton wrappers unwrap, a top-level option contributes an empty
+    -- alternative (removeOpts), everything else is a single alternative.
+    unwrapTop (IAlt [c]) = unwrapTop c
+    unwrapTop (ISeq [c]) = unwrapTop c
+    unwrapTop c          = c
+    topAlts c = case unwrapTop c of
+                  IAlt cs -> cs
+                  IOpt c1 -> [ISeq [], ISeq [c1]]
+                  c'      -> [c']
+
+    -- The non-nullable core of an alternative: Just n for a nonterminal
+    -- whose value passes through (a plain or lifted reference), Nothing for
+    -- anything opaque (tokens, ignored or repeated material, nested
+    -- alternatives, which normalize to proxy rules).
+    coreElems c
+      | isNullable c = []
+      | otherwise = case c of
+          ISeq cs    -> concatMap coreElems cs
+          IId n      -> [Just n]
+          ILifted c1 -> coreElems c1
+          _          -> [Nothing]
+    unitTarget alt = case coreElems alt of
+                       [Just n] -> Just n
+                       _        -> Nothing
+
+    -- Mirror of the addRuleWithQQ guard: would this clause get the splice
+    -- alternative at all? (STMany rules take the list-proxy path; a leading
+    -- lifted (,) clause suppresses the alternative.)
+    eligibleClause c = case unwrapTop c of
+      IStar{}   -> False
+      IPlus{}   -> False
+      ILifted _ -> False
+      c'        -> not $ any altLeadsLifted (topAlts c')
+    altLeadsLifted (ISeq (c:_)) = liftedIdHead c
+    altLeadsLifted c            = liftedIdHead c
+    liftedIdHead (ILifted (IId _)) = True
+    liftedIdHead _                 = False
+
+    allIdRefs :: IClause -> [ID]
+    allIdRefs = everything (++) ([] `mkQ` idRef)
+      where idRef (IId n) = [n]
+            idRef _       = []
+
+    attachFor (t, [r]) = (t, S.singleton (getIRuleName r))
+    attachFor (t, rs)  = (t, picked)
+      where
+        names = L.nub $ map getIRuleName rs   -- in declaration order
+        nameSet = S.fromList names
+
+        -- lift graph: source -> targets it reduces to by a unit production
+        edges = M.fromListWith S.union
+                  [ (src, S.singleton (getIRuleName r))
+                  | r <- rs
+                  , alt <- topAlts (getIClause r)
+                  , Just src <- [unitTarget alt]
+                  , src `S.member` nameSet ]
+        closureOf n0 = go (S.singleton n0) [n0]
+          where go seen [] = seen
+                go seen (x:xs) =
+                  let new = [ y | y <- S.toList (M.findWithDefault S.empty x edges)
+                                , not (S.member y seen) ]
+                  in go (foldr S.insert seen new) (new ++ xs)
+        closures = M.fromList [ (n, closureOf n) | n <- names ]
+
+        -- rules of this group demanded by some position of the grammar
+        demandRefs r alt =
+          let refs = filter (`S.member` nameSet) (allIdRefs alt)
+          in case unitTarget alt of
+               Just n | M.lookup (getIRuleName r) groupOfRule == Just t
+                      , n `S.member` nameSet -> L.delete n refs
+               _ -> refs
+        demanded
+          | t `S.member` nameSet = S.insert t demanded0
+          | otherwise            = nameSet   -- no rule carries the type name:
+                                             -- assume everything is demanded
+          where demanded0 = S.fromList [ ref | r <- synRules
+                                             , alt <- topAlts (getIClause r)
+                                             , ref <- demandRefs r alt ]
+
+        candidates = [ n | n <- names
+                         , any (eligibleClause . getIClause)
+                               [ r | r <- rs, getIRuleName r == n ] ]
+
+        greedy uncovered acc
+          | S.null uncovered = reverse acc
+          | otherwise = case best of
+              Just n  -> greedy (uncovered S.\\ (closures M.! n)) (n : acc)
+              Nothing -> reverse acc
+          where -- most newly covered demands first; among equals the rule
+                -- with the larger closure, i.e. the bottom-most rule of the
+                -- chain (a chain bottom and the rule just above it cover the
+                -- same demands when the bottom itself is never demanded, but
+                -- splices must enter the chain at the bottom to be able to
+                -- climb everywhere); declaration order breaks remaining ties
+                gain n = (S.size $ (closures M.! n) `S.intersection` uncovered,
+                          S.size $ closures M.! n)
+                best = fst $ L.foldl' pick (Nothing, (0, 0)) candidates
+                pick (b, g0) n = let g = gain n
+                                 in if fst g > 0 && g > g0 then (Just n, g) else (b, g0)
+
+        picked = case greedy demanded [] of
+                   [] -> S.fromList candidates  -- cover made no progress: keep
+                                                -- the old attach-everywhere
+                   ns -> S.fromList ns
+
 doNM :: InitialGrammar -> Normalization ()
 doNM grammar = do
   let grammar0 = everywhereBut (False `mkQ` (isLexicalRule . getIRuleName)) (mkT removeOpts) grammar
@@ -398,8 +587,9 @@ normalizeTopLevelClauses grammar =
     (firstIRule:_) -> do
       let firstID = maybe (getIRuleName firstIRule) Prelude.id (getIDataTypeName firstIRule)
           ruleTypeMap = buildRuleToTypeMap grammar
-      (_, NormalizationState nrs nls counter antiRules shortcuts proxyRules _ _ _ _) <-
-        runStateT (doNM grammar) (NormalizationState M.empty [] 0 [] [] S.empty M.empty M.empty ruleTypeMap Nothing)
+          attachPoints = computeQQAttachPoints grammar
+      (_, NormalizationState nrs nls counter antiRules shortcuts proxyRules _ _ _ _ _) <-
+        runStateT (doNM grammar) (NormalizationState M.empty [] 0 [] [] S.empty M.empty M.empty ruleTypeMap attachPoints Nothing)
       firstRuleGroupRules <- case M.lookup firstID nrs of
         Just rs -> Right rs
         Nothing -> Left $ Diagnostic (getIRulePos firstIRule) Nothing $

--- a/test-grammars/java-qq-test.hs
+++ b/test-grammars/java-qq-test.hs
@@ -23,6 +23,8 @@ main = do
     putStrLn ""
     testDollarEscape
     putStrLn ""
+    testSubExpressionSplices
+    putStrLn ""
 
     putStrLn "=========================================================="
     putStrLn "All tests completed successfully!"
@@ -239,6 +241,66 @@ testDollarEscape = do
     putStrLn ""
     putStrLn "Dollar-escape tests: ALL PASSED ✅"
 
+-- ========== PART 5: Sub-expression splice positions ==========
+-- The splice alternative sits only on PrimaryNoPostfix, the bottom of the
+-- expression precedence chain; a spliced expression climbs the chain's unit
+-- productions up to whatever level its position demands. Each build here is
+-- round-tripped through the equivalent pattern splice: the pattern anchors
+-- at the same chain position, so it must hand back exactly the values that
+-- were spliced in. Mismatches are fatal (they fail `make test-java-qq`).
+testSubExpressionSplices :: IO ()
+testSubExpressionSplices = do
+    putStrLn "========== PART 5: Sub-expression splice positions =========="
+    putStrLn ""
+    let x   = [J.expression| x |]
+        one = [J.expression| 1 |]
+        two = [J.expression| 2 |]
+
+    putStrLn "--- Test: operands of '+' ---"
+    case [J.expression| $Expression:x + $Expression:one |] of
+        [J.expression| $Expression:l + $Expression:r |]
+            | l == x && r == one -> putStrLn "✅ splices as '+' operands round-trip"
+        other -> error $ "FAILED: '+' operand splices did not round-trip:\n" ++ ppShow other
+
+    putStrLn "--- Test: operand of a prefix operator ---"
+    case [J.expression| - $Expression:x |] of
+        [J.expression| - $Expression:e |]
+            | e == x -> putStrLn "✅ splice as a prefix-operator operand round-trips"
+        other -> error $ "FAILED: prefix operand splice did not round-trip:\n" ++ ppShow other
+
+    putStrLn "--- Test: operand of a cast ---"
+    case [J.expression| (int) $Expression:x |] of
+        [J.expression| (int) $Expression:e |]
+            | e == x -> putStrLn "✅ splice as a cast operand round-trips"
+        other -> error $ "FAILED: cast operand splice did not round-trip:\n" ++ ppShow other
+
+    putStrLn "--- Test: array base and index ---"
+    case [J.expression| $Expression:x[$Expression:one] |] of
+        [J.expression| $Expression:arr[$Expression:idx] |]
+            | arr == x && idx == one -> putStrLn "✅ splices as array base and index round-trip"
+        other -> error $ "FAILED: indexing splices did not round-trip:\n" ++ ppShow other
+
+    putStrLn "--- Test: all three ternary positions ---"
+    case [J.expression| $Expression:x ? $Expression:one : $Expression:two |] of
+        [J.expression| $Expression:c ? $Expression:t : $Expression:e |]
+            | c == x && t == one && e == two -> putStrLn "✅ splices in ternary positions round-trip"
+        other -> error $ "FAILED: ternary splices did not round-trip:\n" ++ ppShow other
+
+    putStrLn "--- Test: method call arguments ---"
+    case [J.expression| f($Expression:x, $Expression:two) |] of
+        [J.expression| f($Expression:a, $Expression:b) |]
+            | a == x && b == two -> putStrLn "✅ splices as call arguments round-trip"
+        other -> error $ "FAILED: call argument splices did not round-trip:\n" ++ ppShow other
+
+    putStrLn "--- Test: several precedence levels at once ---"
+    case [J.expression| $Expression:x * $Expression:two + $Expression:one |] of
+        [J.expression| $Expression:a * $Expression:b + $Expression:c |]
+            | a == x && b == two && c == one -> putStrLn "✅ splices across precedence levels round-trip"
+        other -> error $ "FAILED: mixed-level splices did not round-trip:\n" ++ ppShow other
+
+    putStrLn ""
+    putStrLn "Sub-expression splice tests: ALL PASSED ✅"
+
 -- Unlike the informational checks above, a wrong AST here must fail the
 -- test binary (and with it `make test-java-qq`), so mismatches are fatal.
 expectInAST :: String -> String -> String -> IO ()
@@ -259,13 +321,15 @@ TEST SUMMARY:
    - 26+ different test cases covering expressions, statements, blocks, etc.
 
 ✅ Shared Types: Working
-   - Grammar uses shared Expression type for all 17 expression rules
+   - Grammar uses shared Expression type for all 18 expression rules
    - GenAST deduplicates constructors when combining shared-type rules
-   - Anti-alternatives added to ALL rules for complete splicing support
+   - The anti-alternative is attached at PrimaryNoPostfix, the bottom of the
+     precedence chain; splices reach every other rule of the group by
+     climbing the chain's unit productions (see Normalize.computeQQAttachPoints)
 
 ✅ Splicing: Fully working
-   - Anti-alternatives in all grammar rule contexts
-   - Constructor deduplication in GenAST prevents duplicate declarations
+   - One anti-alternative per shared-type group keeps the parser free of
+     splice-induced reduce/reduce conflicts
    - Syntax: $TypeName:variable
    - Tests: addition, multiplication, complex expressions, nested
 
@@ -274,9 +338,12 @@ TEST SUMMARY:
    - Same syntax as splicing
    - Tests: pattern matching, negative matches, extraction
 
+✅ Sub-expression positions: Fully working
+   - Splices parse as operands of binary/prefix/cast/ternary/call/indexing
+     constructs and round-trip through the equivalent pattern splices
+
 IMPACT:
 This test suite demonstrates the COMPLETE solution to the "hierarchical QQ
 problem"! Construction, splicing, and pattern matching ALL work with shared
-types in hierarchical grammars. The key insight: GenAST deduplicates
-constructors while Normalize adds anti-alternatives to all rule contexts.
+types in hierarchical grammars, in any sub-expression position.
 -}

--- a/test/UnitTests.hs
+++ b/test/UnitTests.hs
@@ -237,6 +237,8 @@ normalizationTests = TestList
     [ TestLabel "string literals become shared ignored keyword tokens" testStringLiterals
     , TestLabel "list rules get an element proxy with QQ splicing support" testListProxy
     , TestLabel "QQ anti machinery is created once per shared type" testAntiRuleSharing
+    , TestLabel "a precedence chain gets one splice alternative, at its bottom" testChainAttachment
+    , TestLabel "splice attachment falls back to eligible rules when nothing covers" testAttachFallbackNoCover
     , TestLabel "shortcuts are recorded against the rule's type" testShortcuts
     , TestLabel "optional clauses desugar to an empty alternative" testOptionalDesugars
     , TestLabel "lexical rule type and conversion defaults" testLexicalRuleDefaults
@@ -315,6 +317,50 @@ testAntiRuleSharing = TestCase $ do
                                 , alt@(STSeq "Anti_Expr" _) <- alts ]
     assertEqual "Add accepts $Expr: splices" [STSeq "Anti_Expr" [SSId "qq_Expr"]] (antiAltsOf "Add")
     assertEqual "Mul accepts $Expr: splices" [STSeq "Anti_Expr" [SSId "qq_Expr"]] (antiAltsOf "Mul")
+
+-- | In a shared-type group whose rules form a unit-production chain
+-- (java.pg's Expression hierarchy in miniature), only the bottom rule of
+-- the chain receives the splice alternative; a splice climbs the unit
+-- productions to whatever level its position demands. One alternative
+-- means one reduce item for the splice token, so the parser has no
+-- reduce/reduce conflict to resolve arbitrarily.
+testChainAttachment :: Test
+testChainAttachment = TestCase $ do
+    let g = normalizeNoFill $ unlines
+                [ "grammar 'Chain';"
+                , "Top = Expr ';' ;"
+                , "Expr : Expr = Add ;"
+                , "Expr : Add = Mul | Add '+' Mul ;"
+                , "Expr : Mul = aa | Mul '*' aa ;"
+                , "aa = [a]+ ;"
+                ]
+        antiAltsOf name = [ alt | SyntaxRule rn (STAltOfSeq alts) <- allRules g, rn == name
+                                , alt@(STSeq "Anti_Expr" _) <- alts ]
+    assertEqual "Mul (the chain bottom) accepts $Expr: splices"
+        [STSeq "Anti_Expr" [SSId "qq_Expr"]] (antiAltsOf "Mul")
+    assertEqual "Add has no splice alternative of its own" [] (antiAltsOf "Add")
+    assertEqual "Expr has no splice alternative of its own" [] (antiAltsOf "Expr")
+
+-- | When no attach point can cover a demanded rule (here T is all-lifted,
+-- so it cannot carry the alternative, and no unit production reaches it),
+-- attachment falls back to every eligible rule of the group -- and, just as
+-- important, normalization terminates instead of retrying a candidate that
+-- covers nothing.
+testAttachFallbackNoCover :: Test
+testAttachFallbackNoCover = TestCase $ do
+    let g = normalizeNoFill $ unlines
+                [ "grammar 'X';"
+                , "S = T ;"
+                , "T : T = ,Q ;"
+                , "T : U = uu ;"
+                , "Q = qq ;"
+                , "uu = [u]+ ;"
+                , "qq = [q]+ ;"
+                ]
+        antiAltsOf name = [ alt | SyntaxRule rn (STAltOfSeq alts) <- allRules g, rn == name
+                                , alt@(STSeq "Anti_T" _) <- alts ]
+    assertEqual "U accepts $T: splices" [STSeq "Anti_T" [SSId "qq_T"]] (antiAltsOf "U")
+    assertEqual "the lifted rule carries no splice alternative" [] (antiAltsOf "T")
 
 testShortcuts :: Test
 testShortcuts = TestCase $ do

--- a/test/golden/java/JavaParser.y
+++ b/test/golden/java/JavaParser.y
@@ -454,76 +454,59 @@ PrimaryNoPostfix : qq_Expression { Anti_Expression $1 } |
                    CompoundName Rule_74 { Ctr__Expression__4 $1 $2 } |
                    tok_super_81 tok__dot__3 id Rule_76 { Ctr__Expression__5 $3 $4 }
 
-PostfixExpression : qq_Expression { Anti_Expression $1 } |
-                    PrimaryNoPostfix { Ctr__Expression__6 $1 } |
+PostfixExpression : PrimaryNoPostfix { Ctr__Expression__6 $1 } |
                     PostfixExpression PostfixOp { Ctr__Expression__7 $1 $2 } |
                     PostfixExpression tok__dot__3 id { Ctr__Expression__8 $1 $3 } |
                     PostfixExpression tok__dot__3 id tok__lparen__6 Arglist tok__rparen__7 { Ctr__Expression__9 $1 $3 $5 } |
                     PostfixExpression tok__sq_bkt_l__18 Expression tok__sq_bkt_r__19 { Ctr__Expression__10 $1 $3 }
 
-UnaryExpressionNotPlusMinus : qq_Expression { Anti_Expression $1 } |
-                              PostfixExpression { Ctr__Expression__11 $1 } |
+UnaryExpressionNotPlusMinus : PostfixExpression { Ctr__Expression__11 $1 } |
                               tok__tilde__78 UnaryExpression { Ctr__Expression__12 $2 } |
                               tok__exclamation__79 UnaryExpression { Ctr__Expression__13 $2 } |
                               CastExpression { Ctr__Expression__14 $1 }
 
-UnaryExpression : qq_Expression { Anti_Expression $1 } |
-                  PrefixOp UnaryExpression { Ctr__Expression__15 $1 $2 } |
+UnaryExpression : PrefixOp UnaryExpression { Ctr__Expression__15 $1 $2 } |
                   UnaryExpressionNotPlusMinus { Ctr__Expression__16 $1 }
 
-CastExpression : qq_Expression { Anti_Expression $1 } |
-                 tok__lparen__6 Type tok__rparen__7 UnaryExpression { Ctr__Expression__17 $2 $4 }
+CastExpression : tok__lparen__6 Type tok__rparen__7 UnaryExpression { Ctr__Expression__17 $2 $4 }
 
-MultiplicativeExpression : qq_Expression { Anti_Expression $1 } |
-                           UnaryExpression { Ctr__Expression__18 $1 } |
+MultiplicativeExpression : UnaryExpression { Ctr__Expression__18 $1 } |
                            MultiplicativeExpression MultiplicativeOp UnaryExpression { Ctr__Expression__19 $1 $2 $3 }
 
-AdditiveExpression : qq_Expression { Anti_Expression $1 } |
-                     MultiplicativeExpression { Ctr__Expression__20 $1 } |
+AdditiveExpression : MultiplicativeExpression { Ctr__Expression__20 $1 } |
                      AdditiveExpression AdditiveOp MultiplicativeExpression { Ctr__Expression__21 $1 $2 $3 }
 
-ShiftExpression : qq_Expression { Anti_Expression $1 } |
-                  AdditiveExpression { Ctr__Expression__22 $1 } |
+ShiftExpression : AdditiveExpression { Ctr__Expression__22 $1 } |
                   ShiftExpression ShiftOp AdditiveExpression { Ctr__Expression__23 $1 $2 $3 }
 
-RelationalExpression : qq_Expression { Anti_Expression $1 } |
-                       ShiftExpression { Ctr__Expression__24 $1 } |
+RelationalExpression : ShiftExpression { Ctr__Expression__24 $1 } |
                        RelationalExpression RelationalOp ShiftExpression { Ctr__Expression__25 $1 $2 $3 } |
                        RelationalExpression tok_instanceof_68 Type { Ctr__Expression__26 $1 $3 }
 
-EqualityExpression : qq_Expression { Anti_Expression $1 } |
-                     RelationalExpression { Ctr__Expression__27 $1 } |
+EqualityExpression : RelationalExpression { Ctr__Expression__27 $1 } |
                      EqualityExpression EqualityOp RelationalExpression { Ctr__Expression__28 $1 $2 $3 }
 
-AndExpression : qq_Expression { Anti_Expression $1 } |
-                EqualityExpression { Ctr__Expression__29 $1 } |
+AndExpression : EqualityExpression { Ctr__Expression__29 $1 } |
                 AndExpression tok__symbol__61 EqualityExpression { Ctr__Expression__30 $1 $3 }
 
-ExclusiveOrExpression : qq_Expression { Anti_Expression $1 } |
-                        AndExpression { Ctr__Expression__31 $1 } |
+ExclusiveOrExpression : AndExpression { Ctr__Expression__31 $1 } |
                         ExclusiveOrExpression tok__symbol__60 AndExpression { Ctr__Expression__32 $1 $3 }
 
-InclusiveOrEpression : qq_Expression { Anti_Expression $1 } |
-                       ExclusiveOrExpression { Ctr__Expression__33 $1 } |
+InclusiveOrEpression : ExclusiveOrExpression { Ctr__Expression__33 $1 } |
                        InclusiveOrEpression tok__pipe__59 ExclusiveOrExpression { Ctr__Expression__34 $1 $3 }
 
-ConditionalAndExpression : qq_Expression { Anti_Expression $1 } |
-                           InclusiveOrEpression { Ctr__Expression__35 $1 } |
+ConditionalAndExpression : InclusiveOrEpression { Ctr__Expression__35 $1 } |
                            ConditionalAndExpression tok__symbol__symbol__58 InclusiveOrEpression { Ctr__Expression__36 $1 $3 }
 
-ConditionalOrExpression : qq_Expression { Anti_Expression $1 } |
-                          ConditionalAndExpression { Ctr__Expression__37 $1 } |
+ConditionalOrExpression : ConditionalAndExpression { Ctr__Expression__37 $1 } |
                           ConditionalOrExpression tok__pipe__pipe__57 ConditionalAndExpression { Ctr__Expression__38 $1 $3 }
 
-ConditionalExpression : qq_Expression { Anti_Expression $1 } |
-                        ConditionalOrExpression { Ctr__Expression__39 $1 } |
+ConditionalExpression : ConditionalOrExpression { Ctr__Expression__39 $1 } |
                         ConditionalOrExpression tok__symbol__56 Expression tok__colon__32 ConditionalExpression { Ctr__Expression__40 $1 $3 $5 }
 
-AssignmentExpression : qq_Expression { Anti_Expression $1 } |
-                       ConditionalExpression Rule_72 { Ctr__Expression__41 $1 $2 }
+AssignmentExpression : ConditionalExpression Rule_72 { Ctr__Expression__41 $1 $2 }
 
-Expression : qq_Expression { Anti_Expression $1 } |
-             AssignmentExpression { Ctr__Expression__42 $1 }
+Expression : AssignmentExpression { Ctr__Expression__42 $1 }
 
 ExtendsList : qq_ExtendsList { Anti_ExtendsList $1 } |
               { Ctr__ExtendsList__0 } |


### PR DESCRIPTION
## Summary

This change optimizes the placement of quasi-quotation (QQ) splice alternatives in shared-type grammar groups to eliminate reduce/reduce conflicts caused by attaching the same alternative to every rule.

Instead of adding the `$Type:var` splice alternative to all rules of a shared type, the normalizer now computes a minimal set of "attach points" — rules from which all other rules in the group are reachable via unit productions. A splice token reduces at an attach point and climbs the unit-production chain to whatever precedence level its position demands.

## Key Changes

- **New `computeQQAttachPoints` function** in `Normalize.hs`: Analyzes each shared-type group to determine optimal attach points by:
  - Building the intra-group "lift graph" (edges for unit productions)
  - Identifying rules demanded by grammar positions
  - Greedily selecting attach points whose unit-closures cover all demanded rules
  - Falling back to all eligible rules if no single point covers everything

- **Modified `addRuleWithQQ`**: Now checks whether a rule is an attach point before adding the splice alternative, rather than unconditionally adding it to every rule

- **Updated `NormalizationState`**: Added `_qqAttachPoints` field to track which rules receive splice alternatives

- **Test coverage**: Added two new unit tests (`testChainAttachment`, `testAttachFallbackNoCover`) and comprehensive integration tests in `java-qq-test.hs` validating splices work correctly at all precedence levels

## Impact

For java.pg's 18-rule Expression precedence chain:
- Reduces reduce/reduce conflicts from 883 to 77 (806 eliminated)
- Removes three "rule is unused" warnings
- Makes splice parsing independent of conflict-resolution accidents
- Single attach point at `PrimaryNoPostfix` (the chain bottom)

All other test grammars (grammar.pg bootstrap, debug-test.pg, haskell.pg, and every single-rule-type grammar) generate byte-identical output. (After master's rejection of duplicate rule definitions, debug-test.pg no longer has a shared-type group; haskell.pg's remaining reduce/reduce conflicts stem from its own Type/BType ambiguities, not from splice alternatives.)

Single-rule types are unaffected. Groups whose demanded rules cannot be covered from one attach point receive multiple attach points; overlapping closures may reintroduce conflicts inherent to the grammar itself.

Verified: unit + golden suites, test-all-java, test-lex-java, test-java-qq (extended with sub-expression splice round-trips), test-bootstrap, and the commons-lang corpus (526 files lex + parse, 0 failures), all re-run after rebasing onto master.

https://claude.ai/code/session_01Qa3KBnenaCE5Ks7iGcAmUe