### PR TITLE
Fix four structural defects in the Java grammar

### DIFF
--- a/test-grammars/java.pg
+++ b/test-grammars/java.pg
@@ -27,7 +27,11 @@ Annotation = '@' CompoundName ('(' AnnotationArguments? ')')? ;
 
 AnnotationArguments = AnnotationElement (',' AnnotationElement)* ;
 
-AnnotationElement = (id '=')? Expression ;
+# Explicit alternatives (not (id '=')? Expression) so LALR keeps both items
+# alive after shifting id; otherwise values starting with an identifier, e.g.
+# @Retention(RetentionPolicy.RUNTIME), fail. ConditionalExpression is the JLS
+# ElementValue level; full Expression would make @Foo(a = b) ambiguous.
+AnnotationElement = id '=' ConditionalExpression | ConditionalExpression ;
 
 AnnotationList = Annotation* ;
 
@@ -36,7 +40,7 @@ AnnotationList = Annotation* ;
 # resolve correctly with lookahead (inherent to the grammar design).
 ModifierList = (Modifier | Annotation)* ;
 
-ExtendsList = ('extends' CompoundName (',' CompoundName)*)? ;
+ExtendsList = 'extends' CompoundName (',' CompoundName)* ;
 ImplementsList = 'implements' CompoundName + ~',';
 FieldDeclarationList = FieldDeclaration *;
 
@@ -48,7 +52,7 @@ ClassDeclaration  =
 
 InterfaceDeclaration  =
  ModifierList 'interface' id TypeParameters
- ExtendsList
+ ExtendsList?
  '{'  FieldDeclarationList  '}'  ;
 
 # Annotation declaration (@interface)
@@ -58,9 +62,10 @@ AnnotationDeclaration =
 
 AnnotationTypeElementList = AnnotationTypeElement* ;
 
-AnnotationTypeElement =
- ModifierList Type id '(' ')' ('default' Expression)? ';'
- | FieldDeclaration ;
+# Annotation-type elements reuse FieldDeclaration; the default clause is
+# handled by MemberRest (a dedicated alternative here would race its nullable
+# ModifierList against FieldDeclaration's nullable OptDocComment → r/r).
+AnnotationTypeElement = FieldDeclaration ;
 
 # Enum declaration
 EnumConstant = AnnotationList id ('(' Arglist ')')? ('{' FieldDeclarationList '}')? ;
@@ -124,8 +129,11 @@ MoreTypeSpecifier =
 # MemberRest branches on what follows "Type id":
 # - '(' indicates a method declaration
 # - '[' or '=' or ',' or ';' indicates a variable declaration
+# The optional 'default' clause before ';' is for annotation-type elements
+# (int value() default 5;). Accepting it on ordinary methods too is
+# parser-level tolerance; rejecting it there is a semantic check (javac's job).
 MemberRest =
- '(' ParameterList? ')' SquareBracketsList ( StatementBlock | ';' )
+ '(' ParameterList? ')' SquareBracketsList ( StatementBlock | ('default' Expression)? ';' )
  | SquareBracketsList OptVariableInitializer MoreVariableDeclarators ';' ;
 
 MoreVariableDeclarators = (',' VariableDeclarator)* ;
@@ -310,7 +318,10 @@ Expression : MultiplicativeExpression = UnaryExpression | MultiplicativeExpressi
 
 Expression : CastExpression = '(' Type ')' UnaryExpression ;
 
-PrefixOp = '++' | '--' | '+' | '-' | '~' | '!' ;
+# '~' and '!' live in UnaryExpressionNotPlusMinus (JLS 15.15), not here:
+# keeping them in both derives ~x two ways, and they must stay in
+# UnaryExpressionNotPlusMinus so reference-type casts can be followed by ~/!.
+PrefixOp = '++' | '--' | '+' | '-' ;
 
 PostfixOp = '++' | '--' ;
 

--- a/test-grammars/java/lexical/char-literals.tokens
+++ b/test-grammars/java/lexical/char-literals.tokens
@@ -1,67 +1,67 @@
 Tk__tok_class_12
 Tk__id "CharLiterals"
 Tk__tok__symbol__13
-Tk__tok_char_22
+Tk__tok_char_21
 Tk__id "simple"
 Tk__tok__eql__9
 Tk__char "'a'"
 Tk__tok__semi__1
-Tk__tok_char_22
+Tk__tok_char_21
 Tk__id "digit"
 Tk__tok__eql__9
 Tk__char "'7'"
 Tk__tok__semi__1
-Tk__tok_char_22
+Tk__tok_char_21
 Tk__id "space"
 Tk__tok__eql__9
 Tk__char "' '"
 Tk__tok__semi__1
-Tk__tok_char_22
+Tk__tok_char_21
 Tk__id "newline"
 Tk__tok__eql__9
 Tk__char "'\\n'"
 Tk__tok__semi__1
-Tk__tok_char_22
+Tk__tok_char_21
 Tk__id "tab"
 Tk__tok__eql__9
 Tk__char "'\\t'"
 Tk__tok__semi__1
-Tk__tok_char_22
+Tk__tok_char_21
 Tk__id "backslash"
 Tk__tok__eql__9
 Tk__char "'\\\\'"
 Tk__tok__semi__1
-Tk__tok_char_22
+Tk__tok_char_21
 Tk__id "quote"
 Tk__tok__eql__9
 Tk__char "'\\''"
 Tk__tok__semi__1
-Tk__tok_char_22
+Tk__tok_char_21
 Tk__id "doubleQuote"
 Tk__tok__eql__9
 Tk__char "'\"'"
 Tk__tok__semi__1
-Tk__tok_char_22
+Tk__tok_char_21
 Tk__id "nul"
 Tk__tok__eql__9
 Tk__char "'\\0'"
 Tk__tok__semi__1
-Tk__tok_char_22
+Tk__tok_char_21
 Tk__id "octal2"
 Tk__tok__eql__9
 Tk__char "'\\12'"
 Tk__tok__semi__1
-Tk__tok_char_22
+Tk__tok_char_21
 Tk__id "octal3"
 Tk__tok__eql__9
 Tk__char "'\\101'"
 Tk__tok__semi__1
-Tk__tok_char_22
+Tk__tok_char_21
 Tk__id "octalMax"
 Tk__tok__eql__9
 Tk__char "'\\377'"
 Tk__tok__semi__1
-Tk__tok_char_22
+Tk__tok_char_21
 Tk__id "unicode"
 Tk__tok__eql__9
 Tk__char "'\\u0041'"

--- a/test-grammars/java/lexical/comments.tokens
+++ b/test-grammars/java/lexical/comments.tokens
@@ -2,7 +2,7 @@ Tk__doccomment "/** A doc comment with {@link Foo#bar()}.\n *\n * @param none\n 
 Tk__tok_class_12
 Tk__id "Comments"
 Tk__tok__symbol__13
-Tk__tok_int_24
+Tk__tok_int_23
 Tk__id "x"
 Tk__tok__eql__9
 Tk__integerLiteral "1"

--- a/test-grammars/java/lexical/float-literals.tokens
+++ b/test-grammars/java/lexical/float-literals.tokens
@@ -1,82 +1,82 @@
 Tk__tok_class_12
 Tk__id "FloatLiterals"
 Tk__tok__symbol__13
-Tk__tok_double_27
+Tk__tok_double_26
 Tk__id "plain"
 Tk__tok__eql__9
 Tk__floatLiteral "1.5"
 Tk__tok__semi__1
-Tk__tok_double_27
+Tk__tok_double_26
 Tk__id "leadingDot"
 Tk__tok__eql__9
 Tk__floatLiteral ".5"
 Tk__tok__semi__1
-Tk__tok_double_27
+Tk__tok_double_26
 Tk__id "trailingDot"
 Tk__tok__eql__9
 Tk__floatLiteral "1."
 Tk__tok__semi__1
-Tk__tok_float_25
+Tk__tok_float_24
 Tk__id "suffixF"
 Tk__tok__eql__9
 Tk__floatLiteral "1.5f"
 Tk__tok__semi__1
-Tk__tok_float_25
+Tk__tok_float_24
 Tk__id "suffixFUpper"
 Tk__tok__eql__9
 Tk__floatLiteral "1.5F"
 Tk__tok__semi__1
-Tk__tok_double_27
+Tk__tok_double_26
 Tk__id "suffixD"
 Tk__tok__eql__9
 Tk__floatLiteral "1.5d"
 Tk__tok__semi__1
-Tk__tok_double_27
+Tk__tok_double_26
 Tk__id "suffixDUpper"
 Tk__tok__eql__9
 Tk__floatLiteral "1.5D"
 Tk__tok__semi__1
-Tk__tok_double_27
+Tk__tok_double_26
 Tk__id "expLower"
 Tk__tok__eql__9
 Tk__floatLiteral "1.5e10"
 Tk__tok__semi__1
-Tk__tok_double_27
+Tk__tok_double_26
 Tk__id "expUpper"
 Tk__tok__eql__9
 Tk__floatLiteral "1.5E10"
 Tk__tok__semi__1
-Tk__tok_double_27
+Tk__tok_double_26
 Tk__id "expPlus"
 Tk__tok__eql__9
 Tk__floatLiteral "1.5e+10"
 Tk__tok__semi__1
-Tk__tok_double_27
+Tk__tok_double_26
 Tk__id "expMinus"
 Tk__tok__eql__9
 Tk__floatLiteral "1.5e-10"
 Tk__tok__semi__1
-Tk__tok_double_27
+Tk__tok_double_26
 Tk__id "intExp"
 Tk__tok__eql__9
 Tk__floatLiteral "1e5"
 Tk__tok__semi__1
-Tk__tok_double_27
+Tk__tok_double_26
 Tk__id "intExpSuffix"
 Tk__tok__eql__9
 Tk__floatLiteral "2E5d"
 Tk__tok__semi__1
-Tk__tok_float_25
+Tk__tok_float_24
 Tk__id "intSuffix"
 Tk__tok__eql__9
 Tk__floatLiteral "10f"
 Tk__tok__semi__1
-Tk__tok_double_27
+Tk__tok_double_26
 Tk__id "intSuffixUpper"
 Tk__tok__eql__9
 Tk__floatLiteral "10D"
 Tk__tok__semi__1
-Tk__tok_double_27
+Tk__tok_double_26
 Tk__id "underscore"
 Tk__tok__eql__9
 Tk__floatLiteral "1_000.000_1"

--- a/test-grammars/java/lexical/int-literals.tokens
+++ b/test-grammars/java/lexical/int-literals.tokens
@@ -1,72 +1,72 @@
 Tk__tok_class_12
 Tk__id "IntLiterals"
 Tk__tok__symbol__13
-Tk__tok_int_24
+Tk__tok_int_23
 Tk__id "dec"
 Tk__tok__eql__9
 Tk__integerLiteral "42"
 Tk__tok__semi__1
-Tk__tok_int_24
+Tk__tok_int_23
 Tk__id "zero"
 Tk__tok__eql__9
 Tk__integerLiteral "0"
 Tk__tok__semi__1
-Tk__tok_int_24
+Tk__tok_int_23
 Tk__id "oct"
 Tk__tok__eql__9
 Tk__integerLiteral "0777"
 Tk__tok__semi__1
-Tk__tok_int_24
+Tk__tok_int_23
 Tk__id "hexLower"
 Tk__tok__eql__9
 Tk__integerLiteral "0xCafeBabe"
 Tk__tok__semi__1
-Tk__tok_int_24
+Tk__tok_int_23
 Tk__id "hexUpper"
 Tk__tok__eql__9
 Tk__integerLiteral "0X1F"
 Tk__tok__semi__1
-Tk__tok_int_24
+Tk__tok_int_23
 Tk__id "bin"
 Tk__tok__eql__9
 Tk__integerLiteral "0b1010"
 Tk__tok__semi__1
-Tk__tok_int_24
+Tk__tok_int_23
 Tk__id "binUpper"
 Tk__tok__eql__9
 Tk__integerLiteral "0B1"
 Tk__tok__semi__1
-Tk__tok_long_26
+Tk__tok_long_25
 Tk__id "longLower"
 Tk__tok__eql__9
 Tk__integerLiteral "42l"
 Tk__tok__semi__1
-Tk__tok_long_26
+Tk__tok_long_25
 Tk__id "longUpper"
 Tk__tok__eql__9
 Tk__integerLiteral "42L"
 Tk__tok__semi__1
-Tk__tok_long_26
+Tk__tok_long_25
 Tk__id "hexLong"
 Tk__tok__eql__9
 Tk__integerLiteral "0xFFL"
 Tk__tok__semi__1
-Tk__tok_int_24
+Tk__tok_int_23
 Tk__id "underscore"
 Tk__tok__eql__9
 Tk__integerLiteral "1_000_000"
 Tk__tok__semi__1
-Tk__tok_int_24
+Tk__tok_int_23
 Tk__id "underscoreHex"
 Tk__tok__eql__9
 Tk__integerLiteral "0xFF_EC_DE_5E"
 Tk__tok__semi__1
-Tk__tok_int_24
+Tk__tok_int_23
 Tk__id "underscoreBin"
 Tk__tok__eql__9
 Tk__integerLiteral "0b1010_1010"
 Tk__tok__semi__1
-Tk__tok_long_26
+Tk__tok_long_25
 Tk__id "underscoreLong"
 Tk__tok__eql__9
 Tk__integerLiteral "9_999_999_999L"

--- a/test-grammars/java/lexical/operators.tokens
+++ b/test-grammars/java/lexical/operators.tokens
@@ -1,12 +1,12 @@
 Tk__tok_class_12
 Tk__id "Operators"
 Tk__tok__symbol__13
-Tk__tok_void_28
+Tk__tok_void_27
 Tk__id "m"
 Tk__tok__lparen__6
 Tk__tok__rparen__7
 Tk__tok__symbol__13
-Tk__tok_int_24
+Tk__tok_int_23
 Tk__id "a"
 Tk__tok__eql__9
 Tk__integerLiteral "1"
@@ -65,7 +65,7 @@ Tk__id "a"
 Tk__tok__symbol__eql__51
 Tk__integerLiteral "1"
 Tk__tok__semi__1
-Tk__tok_int_24
+Tk__tok_int_23
 Tk__id "b"
 Tk__tok__eql__9
 Tk__id "a"
@@ -83,7 +83,7 @@ Tk__tok__symbol__60
 Tk__tok__tilde__78
 Tk__id "a"
 Tk__tok__semi__1
-Tk__tok_boolean_20
+Tk__tok_boolean_19
 Tk__id "c"
 Tk__tok__eql__9
 Tk__id "a"
@@ -110,7 +110,7 @@ Tk__id "a"
 Tk__tok__exclamation__eql__63
 Tk__id "b"
 Tk__tok__semi__1
-Tk__tok_boolean_20
+Tk__tok_boolean_19
 Tk__id "d"
 Tk__tok__eql__9
 Tk__tok__exclamation__79
@@ -128,7 +128,7 @@ Tk__tok__semi__1
 Tk__tok__minus__minus__77
 Tk__id "a"
 Tk__tok__semi__1
-Tk__tok_int_24
+Tk__tok_int_23
 Tk__id "e"
 Tk__tok__eql__9
 Tk__id "c"

--- a/test-suites/commons-lang-parser-blacklist.txt
+++ b/test-suites/commons-lang-parser-blacklist.txt
@@ -5,7 +5,7 @@
 # - Anonymous inner classes
 # - Enhanced for-each with colon
 #
-# Total: 250 files blacklisted, 9 files passing
+# Total: 245 files blacklisted, 14 files passing
 # As grammar support is added, remove files from this list
 
 org/apache/commons/lang3/AnnotationUtils.java
@@ -59,12 +59,9 @@ org/apache/commons/lang3/builder/AbstractSupplier.java
 org/apache/commons/lang3/builder/CompareToBuilder.java
 org/apache/commons/lang3/builder/Diff.java
 org/apache/commons/lang3/builder/DiffBuilder.java
-org/apache/commons/lang3/builder/DiffExclude.java
 org/apache/commons/lang3/builder/DiffResult.java
 org/apache/commons/lang3/builder/EqualsBuilder.java
-org/apache/commons/lang3/builder/EqualsExclude.java
 org/apache/commons/lang3/builder/HashCodeBuilder.java
-org/apache/commons/lang3/builder/HashCodeExclude.java
 org/apache/commons/lang3/builder/IDKey.java
 org/apache/commons/lang3/builder/MultilineRecursiveToStringStyle.java
 org/apache/commons/lang3/builder/RecursiveToStringStyle.java
@@ -73,9 +70,7 @@ org/apache/commons/lang3/builder/ReflectionDiffBuilder.java
 org/apache/commons/lang3/builder/ReflectionToStringBuilder.java
 org/apache/commons/lang3/builder/StandardToStringStyle.java
 org/apache/commons/lang3/builder/ToStringBuilder.java
-org/apache/commons/lang3/builder/ToStringExclude.java
 org/apache/commons/lang3/builder/ToStringStyle.java
-org/apache/commons/lang3/builder/ToStringSummary.java
 org/apache/commons/lang3/builder/package-info.java
 org/apache/commons/lang3/compare/ComparableUtils.java
 org/apache/commons/lang3/compare/ObjectToStringComparator.java

--- a/test/golden/java/JavaLexer.x
+++ b/test/golden/java/JavaLexer.x
@@ -8,85 +8,85 @@ where
 @exponentPart = ([eE]  ("+"| "-") ?  [0-9]  ([0-9_]*  [0-9]) ?)
 @floatTypeSuffix = ([fFdD])
 
-tokens :- "tok_AdditiveOp_dummy_171" { simple Tk__tok_AdditiveOp_dummy_171 }
-          "tok_Annotation_dummy_170" { simple Tk__tok_Annotation_dummy_170 }
-          "tok_AnnotationArguments_dummy_169" { simple Tk__tok_AnnotationArguments_dummy_169 }
-          "tok_AnnotationDeclaration_dummy_168" { simple Tk__tok_AnnotationDeclaration_dummy_168 }
-          "tok_AnnotationElement_dummy_167" { simple Tk__tok_AnnotationElement_dummy_167 }
-          "tok_AnnotationList_dummy_166" { simple Tk__tok_AnnotationList_dummy_166 }
-          "tok_AnnotationTypeElement_dummy_165" { simple Tk__tok_AnnotationTypeElement_dummy_165 }
-          "tok_AnnotationTypeElementList_dummy_164" { simple Tk__tok_AnnotationTypeElementList_dummy_164 }
-          "tok_Arglist_dummy_163" { simple Tk__tok_Arglist_dummy_163 }
-          "tok_AssignmentOp_dummy_162" { simple Tk__tok_AssignmentOp_dummy_162 }
-          "tok_CatchList_dummy_161" { simple Tk__tok_CatchList_dummy_161 }
-          "tok_ClassDeclaration_dummy_160" { simple Tk__tok_ClassDeclaration_dummy_160 }
-          "tok_CompilationUnit_dummy_159" { simple Tk__tok_CompilationUnit_dummy_159 }
-          "tok_CompoundName_dummy_158" { simple Tk__tok_CompoundName_dummy_158 }
-          "tok_CreationExpression_dummy_157" { simple Tk__tok_CreationExpression_dummy_157 }
-          "tok_DoStatement_dummy_156" { simple Tk__tok_DoStatement_dummy_156 }
-          "tok_DocComment_dummy_155" { simple Tk__tok_DocComment_dummy_155 }
-          "tok_EnumConstant_dummy_154" { simple Tk__tok_EnumConstant_dummy_154 }
-          "tok_EnumConstantList_dummy_153" { simple Tk__tok_EnumConstantList_dummy_153 }
-          "tok_EnumDeclaration_dummy_152" { simple Tk__tok_EnumDeclaration_dummy_152 }
-          "tok_EqualityOp_dummy_151" { simple Tk__tok_EqualityOp_dummy_151 }
-          "tok_Expression_dummy_150" { simple Tk__tok_Expression_dummy_150 }
-          "tok_ExtendsList_dummy_149" { simple Tk__tok_ExtendsList_dummy_149 }
-          "tok_FieldDeclaration_dummy_148" { simple Tk__tok_FieldDeclaration_dummy_148 }
-          "tok_FieldDeclarationList_dummy_147" { simple Tk__tok_FieldDeclarationList_dummy_147 }
-          "tok_ForStatement_dummy_146" { simple Tk__tok_ForStatement_dummy_146 }
-          "tok_IfStatement_dummy_145" { simple Tk__tok_IfStatement_dummy_145 }
-          "tok_ImplementsList_dummy_144" { simple Tk__tok_ImplementsList_dummy_144 }
-          "tok_ImportList_dummy_143" { simple Tk__tok_ImportList_dummy_143 }
-          "tok_ImportStatement_dummy_142" { simple Tk__tok_ImportStatement_dummy_142 }
-          "tok_InterfaceDeclaration_dummy_141" { simple Tk__tok_InterfaceDeclaration_dummy_141 }
-          "tok_Java_dummy_172" { simple Tk__tok_Java_dummy_172 }
-          "tok_Literal_dummy_140" { simple Tk__tok_Literal_dummy_140 }
-          "tok_MemberAfterFirstId_dummy_139" { simple Tk__tok_MemberAfterFirstId_dummy_139 }
-          "tok_MemberDeclaration_dummy_138" { simple Tk__tok_MemberDeclaration_dummy_138 }
-          "tok_MemberRest_dummy_137" { simple Tk__tok_MemberRest_dummy_137 }
-          "tok_Modifier_dummy_136" { simple Tk__tok_Modifier_dummy_136 }
-          "tok_ModifierList_dummy_135" { simple Tk__tok_ModifierList_dummy_135 }
-          "tok_MoreTypeSpecifier_dummy_134" { simple Tk__tok_MoreTypeSpecifier_dummy_134 }
-          "tok_MoreVariableDeclarators_dummy_133" { simple Tk__tok_MoreVariableDeclarators_dummy_133 }
-          "tok_MultiplicativeOp_dummy_132" { simple Tk__tok_MultiplicativeOp_dummy_132 }
-          "tok_NestedTypeDeclaration_dummy_131" { simple Tk__tok_NestedTypeDeclaration_dummy_131 }
-          "tok_OptDocComment_dummy_130" { simple Tk__tok_OptDocComment_dummy_130 }
-          "tok_OptElsePart_dummy_129" { simple Tk__tok_OptElsePart_dummy_129 }
-          "tok_OptExpression_dummy_128" { simple Tk__tok_OptExpression_dummy_128 }
-          "tok_OptFinally_dummy_127" { simple Tk__tok_OptFinally_dummy_127 }
-          "tok_OptId_dummy_126" { simple Tk__tok_OptId_dummy_126 }
-          "tok_OptVariableInitializer_dummy_125" { simple Tk__tok_OptVariableInitializer_dummy_125 }
-          "tok_Package_dummy_124" { simple Tk__tok_Package_dummy_124 }
-          "tok_Parameter_dummy_123" { simple Tk__tok_Parameter_dummy_123 }
-          "tok_ParameterList_dummy_122" { simple Tk__tok_ParameterList_dummy_122 }
-          "tok_PostfixOp_dummy_121" { simple Tk__tok_PostfixOp_dummy_121 }
-          "tok_PrefixOp_dummy_120" { simple Tk__tok_PrefixOp_dummy_120 }
-          "tok_PrimitiveTypeKeyword_dummy_119" { simple Tk__tok_PrimitiveTypeKeyword_dummy_119 }
-          "tok_RelationalOp_dummy_118" { simple Tk__tok_RelationalOp_dummy_118 }
-          "tok_ShiftOp_dummy_117" { simple Tk__tok_ShiftOp_dummy_117 }
-          "tok_SquareBracketsList_dummy_116" { simple Tk__tok_SquareBracketsList_dummy_116 }
-          "tok_Statement_dummy_115" { simple Tk__tok_Statement_dummy_115 }
-          "tok_StatementBlock_dummy_114" { simple Tk__tok_StatementBlock_dummy_114 }
-          "tok_StatementList_dummy_113" { simple Tk__tok_StatementList_dummy_113 }
-          "tok_StatementWithoutIf_dummy_112" { simple Tk__tok_StatementWithoutIf_dummy_112 }
-          "tok_StaticInitializer_dummy_111" { simple Tk__tok_StaticInitializer_dummy_111 }
-          "tok_SwitchCaseList_dummy_110" { simple Tk__tok_SwitchCaseList_dummy_110 }
-          "tok_SwitchStatement_dummy_109" { simple Tk__tok_SwitchStatement_dummy_109 }
-          "tok_TryStatement_dummy_108" { simple Tk__tok_TryStatement_dummy_108 }
-          "tok_Type_dummy_107" { simple Tk__tok_Type_dummy_107 }
-          "tok_TypeArgument_dummy_106" { simple Tk__tok_TypeArgument_dummy_106 }
-          "tok_TypeArguments_dummy_105" { simple Tk__tok_TypeArguments_dummy_105 }
-          "tok_TypeDeclaration_dummy_104" { simple Tk__tok_TypeDeclaration_dummy_104 }
-          "tok_TypeParameter_dummy_103" { simple Tk__tok_TypeParameter_dummy_103 }
-          "tok_TypeParameters_dummy_102" { simple Tk__tok_TypeParameters_dummy_102 }
-          "tok_TypeSpecifier_dummy_101" { simple Tk__tok_TypeSpecifier_dummy_101 }
-          "tok_VariableDeclaration_dummy_100" { simple Tk__tok_VariableDeclaration_dummy_100 }
-          "tok_VariableDeclarator_dummy_99" { simple Tk__tok_VariableDeclarator_dummy_99 }
-          "tok_VariableDeclaratorList_dummy_98" { simple Tk__tok_VariableDeclaratorList_dummy_98 }
-          "tok_VariableInitializer_dummy_97" { simple Tk__tok_VariableInitializer_dummy_97 }
-          "tok_VariableInitializerList_dummy_96" { simple Tk__tok_VariableInitializerList_dummy_96 }
-          "tok_WhileStatement_dummy_95" { simple Tk__tok_WhileStatement_dummy_95 }
-          "tok_WildcardType_dummy_94" { simple Tk__tok_WildcardType_dummy_94 }
+tokens :- "tok_AdditiveOp_dummy_169" { simple Tk__tok_AdditiveOp_dummy_169 }
+          "tok_Annotation_dummy_168" { simple Tk__tok_Annotation_dummy_168 }
+          "tok_AnnotationArguments_dummy_167" { simple Tk__tok_AnnotationArguments_dummy_167 }
+          "tok_AnnotationDeclaration_dummy_166" { simple Tk__tok_AnnotationDeclaration_dummy_166 }
+          "tok_AnnotationElement_dummy_165" { simple Tk__tok_AnnotationElement_dummy_165 }
+          "tok_AnnotationList_dummy_164" { simple Tk__tok_AnnotationList_dummy_164 }
+          "tok_AnnotationTypeElement_dummy_163" { simple Tk__tok_AnnotationTypeElement_dummy_163 }
+          "tok_AnnotationTypeElementList_dummy_162" { simple Tk__tok_AnnotationTypeElementList_dummy_162 }
+          "tok_Arglist_dummy_161" { simple Tk__tok_Arglist_dummy_161 }
+          "tok_AssignmentOp_dummy_160" { simple Tk__tok_AssignmentOp_dummy_160 }
+          "tok_CatchList_dummy_159" { simple Tk__tok_CatchList_dummy_159 }
+          "tok_ClassDeclaration_dummy_158" { simple Tk__tok_ClassDeclaration_dummy_158 }
+          "tok_CompilationUnit_dummy_157" { simple Tk__tok_CompilationUnit_dummy_157 }
+          "tok_CompoundName_dummy_156" { simple Tk__tok_CompoundName_dummy_156 }
+          "tok_CreationExpression_dummy_155" { simple Tk__tok_CreationExpression_dummy_155 }
+          "tok_DoStatement_dummy_154" { simple Tk__tok_DoStatement_dummy_154 }
+          "tok_DocComment_dummy_153" { simple Tk__tok_DocComment_dummy_153 }
+          "tok_EnumConstant_dummy_152" { simple Tk__tok_EnumConstant_dummy_152 }
+          "tok_EnumConstantList_dummy_151" { simple Tk__tok_EnumConstantList_dummy_151 }
+          "tok_EnumDeclaration_dummy_150" { simple Tk__tok_EnumDeclaration_dummy_150 }
+          "tok_EqualityOp_dummy_149" { simple Tk__tok_EqualityOp_dummy_149 }
+          "tok_Expression_dummy_148" { simple Tk__tok_Expression_dummy_148 }
+          "tok_ExtendsList_dummy_147" { simple Tk__tok_ExtendsList_dummy_147 }
+          "tok_FieldDeclaration_dummy_146" { simple Tk__tok_FieldDeclaration_dummy_146 }
+          "tok_FieldDeclarationList_dummy_145" { simple Tk__tok_FieldDeclarationList_dummy_145 }
+          "tok_ForStatement_dummy_144" { simple Tk__tok_ForStatement_dummy_144 }
+          "tok_IfStatement_dummy_143" { simple Tk__tok_IfStatement_dummy_143 }
+          "tok_ImplementsList_dummy_142" { simple Tk__tok_ImplementsList_dummy_142 }
+          "tok_ImportList_dummy_141" { simple Tk__tok_ImportList_dummy_141 }
+          "tok_ImportStatement_dummy_140" { simple Tk__tok_ImportStatement_dummy_140 }
+          "tok_InterfaceDeclaration_dummy_139" { simple Tk__tok_InterfaceDeclaration_dummy_139 }
+          "tok_Java_dummy_170" { simple Tk__tok_Java_dummy_170 }
+          "tok_Literal_dummy_138" { simple Tk__tok_Literal_dummy_138 }
+          "tok_MemberAfterFirstId_dummy_137" { simple Tk__tok_MemberAfterFirstId_dummy_137 }
+          "tok_MemberDeclaration_dummy_136" { simple Tk__tok_MemberDeclaration_dummy_136 }
+          "tok_MemberRest_dummy_135" { simple Tk__tok_MemberRest_dummy_135 }
+          "tok_Modifier_dummy_134" { simple Tk__tok_Modifier_dummy_134 }
+          "tok_ModifierList_dummy_133" { simple Tk__tok_ModifierList_dummy_133 }
+          "tok_MoreTypeSpecifier_dummy_132" { simple Tk__tok_MoreTypeSpecifier_dummy_132 }
+          "tok_MoreVariableDeclarators_dummy_131" { simple Tk__tok_MoreVariableDeclarators_dummy_131 }
+          "tok_MultiplicativeOp_dummy_130" { simple Tk__tok_MultiplicativeOp_dummy_130 }
+          "tok_NestedTypeDeclaration_dummy_129" { simple Tk__tok_NestedTypeDeclaration_dummy_129 }
+          "tok_OptDocComment_dummy_128" { simple Tk__tok_OptDocComment_dummy_128 }
+          "tok_OptElsePart_dummy_127" { simple Tk__tok_OptElsePart_dummy_127 }
+          "tok_OptExpression_dummy_126" { simple Tk__tok_OptExpression_dummy_126 }
+          "tok_OptFinally_dummy_125" { simple Tk__tok_OptFinally_dummy_125 }
+          "tok_OptId_dummy_124" { simple Tk__tok_OptId_dummy_124 }
+          "tok_OptVariableInitializer_dummy_123" { simple Tk__tok_OptVariableInitializer_dummy_123 }
+          "tok_Package_dummy_122" { simple Tk__tok_Package_dummy_122 }
+          "tok_Parameter_dummy_121" { simple Tk__tok_Parameter_dummy_121 }
+          "tok_ParameterList_dummy_120" { simple Tk__tok_ParameterList_dummy_120 }
+          "tok_PostfixOp_dummy_119" { simple Tk__tok_PostfixOp_dummy_119 }
+          "tok_PrefixOp_dummy_118" { simple Tk__tok_PrefixOp_dummy_118 }
+          "tok_PrimitiveTypeKeyword_dummy_117" { simple Tk__tok_PrimitiveTypeKeyword_dummy_117 }
+          "tok_RelationalOp_dummy_116" { simple Tk__tok_RelationalOp_dummy_116 }
+          "tok_ShiftOp_dummy_115" { simple Tk__tok_ShiftOp_dummy_115 }
+          "tok_SquareBracketsList_dummy_114" { simple Tk__tok_SquareBracketsList_dummy_114 }
+          "tok_Statement_dummy_113" { simple Tk__tok_Statement_dummy_113 }
+          "tok_StatementBlock_dummy_112" { simple Tk__tok_StatementBlock_dummy_112 }
+          "tok_StatementList_dummy_111" { simple Tk__tok_StatementList_dummy_111 }
+          "tok_StatementWithoutIf_dummy_110" { simple Tk__tok_StatementWithoutIf_dummy_110 }
+          "tok_StaticInitializer_dummy_109" { simple Tk__tok_StaticInitializer_dummy_109 }
+          "tok_SwitchCaseList_dummy_108" { simple Tk__tok_SwitchCaseList_dummy_108 }
+          "tok_SwitchStatement_dummy_107" { simple Tk__tok_SwitchStatement_dummy_107 }
+          "tok_TryStatement_dummy_106" { simple Tk__tok_TryStatement_dummy_106 }
+          "tok_Type_dummy_105" { simple Tk__tok_Type_dummy_105 }
+          "tok_TypeArgument_dummy_104" { simple Tk__tok_TypeArgument_dummy_104 }
+          "tok_TypeArguments_dummy_103" { simple Tk__tok_TypeArguments_dummy_103 }
+          "tok_TypeDeclaration_dummy_102" { simple Tk__tok_TypeDeclaration_dummy_102 }
+          "tok_TypeParameter_dummy_101" { simple Tk__tok_TypeParameter_dummy_101 }
+          "tok_TypeParameters_dummy_100" { simple Tk__tok_TypeParameters_dummy_100 }
+          "tok_TypeSpecifier_dummy_99" { simple Tk__tok_TypeSpecifier_dummy_99 }
+          "tok_VariableDeclaration_dummy_98" { simple Tk__tok_VariableDeclaration_dummy_98 }
+          "tok_VariableDeclarator_dummy_97" { simple Tk__tok_VariableDeclarator_dummy_97 }
+          "tok_VariableDeclaratorList_dummy_96" { simple Tk__tok_VariableDeclaratorList_dummy_96 }
+          "tok_VariableInitializer_dummy_95" { simple Tk__tok_VariableInitializer_dummy_95 }
+          "tok_VariableInitializerList_dummy_94" { simple Tk__tok_VariableInitializerList_dummy_94 }
+          "tok_WhileStatement_dummy_93" { simple Tk__tok_WhileStatement_dummy_93 }
+          "tok_WildcardType_dummy_92" { simple Tk__tok_WildcardType_dummy_92 }
           "~" { simple Tk__tok__tilde__78 }
           "}" { simple Tk__tok__symbol__14 }
           "||" { simple Tk__tok__pipe__pipe__57 }
@@ -94,7 +94,7 @@ tokens :- "tok_AdditiveOp_dummy_171" { simple Tk__tok_AdditiveOp_dummy_171 }
           "|" { simple Tk__tok__pipe__59 }
           "{" { simple Tk__tok__symbol__13 }
           "while" { simple Tk__tok_while_38 }
-          "void" { simple Tk__tok_void_28 }
+          "void" { simple Tk__tok_void_27 }
           "try" { simple Tk__tok_try_42 }
           "true" { simple Tk__tok_true_83 }
           "transient" { simple Tk__tok_transient_94 }
@@ -105,7 +105,7 @@ tokens :- "tok_AdditiveOp_dummy_171" { simple Tk__tok_AdditiveOp_dummy_171 }
           "switch" { simple Tk__tok_switch_44 }
           "super" { simple Tk__tok_super_81 }
           "static" { simple Tk__tok_static_89 }
-          "short" { simple Tk__tok_short_23 }
+          "short" { simple Tk__tok_short_22 }
           "return" { simple Tk__tok_return_29 }
           "public" { simple Tk__tok_public_86 }
           "protected" { simple Tk__tok_protected_88 }
@@ -114,37 +114,37 @@ tokens :- "tok_AdditiveOp_dummy_171" { simple Tk__tok_AdditiveOp_dummy_171 }
           "null" { simple Tk__tok_null_85 }
           "new" { simple Tk__tok_new_82 }
           "native" { simple Tk__tok_native_91 }
-          "long" { simple Tk__tok_long_26 }
+          "long" { simple Tk__tok_long_25 }
           "interface" { simple Tk__tok_interface_15 }
-          "int" { simple Tk__tok_int_24 }
+          "int" { simple Tk__tok_int_23 }
           "instanceof" { simple Tk__tok_instanceof_68 }
           "import" { simple Tk__tok_import_2 }
           "implements" { simple Tk__tok_implements_11 }
           "if" { simple Tk__tok_if_36 }
           "for" { simple Tk__tok_for_39 }
-          "float" { simple Tk__tok_float_25 }
+          "float" { simple Tk__tok_float_24 }
           "finally" { simple Tk__tok_finally_41 }
           "final" { simple Tk__tok_final_90 }
           "false" { simple Tk__tok_false_84 }
           "extends" { simple Tk__tok_extends_10 }
-          "enum" { simple Tk__tok_enum_17 }
+          "enum" { simple Tk__tok_enum_16 }
           "else" { simple Tk__tok_else_35 }
-          "double" { simple Tk__tok_double_27 }
+          "double" { simple Tk__tok_double_26 }
           "do" { simple Tk__tok_do_37 }
-          "default" { simple Tk__tok_default_16 }
+          "default" { simple Tk__tok_default_28 }
           "continue" { simple Tk__tok_continue_34 }
           "class" { simple Tk__tok_class_12 }
-          "char" { simple Tk__tok_char_22 }
+          "char" { simple Tk__tok_char_21 }
           "catch" { simple Tk__tok_catch_40 }
           "case" { simple Tk__tok_case_43 }
-          "byte" { simple Tk__tok_byte_21 }
+          "byte" { simple Tk__tok_byte_20 }
           "break" { simple Tk__tok_break_33 }
-          "boolean" { simple Tk__tok_boolean_20 }
+          "boolean" { simple Tk__tok_boolean_19 }
           "abstract" { simple Tk__tok_abstract_92 }
           "^=" { simple Tk__tok__symbol__eql__51 }
           "^" { simple Tk__tok__symbol__60 }
-          "]" { simple Tk__tok__sq_bkt_r__19 }
-          "[" { simple Tk__tok__sq_bkt_l__18 }
+          "]" { simple Tk__tok__sq_bkt_r__18 }
+          "[" { simple Tk__tok__sq_bkt_l__17 }
           "@" { simple Tk__tok__symbol__5 }
           "?" { simple Tk__tok__symbol__56 }
           ">>>=" { simple Tk__tok__symbol__symbol__symbol__eql__55 }
@@ -276,85 +276,85 @@ tokens :- "tok_AdditiveOp_dummy_171" { simple Tk__tok_AdditiveOp_dummy_171 }
 
 {
 data Token = EndOfFile |
-             Tk__tok_AdditiveOp_dummy_171 |
-             Tk__tok_Annotation_dummy_170 |
-             Tk__tok_AnnotationArguments_dummy_169 |
-             Tk__tok_AnnotationDeclaration_dummy_168 |
-             Tk__tok_AnnotationElement_dummy_167 |
-             Tk__tok_AnnotationList_dummy_166 |
-             Tk__tok_AnnotationTypeElement_dummy_165 |
-             Tk__tok_AnnotationTypeElementList_dummy_164 |
-             Tk__tok_Arglist_dummy_163 |
-             Tk__tok_AssignmentOp_dummy_162 |
-             Tk__tok_CatchList_dummy_161 |
-             Tk__tok_ClassDeclaration_dummy_160 |
-             Tk__tok_CompilationUnit_dummy_159 |
-             Tk__tok_CompoundName_dummy_158 |
-             Tk__tok_CreationExpression_dummy_157 |
-             Tk__tok_DoStatement_dummy_156 |
-             Tk__tok_DocComment_dummy_155 |
-             Tk__tok_EnumConstant_dummy_154 |
-             Tk__tok_EnumConstantList_dummy_153 |
-             Tk__tok_EnumDeclaration_dummy_152 |
-             Tk__tok_EqualityOp_dummy_151 |
-             Tk__tok_Expression_dummy_150 |
-             Tk__tok_ExtendsList_dummy_149 |
-             Tk__tok_FieldDeclaration_dummy_148 |
-             Tk__tok_FieldDeclarationList_dummy_147 |
-             Tk__tok_ForStatement_dummy_146 |
-             Tk__tok_IfStatement_dummy_145 |
-             Tk__tok_ImplementsList_dummy_144 |
-             Tk__tok_ImportList_dummy_143 |
-             Tk__tok_ImportStatement_dummy_142 |
-             Tk__tok_InterfaceDeclaration_dummy_141 |
-             Tk__tok_Java_dummy_172 |
-             Tk__tok_Literal_dummy_140 |
-             Tk__tok_MemberAfterFirstId_dummy_139 |
-             Tk__tok_MemberDeclaration_dummy_138 |
-             Tk__tok_MemberRest_dummy_137 |
-             Tk__tok_Modifier_dummy_136 |
-             Tk__tok_ModifierList_dummy_135 |
-             Tk__tok_MoreTypeSpecifier_dummy_134 |
-             Tk__tok_MoreVariableDeclarators_dummy_133 |
-             Tk__tok_MultiplicativeOp_dummy_132 |
-             Tk__tok_NestedTypeDeclaration_dummy_131 |
-             Tk__tok_OptDocComment_dummy_130 |
-             Tk__tok_OptElsePart_dummy_129 |
-             Tk__tok_OptExpression_dummy_128 |
-             Tk__tok_OptFinally_dummy_127 |
-             Tk__tok_OptId_dummy_126 |
-             Tk__tok_OptVariableInitializer_dummy_125 |
-             Tk__tok_Package_dummy_124 |
-             Tk__tok_Parameter_dummy_123 |
-             Tk__tok_ParameterList_dummy_122 |
-             Tk__tok_PostfixOp_dummy_121 |
-             Tk__tok_PrefixOp_dummy_120 |
-             Tk__tok_PrimitiveTypeKeyword_dummy_119 |
-             Tk__tok_RelationalOp_dummy_118 |
-             Tk__tok_ShiftOp_dummy_117 |
-             Tk__tok_SquareBracketsList_dummy_116 |
-             Tk__tok_Statement_dummy_115 |
-             Tk__tok_StatementBlock_dummy_114 |
-             Tk__tok_StatementList_dummy_113 |
-             Tk__tok_StatementWithoutIf_dummy_112 |
-             Tk__tok_StaticInitializer_dummy_111 |
-             Tk__tok_SwitchCaseList_dummy_110 |
-             Tk__tok_SwitchStatement_dummy_109 |
-             Tk__tok_TryStatement_dummy_108 |
-             Tk__tok_Type_dummy_107 |
-             Tk__tok_TypeArgument_dummy_106 |
-             Tk__tok_TypeArguments_dummy_105 |
-             Tk__tok_TypeDeclaration_dummy_104 |
-             Tk__tok_TypeParameter_dummy_103 |
-             Tk__tok_TypeParameters_dummy_102 |
-             Tk__tok_TypeSpecifier_dummy_101 |
-             Tk__tok_VariableDeclaration_dummy_100 |
-             Tk__tok_VariableDeclarator_dummy_99 |
-             Tk__tok_VariableDeclaratorList_dummy_98 |
-             Tk__tok_VariableInitializer_dummy_97 |
-             Tk__tok_VariableInitializerList_dummy_96 |
-             Tk__tok_WhileStatement_dummy_95 |
-             Tk__tok_WildcardType_dummy_94 |
+             Tk__tok_AdditiveOp_dummy_169 |
+             Tk__tok_Annotation_dummy_168 |
+             Tk__tok_AnnotationArguments_dummy_167 |
+             Tk__tok_AnnotationDeclaration_dummy_166 |
+             Tk__tok_AnnotationElement_dummy_165 |
+             Tk__tok_AnnotationList_dummy_164 |
+             Tk__tok_AnnotationTypeElement_dummy_163 |
+             Tk__tok_AnnotationTypeElementList_dummy_162 |
+             Tk__tok_Arglist_dummy_161 |
+             Tk__tok_AssignmentOp_dummy_160 |
+             Tk__tok_CatchList_dummy_159 |
+             Tk__tok_ClassDeclaration_dummy_158 |
+             Tk__tok_CompilationUnit_dummy_157 |
+             Tk__tok_CompoundName_dummy_156 |
+             Tk__tok_CreationExpression_dummy_155 |
+             Tk__tok_DoStatement_dummy_154 |
+             Tk__tok_DocComment_dummy_153 |
+             Tk__tok_EnumConstant_dummy_152 |
+             Tk__tok_EnumConstantList_dummy_151 |
+             Tk__tok_EnumDeclaration_dummy_150 |
+             Tk__tok_EqualityOp_dummy_149 |
+             Tk__tok_Expression_dummy_148 |
+             Tk__tok_ExtendsList_dummy_147 |
+             Tk__tok_FieldDeclaration_dummy_146 |
+             Tk__tok_FieldDeclarationList_dummy_145 |
+             Tk__tok_ForStatement_dummy_144 |
+             Tk__tok_IfStatement_dummy_143 |
+             Tk__tok_ImplementsList_dummy_142 |
+             Tk__tok_ImportList_dummy_141 |
+             Tk__tok_ImportStatement_dummy_140 |
+             Tk__tok_InterfaceDeclaration_dummy_139 |
+             Tk__tok_Java_dummy_170 |
+             Tk__tok_Literal_dummy_138 |
+             Tk__tok_MemberAfterFirstId_dummy_137 |
+             Tk__tok_MemberDeclaration_dummy_136 |
+             Tk__tok_MemberRest_dummy_135 |
+             Tk__tok_Modifier_dummy_134 |
+             Tk__tok_ModifierList_dummy_133 |
+             Tk__tok_MoreTypeSpecifier_dummy_132 |
+             Tk__tok_MoreVariableDeclarators_dummy_131 |
+             Tk__tok_MultiplicativeOp_dummy_130 |
+             Tk__tok_NestedTypeDeclaration_dummy_129 |
+             Tk__tok_OptDocComment_dummy_128 |
+             Tk__tok_OptElsePart_dummy_127 |
+             Tk__tok_OptExpression_dummy_126 |
+             Tk__tok_OptFinally_dummy_125 |
+             Tk__tok_OptId_dummy_124 |
+             Tk__tok_OptVariableInitializer_dummy_123 |
+             Tk__tok_Package_dummy_122 |
+             Tk__tok_Parameter_dummy_121 |
+             Tk__tok_ParameterList_dummy_120 |
+             Tk__tok_PostfixOp_dummy_119 |
+             Tk__tok_PrefixOp_dummy_118 |
+             Tk__tok_PrimitiveTypeKeyword_dummy_117 |
+             Tk__tok_RelationalOp_dummy_116 |
+             Tk__tok_ShiftOp_dummy_115 |
+             Tk__tok_SquareBracketsList_dummy_114 |
+             Tk__tok_Statement_dummy_113 |
+             Tk__tok_StatementBlock_dummy_112 |
+             Tk__tok_StatementList_dummy_111 |
+             Tk__tok_StatementWithoutIf_dummy_110 |
+             Tk__tok_StaticInitializer_dummy_109 |
+             Tk__tok_SwitchCaseList_dummy_108 |
+             Tk__tok_SwitchStatement_dummy_107 |
+             Tk__tok_TryStatement_dummy_106 |
+             Tk__tok_Type_dummy_105 |
+             Tk__tok_TypeArgument_dummy_104 |
+             Tk__tok_TypeArguments_dummy_103 |
+             Tk__tok_TypeDeclaration_dummy_102 |
+             Tk__tok_TypeParameter_dummy_101 |
+             Tk__tok_TypeParameters_dummy_100 |
+             Tk__tok_TypeSpecifier_dummy_99 |
+             Tk__tok_VariableDeclaration_dummy_98 |
+             Tk__tok_VariableDeclarator_dummy_97 |
+             Tk__tok_VariableDeclaratorList_dummy_96 |
+             Tk__tok_VariableInitializer_dummy_95 |
+             Tk__tok_VariableInitializerList_dummy_94 |
+             Tk__tok_WhileStatement_dummy_93 |
+             Tk__tok_WildcardType_dummy_92 |
              Tk__tok__tilde__78 |
              Tk__tok__symbol__14 |
              Tk__tok__pipe__pipe__57 |
@@ -362,7 +362,7 @@ data Token = EndOfFile |
              Tk__tok__pipe__59 |
              Tk__tok__symbol__13 |
              Tk__tok_while_38 |
-             Tk__tok_void_28 |
+             Tk__tok_void_27 |
              Tk__tok_try_42 |
              Tk__tok_true_83 |
              Tk__tok_transient_94 |
@@ -373,7 +373,7 @@ data Token = EndOfFile |
              Tk__tok_switch_44 |
              Tk__tok_super_81 |
              Tk__tok_static_89 |
-             Tk__tok_short_23 |
+             Tk__tok_short_22 |
              Tk__tok_return_29 |
              Tk__tok_public_86 |
              Tk__tok_protected_88 |
@@ -382,37 +382,37 @@ data Token = EndOfFile |
              Tk__tok_null_85 |
              Tk__tok_new_82 |
              Tk__tok_native_91 |
-             Tk__tok_long_26 |
+             Tk__tok_long_25 |
              Tk__tok_interface_15 |
-             Tk__tok_int_24 |
+             Tk__tok_int_23 |
              Tk__tok_instanceof_68 |
              Tk__tok_import_2 |
              Tk__tok_implements_11 |
              Tk__tok_if_36 |
              Tk__tok_for_39 |
-             Tk__tok_float_25 |
+             Tk__tok_float_24 |
              Tk__tok_finally_41 |
              Tk__tok_final_90 |
              Tk__tok_false_84 |
              Tk__tok_extends_10 |
-             Tk__tok_enum_17 |
+             Tk__tok_enum_16 |
              Tk__tok_else_35 |
-             Tk__tok_double_27 |
+             Tk__tok_double_26 |
              Tk__tok_do_37 |
-             Tk__tok_default_16 |
+             Tk__tok_default_28 |
              Tk__tok_continue_34 |
              Tk__tok_class_12 |
-             Tk__tok_char_22 |
+             Tk__tok_char_21 |
              Tk__tok_catch_40 |
              Tk__tok_case_43 |
-             Tk__tok_byte_21 |
+             Tk__tok_byte_20 |
              Tk__tok_break_33 |
-             Tk__tok_boolean_20 |
+             Tk__tok_boolean_19 |
              Tk__tok_abstract_92 |
              Tk__tok__symbol__eql__51 |
              Tk__tok__symbol__60 |
-             Tk__tok__sq_bkt_r__19 |
-             Tk__tok__sq_bkt_l__18 |
+             Tk__tok__sq_bkt_r__18 |
+             Tk__tok__sq_bkt_l__17 |
              Tk__tok__symbol__5 |
              Tk__tok__symbol__56 |
              Tk__tok__symbol__symbol__symbol__eql__55 |

--- a/test/golden/java/JavaParser.y
+++ b/test/golden/java/JavaParser.y
@@ -13,85 +13,85 @@ import qualified JavaLexer as L (Token(..), PosToken(..), AlexPosn(..), alexScan
 %token
 
 rtk__eof { L.PosToken _ L.EndOfFile }
-tok_AdditiveOp_dummy_171 { L.PosToken _ L.Tk__tok_AdditiveOp_dummy_171 }
-tok_Annotation_dummy_170 { L.PosToken _ L.Tk__tok_Annotation_dummy_170 }
-tok_AnnotationArguments_dummy_169 { L.PosToken _ L.Tk__tok_AnnotationArguments_dummy_169 }
-tok_AnnotationDeclaration_dummy_168 { L.PosToken _ L.Tk__tok_AnnotationDeclaration_dummy_168 }
-tok_AnnotationElement_dummy_167 { L.PosToken _ L.Tk__tok_AnnotationElement_dummy_167 }
-tok_AnnotationList_dummy_166 { L.PosToken _ L.Tk__tok_AnnotationList_dummy_166 }
-tok_AnnotationTypeElement_dummy_165 { L.PosToken _ L.Tk__tok_AnnotationTypeElement_dummy_165 }
-tok_AnnotationTypeElementList_dummy_164 { L.PosToken _ L.Tk__tok_AnnotationTypeElementList_dummy_164 }
-tok_Arglist_dummy_163 { L.PosToken _ L.Tk__tok_Arglist_dummy_163 }
-tok_AssignmentOp_dummy_162 { L.PosToken _ L.Tk__tok_AssignmentOp_dummy_162 }
-tok_CatchList_dummy_161 { L.PosToken _ L.Tk__tok_CatchList_dummy_161 }
-tok_ClassDeclaration_dummy_160 { L.PosToken _ L.Tk__tok_ClassDeclaration_dummy_160 }
-tok_CompilationUnit_dummy_159 { L.PosToken _ L.Tk__tok_CompilationUnit_dummy_159 }
-tok_CompoundName_dummy_158 { L.PosToken _ L.Tk__tok_CompoundName_dummy_158 }
-tok_CreationExpression_dummy_157 { L.PosToken _ L.Tk__tok_CreationExpression_dummy_157 }
-tok_DoStatement_dummy_156 { L.PosToken _ L.Tk__tok_DoStatement_dummy_156 }
-tok_DocComment_dummy_155 { L.PosToken _ L.Tk__tok_DocComment_dummy_155 }
-tok_EnumConstant_dummy_154 { L.PosToken _ L.Tk__tok_EnumConstant_dummy_154 }
-tok_EnumConstantList_dummy_153 { L.PosToken _ L.Tk__tok_EnumConstantList_dummy_153 }
-tok_EnumDeclaration_dummy_152 { L.PosToken _ L.Tk__tok_EnumDeclaration_dummy_152 }
-tok_EqualityOp_dummy_151 { L.PosToken _ L.Tk__tok_EqualityOp_dummy_151 }
-tok_Expression_dummy_150 { L.PosToken _ L.Tk__tok_Expression_dummy_150 }
-tok_ExtendsList_dummy_149 { L.PosToken _ L.Tk__tok_ExtendsList_dummy_149 }
-tok_FieldDeclaration_dummy_148 { L.PosToken _ L.Tk__tok_FieldDeclaration_dummy_148 }
-tok_FieldDeclarationList_dummy_147 { L.PosToken _ L.Tk__tok_FieldDeclarationList_dummy_147 }
-tok_ForStatement_dummy_146 { L.PosToken _ L.Tk__tok_ForStatement_dummy_146 }
-tok_IfStatement_dummy_145 { L.PosToken _ L.Tk__tok_IfStatement_dummy_145 }
-tok_ImplementsList_dummy_144 { L.PosToken _ L.Tk__tok_ImplementsList_dummy_144 }
-tok_ImportList_dummy_143 { L.PosToken _ L.Tk__tok_ImportList_dummy_143 }
-tok_ImportStatement_dummy_142 { L.PosToken _ L.Tk__tok_ImportStatement_dummy_142 }
-tok_InterfaceDeclaration_dummy_141 { L.PosToken _ L.Tk__tok_InterfaceDeclaration_dummy_141 }
-tok_Java_dummy_172 { L.PosToken _ L.Tk__tok_Java_dummy_172 }
-tok_Literal_dummy_140 { L.PosToken _ L.Tk__tok_Literal_dummy_140 }
-tok_MemberAfterFirstId_dummy_139 { L.PosToken _ L.Tk__tok_MemberAfterFirstId_dummy_139 }
-tok_MemberDeclaration_dummy_138 { L.PosToken _ L.Tk__tok_MemberDeclaration_dummy_138 }
-tok_MemberRest_dummy_137 { L.PosToken _ L.Tk__tok_MemberRest_dummy_137 }
-tok_Modifier_dummy_136 { L.PosToken _ L.Tk__tok_Modifier_dummy_136 }
-tok_ModifierList_dummy_135 { L.PosToken _ L.Tk__tok_ModifierList_dummy_135 }
-tok_MoreTypeSpecifier_dummy_134 { L.PosToken _ L.Tk__tok_MoreTypeSpecifier_dummy_134 }
-tok_MoreVariableDeclarators_dummy_133 { L.PosToken _ L.Tk__tok_MoreVariableDeclarators_dummy_133 }
-tok_MultiplicativeOp_dummy_132 { L.PosToken _ L.Tk__tok_MultiplicativeOp_dummy_132 }
-tok_NestedTypeDeclaration_dummy_131 { L.PosToken _ L.Tk__tok_NestedTypeDeclaration_dummy_131 }
-tok_OptDocComment_dummy_130 { L.PosToken _ L.Tk__tok_OptDocComment_dummy_130 }
-tok_OptElsePart_dummy_129 { L.PosToken _ L.Tk__tok_OptElsePart_dummy_129 }
-tok_OptExpression_dummy_128 { L.PosToken _ L.Tk__tok_OptExpression_dummy_128 }
-tok_OptFinally_dummy_127 { L.PosToken _ L.Tk__tok_OptFinally_dummy_127 }
-tok_OptId_dummy_126 { L.PosToken _ L.Tk__tok_OptId_dummy_126 }
-tok_OptVariableInitializer_dummy_125 { L.PosToken _ L.Tk__tok_OptVariableInitializer_dummy_125 }
-tok_Package_dummy_124 { L.PosToken _ L.Tk__tok_Package_dummy_124 }
-tok_Parameter_dummy_123 { L.PosToken _ L.Tk__tok_Parameter_dummy_123 }
-tok_ParameterList_dummy_122 { L.PosToken _ L.Tk__tok_ParameterList_dummy_122 }
-tok_PostfixOp_dummy_121 { L.PosToken _ L.Tk__tok_PostfixOp_dummy_121 }
-tok_PrefixOp_dummy_120 { L.PosToken _ L.Tk__tok_PrefixOp_dummy_120 }
-tok_PrimitiveTypeKeyword_dummy_119 { L.PosToken _ L.Tk__tok_PrimitiveTypeKeyword_dummy_119 }
-tok_RelationalOp_dummy_118 { L.PosToken _ L.Tk__tok_RelationalOp_dummy_118 }
-tok_ShiftOp_dummy_117 { L.PosToken _ L.Tk__tok_ShiftOp_dummy_117 }
-tok_SquareBracketsList_dummy_116 { L.PosToken _ L.Tk__tok_SquareBracketsList_dummy_116 }
-tok_Statement_dummy_115 { L.PosToken _ L.Tk__tok_Statement_dummy_115 }
-tok_StatementBlock_dummy_114 { L.PosToken _ L.Tk__tok_StatementBlock_dummy_114 }
-tok_StatementList_dummy_113 { L.PosToken _ L.Tk__tok_StatementList_dummy_113 }
-tok_StatementWithoutIf_dummy_112 { L.PosToken _ L.Tk__tok_StatementWithoutIf_dummy_112 }
-tok_StaticInitializer_dummy_111 { L.PosToken _ L.Tk__tok_StaticInitializer_dummy_111 }
-tok_SwitchCaseList_dummy_110 { L.PosToken _ L.Tk__tok_SwitchCaseList_dummy_110 }
-tok_SwitchStatement_dummy_109 { L.PosToken _ L.Tk__tok_SwitchStatement_dummy_109 }
-tok_TryStatement_dummy_108 { L.PosToken _ L.Tk__tok_TryStatement_dummy_108 }
-tok_Type_dummy_107 { L.PosToken _ L.Tk__tok_Type_dummy_107 }
-tok_TypeArgument_dummy_106 { L.PosToken _ L.Tk__tok_TypeArgument_dummy_106 }
-tok_TypeArguments_dummy_105 { L.PosToken _ L.Tk__tok_TypeArguments_dummy_105 }
-tok_TypeDeclaration_dummy_104 { L.PosToken _ L.Tk__tok_TypeDeclaration_dummy_104 }
-tok_TypeParameter_dummy_103 { L.PosToken _ L.Tk__tok_TypeParameter_dummy_103 }
-tok_TypeParameters_dummy_102 { L.PosToken _ L.Tk__tok_TypeParameters_dummy_102 }
-tok_TypeSpecifier_dummy_101 { L.PosToken _ L.Tk__tok_TypeSpecifier_dummy_101 }
-tok_VariableDeclaration_dummy_100 { L.PosToken _ L.Tk__tok_VariableDeclaration_dummy_100 }
-tok_VariableDeclarator_dummy_99 { L.PosToken _ L.Tk__tok_VariableDeclarator_dummy_99 }
-tok_VariableDeclaratorList_dummy_98 { L.PosToken _ L.Tk__tok_VariableDeclaratorList_dummy_98 }
-tok_VariableInitializer_dummy_97 { L.PosToken _ L.Tk__tok_VariableInitializer_dummy_97 }
-tok_VariableInitializerList_dummy_96 { L.PosToken _ L.Tk__tok_VariableInitializerList_dummy_96 }
-tok_WhileStatement_dummy_95 { L.PosToken _ L.Tk__tok_WhileStatement_dummy_95 }
-tok_WildcardType_dummy_94 { L.PosToken _ L.Tk__tok_WildcardType_dummy_94 }
+tok_AdditiveOp_dummy_169 { L.PosToken _ L.Tk__tok_AdditiveOp_dummy_169 }
+tok_Annotation_dummy_168 { L.PosToken _ L.Tk__tok_Annotation_dummy_168 }
+tok_AnnotationArguments_dummy_167 { L.PosToken _ L.Tk__tok_AnnotationArguments_dummy_167 }
+tok_AnnotationDeclaration_dummy_166 { L.PosToken _ L.Tk__tok_AnnotationDeclaration_dummy_166 }
+tok_AnnotationElement_dummy_165 { L.PosToken _ L.Tk__tok_AnnotationElement_dummy_165 }
+tok_AnnotationList_dummy_164 { L.PosToken _ L.Tk__tok_AnnotationList_dummy_164 }
+tok_AnnotationTypeElement_dummy_163 { L.PosToken _ L.Tk__tok_AnnotationTypeElement_dummy_163 }
+tok_AnnotationTypeElementList_dummy_162 { L.PosToken _ L.Tk__tok_AnnotationTypeElementList_dummy_162 }
+tok_Arglist_dummy_161 { L.PosToken _ L.Tk__tok_Arglist_dummy_161 }
+tok_AssignmentOp_dummy_160 { L.PosToken _ L.Tk__tok_AssignmentOp_dummy_160 }
+tok_CatchList_dummy_159 { L.PosToken _ L.Tk__tok_CatchList_dummy_159 }
+tok_ClassDeclaration_dummy_158 { L.PosToken _ L.Tk__tok_ClassDeclaration_dummy_158 }
+tok_CompilationUnit_dummy_157 { L.PosToken _ L.Tk__tok_CompilationUnit_dummy_157 }
+tok_CompoundName_dummy_156 { L.PosToken _ L.Tk__tok_CompoundName_dummy_156 }
+tok_CreationExpression_dummy_155 { L.PosToken _ L.Tk__tok_CreationExpression_dummy_155 }
+tok_DoStatement_dummy_154 { L.PosToken _ L.Tk__tok_DoStatement_dummy_154 }
+tok_DocComment_dummy_153 { L.PosToken _ L.Tk__tok_DocComment_dummy_153 }
+tok_EnumConstant_dummy_152 { L.PosToken _ L.Tk__tok_EnumConstant_dummy_152 }
+tok_EnumConstantList_dummy_151 { L.PosToken _ L.Tk__tok_EnumConstantList_dummy_151 }
+tok_EnumDeclaration_dummy_150 { L.PosToken _ L.Tk__tok_EnumDeclaration_dummy_150 }
+tok_EqualityOp_dummy_149 { L.PosToken _ L.Tk__tok_EqualityOp_dummy_149 }
+tok_Expression_dummy_148 { L.PosToken _ L.Tk__tok_Expression_dummy_148 }
+tok_ExtendsList_dummy_147 { L.PosToken _ L.Tk__tok_ExtendsList_dummy_147 }
+tok_FieldDeclaration_dummy_146 { L.PosToken _ L.Tk__tok_FieldDeclaration_dummy_146 }
+tok_FieldDeclarationList_dummy_145 { L.PosToken _ L.Tk__tok_FieldDeclarationList_dummy_145 }
+tok_ForStatement_dummy_144 { L.PosToken _ L.Tk__tok_ForStatement_dummy_144 }
+tok_IfStatement_dummy_143 { L.PosToken _ L.Tk__tok_IfStatement_dummy_143 }
+tok_ImplementsList_dummy_142 { L.PosToken _ L.Tk__tok_ImplementsList_dummy_142 }
+tok_ImportList_dummy_141 { L.PosToken _ L.Tk__tok_ImportList_dummy_141 }
+tok_ImportStatement_dummy_140 { L.PosToken _ L.Tk__tok_ImportStatement_dummy_140 }
+tok_InterfaceDeclaration_dummy_139 { L.PosToken _ L.Tk__tok_InterfaceDeclaration_dummy_139 }
+tok_Java_dummy_170 { L.PosToken _ L.Tk__tok_Java_dummy_170 }
+tok_Literal_dummy_138 { L.PosToken _ L.Tk__tok_Literal_dummy_138 }
+tok_MemberAfterFirstId_dummy_137 { L.PosToken _ L.Tk__tok_MemberAfterFirstId_dummy_137 }
+tok_MemberDeclaration_dummy_136 { L.PosToken _ L.Tk__tok_MemberDeclaration_dummy_136 }
+tok_MemberRest_dummy_135 { L.PosToken _ L.Tk__tok_MemberRest_dummy_135 }
+tok_Modifier_dummy_134 { L.PosToken _ L.Tk__tok_Modifier_dummy_134 }
+tok_ModifierList_dummy_133 { L.PosToken _ L.Tk__tok_ModifierList_dummy_133 }
+tok_MoreTypeSpecifier_dummy_132 { L.PosToken _ L.Tk__tok_MoreTypeSpecifier_dummy_132 }
+tok_MoreVariableDeclarators_dummy_131 { L.PosToken _ L.Tk__tok_MoreVariableDeclarators_dummy_131 }
+tok_MultiplicativeOp_dummy_130 { L.PosToken _ L.Tk__tok_MultiplicativeOp_dummy_130 }
+tok_NestedTypeDeclaration_dummy_129 { L.PosToken _ L.Tk__tok_NestedTypeDeclaration_dummy_129 }
+tok_OptDocComment_dummy_128 { L.PosToken _ L.Tk__tok_OptDocComment_dummy_128 }
+tok_OptElsePart_dummy_127 { L.PosToken _ L.Tk__tok_OptElsePart_dummy_127 }
+tok_OptExpression_dummy_126 { L.PosToken _ L.Tk__tok_OptExpression_dummy_126 }
+tok_OptFinally_dummy_125 { L.PosToken _ L.Tk__tok_OptFinally_dummy_125 }
+tok_OptId_dummy_124 { L.PosToken _ L.Tk__tok_OptId_dummy_124 }
+tok_OptVariableInitializer_dummy_123 { L.PosToken _ L.Tk__tok_OptVariableInitializer_dummy_123 }
+tok_Package_dummy_122 { L.PosToken _ L.Tk__tok_Package_dummy_122 }
+tok_Parameter_dummy_121 { L.PosToken _ L.Tk__tok_Parameter_dummy_121 }
+tok_ParameterList_dummy_120 { L.PosToken _ L.Tk__tok_ParameterList_dummy_120 }
+tok_PostfixOp_dummy_119 { L.PosToken _ L.Tk__tok_PostfixOp_dummy_119 }
+tok_PrefixOp_dummy_118 { L.PosToken _ L.Tk__tok_PrefixOp_dummy_118 }
+tok_PrimitiveTypeKeyword_dummy_117 { L.PosToken _ L.Tk__tok_PrimitiveTypeKeyword_dummy_117 }
+tok_RelationalOp_dummy_116 { L.PosToken _ L.Tk__tok_RelationalOp_dummy_116 }
+tok_ShiftOp_dummy_115 { L.PosToken _ L.Tk__tok_ShiftOp_dummy_115 }
+tok_SquareBracketsList_dummy_114 { L.PosToken _ L.Tk__tok_SquareBracketsList_dummy_114 }
+tok_Statement_dummy_113 { L.PosToken _ L.Tk__tok_Statement_dummy_113 }
+tok_StatementBlock_dummy_112 { L.PosToken _ L.Tk__tok_StatementBlock_dummy_112 }
+tok_StatementList_dummy_111 { L.PosToken _ L.Tk__tok_StatementList_dummy_111 }
+tok_StatementWithoutIf_dummy_110 { L.PosToken _ L.Tk__tok_StatementWithoutIf_dummy_110 }
+tok_StaticInitializer_dummy_109 { L.PosToken _ L.Tk__tok_StaticInitializer_dummy_109 }
+tok_SwitchCaseList_dummy_108 { L.PosToken _ L.Tk__tok_SwitchCaseList_dummy_108 }
+tok_SwitchStatement_dummy_107 { L.PosToken _ L.Tk__tok_SwitchStatement_dummy_107 }
+tok_TryStatement_dummy_106 { L.PosToken _ L.Tk__tok_TryStatement_dummy_106 }
+tok_Type_dummy_105 { L.PosToken _ L.Tk__tok_Type_dummy_105 }
+tok_TypeArgument_dummy_104 { L.PosToken _ L.Tk__tok_TypeArgument_dummy_104 }
+tok_TypeArguments_dummy_103 { L.PosToken _ L.Tk__tok_TypeArguments_dummy_103 }
+tok_TypeDeclaration_dummy_102 { L.PosToken _ L.Tk__tok_TypeDeclaration_dummy_102 }
+tok_TypeParameter_dummy_101 { L.PosToken _ L.Tk__tok_TypeParameter_dummy_101 }
+tok_TypeParameters_dummy_100 { L.PosToken _ L.Tk__tok_TypeParameters_dummy_100 }
+tok_TypeSpecifier_dummy_99 { L.PosToken _ L.Tk__tok_TypeSpecifier_dummy_99 }
+tok_VariableDeclaration_dummy_98 { L.PosToken _ L.Tk__tok_VariableDeclaration_dummy_98 }
+tok_VariableDeclarator_dummy_97 { L.PosToken _ L.Tk__tok_VariableDeclarator_dummy_97 }
+tok_VariableDeclaratorList_dummy_96 { L.PosToken _ L.Tk__tok_VariableDeclaratorList_dummy_96 }
+tok_VariableInitializer_dummy_95 { L.PosToken _ L.Tk__tok_VariableInitializer_dummy_95 }
+tok_VariableInitializerList_dummy_94 { L.PosToken _ L.Tk__tok_VariableInitializerList_dummy_94 }
+tok_WhileStatement_dummy_93 { L.PosToken _ L.Tk__tok_WhileStatement_dummy_93 }
+tok_WildcardType_dummy_92 { L.PosToken _ L.Tk__tok_WildcardType_dummy_92 }
 tok__tilde__78 { L.PosToken _ L.Tk__tok__tilde__78 }
 tok__symbol__14 { L.PosToken _ L.Tk__tok__symbol__14 }
 tok__pipe__pipe__57 { L.PosToken _ L.Tk__tok__pipe__pipe__57 }
@@ -99,7 +99,7 @@ tok__pipe__eql__49 { L.PosToken _ L.Tk__tok__pipe__eql__49 }
 tok__pipe__59 { L.PosToken _ L.Tk__tok__pipe__59 }
 tok__symbol__13 { L.PosToken _ L.Tk__tok__symbol__13 }
 tok_while_38 { L.PosToken _ L.Tk__tok_while_38 }
-tok_void_28 { L.PosToken _ L.Tk__tok_void_28 }
+tok_void_27 { L.PosToken _ L.Tk__tok_void_27 }
 tok_try_42 { L.PosToken _ L.Tk__tok_try_42 }
 tok_true_83 { L.PosToken _ L.Tk__tok_true_83 }
 tok_transient_94 { L.PosToken _ L.Tk__tok_transient_94 }
@@ -110,7 +110,7 @@ tok_synchronized_30 { L.PosToken _ L.Tk__tok_synchronized_30 }
 tok_switch_44 { L.PosToken _ L.Tk__tok_switch_44 }
 tok_super_81 { L.PosToken _ L.Tk__tok_super_81 }
 tok_static_89 { L.PosToken _ L.Tk__tok_static_89 }
-tok_short_23 { L.PosToken _ L.Tk__tok_short_23 }
+tok_short_22 { L.PosToken _ L.Tk__tok_short_22 }
 tok_return_29 { L.PosToken _ L.Tk__tok_return_29 }
 tok_public_86 { L.PosToken _ L.Tk__tok_public_86 }
 tok_protected_88 { L.PosToken _ L.Tk__tok_protected_88 }
@@ -119,37 +119,37 @@ tok_package_0 { L.PosToken _ L.Tk__tok_package_0 }
 tok_null_85 { L.PosToken _ L.Tk__tok_null_85 }
 tok_new_82 { L.PosToken _ L.Tk__tok_new_82 }
 tok_native_91 { L.PosToken _ L.Tk__tok_native_91 }
-tok_long_26 { L.PosToken _ L.Tk__tok_long_26 }
+tok_long_25 { L.PosToken _ L.Tk__tok_long_25 }
 tok_interface_15 { L.PosToken _ L.Tk__tok_interface_15 }
-tok_int_24 { L.PosToken _ L.Tk__tok_int_24 }
+tok_int_23 { L.PosToken _ L.Tk__tok_int_23 }
 tok_instanceof_68 { L.PosToken _ L.Tk__tok_instanceof_68 }
 tok_import_2 { L.PosToken _ L.Tk__tok_import_2 }
 tok_implements_11 { L.PosToken _ L.Tk__tok_implements_11 }
 tok_if_36 { L.PosToken _ L.Tk__tok_if_36 }
 tok_for_39 { L.PosToken _ L.Tk__tok_for_39 }
-tok_float_25 { L.PosToken _ L.Tk__tok_float_25 }
+tok_float_24 { L.PosToken _ L.Tk__tok_float_24 }
 tok_finally_41 { L.PosToken _ L.Tk__tok_finally_41 }
 tok_final_90 { L.PosToken _ L.Tk__tok_final_90 }
 tok_false_84 { L.PosToken _ L.Tk__tok_false_84 }
 tok_extends_10 { L.PosToken _ L.Tk__tok_extends_10 }
-tok_enum_17 { L.PosToken _ L.Tk__tok_enum_17 }
+tok_enum_16 { L.PosToken _ L.Tk__tok_enum_16 }
 tok_else_35 { L.PosToken _ L.Tk__tok_else_35 }
-tok_double_27 { L.PosToken _ L.Tk__tok_double_27 }
+tok_double_26 { L.PosToken _ L.Tk__tok_double_26 }
 tok_do_37 { L.PosToken _ L.Tk__tok_do_37 }
-tok_default_16 { L.PosToken _ L.Tk__tok_default_16 }
+tok_default_28 { L.PosToken _ L.Tk__tok_default_28 }
 tok_continue_34 { L.PosToken _ L.Tk__tok_continue_34 }
 tok_class_12 { L.PosToken _ L.Tk__tok_class_12 }
-tok_char_22 { L.PosToken _ L.Tk__tok_char_22 }
+tok_char_21 { L.PosToken _ L.Tk__tok_char_21 }
 tok_catch_40 { L.PosToken _ L.Tk__tok_catch_40 }
 tok_case_43 { L.PosToken _ L.Tk__tok_case_43 }
-tok_byte_21 { L.PosToken _ L.Tk__tok_byte_21 }
+tok_byte_20 { L.PosToken _ L.Tk__tok_byte_20 }
 tok_break_33 { L.PosToken _ L.Tk__tok_break_33 }
-tok_boolean_20 { L.PosToken _ L.Tk__tok_boolean_20 }
+tok_boolean_19 { L.PosToken _ L.Tk__tok_boolean_19 }
 tok_abstract_92 { L.PosToken _ L.Tk__tok_abstract_92 }
 tok__symbol__eql__51 { L.PosToken _ L.Tk__tok__symbol__eql__51 }
 tok__symbol__60 { L.PosToken _ L.Tk__tok__symbol__60 }
-tok__sq_bkt_r__19 { L.PosToken _ L.Tk__tok__sq_bkt_r__19 }
-tok__sq_bkt_l__18 { L.PosToken _ L.Tk__tok__sq_bkt_l__18 }
+tok__sq_bkt_r__18 { L.PosToken _ L.Tk__tok__sq_bkt_r__18 }
+tok__sq_bkt_l__17 { L.PosToken _ L.Tk__tok__sq_bkt_l__17 }
 tok__symbol__5 { L.PosToken _ L.Tk__tok__symbol__5 }
 tok__symbol__56 { L.PosToken _ L.Tk__tok__symbol__56 }
 tok__symbol__symbol__symbol__eql__55 { L.PosToken _ L.Tk__tok__symbol__symbol__symbol__eql__55 }
@@ -279,85 +279,85 @@ qq_Java { L.PosToken _ (L.Tk__qq_Java $$) }
 
 Java__top : Java rtk__eof { $1 }
 
-Java : tok_Java_dummy_172 Java tok_Java_dummy_172 { Ctr__Java__0 $2 } |
-       tok_AdditiveOp_dummy_171 AdditiveOp tok_AdditiveOp_dummy_171 { Ctr__Java__1 $2 } |
-       tok_Annotation_dummy_170 Annotation tok_Annotation_dummy_170 { Ctr__Java__2 $2 } |
-       tok_AnnotationArguments_dummy_169 AnnotationArguments tok_AnnotationArguments_dummy_169 { Ctr__Java__3 $2 } |
-       tok_AnnotationDeclaration_dummy_168 AnnotationDeclaration tok_AnnotationDeclaration_dummy_168 { Ctr__Java__4 $2 } |
-       tok_AnnotationElement_dummy_167 AnnotationElement tok_AnnotationElement_dummy_167 { Ctr__Java__5 $2 } |
-       tok_AnnotationList_dummy_166 AnnotationList tok_AnnotationList_dummy_166 { Ctr__Java__6 (reverse $2) } |
-       tok_AnnotationTypeElement_dummy_165 AnnotationTypeElement tok_AnnotationTypeElement_dummy_165 { Ctr__Java__7 $2 } |
-       tok_AnnotationTypeElementList_dummy_164 AnnotationTypeElementList tok_AnnotationTypeElementList_dummy_164 { Ctr__Java__8 (reverse $2) } |
-       tok_Arglist_dummy_163 Arglist tok_Arglist_dummy_163 { Ctr__Java__9 $2 } |
-       tok_AssignmentOp_dummy_162 AssignmentOp tok_AssignmentOp_dummy_162 { Ctr__Java__10 $2 } |
-       tok_CatchList_dummy_161 CatchList tok_CatchList_dummy_161 { Ctr__Java__11 (reverse $2) } |
-       tok_ClassDeclaration_dummy_160 ClassDeclaration tok_ClassDeclaration_dummy_160 { Ctr__Java__12 $2 } |
-       tok_CompilationUnit_dummy_159 CompilationUnit tok_CompilationUnit_dummy_159 { Ctr__Java__13 $2 } |
-       tok_CompoundName_dummy_158 CompoundName tok_CompoundName_dummy_158 { Ctr__Java__14 $2 } |
-       tok_CreationExpression_dummy_157 CreationExpression tok_CreationExpression_dummy_157 { Ctr__Java__15 $2 } |
-       tok_DoStatement_dummy_156 DoStatement tok_DoStatement_dummy_156 { Ctr__Java__16 $2 } |
-       tok_DocComment_dummy_155 DocComment tok_DocComment_dummy_155 { Ctr__Java__17 $2 } |
-       tok_EnumConstant_dummy_154 EnumConstant tok_EnumConstant_dummy_154 { Ctr__Java__18 $2 } |
-       tok_EnumConstantList_dummy_153 EnumConstantList tok_EnumConstantList_dummy_153 { Ctr__Java__19 $2 } |
-       tok_EnumDeclaration_dummy_152 EnumDeclaration tok_EnumDeclaration_dummy_152 { Ctr__Java__20 $2 } |
-       tok_EqualityOp_dummy_151 EqualityOp tok_EqualityOp_dummy_151 { Ctr__Java__21 $2 } |
-       tok_Expression_dummy_150 Expression tok_Expression_dummy_150 { Ctr__Java__22 $2 } |
-       tok_ExtendsList_dummy_149 ExtendsList tok_ExtendsList_dummy_149 { Ctr__Java__23 $2 } |
-       tok_FieldDeclaration_dummy_148 FieldDeclaration tok_FieldDeclaration_dummy_148 { Ctr__Java__24 $2 } |
-       tok_FieldDeclarationList_dummy_147 FieldDeclarationList tok_FieldDeclarationList_dummy_147 { Ctr__Java__25 (reverse $2) } |
-       tok_ForStatement_dummy_146 ForStatement tok_ForStatement_dummy_146 { Ctr__Java__26 $2 } |
-       tok_IfStatement_dummy_145 IfStatement tok_IfStatement_dummy_145 { Ctr__Java__27 $2 } |
-       tok_ImplementsList_dummy_144 ImplementsList tok_ImplementsList_dummy_144 { Ctr__Java__28 $2 } |
-       tok_ImportList_dummy_143 ImportList tok_ImportList_dummy_143 { Ctr__Java__29 (reverse $2) } |
-       tok_ImportStatement_dummy_142 ImportStatement tok_ImportStatement_dummy_142 { Ctr__Java__30 $2 } |
-       tok_InterfaceDeclaration_dummy_141 InterfaceDeclaration tok_InterfaceDeclaration_dummy_141 { Ctr__Java__31 $2 } |
-       tok_Literal_dummy_140 Literal tok_Literal_dummy_140 { Ctr__Java__32 $2 } |
-       tok_MemberAfterFirstId_dummy_139 MemberAfterFirstId tok_MemberAfterFirstId_dummy_139 { Ctr__Java__33 $2 } |
-       tok_MemberDeclaration_dummy_138 MemberDeclaration tok_MemberDeclaration_dummy_138 { Ctr__Java__34 $2 } |
-       tok_MemberRest_dummy_137 MemberRest tok_MemberRest_dummy_137 { Ctr__Java__35 $2 } |
-       tok_Modifier_dummy_136 Modifier tok_Modifier_dummy_136 { Ctr__Java__36 $2 } |
-       tok_ModifierList_dummy_135 ModifierList tok_ModifierList_dummy_135 { Ctr__Java__37 (reverse $2) } |
-       tok_MoreTypeSpecifier_dummy_134 MoreTypeSpecifier tok_MoreTypeSpecifier_dummy_134 { Ctr__Java__38 $2 } |
-       tok_MoreVariableDeclarators_dummy_133 MoreVariableDeclarators tok_MoreVariableDeclarators_dummy_133 { Ctr__Java__39 (reverse $2) } |
-       tok_MultiplicativeOp_dummy_132 MultiplicativeOp tok_MultiplicativeOp_dummy_132 { Ctr__Java__40 $2 } |
-       tok_NestedTypeDeclaration_dummy_131 NestedTypeDeclaration tok_NestedTypeDeclaration_dummy_131 { Ctr__Java__41 $2 } |
-       tok_OptDocComment_dummy_130 OptDocComment tok_OptDocComment_dummy_130 { Ctr__Java__42 $2 } |
-       tok_OptElsePart_dummy_129 OptElsePart tok_OptElsePart_dummy_129 { Ctr__Java__43 $2 } |
-       tok_OptExpression_dummy_128 OptExpression tok_OptExpression_dummy_128 { Ctr__Java__44 $2 } |
-       tok_OptFinally_dummy_127 OptFinally tok_OptFinally_dummy_127 { Ctr__Java__45 $2 } |
-       tok_OptId_dummy_126 OptId tok_OptId_dummy_126 { Ctr__Java__46 $2 } |
-       tok_OptVariableInitializer_dummy_125 OptVariableInitializer tok_OptVariableInitializer_dummy_125 { Ctr__Java__47 $2 } |
-       tok_Package_dummy_124 Package tok_Package_dummy_124 { Ctr__Java__48 $2 } |
-       tok_Parameter_dummy_123 Parameter tok_Parameter_dummy_123 { Ctr__Java__49 $2 } |
-       tok_ParameterList_dummy_122 ParameterList tok_ParameterList_dummy_122 { Ctr__Java__50 $2 } |
-       tok_PostfixOp_dummy_121 PostfixOp tok_PostfixOp_dummy_121 { Ctr__Java__51 $2 } |
-       tok_PrefixOp_dummy_120 PrefixOp tok_PrefixOp_dummy_120 { Ctr__Java__52 $2 } |
-       tok_PrimitiveTypeKeyword_dummy_119 PrimitiveTypeKeyword tok_PrimitiveTypeKeyword_dummy_119 { Ctr__Java__53 $2 } |
-       tok_RelationalOp_dummy_118 RelationalOp tok_RelationalOp_dummy_118 { Ctr__Java__54 $2 } |
-       tok_ShiftOp_dummy_117 ShiftOp tok_ShiftOp_dummy_117 { Ctr__Java__55 $2 } |
-       tok_SquareBracketsList_dummy_116 SquareBracketsList tok_SquareBracketsList_dummy_116 { Ctr__Java__56 (reverse $2) } |
-       tok_Statement_dummy_115 Statement tok_Statement_dummy_115 { Ctr__Java__57 $2 } |
-       tok_StatementBlock_dummy_114 StatementBlock tok_StatementBlock_dummy_114 { Ctr__Java__58 $2 } |
-       tok_StatementList_dummy_113 StatementList tok_StatementList_dummy_113 { Ctr__Java__59 (reverse $2) } |
-       tok_StatementWithoutIf_dummy_112 StatementWithoutIf tok_StatementWithoutIf_dummy_112 { Ctr__Java__60 $2 } |
-       tok_StaticInitializer_dummy_111 StaticInitializer tok_StaticInitializer_dummy_111 { Ctr__Java__61 $2 } |
-       tok_SwitchCaseList_dummy_110 SwitchCaseList tok_SwitchCaseList_dummy_110 { Ctr__Java__62 (reverse $2) } |
-       tok_SwitchStatement_dummy_109 SwitchStatement tok_SwitchStatement_dummy_109 { Ctr__Java__63 $2 } |
-       tok_TryStatement_dummy_108 TryStatement tok_TryStatement_dummy_108 { Ctr__Java__64 $2 } |
-       tok_Type_dummy_107 Type tok_Type_dummy_107 { Ctr__Java__65 $2 } |
-       tok_TypeArgument_dummy_106 TypeArgument tok_TypeArgument_dummy_106 { Ctr__Java__66 $2 } |
-       tok_TypeArguments_dummy_105 TypeArguments tok_TypeArguments_dummy_105 { Ctr__Java__67 $2 } |
-       tok_TypeDeclaration_dummy_104 TypeDeclaration tok_TypeDeclaration_dummy_104 { Ctr__Java__68 $2 } |
-       tok_TypeParameter_dummy_103 TypeParameter tok_TypeParameter_dummy_103 { Ctr__Java__69 $2 } |
-       tok_TypeParameters_dummy_102 TypeParameters tok_TypeParameters_dummy_102 { Ctr__Java__70 $2 } |
-       tok_TypeSpecifier_dummy_101 TypeSpecifier tok_TypeSpecifier_dummy_101 { Ctr__Java__71 $2 } |
-       tok_VariableDeclaration_dummy_100 VariableDeclaration tok_VariableDeclaration_dummy_100 { Ctr__Java__72 $2 } |
-       tok_VariableDeclarator_dummy_99 VariableDeclarator tok_VariableDeclarator_dummy_99 { Ctr__Java__73 $2 } |
-       tok_VariableDeclaratorList_dummy_98 VariableDeclaratorList tok_VariableDeclaratorList_dummy_98 { Ctr__Java__74 $2 } |
-       tok_VariableInitializer_dummy_97 VariableInitializer tok_VariableInitializer_dummy_97 { Ctr__Java__75 $2 } |
-       tok_VariableInitializerList_dummy_96 VariableInitializerList tok_VariableInitializerList_dummy_96 { Ctr__Java__76 $2 } |
-       tok_WhileStatement_dummy_95 WhileStatement tok_WhileStatement_dummy_95 { Ctr__Java__77 $2 } |
-       tok_WildcardType_dummy_94 WildcardType tok_WildcardType_dummy_94 { Ctr__Java__78 $2 }
+Java : tok_Java_dummy_170 Java tok_Java_dummy_170 { Ctr__Java__0 $2 } |
+       tok_AdditiveOp_dummy_169 AdditiveOp tok_AdditiveOp_dummy_169 { Ctr__Java__1 $2 } |
+       tok_Annotation_dummy_168 Annotation tok_Annotation_dummy_168 { Ctr__Java__2 $2 } |
+       tok_AnnotationArguments_dummy_167 AnnotationArguments tok_AnnotationArguments_dummy_167 { Ctr__Java__3 $2 } |
+       tok_AnnotationDeclaration_dummy_166 AnnotationDeclaration tok_AnnotationDeclaration_dummy_166 { Ctr__Java__4 $2 } |
+       tok_AnnotationElement_dummy_165 AnnotationElement tok_AnnotationElement_dummy_165 { Ctr__Java__5 $2 } |
+       tok_AnnotationList_dummy_164 AnnotationList tok_AnnotationList_dummy_164 { Ctr__Java__6 (reverse $2) } |
+       tok_AnnotationTypeElement_dummy_163 AnnotationTypeElement tok_AnnotationTypeElement_dummy_163 { Ctr__Java__7 $2 } |
+       tok_AnnotationTypeElementList_dummy_162 AnnotationTypeElementList tok_AnnotationTypeElementList_dummy_162 { Ctr__Java__8 (reverse $2) } |
+       tok_Arglist_dummy_161 Arglist tok_Arglist_dummy_161 { Ctr__Java__9 $2 } |
+       tok_AssignmentOp_dummy_160 AssignmentOp tok_AssignmentOp_dummy_160 { Ctr__Java__10 $2 } |
+       tok_CatchList_dummy_159 CatchList tok_CatchList_dummy_159 { Ctr__Java__11 (reverse $2) } |
+       tok_ClassDeclaration_dummy_158 ClassDeclaration tok_ClassDeclaration_dummy_158 { Ctr__Java__12 $2 } |
+       tok_CompilationUnit_dummy_157 CompilationUnit tok_CompilationUnit_dummy_157 { Ctr__Java__13 $2 } |
+       tok_CompoundName_dummy_156 CompoundName tok_CompoundName_dummy_156 { Ctr__Java__14 $2 } |
+       tok_CreationExpression_dummy_155 CreationExpression tok_CreationExpression_dummy_155 { Ctr__Java__15 $2 } |
+       tok_DoStatement_dummy_154 DoStatement tok_DoStatement_dummy_154 { Ctr__Java__16 $2 } |
+       tok_DocComment_dummy_153 DocComment tok_DocComment_dummy_153 { Ctr__Java__17 $2 } |
+       tok_EnumConstant_dummy_152 EnumConstant tok_EnumConstant_dummy_152 { Ctr__Java__18 $2 } |
+       tok_EnumConstantList_dummy_151 EnumConstantList tok_EnumConstantList_dummy_151 { Ctr__Java__19 $2 } |
+       tok_EnumDeclaration_dummy_150 EnumDeclaration tok_EnumDeclaration_dummy_150 { Ctr__Java__20 $2 } |
+       tok_EqualityOp_dummy_149 EqualityOp tok_EqualityOp_dummy_149 { Ctr__Java__21 $2 } |
+       tok_Expression_dummy_148 Expression tok_Expression_dummy_148 { Ctr__Java__22 $2 } |
+       tok_ExtendsList_dummy_147 ExtendsList tok_ExtendsList_dummy_147 { Ctr__Java__23 $2 } |
+       tok_FieldDeclaration_dummy_146 FieldDeclaration tok_FieldDeclaration_dummy_146 { Ctr__Java__24 $2 } |
+       tok_FieldDeclarationList_dummy_145 FieldDeclarationList tok_FieldDeclarationList_dummy_145 { Ctr__Java__25 (reverse $2) } |
+       tok_ForStatement_dummy_144 ForStatement tok_ForStatement_dummy_144 { Ctr__Java__26 $2 } |
+       tok_IfStatement_dummy_143 IfStatement tok_IfStatement_dummy_143 { Ctr__Java__27 $2 } |
+       tok_ImplementsList_dummy_142 ImplementsList tok_ImplementsList_dummy_142 { Ctr__Java__28 $2 } |
+       tok_ImportList_dummy_141 ImportList tok_ImportList_dummy_141 { Ctr__Java__29 (reverse $2) } |
+       tok_ImportStatement_dummy_140 ImportStatement tok_ImportStatement_dummy_140 { Ctr__Java__30 $2 } |
+       tok_InterfaceDeclaration_dummy_139 InterfaceDeclaration tok_InterfaceDeclaration_dummy_139 { Ctr__Java__31 $2 } |
+       tok_Literal_dummy_138 Literal tok_Literal_dummy_138 { Ctr__Java__32 $2 } |
+       tok_MemberAfterFirstId_dummy_137 MemberAfterFirstId tok_MemberAfterFirstId_dummy_137 { Ctr__Java__33 $2 } |
+       tok_MemberDeclaration_dummy_136 MemberDeclaration tok_MemberDeclaration_dummy_136 { Ctr__Java__34 $2 } |
+       tok_MemberRest_dummy_135 MemberRest tok_MemberRest_dummy_135 { Ctr__Java__35 $2 } |
+       tok_Modifier_dummy_134 Modifier tok_Modifier_dummy_134 { Ctr__Java__36 $2 } |
+       tok_ModifierList_dummy_133 ModifierList tok_ModifierList_dummy_133 { Ctr__Java__37 (reverse $2) } |
+       tok_MoreTypeSpecifier_dummy_132 MoreTypeSpecifier tok_MoreTypeSpecifier_dummy_132 { Ctr__Java__38 $2 } |
+       tok_MoreVariableDeclarators_dummy_131 MoreVariableDeclarators tok_MoreVariableDeclarators_dummy_131 { Ctr__Java__39 (reverse $2) } |
+       tok_MultiplicativeOp_dummy_130 MultiplicativeOp tok_MultiplicativeOp_dummy_130 { Ctr__Java__40 $2 } |
+       tok_NestedTypeDeclaration_dummy_129 NestedTypeDeclaration tok_NestedTypeDeclaration_dummy_129 { Ctr__Java__41 $2 } |
+       tok_OptDocComment_dummy_128 OptDocComment tok_OptDocComment_dummy_128 { Ctr__Java__42 $2 } |
+       tok_OptElsePart_dummy_127 OptElsePart tok_OptElsePart_dummy_127 { Ctr__Java__43 $2 } |
+       tok_OptExpression_dummy_126 OptExpression tok_OptExpression_dummy_126 { Ctr__Java__44 $2 } |
+       tok_OptFinally_dummy_125 OptFinally tok_OptFinally_dummy_125 { Ctr__Java__45 $2 } |
+       tok_OptId_dummy_124 OptId tok_OptId_dummy_124 { Ctr__Java__46 $2 } |
+       tok_OptVariableInitializer_dummy_123 OptVariableInitializer tok_OptVariableInitializer_dummy_123 { Ctr__Java__47 $2 } |
+       tok_Package_dummy_122 Package tok_Package_dummy_122 { Ctr__Java__48 $2 } |
+       tok_Parameter_dummy_121 Parameter tok_Parameter_dummy_121 { Ctr__Java__49 $2 } |
+       tok_ParameterList_dummy_120 ParameterList tok_ParameterList_dummy_120 { Ctr__Java__50 $2 } |
+       tok_PostfixOp_dummy_119 PostfixOp tok_PostfixOp_dummy_119 { Ctr__Java__51 $2 } |
+       tok_PrefixOp_dummy_118 PrefixOp tok_PrefixOp_dummy_118 { Ctr__Java__52 $2 } |
+       tok_PrimitiveTypeKeyword_dummy_117 PrimitiveTypeKeyword tok_PrimitiveTypeKeyword_dummy_117 { Ctr__Java__53 $2 } |
+       tok_RelationalOp_dummy_116 RelationalOp tok_RelationalOp_dummy_116 { Ctr__Java__54 $2 } |
+       tok_ShiftOp_dummy_115 ShiftOp tok_ShiftOp_dummy_115 { Ctr__Java__55 $2 } |
+       tok_SquareBracketsList_dummy_114 SquareBracketsList tok_SquareBracketsList_dummy_114 { Ctr__Java__56 (reverse $2) } |
+       tok_Statement_dummy_113 Statement tok_Statement_dummy_113 { Ctr__Java__57 $2 } |
+       tok_StatementBlock_dummy_112 StatementBlock tok_StatementBlock_dummy_112 { Ctr__Java__58 $2 } |
+       tok_StatementList_dummy_111 StatementList tok_StatementList_dummy_111 { Ctr__Java__59 (reverse $2) } |
+       tok_StatementWithoutIf_dummy_110 StatementWithoutIf tok_StatementWithoutIf_dummy_110 { Ctr__Java__60 $2 } |
+       tok_StaticInitializer_dummy_109 StaticInitializer tok_StaticInitializer_dummy_109 { Ctr__Java__61 $2 } |
+       tok_SwitchCaseList_dummy_108 SwitchCaseList tok_SwitchCaseList_dummy_108 { Ctr__Java__62 (reverse $2) } |
+       tok_SwitchStatement_dummy_107 SwitchStatement tok_SwitchStatement_dummy_107 { Ctr__Java__63 $2 } |
+       tok_TryStatement_dummy_106 TryStatement tok_TryStatement_dummy_106 { Ctr__Java__64 $2 } |
+       tok_Type_dummy_105 Type tok_Type_dummy_105 { Ctr__Java__65 $2 } |
+       tok_TypeArgument_dummy_104 TypeArgument tok_TypeArgument_dummy_104 { Ctr__Java__66 $2 } |
+       tok_TypeArguments_dummy_103 TypeArguments tok_TypeArguments_dummy_103 { Ctr__Java__67 $2 } |
+       tok_TypeDeclaration_dummy_102 TypeDeclaration tok_TypeDeclaration_dummy_102 { Ctr__Java__68 $2 } |
+       tok_TypeParameter_dummy_101 TypeParameter tok_TypeParameter_dummy_101 { Ctr__Java__69 $2 } |
+       tok_TypeParameters_dummy_100 TypeParameters tok_TypeParameters_dummy_100 { Ctr__Java__70 $2 } |
+       tok_TypeSpecifier_dummy_99 TypeSpecifier tok_TypeSpecifier_dummy_99 { Ctr__Java__71 $2 } |
+       tok_VariableDeclaration_dummy_98 VariableDeclaration tok_VariableDeclaration_dummy_98 { Ctr__Java__72 $2 } |
+       tok_VariableDeclarator_dummy_97 VariableDeclarator tok_VariableDeclarator_dummy_97 { Ctr__Java__73 $2 } |
+       tok_VariableDeclaratorList_dummy_96 VariableDeclaratorList tok_VariableDeclaratorList_dummy_96 { Ctr__Java__74 $2 } |
+       tok_VariableInitializer_dummy_95 VariableInitializer tok_VariableInitializer_dummy_95 { Ctr__Java__75 $2 } |
+       tok_VariableInitializerList_dummy_94 VariableInitializerList tok_VariableInitializerList_dummy_94 { Ctr__Java__76 $2 } |
+       tok_WhileStatement_dummy_93 WhileStatement tok_WhileStatement_dummy_93 { Ctr__Java__77 $2 } |
+       tok_WildcardType_dummy_92 WildcardType tok_WildcardType_dummy_92 { Ctr__Java__78 $2 }
 
 Java : qq_Java { Anti_Java $1 } |
        CompilationUnit { Ctr__Java__79 $1 }
@@ -366,7 +366,7 @@ AdditiveOp : qq_AdditiveOp { Anti_AdditiveOp $1 } |
              tok__plus__72 { Ctr__AdditiveOp__0 } |
              tok__minus__73 { Ctr__AdditiveOp__1 }
 
-ListElem_AnnotationList17 : qq_AnnotationList { Anti_Annotation $1 } |
+ListElem_AnnotationList15 : qq_AnnotationList { Anti_Annotation $1 } |
                             Annotation { $1 }
 
 Annotation : qq_Annotation { Anti_Annotation $1 } |
@@ -379,24 +379,24 @@ AnnotationDeclaration : qq_AnnotationDeclaration { Anti_AnnotationDeclaration $1
                         ModifierList tok__symbol__5 tok_interface_15 id tok__symbol__13 AnnotationTypeElementList tok__symbol__14 { Ctr__AnnotationDeclaration__0 (reverse $1) $4 (reverse $6) }
 
 AnnotationElement : qq_AnnotationElement { Anti_AnnotationElement $1 } |
-                    Rule_15 Expression { Ctr__AnnotationElement__0 $1 $2 }
+                    id tok__eql__9 ConditionalExpression { Ctr__AnnotationElement__0 $1 $3 } |
+                    ConditionalExpression { Ctr__AnnotationElement__1 $1 }
 
 AnnotationList : {- empty -} { [] } |
-                 AnnotationList ListElem_AnnotationList17 { $2 : $1 }
+                 AnnotationList ListElem_AnnotationList15 { $2 : $1 }
 
 AnnotationTypeElement : qq_AnnotationTypeElement { Anti_AnnotationTypeElement $1 } |
-                        ModifierList Type id tok__lparen__6 tok__rparen__7 Rule_28 tok__semi__1 { Ctr__AnnotationTypeElement__0 (reverse $1) $2 $3 $6 } |
-                        FieldDeclaration { Ctr__AnnotationTypeElement__1 $1 }
+                        FieldDeclaration { Ctr__AnnotationTypeElement__0 $1 }
 
-ListElem_AnnotationTypeElementList27 : qq_AnnotationTypeElementList { Anti_AnnotationTypeElement $1 } |
+ListElem_AnnotationTypeElementList25 : qq_AnnotationTypeElementList { Anti_AnnotationTypeElement $1 } |
                                        AnnotationTypeElement { $1 }
 
 AnnotationTypeElementList : {- empty -} { [] } |
-                            AnnotationTypeElementList ListElem_AnnotationTypeElementList27 { $2 : $1 }
+                            AnnotationTypeElementList ListElem_AnnotationTypeElementList25 { $2 : $1 }
 
 Arglist : qq_Arglist { Anti_Arglist $1 } |
           { Ctr__Arglist__0 } |
-          Rule_79 { Ctr__Arglist__1 $1 }
+          Rule_77 { Ctr__Arglist__1 $1 }
 
 AssignmentOp : qq_AssignmentOp { Anti_AssignmentOp $1 } |
                tok__eql__9 { Ctr__AssignmentOp__0 } |
@@ -413,19 +413,19 @@ AssignmentOp : qq_AssignmentOp { Anti_AssignmentOp $1 } |
                tok__symbol__symbol__symbol__eql__55 { Ctr__AssignmentOp__11 }
 
 CatchList : {- empty -} { [] } |
-            CatchList ListElem_CatchList66 { $2 : $1 }
+            CatchList ListElem_CatchList64 { $2 : $1 }
 
 ClassDeclaration : qq_ClassDeclaration { Anti_ClassDeclaration $1 } |
-                   ModifierList tok_class_12 id TypeParameters Rule_25 Rule_26 tok__symbol__13 FieldDeclarationList tok__symbol__14 { Ctr__ClassDeclaration__0 (reverse $1) $3 $4 $5 $6 (reverse $8) }
+                   ModifierList tok_class_12 id TypeParameters Rule_22 Rule_23 tok__symbol__13 FieldDeclarationList tok__symbol__14 { Ctr__ClassDeclaration__0 (reverse $1) $3 $4 $5 $6 (reverse $8) }
 
 CompilationUnit : qq_CompilationUnit { Anti_CompilationUnit $1 } |
                   Rule_4 ImportList Rule_6 { Ctr__CompilationUnit__0 $1 (reverse $2) $3 }
 
 CompoundName : qq_CompoundName { Anti_CompoundName $1 } |
-               id Rule_92 { Ctr__CompoundName__0 $1 (reverse $2) }
+               id Rule_90 { Ctr__CompoundName__0 $1 (reverse $2) }
 
 CreationExpression : qq_CreationExpression { Anti_CreationExpression $1 } |
-                     tok_new_82 Type Rule_78 { Ctr__CreationExpression__0 $2 $3 }
+                     tok_new_82 Type Rule_76 { Ctr__CreationExpression__0 $2 $3 }
 
 DoStatement : qq_DoStatement { Anti_DoStatement $1 } |
               tok_do_37 Statement tok_while_38 tok__lparen__6 Expression tok__rparen__7 tok__semi__1 { Ctr__DoStatement__0 $2 $5 }
@@ -434,13 +434,13 @@ DocComment : qq_DocComment { Anti_DocComment $1 } |
              doccomment { Ctr__DocComment__0 $1 }
 
 EnumConstant : qq_EnumConstant { Anti_EnumConstant $1 } |
-               AnnotationList id Rule_30 Rule_32 { Ctr__EnumConstant__0 (reverse $1) $2 $3 $4 }
+               AnnotationList id Rule_26 Rule_28 { Ctr__EnumConstant__0 (reverse $1) $2 $3 $4 }
 
 EnumConstantList : qq_EnumConstantList { Anti_EnumConstantList $1 } |
-                   EnumConstant Rule_34 Rule_36 { Ctr__EnumConstantList__0 $1 (reverse $2) $3 }
+                   EnumConstant Rule_30 Rule_32 { Ctr__EnumConstantList__0 $1 (reverse $2) $3 }
 
 EnumDeclaration : qq_EnumDeclaration { Anti_EnumDeclaration $1 } |
-                  ModifierList tok_enum_17 id Rule_38 tok__symbol__13 EnumConstantList Rule_39 tok__symbol__14 { Ctr__EnumDeclaration__0 (reverse $1) $3 $4 $6 $7 }
+                  ModifierList tok_enum_16 id Rule_34 tok__symbol__13 EnumConstantList Rule_35 tok__symbol__14 { Ctr__EnumDeclaration__0 (reverse $1) $3 $4 $6 $7 }
 
 EqualityOp : qq_EqualityOp { Anti_EqualityOp $1 } |
              tok__eql__eql__62 { Ctr__EqualityOp__0 } |
@@ -451,14 +451,14 @@ PrimaryNoPostfix : qq_Expression { Anti_Expression $1 } |
                    tok_this_80 { Ctr__Expression__1 } |
                    tok__lparen__6 Expression tok__rparen__7 { Ctr__Expression__2 $2 } |
                    CreationExpression { Ctr__Expression__3 $1 } |
-                   CompoundName Rule_74 { Ctr__Expression__4 $1 $2 } |
-                   tok_super_81 tok__dot__3 id Rule_76 { Ctr__Expression__5 $3 $4 }
+                   CompoundName Rule_72 { Ctr__Expression__4 $1 $2 } |
+                   tok_super_81 tok__dot__3 id Rule_74 { Ctr__Expression__5 $3 $4 }
 
 PostfixExpression : PrimaryNoPostfix { Ctr__Expression__6 $1 } |
                     PostfixExpression PostfixOp { Ctr__Expression__7 $1 $2 } |
                     PostfixExpression tok__dot__3 id { Ctr__Expression__8 $1 $3 } |
                     PostfixExpression tok__dot__3 id tok__lparen__6 Arglist tok__rparen__7 { Ctr__Expression__9 $1 $3 $5 } |
-                    PostfixExpression tok__sq_bkt_l__18 Expression tok__sq_bkt_r__19 { Ctr__Expression__10 $1 $3 }
+                    PostfixExpression tok__sq_bkt_l__17 Expression tok__sq_bkt_r__18 { Ctr__Expression__10 $1 $3 }
 
 UnaryExpressionNotPlusMinus : PostfixExpression { Ctr__Expression__11 $1 } |
                               tok__tilde__78 UnaryExpression { Ctr__Expression__12 $2 } |
@@ -504,32 +504,31 @@ ConditionalOrExpression : ConditionalAndExpression { Ctr__Expression__37 $1 } |
 ConditionalExpression : ConditionalOrExpression { Ctr__Expression__39 $1 } |
                         ConditionalOrExpression tok__symbol__56 Expression tok__colon__32 ConditionalExpression { Ctr__Expression__40 $1 $3 $5 }
 
-AssignmentExpression : ConditionalExpression Rule_72 { Ctr__Expression__41 $1 $2 }
+AssignmentExpression : ConditionalExpression Rule_70 { Ctr__Expression__41 $1 $2 }
 
 Expression : AssignmentExpression { Ctr__Expression__42 $1 }
 
 ExtendsList : qq_ExtendsList { Anti_ExtendsList $1 } |
-              { Ctr__ExtendsList__0 } |
-              Rule_20 { Ctr__ExtendsList__1 $1 }
+              tok_extends_10 CompoundName Rule_18 { Ctr__ExtendsList__0 $2 (reverse $3) }
 
 FieldDeclaration : qq_FieldDeclaration { Anti_FieldDeclaration $1 } |
-                   OptDocComment Rule_41 { Ctr__FieldDeclaration__0 $1 $2 } |
+                   OptDocComment Rule_37 { Ctr__FieldDeclaration__0 $1 $2 } |
                    tok__semi__1 { Ctr__FieldDeclaration__1 }
 
-ListElem_FieldDeclarationList24 : qq_FieldDeclarationList { Anti_FieldDeclaration $1 } |
+ListElem_FieldDeclarationList21 : qq_FieldDeclarationList { Anti_FieldDeclaration $1 } |
                                   FieldDeclaration { $1 }
 
 FieldDeclarationList : {- empty -} { [] } |
-                       FieldDeclarationList ListElem_FieldDeclarationList24 { $2 : $1 }
+                       FieldDeclarationList ListElem_FieldDeclarationList21 { $2 : $1 }
 
 ForStatement : qq_ForStatement { Anti_ForStatement $1 } |
-               tok_for_39 tok__lparen__6 Rule_63 OptExpression tok__semi__1 OptExpression tok__rparen__7 Statement { Ctr__ForStatement__0 $3 $4 $6 $8 }
+               tok_for_39 tok__lparen__6 Rule_61 OptExpression tok__semi__1 OptExpression tok__rparen__7 Statement { Ctr__ForStatement__0 $3 $4 $6 $8 }
 
 IfStatement : qq_IfStatement { Anti_IfStatement $1 } |
               tok_if_36 tok__lparen__6 Expression tok__rparen__7 StatementWithoutIf OptElsePart { Ctr__IfStatement__0 $3 $5 $6 }
 
 ImplementsList : qq_ImplementsList { Anti_ImplementsList $1 } |
-                 tok_implements_11 Rule_23 { Ctr__ImplementsList__0 (reverse $2) }
+                 tok_implements_11 Rule_20 { Ctr__ImplementsList__0 (reverse $2) }
 
 ImportList : {- empty -} { [] } |
              ImportList ListElem_ImportList3 { $2 : $1 }
@@ -538,7 +537,7 @@ ImportStatement : qq_ImportStatement { Anti_ImportStatement $1 } |
                   tok_import_2 Rule_8 tok__semi__1 { Ctr__ImportStatement__0 $2 }
 
 InterfaceDeclaration : qq_InterfaceDeclaration { Anti_InterfaceDeclaration $1 } |
-                       ModifierList tok_interface_15 id TypeParameters ExtendsList tok__symbol__13 FieldDeclarationList tok__symbol__14 { Ctr__InterfaceDeclaration__0 (reverse $1) $3 $4 $5 (reverse $7) }
+                       ModifierList tok_interface_15 id TypeParameters Rule_24 tok__symbol__13 FieldDeclarationList tok__symbol__14 { Ctr__InterfaceDeclaration__0 (reverse $1) $3 $4 $5 (reverse $7) }
 
 Literal : qq_Literal { Anti_Literal $1 } |
           integerLiteral { Ctr__Literal__0 $1 } |
@@ -550,7 +549,7 @@ Literal : qq_Literal { Anti_Literal $1 } |
           tok_null_85 { Ctr__Literal__6 }
 
 MemberAfterFirstId : qq_MemberAfterFirstId { Anti_MemberAfterFirstId $1 } |
-                     tok__lparen__6 Rule_46 tok__rparen__7 StatementBlock { Ctr__MemberAfterFirstId__0 $2 $4 } |
+                     tok__lparen__6 Rule_42 tok__rparen__7 StatementBlock { Ctr__MemberAfterFirstId__0 $2 $4 } |
                      MoreTypeSpecifier id MemberRest { Ctr__MemberAfterFirstId__1 $1 $2 $3 }
 
 MemberDeclaration : qq_MemberDeclaration { Anti_MemberDeclaration $1 } |
@@ -559,7 +558,7 @@ MemberDeclaration : qq_MemberDeclaration { Anti_MemberDeclaration $1 } |
                     id MemberAfterFirstId { Ctr__MemberDeclaration__2 $1 $2 }
 
 MemberRest : qq_MemberRest { Anti_MemberRest $1 } |
-             tok__lparen__6 Rule_47 tok__rparen__7 SquareBracketsList Rule_48 { Ctr__MemberRest__0 $2 (reverse $4) $5 } |
+             tok__lparen__6 Rule_43 tok__rparen__7 SquareBracketsList Rule_44 { Ctr__MemberRest__0 $2 (reverse $4) $5 } |
              SquareBracketsList OptVariableInitializer MoreVariableDeclarators tok__semi__1 { Ctr__MemberRest__1 (reverse $1) $2 (reverse $3) }
 
 Modifier : qq_Modifier { Anti_Modifier $1 } |
@@ -575,14 +574,14 @@ Modifier : qq_Modifier { Anti_Modifier $1 } |
            tok_transient_94 { Ctr__Modifier__9 }
 
 ModifierList : {- empty -} { [] } |
-               ModifierList ListElem_ModifierList19 { $2 : $1 }
+               ModifierList ListElem_ModifierList17 { $2 : $1 }
 
 MoreTypeSpecifier : qq_MoreTypeSpecifier { Anti_MoreTypeSpecifier $1 } |
                     tok__dot__3 id MoreTypeSpecifier { Ctr__MoreTypeSpecifier__0 $2 $3 } |
                     TypeArguments SquareBracketsList { Ctr__MoreTypeSpecifier__1 $1 (reverse $2) }
 
 MoreVariableDeclarators : {- empty -} { [] } |
-                          MoreVariableDeclarators ListElem_MoreVariableDeclarators50 { $2 : $1 }
+                          MoreVariableDeclarators ListElem_MoreVariableDeclarators48 { $2 : $1 }
 
 MultiplicativeOp : qq_MultiplicativeOp { Anti_MultiplicativeOp $1 } |
                    tok__star__4 { Ctr__MultiplicativeOp__0 } |
@@ -601,7 +600,7 @@ OptDocComment : qq_OptDocComment { Anti_OptDocComment $1 } |
 
 OptElsePart : qq_OptElsePart { Anti_OptElsePart $1 } |
               { Ctr__OptElsePart__0 } |
-              Rule_62 { Ctr__OptElsePart__1 $1 }
+              Rule_60 { Ctr__OptElsePart__1 $1 }
 
 OptExpression : qq_OptExpression { Anti_OptExpression $1 } |
                 { Ctr__OptExpression__0 } |
@@ -609,7 +608,7 @@ OptExpression : qq_OptExpression { Anti_OptExpression $1 } |
 
 OptFinally : qq_OptFinally { Anti_OptFinally $1 } |
              { Ctr__OptFinally__0 } |
-             Rule_67 { Ctr__OptFinally__1 $1 }
+             Rule_65 { Ctr__OptFinally__1 $1 }
 
 OptId : qq_OptId { Anti_OptId $1 } |
         { Ctr__OptId__0 } |
@@ -617,7 +616,7 @@ OptId : qq_OptId { Anti_OptId $1 } |
 
 OptVariableInitializer : qq_OptVariableInitializer { Anti_OptVariableInitializer $1 } |
                          { Ctr__OptVariableInitializer__0 } |
-                         Rule_53 { Ctr__OptVariableInitializer__1 $1 }
+                         Rule_51 { Ctr__OptVariableInitializer__1 $1 }
 
 Package : qq_Package { Anti_Package $1 } |
           tok_package_0 CompoundName tok__semi__1 { Ctr__Package__0 $2 }
@@ -626,7 +625,7 @@ Parameter : qq_Parameter { Anti_Parameter $1 } |
             Type id SquareBracketsList { Ctr__Parameter__0 $1 $2 (reverse $3) }
 
 ParameterList : qq_ParameterList { Anti_ParameterList $1 } |
-                Parameter Rule_59 { Ctr__ParameterList__0 $1 (reverse $2) }
+                Parameter Rule_57 { Ctr__ParameterList__0 $1 (reverse $2) }
 
 PostfixOp : qq_PostfixOp { Anti_PostfixOp $1 } |
             tok__plus__plus__76 { Ctr__PostfixOp__0 } |
@@ -636,20 +635,18 @@ PrefixOp : qq_PrefixOp { Anti_PrefixOp $1 } |
            tok__plus__plus__76 { Ctr__PrefixOp__0 } |
            tok__minus__minus__77 { Ctr__PrefixOp__1 } |
            tok__plus__72 { Ctr__PrefixOp__2 } |
-           tok__minus__73 { Ctr__PrefixOp__3 } |
-           tok__tilde__78 { Ctr__PrefixOp__4 } |
-           tok__exclamation__79 { Ctr__PrefixOp__5 }
+           tok__minus__73 { Ctr__PrefixOp__3 }
 
 PrimitiveTypeKeyword : qq_PrimitiveTypeKeyword { Anti_PrimitiveTypeKeyword $1 } |
-                       tok_boolean_20 { Ctr__PrimitiveTypeKeyword__0 } |
-                       tok_byte_21 { Ctr__PrimitiveTypeKeyword__1 } |
-                       tok_char_22 { Ctr__PrimitiveTypeKeyword__2 } |
-                       tok_short_23 { Ctr__PrimitiveTypeKeyword__3 } |
-                       tok_int_24 { Ctr__PrimitiveTypeKeyword__4 } |
-                       tok_float_25 { Ctr__PrimitiveTypeKeyword__5 } |
-                       tok_long_26 { Ctr__PrimitiveTypeKeyword__6 } |
-                       tok_double_27 { Ctr__PrimitiveTypeKeyword__7 } |
-                       tok_void_28 { Ctr__PrimitiveTypeKeyword__8 }
+                       tok_boolean_19 { Ctr__PrimitiveTypeKeyword__0 } |
+                       tok_byte_20 { Ctr__PrimitiveTypeKeyword__1 } |
+                       tok_char_21 { Ctr__PrimitiveTypeKeyword__2 } |
+                       tok_short_22 { Ctr__PrimitiveTypeKeyword__3 } |
+                       tok_int_23 { Ctr__PrimitiveTypeKeyword__4 } |
+                       tok_float_24 { Ctr__PrimitiveTypeKeyword__5 } |
+                       tok_long_25 { Ctr__PrimitiveTypeKeyword__6 } |
+                       tok_double_26 { Ctr__PrimitiveTypeKeyword__7 } |
+                       tok_void_27 { Ctr__PrimitiveTypeKeyword__8 }
 
 RelationalOp : qq_RelationalOp { Anti_RelationalOp $1 } |
                tok__symbol__64 { Ctr__RelationalOp__0 } |
@@ -677,216 +674,212 @@ Rule_13 : {- empty -} { [] } |
 
 Rule_14 : tok__coma__8 AnnotationElement { Ctr__Rule_14__0 $2 }
 
-Rule_15 : { Ctr__Rule_15__0 } |
-          Rule_16 { Ctr__Rule_15__1 $1 }
+ListElem_ModifierList17 : qq_ModifierList { Anti_Rule_16 $1 } |
+                          Rule_16 { $1 }
 
-Rule_16 : id tok__eql__9 { Ctr__Rule_16__0 $1 }
+Rule_16 : Modifier { Ctr__Rule_16__1 $1 } |
+          Annotation { Ctr__Rule_16__2 $1 }
 
-ListElem_ModifierList19 : qq_ModifierList { Anti_Rule_18 $1 } |
-                          Rule_18 { $1 }
+Rule_18 : {- empty -} { [] } |
+          Rule_18 Rule_19 { $2 : $1 }
 
-Rule_18 : Modifier { Ctr__Rule_18__1 $1 } |
-          Annotation { Ctr__Rule_18__2 $1 }
+Rule_19 : tok__coma__8 CompoundName { Ctr__Rule_19__0 $2 }
 
 ListElem_ImportList3 : qq_ImportList { Anti_Rule_2 $1 } |
                        Rule_2 { $1 }
 
 Rule_2 : ImportStatement { Ctr__Rule_2__1 $1 }
 
-Rule_20 : tok_extends_10 CompoundName Rule_21 { Ctr__Rule_20__0 $2 (reverse $3) }
+Rule_20 : CompoundName { [$1] } |
+          Rule_20 tok__coma__8 CompoundName { $3 : $1 }
 
-Rule_21 : {- empty -} { [] } |
-          Rule_21 Rule_22 { $2 : $1 }
+Rule_22 : { Ctr__Rule_22__0 } |
+          ExtendsList { Ctr__Rule_22__1 $1 }
 
-Rule_22 : tok__coma__8 CompoundName { Ctr__Rule_22__0 $2 }
+Rule_23 : { Ctr__Rule_23__0 } |
+          ImplementsList { Ctr__Rule_23__1 $1 }
 
-Rule_23 : CompoundName { [$1] } |
-          Rule_23 tok__coma__8 CompoundName { $3 : $1 }
-
-Rule_25 : { Ctr__Rule_25__0 } |
-          ExtendsList { Ctr__Rule_25__1 $1 }
+Rule_24 : { Ctr__Rule_24__0 } |
+          ExtendsList { Ctr__Rule_24__1 $1 }
 
 Rule_26 : { Ctr__Rule_26__0 } |
-          ImplementsList { Ctr__Rule_26__1 $1 }
+          Rule_27 { Ctr__Rule_26__1 $1 }
+
+Rule_27 : tok__lparen__6 Arglist tok__rparen__7 { Ctr__Rule_27__0 $2 }
 
 Rule_28 : { Ctr__Rule_28__0 } |
           Rule_29 { Ctr__Rule_28__1 $1 }
 
-Rule_29 : tok_default_16 Expression { Ctr__Rule_29__0 $2 }
+Rule_29 : tok__symbol__13 FieldDeclarationList tok__symbol__14 { Ctr__Rule_29__0 (reverse $2) }
 
-Rule_30 : { Ctr__Rule_30__0 } |
-          Rule_31 { Ctr__Rule_30__1 $1 }
+Rule_30 : {- empty -} { [] } |
+          Rule_30 Rule_31 { $2 : $1 }
 
-Rule_31 : tok__lparen__6 Arglist tok__rparen__7 { Ctr__Rule_31__0 $2 }
+Rule_31 : tok__coma__8 EnumConstant { Ctr__Rule_31__0 $2 }
 
 Rule_32 : { Ctr__Rule_32__0 } |
           Rule_33 { Ctr__Rule_32__1 $1 }
 
-Rule_33 : tok__symbol__13 FieldDeclarationList tok__symbol__14 { Ctr__Rule_33__0 (reverse $2) }
+Rule_33 : tok__coma__8 { Ctr__Rule_33__0 }
 
-Rule_34 : {- empty -} { [] } |
-          Rule_34 Rule_35 { $2 : $1 }
+Rule_34 : { Ctr__Rule_34__0 } |
+          ImplementsList { Ctr__Rule_34__1 $1 }
 
-Rule_35 : tok__coma__8 EnumConstant { Ctr__Rule_35__0 $2 }
+Rule_35 : { Ctr__Rule_35__0 } |
+          Rule_36 { Ctr__Rule_35__1 $1 }
 
-Rule_36 : { Ctr__Rule_36__0 } |
-          Rule_37 { Ctr__Rule_36__1 $1 }
+Rule_36 : tok__semi__1 FieldDeclarationList { Ctr__Rule_36__0 (reverse $2) }
 
-Rule_37 : tok__coma__8 { Ctr__Rule_37__0 }
+Rule_37 : ModifierList Rule_38 { Ctr__Rule_37__0 (reverse $1) $2 }
 
-Rule_38 : { Ctr__Rule_38__0 } |
-          ImplementsList { Ctr__Rule_38__1 $1 }
+Rule_38 : Rule_39 { Ctr__Rule_38__0 $1 } |
+          StaticInitializer { Ctr__Rule_38__1 $1 }
 
-Rule_39 : { Ctr__Rule_39__0 } |
-          Rule_40 { Ctr__Rule_39__1 $1 }
+Rule_39 : MemberDeclaration { Ctr__Rule_39__0 $1 } |
+          NestedTypeDeclaration { Ctr__Rule_39__1 $1 }
 
 Rule_4 : { Ctr__Rule_4__0 } |
          Rule_5 { Ctr__Rule_4__1 $1 }
 
-Rule_40 : tok__semi__1 FieldDeclarationList { Ctr__Rule_40__0 (reverse $2) }
+ListElem_SquareBracketsList41 : qq_SquareBracketsList { Anti_Rule_40 $1 } |
+                                Rule_40 { $1 }
 
-Rule_41 : ModifierList Rule_42 { Ctr__Rule_41__0 (reverse $1) $2 }
+Rule_40 : tok__sq_bkt_l__17 OptExpression tok__sq_bkt_r__18 { Ctr__Rule_40__1 $2 }
 
-Rule_42 : Rule_43 { Ctr__Rule_42__0 $1 } |
-          StaticInitializer { Ctr__Rule_42__1 $1 }
+Rule_42 : { Ctr__Rule_42__0 } |
+          ParameterList { Ctr__Rule_42__1 $1 }
 
-Rule_43 : MemberDeclaration { Ctr__Rule_43__0 $1 } |
-          NestedTypeDeclaration { Ctr__Rule_43__1 $1 }
+Rule_43 : { Ctr__Rule_43__0 } |
+          ParameterList { Ctr__Rule_43__1 $1 }
 
-ListElem_SquareBracketsList45 : qq_SquareBracketsList { Anti_Rule_44 $1 } |
-                                Rule_44 { $1 }
+Rule_44 : StatementBlock { Ctr__Rule_44__0 $1 } |
+          Rule_45 tok__semi__1 { Ctr__Rule_44__1 $1 }
 
-Rule_44 : tok__sq_bkt_l__18 OptExpression tok__sq_bkt_r__19 { Ctr__Rule_44__1 $2 }
+Rule_45 : { Ctr__Rule_45__0 } |
+          Rule_46 { Ctr__Rule_45__1 $1 }
 
-Rule_46 : { Ctr__Rule_46__0 } |
-          ParameterList { Ctr__Rule_46__1 $1 }
+Rule_46 : tok_default_28 Expression { Ctr__Rule_46__0 $2 }
 
-Rule_47 : { Ctr__Rule_47__0 } |
-          ParameterList { Ctr__Rule_47__1 $1 }
+ListElem_MoreVariableDeclarators48 : qq_MoreVariableDeclarators { Anti_Rule_47 $1 } |
+                                     Rule_47 { $1 }
 
-Rule_48 : StatementBlock { Ctr__Rule_48__0 $1 } |
-          tok__semi__1 { Ctr__Rule_48__1 }
+Rule_47 : tok__coma__8 VariableDeclarator { Ctr__Rule_47__1 $2 }
 
-ListElem_MoreVariableDeclarators50 : qq_MoreVariableDeclarators { Anti_Rule_49 $1 } |
-                                     Rule_49 { $1 }
-
-Rule_49 : tok__coma__8 VariableDeclarator { Ctr__Rule_49__1 $2 }
+Rule_49 : {- empty -} { [] } |
+          Rule_49 Rule_50 { $2 : $1 }
 
 Rule_5 : Package { Ctr__Rule_5__0 $1 }
 
-Rule_51 : {- empty -} { [] } |
-          Rule_51 Rule_52 { $2 : $1 }
+Rule_50 : tok__coma__8 VariableDeclarator { Ctr__Rule_50__0 $2 }
 
-Rule_52 : tok__coma__8 VariableDeclarator { Ctr__Rule_52__0 $2 }
+Rule_51 : tok__eql__9 VariableInitializer { Ctr__Rule_51__0 $2 }
 
-Rule_53 : tok__eql__9 VariableInitializer { Ctr__Rule_53__0 $2 }
+Rule_52 : VariableInitializer Rule_53 Rule_55 { Ctr__Rule_52__0 $1 (reverse $2) $3 }
 
-Rule_54 : VariableInitializer Rule_55 Rule_57 { Ctr__Rule_54__0 $1 (reverse $2) $3 }
+Rule_53 : {- empty -} { [] } |
+          Rule_53 Rule_54 { $2 : $1 }
 
-Rule_55 : {- empty -} { [] } |
-          Rule_55 Rule_56 { $2 : $1 }
+Rule_54 : tok__coma__8 VariableInitializer { Ctr__Rule_54__0 $2 }
 
-Rule_56 : tok__coma__8 VariableInitializer { Ctr__Rule_56__0 $2 }
+Rule_55 : { Ctr__Rule_55__0 } |
+          Rule_56 { Ctr__Rule_55__1 $1 }
 
-Rule_57 : { Ctr__Rule_57__0 } |
-          Rule_58 { Ctr__Rule_57__1 $1 }
+Rule_56 : tok__coma__8 { Ctr__Rule_56__0 }
 
-Rule_58 : tok__coma__8 { Ctr__Rule_58__0 }
+Rule_57 : {- empty -} { [] } |
+          Rule_57 Rule_58 { $2 : $1 }
 
-Rule_59 : {- empty -} { [] } |
-          Rule_59 Rule_60 { $2 : $1 }
+Rule_58 : tok__coma__8 Parameter { Ctr__Rule_58__0 $2 }
 
 Rule_6 : { Ctr__Rule_6__0 } |
          Rule_7 { Ctr__Rule_6__1 $1 }
 
-Rule_60 : tok__coma__8 Parameter { Ctr__Rule_60__0 $2 }
+Rule_60 : tok_else_35 Statement { Ctr__Rule_60__0 $2 }
 
-Rule_62 : tok_else_35 Statement { Ctr__Rule_62__0 $2 }
+Rule_61 : VariableDeclaration { Ctr__Rule_61__0 $1 } |
+          Rule_62 { Ctr__Rule_61__1 $1 } |
+          tok__semi__1 { Ctr__Rule_61__2 }
 
-Rule_63 : VariableDeclaration { Ctr__Rule_63__0 $1 } |
-          Rule_64 { Ctr__Rule_63__1 $1 } |
-          tok__semi__1 { Ctr__Rule_63__2 }
+Rule_62 : Expression tok__semi__1 { Ctr__Rule_62__0 $1 }
 
-Rule_64 : Expression tok__semi__1 { Ctr__Rule_64__0 $1 }
+ListElem_CatchList64 : qq_CatchList { Anti_Rule_63 $1 } |
+                       Rule_63 { $1 }
 
-ListElem_CatchList66 : qq_CatchList { Anti_Rule_65 $1 } |
-                       Rule_65 { $1 }
+Rule_63 : tok_catch_40 tok__lparen__6 Parameter tok__rparen__7 Statement { Ctr__Rule_63__1 $3 $5 }
 
-Rule_65 : tok_catch_40 tok__lparen__6 Parameter tok__rparen__7 Statement { Ctr__Rule_65__1 $3 $5 }
+Rule_65 : tok_finally_41 Statement { Ctr__Rule_65__0 $2 }
 
-Rule_67 : tok_finally_41 Statement { Ctr__Rule_67__0 $2 }
+ListElem_SwitchCaseList69 : qq_SwitchCaseList { Anti_Rule_66 $1 } |
+                            Rule_66 { $1 }
 
-ListElem_SwitchCaseList71 : qq_SwitchCaseList { Anti_Rule_68 $1 } |
-                            Rule_68 { $1 }
+Rule_66 : Rule_67 { Ctr__Rule_66__1 $1 } |
+          Rule_68 { Ctr__Rule_66__2 $1 } |
+          Statement { Ctr__Rule_66__3 $1 }
 
-Rule_68 : Rule_69 { Ctr__Rule_68__1 $1 } |
-          Rule_70 { Ctr__Rule_68__2 $1 } |
-          Statement { Ctr__Rule_68__3 $1 }
+Rule_67 : tok_case_43 Expression tok__colon__32 { Ctr__Rule_67__0 $2 }
 
-Rule_69 : tok_case_43 Expression tok__colon__32 { Ctr__Rule_69__0 $2 }
+Rule_68 : tok_default_28 tok__colon__32 { Ctr__Rule_68__0 }
 
 Rule_7 : TypeDeclaration { Ctr__Rule_7__0 $1 }
 
-Rule_70 : tok_default_16 tok__colon__32 { Ctr__Rule_70__0 }
+Rule_70 : { Ctr__Rule_70__0 } |
+          Rule_71 { Ctr__Rule_70__1 $1 }
+
+Rule_71 : AssignmentOp AssignmentExpression { Ctr__Rule_71__0 $1 $2 }
 
 Rule_72 : { Ctr__Rule_72__0 } |
           Rule_73 { Ctr__Rule_72__1 $1 }
 
-Rule_73 : AssignmentOp AssignmentExpression { Ctr__Rule_73__0 $1 $2 }
+Rule_73 : tok__lparen__6 Arglist tok__rparen__7 { Ctr__Rule_73__0 $2 }
 
 Rule_74 : { Ctr__Rule_74__0 } |
           Rule_75 { Ctr__Rule_74__1 $1 }
 
 Rule_75 : tok__lparen__6 Arglist tok__rparen__7 { Ctr__Rule_75__0 $2 }
 
-Rule_76 : { Ctr__Rule_76__0 } |
-          Rule_77 { Ctr__Rule_76__1 $1 }
+Rule_76 : tok__lparen__6 Arglist tok__rparen__7 { Ctr__Rule_76__0 $2 } |
+          SquareBracketsList { Ctr__Rule_76__1 (reverse $1) }
 
-Rule_77 : tok__lparen__6 Arglist tok__rparen__7 { Ctr__Rule_77__0 $2 }
+Rule_77 : Expression Rule_78 { Ctr__Rule_77__0 $1 (reverse $2) }
 
-Rule_78 : tok__lparen__6 Arglist tok__rparen__7 { Ctr__Rule_78__0 $2 } |
-          SquareBracketsList { Ctr__Rule_78__1 (reverse $1) }
+Rule_78 : {- empty -} { [] } |
+          Rule_78 Rule_79 { $2 : $1 }
 
-Rule_79 : Expression Rule_80 { Ctr__Rule_79__0 $1 (reverse $2) }
+Rule_79 : tok__coma__8 Expression { Ctr__Rule_79__0 $2 }
 
 Rule_8 : Rule_9 { Ctr__Rule_8__0 $1 } |
          CompoundName { Ctr__Rule_8__1 $1 }
 
-Rule_80 : {- empty -} { [] } |
-          Rule_80 Rule_81 { $2 : $1 }
+Rule_80 : tok__symbol__64 TypeArgument Rule_81 tok__symbol__65 { Ctr__Rule_80__0 $2 (reverse $3) }
 
-Rule_81 : tok__coma__8 Expression { Ctr__Rule_81__0 $2 }
+Rule_81 : {- empty -} { [] } |
+          Rule_81 Rule_82 { $2 : $1 }
 
-Rule_82 : tok__symbol__64 TypeArgument Rule_83 tok__symbol__65 { Ctr__Rule_82__0 $2 (reverse $3) }
+Rule_82 : tok__coma__8 TypeArgument { Ctr__Rule_82__0 $2 }
 
-Rule_83 : {- empty -} { [] } |
-          Rule_83 Rule_84 { $2 : $1 }
+Rule_83 : tok__symbol__64 TypeParameter Rule_84 tok__symbol__65 { Ctr__Rule_83__0 $2 (reverse $3) }
 
-Rule_84 : tok__coma__8 TypeArgument { Ctr__Rule_84__0 $2 }
+Rule_84 : {- empty -} { [] } |
+          Rule_84 Rule_85 { $2 : $1 }
 
-Rule_85 : tok__symbol__64 TypeParameter Rule_86 tok__symbol__65 { Ctr__Rule_85__0 $2 (reverse $3) }
+Rule_85 : tok__coma__8 TypeParameter { Ctr__Rule_85__0 $2 }
 
-Rule_86 : {- empty -} { [] } |
-          Rule_86 Rule_87 { $2 : $1 }
+Rule_86 : { Ctr__Rule_86__0 } |
+          Rule_87 { Ctr__Rule_86__1 $1 }
 
-Rule_87 : tok__coma__8 TypeParameter { Ctr__Rule_87__0 $2 }
+Rule_87 : tok_extends_10 Type Rule_88 { Ctr__Rule_87__0 $2 (reverse $3) }
 
-Rule_88 : { Ctr__Rule_88__0 } |
-          Rule_89 { Ctr__Rule_88__1 $1 }
+Rule_88 : {- empty -} { [] } |
+          Rule_88 Rule_89 { $2 : $1 }
 
-Rule_89 : tok_extends_10 Type Rule_90 { Ctr__Rule_89__0 $2 (reverse $3) }
+Rule_89 : tok__symbol__61 Type { Ctr__Rule_89__0 $2 }
 
 Rule_9 : CompoundName tok__dot__3 tok__star__4 { Ctr__Rule_9__0 $1 }
 
 Rule_90 : {- empty -} { [] } |
           Rule_90 Rule_91 { $2 : $1 }
 
-Rule_91 : tok__symbol__61 Type { Ctr__Rule_91__0 $2 }
-
-Rule_92 : {- empty -} { [] } |
-          Rule_92 Rule_93 { $2 : $1 }
-
-Rule_93 : tok__dot__3 id { Ctr__Rule_93__0 $2 }
+Rule_91 : tok__dot__3 id { Ctr__Rule_91__0 $2 }
 
 ShiftOp : qq_ShiftOp { Anti_ShiftOp $1 } |
           tok__symbol__symbol__69 { Ctr__ShiftOp__0 } |
@@ -894,20 +887,20 @@ ShiftOp : qq_ShiftOp { Anti_ShiftOp $1 } |
           tok__symbol__symbol__symbol__71 { Ctr__ShiftOp__2 }
 
 SquareBracketsList : {- empty -} { [] } |
-                     SquareBracketsList ListElem_SquareBracketsList45 { $2 : $1 }
+                     SquareBracketsList ListElem_SquareBracketsList41 { $2 : $1 }
 
 Statement : qq_Statement { Anti_Statement $1 } |
             StatementWithoutIf { Ctr__Statement__0 $1 } |
             IfStatement { Ctr__Statement__1 $1 }
 
-ListElem_StatementList61 : qq_StatementList { Anti_Statement $1 } |
+ListElem_StatementList59 : qq_StatementList { Anti_Statement $1 } |
                            Statement { $1 }
 
 StatementBlock : qq_StatementBlock { Anti_StatementBlock $1 } |
                  tok__symbol__13 StatementList tok__symbol__14 { Ctr__StatementBlock__0 (reverse $2) }
 
 StatementList : {- empty -} { [] } |
-                StatementList ListElem_StatementList61 { $2 : $1 }
+                StatementList ListElem_StatementList59 { $2 : $1 }
 
 StatementWithoutIf : qq_StatementWithoutIf { Anti_StatementWithoutIf $1 } |
                      VariableDeclaration { Ctr__StatementWithoutIf__0 $1 } |
@@ -930,7 +923,7 @@ StaticInitializer : qq_StaticInitializer { Anti_StaticInitializer $1 } |
                     StatementBlock { Ctr__StaticInitializer__0 $1 }
 
 SwitchCaseList : {- empty -} { [] } |
-                 SwitchCaseList ListElem_SwitchCaseList71 { $2 : $1 }
+                 SwitchCaseList ListElem_SwitchCaseList69 { $2 : $1 }
 
 SwitchStatement : qq_SwitchStatement { Anti_SwitchStatement $1 } |
                   tok_switch_44 tok__lparen__6 Expression tok__rparen__7 tok__symbol__13 SwitchCaseList tok__symbol__14 { Ctr__SwitchStatement__0 $3 (reverse $6) }
@@ -947,28 +940,28 @@ TypeArgument : qq_TypeArgument { Anti_TypeArgument $1 } |
 
 TypeArguments : qq_TypeArguments { Anti_TypeArguments $1 } |
                 { Ctr__TypeArguments__0 } |
-                Rule_82 { Ctr__TypeArguments__1 $1 }
+                Rule_80 { Ctr__TypeArguments__1 $1 }
 
 TypeDeclaration : qq_TypeDeclaration { Anti_TypeDeclaration $1 } |
                   OptDocComment Rule_1 { Ctr__TypeDeclaration__0 $1 $2 }
 
 TypeParameter : qq_TypeParameter { Anti_TypeParameter $1 } |
-                id Rule_88 { Ctr__TypeParameter__0 $1 $2 }
+                id Rule_86 { Ctr__TypeParameter__0 $1 $2 }
 
 TypeParameters : qq_TypeParameters { Anti_TypeParameters $1 } |
                  { Ctr__TypeParameters__0 } |
-                 Rule_85 { Ctr__TypeParameters__1 $1 }
+                 Rule_83 { Ctr__TypeParameters__1 $1 }
 
 TypeSpecifier : qq_TypeSpecifier { Anti_TypeSpecifier $1 } |
-                tok_boolean_20 { Ctr__TypeSpecifier__0 } |
-                tok_byte_21 { Ctr__TypeSpecifier__1 } |
-                tok_char_22 { Ctr__TypeSpecifier__2 } |
-                tok_short_23 { Ctr__TypeSpecifier__3 } |
-                tok_int_24 { Ctr__TypeSpecifier__4 } |
-                tok_float_25 { Ctr__TypeSpecifier__5 } |
-                tok_long_26 { Ctr__TypeSpecifier__6 } |
-                tok_double_27 { Ctr__TypeSpecifier__7 } |
-                tok_void_28 { Ctr__TypeSpecifier__8 } |
+                tok_boolean_19 { Ctr__TypeSpecifier__0 } |
+                tok_byte_20 { Ctr__TypeSpecifier__1 } |
+                tok_char_21 { Ctr__TypeSpecifier__2 } |
+                tok_short_22 { Ctr__TypeSpecifier__3 } |
+                tok_int_23 { Ctr__TypeSpecifier__4 } |
+                tok_float_24 { Ctr__TypeSpecifier__5 } |
+                tok_long_25 { Ctr__TypeSpecifier__6 } |
+                tok_double_26 { Ctr__TypeSpecifier__7 } |
+                tok_void_27 { Ctr__TypeSpecifier__8 } |
                 CompoundName TypeArguments { Ctr__TypeSpecifier__9 $1 $2 }
 
 VariableDeclaration : qq_VariableDeclaration { Anti_VariableDeclaration $1 } |
@@ -978,7 +971,7 @@ VariableDeclarator : qq_VariableDeclarator { Anti_VariableDeclarator $1 } |
                      id SquareBracketsList OptVariableInitializer { Ctr__VariableDeclarator__0 $1 (reverse $2) $3 }
 
 VariableDeclaratorList : qq_VariableDeclaratorList { Anti_VariableDeclaratorList $1 } |
-                         VariableDeclarator Rule_51 { Ctr__VariableDeclaratorList__0 $1 (reverse $2) }
+                         VariableDeclarator Rule_49 { Ctr__VariableDeclaratorList__0 $1 (reverse $2) }
 
 VariableInitializer : qq_VariableInitializer { Anti_VariableInitializer $1 } |
                       Expression { Ctr__VariableInitializer__0 $1 } |
@@ -986,7 +979,7 @@ VariableInitializer : qq_VariableInitializer { Anti_VariableInitializer $1 } |
 
 VariableInitializerList : qq_VariableInitializerList { Anti_VariableInitializerList $1 } |
                           { Ctr__VariableInitializerList__0 } |
-                          Rule_54 { Ctr__VariableInitializerList__1 $1 }
+                          Rule_52 { Ctr__VariableInitializerList__1 $1 }
 
 WhileStatement : qq_WhileStatement { Anti_WhileStatement $1 } |
                  tok_while_38 tok__lparen__6 Expression tok__rparen__7 Statement { Ctr__WhileStatement__0 $3 $5 }
@@ -1006,85 +999,85 @@ parseError (L.PosToken (L.AlexPn _ line col) tok : _) =
 -- Render a token the way it appears in the source, for error messages
 showRtkToken :: L.Token -> String
 showRtkToken L.EndOfFile = "end of input"
-showRtkToken L.Tk__tok_AdditiveOp_dummy_171 = "'tok_AdditiveOp_dummy_171'"
-showRtkToken L.Tk__tok_Annotation_dummy_170 = "'tok_Annotation_dummy_170'"
-showRtkToken L.Tk__tok_AnnotationArguments_dummy_169 = "'tok_AnnotationArguments_dummy_169'"
-showRtkToken L.Tk__tok_AnnotationDeclaration_dummy_168 = "'tok_AnnotationDeclaration_dummy_168'"
-showRtkToken L.Tk__tok_AnnotationElement_dummy_167 = "'tok_AnnotationElement_dummy_167'"
-showRtkToken L.Tk__tok_AnnotationList_dummy_166 = "'tok_AnnotationList_dummy_166'"
-showRtkToken L.Tk__tok_AnnotationTypeElement_dummy_165 = "'tok_AnnotationTypeElement_dummy_165'"
-showRtkToken L.Tk__tok_AnnotationTypeElementList_dummy_164 = "'tok_AnnotationTypeElementList_dummy_164'"
-showRtkToken L.Tk__tok_Arglist_dummy_163 = "'tok_Arglist_dummy_163'"
-showRtkToken L.Tk__tok_AssignmentOp_dummy_162 = "'tok_AssignmentOp_dummy_162'"
-showRtkToken L.Tk__tok_CatchList_dummy_161 = "'tok_CatchList_dummy_161'"
-showRtkToken L.Tk__tok_ClassDeclaration_dummy_160 = "'tok_ClassDeclaration_dummy_160'"
-showRtkToken L.Tk__tok_CompilationUnit_dummy_159 = "'tok_CompilationUnit_dummy_159'"
-showRtkToken L.Tk__tok_CompoundName_dummy_158 = "'tok_CompoundName_dummy_158'"
-showRtkToken L.Tk__tok_CreationExpression_dummy_157 = "'tok_CreationExpression_dummy_157'"
-showRtkToken L.Tk__tok_DoStatement_dummy_156 = "'tok_DoStatement_dummy_156'"
-showRtkToken L.Tk__tok_DocComment_dummy_155 = "'tok_DocComment_dummy_155'"
-showRtkToken L.Tk__tok_EnumConstant_dummy_154 = "'tok_EnumConstant_dummy_154'"
-showRtkToken L.Tk__tok_EnumConstantList_dummy_153 = "'tok_EnumConstantList_dummy_153'"
-showRtkToken L.Tk__tok_EnumDeclaration_dummy_152 = "'tok_EnumDeclaration_dummy_152'"
-showRtkToken L.Tk__tok_EqualityOp_dummy_151 = "'tok_EqualityOp_dummy_151'"
-showRtkToken L.Tk__tok_Expression_dummy_150 = "'tok_Expression_dummy_150'"
-showRtkToken L.Tk__tok_ExtendsList_dummy_149 = "'tok_ExtendsList_dummy_149'"
-showRtkToken L.Tk__tok_FieldDeclaration_dummy_148 = "'tok_FieldDeclaration_dummy_148'"
-showRtkToken L.Tk__tok_FieldDeclarationList_dummy_147 = "'tok_FieldDeclarationList_dummy_147'"
-showRtkToken L.Tk__tok_ForStatement_dummy_146 = "'tok_ForStatement_dummy_146'"
-showRtkToken L.Tk__tok_IfStatement_dummy_145 = "'tok_IfStatement_dummy_145'"
-showRtkToken L.Tk__tok_ImplementsList_dummy_144 = "'tok_ImplementsList_dummy_144'"
-showRtkToken L.Tk__tok_ImportList_dummy_143 = "'tok_ImportList_dummy_143'"
-showRtkToken L.Tk__tok_ImportStatement_dummy_142 = "'tok_ImportStatement_dummy_142'"
-showRtkToken L.Tk__tok_InterfaceDeclaration_dummy_141 = "'tok_InterfaceDeclaration_dummy_141'"
-showRtkToken L.Tk__tok_Java_dummy_172 = "'tok_Java_dummy_172'"
-showRtkToken L.Tk__tok_Literal_dummy_140 = "'tok_Literal_dummy_140'"
-showRtkToken L.Tk__tok_MemberAfterFirstId_dummy_139 = "'tok_MemberAfterFirstId_dummy_139'"
-showRtkToken L.Tk__tok_MemberDeclaration_dummy_138 = "'tok_MemberDeclaration_dummy_138'"
-showRtkToken L.Tk__tok_MemberRest_dummy_137 = "'tok_MemberRest_dummy_137'"
-showRtkToken L.Tk__tok_Modifier_dummy_136 = "'tok_Modifier_dummy_136'"
-showRtkToken L.Tk__tok_ModifierList_dummy_135 = "'tok_ModifierList_dummy_135'"
-showRtkToken L.Tk__tok_MoreTypeSpecifier_dummy_134 = "'tok_MoreTypeSpecifier_dummy_134'"
-showRtkToken L.Tk__tok_MoreVariableDeclarators_dummy_133 = "'tok_MoreVariableDeclarators_dummy_133'"
-showRtkToken L.Tk__tok_MultiplicativeOp_dummy_132 = "'tok_MultiplicativeOp_dummy_132'"
-showRtkToken L.Tk__tok_NestedTypeDeclaration_dummy_131 = "'tok_NestedTypeDeclaration_dummy_131'"
-showRtkToken L.Tk__tok_OptDocComment_dummy_130 = "'tok_OptDocComment_dummy_130'"
-showRtkToken L.Tk__tok_OptElsePart_dummy_129 = "'tok_OptElsePart_dummy_129'"
-showRtkToken L.Tk__tok_OptExpression_dummy_128 = "'tok_OptExpression_dummy_128'"
-showRtkToken L.Tk__tok_OptFinally_dummy_127 = "'tok_OptFinally_dummy_127'"
-showRtkToken L.Tk__tok_OptId_dummy_126 = "'tok_OptId_dummy_126'"
-showRtkToken L.Tk__tok_OptVariableInitializer_dummy_125 = "'tok_OptVariableInitializer_dummy_125'"
-showRtkToken L.Tk__tok_Package_dummy_124 = "'tok_Package_dummy_124'"
-showRtkToken L.Tk__tok_Parameter_dummy_123 = "'tok_Parameter_dummy_123'"
-showRtkToken L.Tk__tok_ParameterList_dummy_122 = "'tok_ParameterList_dummy_122'"
-showRtkToken L.Tk__tok_PostfixOp_dummy_121 = "'tok_PostfixOp_dummy_121'"
-showRtkToken L.Tk__tok_PrefixOp_dummy_120 = "'tok_PrefixOp_dummy_120'"
-showRtkToken L.Tk__tok_PrimitiveTypeKeyword_dummy_119 = "'tok_PrimitiveTypeKeyword_dummy_119'"
-showRtkToken L.Tk__tok_RelationalOp_dummy_118 = "'tok_RelationalOp_dummy_118'"
-showRtkToken L.Tk__tok_ShiftOp_dummy_117 = "'tok_ShiftOp_dummy_117'"
-showRtkToken L.Tk__tok_SquareBracketsList_dummy_116 = "'tok_SquareBracketsList_dummy_116'"
-showRtkToken L.Tk__tok_Statement_dummy_115 = "'tok_Statement_dummy_115'"
-showRtkToken L.Tk__tok_StatementBlock_dummy_114 = "'tok_StatementBlock_dummy_114'"
-showRtkToken L.Tk__tok_StatementList_dummy_113 = "'tok_StatementList_dummy_113'"
-showRtkToken L.Tk__tok_StatementWithoutIf_dummy_112 = "'tok_StatementWithoutIf_dummy_112'"
-showRtkToken L.Tk__tok_StaticInitializer_dummy_111 = "'tok_StaticInitializer_dummy_111'"
-showRtkToken L.Tk__tok_SwitchCaseList_dummy_110 = "'tok_SwitchCaseList_dummy_110'"
-showRtkToken L.Tk__tok_SwitchStatement_dummy_109 = "'tok_SwitchStatement_dummy_109'"
-showRtkToken L.Tk__tok_TryStatement_dummy_108 = "'tok_TryStatement_dummy_108'"
-showRtkToken L.Tk__tok_Type_dummy_107 = "'tok_Type_dummy_107'"
-showRtkToken L.Tk__tok_TypeArgument_dummy_106 = "'tok_TypeArgument_dummy_106'"
-showRtkToken L.Tk__tok_TypeArguments_dummy_105 = "'tok_TypeArguments_dummy_105'"
-showRtkToken L.Tk__tok_TypeDeclaration_dummy_104 = "'tok_TypeDeclaration_dummy_104'"
-showRtkToken L.Tk__tok_TypeParameter_dummy_103 = "'tok_TypeParameter_dummy_103'"
-showRtkToken L.Tk__tok_TypeParameters_dummy_102 = "'tok_TypeParameters_dummy_102'"
-showRtkToken L.Tk__tok_TypeSpecifier_dummy_101 = "'tok_TypeSpecifier_dummy_101'"
-showRtkToken L.Tk__tok_VariableDeclaration_dummy_100 = "'tok_VariableDeclaration_dummy_100'"
-showRtkToken L.Tk__tok_VariableDeclarator_dummy_99 = "'tok_VariableDeclarator_dummy_99'"
-showRtkToken L.Tk__tok_VariableDeclaratorList_dummy_98 = "'tok_VariableDeclaratorList_dummy_98'"
-showRtkToken L.Tk__tok_VariableInitializer_dummy_97 = "'tok_VariableInitializer_dummy_97'"
-showRtkToken L.Tk__tok_VariableInitializerList_dummy_96 = "'tok_VariableInitializerList_dummy_96'"
-showRtkToken L.Tk__tok_WhileStatement_dummy_95 = "'tok_WhileStatement_dummy_95'"
-showRtkToken L.Tk__tok_WildcardType_dummy_94 = "'tok_WildcardType_dummy_94'"
+showRtkToken L.Tk__tok_AdditiveOp_dummy_169 = "'tok_AdditiveOp_dummy_169'"
+showRtkToken L.Tk__tok_Annotation_dummy_168 = "'tok_Annotation_dummy_168'"
+showRtkToken L.Tk__tok_AnnotationArguments_dummy_167 = "'tok_AnnotationArguments_dummy_167'"
+showRtkToken L.Tk__tok_AnnotationDeclaration_dummy_166 = "'tok_AnnotationDeclaration_dummy_166'"
+showRtkToken L.Tk__tok_AnnotationElement_dummy_165 = "'tok_AnnotationElement_dummy_165'"
+showRtkToken L.Tk__tok_AnnotationList_dummy_164 = "'tok_AnnotationList_dummy_164'"
+showRtkToken L.Tk__tok_AnnotationTypeElement_dummy_163 = "'tok_AnnotationTypeElement_dummy_163'"
+showRtkToken L.Tk__tok_AnnotationTypeElementList_dummy_162 = "'tok_AnnotationTypeElementList_dummy_162'"
+showRtkToken L.Tk__tok_Arglist_dummy_161 = "'tok_Arglist_dummy_161'"
+showRtkToken L.Tk__tok_AssignmentOp_dummy_160 = "'tok_AssignmentOp_dummy_160'"
+showRtkToken L.Tk__tok_CatchList_dummy_159 = "'tok_CatchList_dummy_159'"
+showRtkToken L.Tk__tok_ClassDeclaration_dummy_158 = "'tok_ClassDeclaration_dummy_158'"
+showRtkToken L.Tk__tok_CompilationUnit_dummy_157 = "'tok_CompilationUnit_dummy_157'"
+showRtkToken L.Tk__tok_CompoundName_dummy_156 = "'tok_CompoundName_dummy_156'"
+showRtkToken L.Tk__tok_CreationExpression_dummy_155 = "'tok_CreationExpression_dummy_155'"
+showRtkToken L.Tk__tok_DoStatement_dummy_154 = "'tok_DoStatement_dummy_154'"
+showRtkToken L.Tk__tok_DocComment_dummy_153 = "'tok_DocComment_dummy_153'"
+showRtkToken L.Tk__tok_EnumConstant_dummy_152 = "'tok_EnumConstant_dummy_152'"
+showRtkToken L.Tk__tok_EnumConstantList_dummy_151 = "'tok_EnumConstantList_dummy_151'"
+showRtkToken L.Tk__tok_EnumDeclaration_dummy_150 = "'tok_EnumDeclaration_dummy_150'"
+showRtkToken L.Tk__tok_EqualityOp_dummy_149 = "'tok_EqualityOp_dummy_149'"
+showRtkToken L.Tk__tok_Expression_dummy_148 = "'tok_Expression_dummy_148'"
+showRtkToken L.Tk__tok_ExtendsList_dummy_147 = "'tok_ExtendsList_dummy_147'"
+showRtkToken L.Tk__tok_FieldDeclaration_dummy_146 = "'tok_FieldDeclaration_dummy_146'"
+showRtkToken L.Tk__tok_FieldDeclarationList_dummy_145 = "'tok_FieldDeclarationList_dummy_145'"
+showRtkToken L.Tk__tok_ForStatement_dummy_144 = "'tok_ForStatement_dummy_144'"
+showRtkToken L.Tk__tok_IfStatement_dummy_143 = "'tok_IfStatement_dummy_143'"
+showRtkToken L.Tk__tok_ImplementsList_dummy_142 = "'tok_ImplementsList_dummy_142'"
+showRtkToken L.Tk__tok_ImportList_dummy_141 = "'tok_ImportList_dummy_141'"
+showRtkToken L.Tk__tok_ImportStatement_dummy_140 = "'tok_ImportStatement_dummy_140'"
+showRtkToken L.Tk__tok_InterfaceDeclaration_dummy_139 = "'tok_InterfaceDeclaration_dummy_139'"
+showRtkToken L.Tk__tok_Java_dummy_170 = "'tok_Java_dummy_170'"
+showRtkToken L.Tk__tok_Literal_dummy_138 = "'tok_Literal_dummy_138'"
+showRtkToken L.Tk__tok_MemberAfterFirstId_dummy_137 = "'tok_MemberAfterFirstId_dummy_137'"
+showRtkToken L.Tk__tok_MemberDeclaration_dummy_136 = "'tok_MemberDeclaration_dummy_136'"
+showRtkToken L.Tk__tok_MemberRest_dummy_135 = "'tok_MemberRest_dummy_135'"
+showRtkToken L.Tk__tok_Modifier_dummy_134 = "'tok_Modifier_dummy_134'"
+showRtkToken L.Tk__tok_ModifierList_dummy_133 = "'tok_ModifierList_dummy_133'"
+showRtkToken L.Tk__tok_MoreTypeSpecifier_dummy_132 = "'tok_MoreTypeSpecifier_dummy_132'"
+showRtkToken L.Tk__tok_MoreVariableDeclarators_dummy_131 = "'tok_MoreVariableDeclarators_dummy_131'"
+showRtkToken L.Tk__tok_MultiplicativeOp_dummy_130 = "'tok_MultiplicativeOp_dummy_130'"
+showRtkToken L.Tk__tok_NestedTypeDeclaration_dummy_129 = "'tok_NestedTypeDeclaration_dummy_129'"
+showRtkToken L.Tk__tok_OptDocComment_dummy_128 = "'tok_OptDocComment_dummy_128'"
+showRtkToken L.Tk__tok_OptElsePart_dummy_127 = "'tok_OptElsePart_dummy_127'"
+showRtkToken L.Tk__tok_OptExpression_dummy_126 = "'tok_OptExpression_dummy_126'"
+showRtkToken L.Tk__tok_OptFinally_dummy_125 = "'tok_OptFinally_dummy_125'"
+showRtkToken L.Tk__tok_OptId_dummy_124 = "'tok_OptId_dummy_124'"
+showRtkToken L.Tk__tok_OptVariableInitializer_dummy_123 = "'tok_OptVariableInitializer_dummy_123'"
+showRtkToken L.Tk__tok_Package_dummy_122 = "'tok_Package_dummy_122'"
+showRtkToken L.Tk__tok_Parameter_dummy_121 = "'tok_Parameter_dummy_121'"
+showRtkToken L.Tk__tok_ParameterList_dummy_120 = "'tok_ParameterList_dummy_120'"
+showRtkToken L.Tk__tok_PostfixOp_dummy_119 = "'tok_PostfixOp_dummy_119'"
+showRtkToken L.Tk__tok_PrefixOp_dummy_118 = "'tok_PrefixOp_dummy_118'"
+showRtkToken L.Tk__tok_PrimitiveTypeKeyword_dummy_117 = "'tok_PrimitiveTypeKeyword_dummy_117'"
+showRtkToken L.Tk__tok_RelationalOp_dummy_116 = "'tok_RelationalOp_dummy_116'"
+showRtkToken L.Tk__tok_ShiftOp_dummy_115 = "'tok_ShiftOp_dummy_115'"
+showRtkToken L.Tk__tok_SquareBracketsList_dummy_114 = "'tok_SquareBracketsList_dummy_114'"
+showRtkToken L.Tk__tok_Statement_dummy_113 = "'tok_Statement_dummy_113'"
+showRtkToken L.Tk__tok_StatementBlock_dummy_112 = "'tok_StatementBlock_dummy_112'"
+showRtkToken L.Tk__tok_StatementList_dummy_111 = "'tok_StatementList_dummy_111'"
+showRtkToken L.Tk__tok_StatementWithoutIf_dummy_110 = "'tok_StatementWithoutIf_dummy_110'"
+showRtkToken L.Tk__tok_StaticInitializer_dummy_109 = "'tok_StaticInitializer_dummy_109'"
+showRtkToken L.Tk__tok_SwitchCaseList_dummy_108 = "'tok_SwitchCaseList_dummy_108'"
+showRtkToken L.Tk__tok_SwitchStatement_dummy_107 = "'tok_SwitchStatement_dummy_107'"
+showRtkToken L.Tk__tok_TryStatement_dummy_106 = "'tok_TryStatement_dummy_106'"
+showRtkToken L.Tk__tok_Type_dummy_105 = "'tok_Type_dummy_105'"
+showRtkToken L.Tk__tok_TypeArgument_dummy_104 = "'tok_TypeArgument_dummy_104'"
+showRtkToken L.Tk__tok_TypeArguments_dummy_103 = "'tok_TypeArguments_dummy_103'"
+showRtkToken L.Tk__tok_TypeDeclaration_dummy_102 = "'tok_TypeDeclaration_dummy_102'"
+showRtkToken L.Tk__tok_TypeParameter_dummy_101 = "'tok_TypeParameter_dummy_101'"
+showRtkToken L.Tk__tok_TypeParameters_dummy_100 = "'tok_TypeParameters_dummy_100'"
+showRtkToken L.Tk__tok_TypeSpecifier_dummy_99 = "'tok_TypeSpecifier_dummy_99'"
+showRtkToken L.Tk__tok_VariableDeclaration_dummy_98 = "'tok_VariableDeclaration_dummy_98'"
+showRtkToken L.Tk__tok_VariableDeclarator_dummy_97 = "'tok_VariableDeclarator_dummy_97'"
+showRtkToken L.Tk__tok_VariableDeclaratorList_dummy_96 = "'tok_VariableDeclaratorList_dummy_96'"
+showRtkToken L.Tk__tok_VariableInitializer_dummy_95 = "'tok_VariableInitializer_dummy_95'"
+showRtkToken L.Tk__tok_VariableInitializerList_dummy_94 = "'tok_VariableInitializerList_dummy_94'"
+showRtkToken L.Tk__tok_WhileStatement_dummy_93 = "'tok_WhileStatement_dummy_93'"
+showRtkToken L.Tk__tok_WildcardType_dummy_92 = "'tok_WildcardType_dummy_92'"
 showRtkToken L.Tk__tok__tilde__78 = "'~'"
 showRtkToken L.Tk__tok__symbol__14 = "'}'"
 showRtkToken L.Tk__tok__pipe__pipe__57 = "'||'"
@@ -1092,7 +1085,7 @@ showRtkToken L.Tk__tok__pipe__eql__49 = "'|='"
 showRtkToken L.Tk__tok__pipe__59 = "'|'"
 showRtkToken L.Tk__tok__symbol__13 = "'{'"
 showRtkToken L.Tk__tok_while_38 = "'while'"
-showRtkToken L.Tk__tok_void_28 = "'void'"
+showRtkToken L.Tk__tok_void_27 = "'void'"
 showRtkToken L.Tk__tok_try_42 = "'try'"
 showRtkToken L.Tk__tok_true_83 = "'true'"
 showRtkToken L.Tk__tok_transient_94 = "'transient'"
@@ -1103,7 +1096,7 @@ showRtkToken L.Tk__tok_synchronized_30 = "'synchronized'"
 showRtkToken L.Tk__tok_switch_44 = "'switch'"
 showRtkToken L.Tk__tok_super_81 = "'super'"
 showRtkToken L.Tk__tok_static_89 = "'static'"
-showRtkToken L.Tk__tok_short_23 = "'short'"
+showRtkToken L.Tk__tok_short_22 = "'short'"
 showRtkToken L.Tk__tok_return_29 = "'return'"
 showRtkToken L.Tk__tok_public_86 = "'public'"
 showRtkToken L.Tk__tok_protected_88 = "'protected'"
@@ -1112,37 +1105,37 @@ showRtkToken L.Tk__tok_package_0 = "'package'"
 showRtkToken L.Tk__tok_null_85 = "'null'"
 showRtkToken L.Tk__tok_new_82 = "'new'"
 showRtkToken L.Tk__tok_native_91 = "'native'"
-showRtkToken L.Tk__tok_long_26 = "'long'"
+showRtkToken L.Tk__tok_long_25 = "'long'"
 showRtkToken L.Tk__tok_interface_15 = "'interface'"
-showRtkToken L.Tk__tok_int_24 = "'int'"
+showRtkToken L.Tk__tok_int_23 = "'int'"
 showRtkToken L.Tk__tok_instanceof_68 = "'instanceof'"
 showRtkToken L.Tk__tok_import_2 = "'import'"
 showRtkToken L.Tk__tok_implements_11 = "'implements'"
 showRtkToken L.Tk__tok_if_36 = "'if'"
 showRtkToken L.Tk__tok_for_39 = "'for'"
-showRtkToken L.Tk__tok_float_25 = "'float'"
+showRtkToken L.Tk__tok_float_24 = "'float'"
 showRtkToken L.Tk__tok_finally_41 = "'finally'"
 showRtkToken L.Tk__tok_final_90 = "'final'"
 showRtkToken L.Tk__tok_false_84 = "'false'"
 showRtkToken L.Tk__tok_extends_10 = "'extends'"
-showRtkToken L.Tk__tok_enum_17 = "'enum'"
+showRtkToken L.Tk__tok_enum_16 = "'enum'"
 showRtkToken L.Tk__tok_else_35 = "'else'"
-showRtkToken L.Tk__tok_double_27 = "'double'"
+showRtkToken L.Tk__tok_double_26 = "'double'"
 showRtkToken L.Tk__tok_do_37 = "'do'"
-showRtkToken L.Tk__tok_default_16 = "'default'"
+showRtkToken L.Tk__tok_default_28 = "'default'"
 showRtkToken L.Tk__tok_continue_34 = "'continue'"
 showRtkToken L.Tk__tok_class_12 = "'class'"
-showRtkToken L.Tk__tok_char_22 = "'char'"
+showRtkToken L.Tk__tok_char_21 = "'char'"
 showRtkToken L.Tk__tok_catch_40 = "'catch'"
 showRtkToken L.Tk__tok_case_43 = "'case'"
-showRtkToken L.Tk__tok_byte_21 = "'byte'"
+showRtkToken L.Tk__tok_byte_20 = "'byte'"
 showRtkToken L.Tk__tok_break_33 = "'break'"
-showRtkToken L.Tk__tok_boolean_20 = "'boolean'"
+showRtkToken L.Tk__tok_boolean_19 = "'boolean'"
 showRtkToken L.Tk__tok_abstract_92 = "'abstract'"
 showRtkToken L.Tk__tok__symbol__eql__51 = "'^='"
 showRtkToken L.Tk__tok__symbol__60 = "'^'"
-showRtkToken L.Tk__tok__sq_bkt_r__19 = "']'"
-showRtkToken L.Tk__tok__sq_bkt_l__18 = "'['"
+showRtkToken L.Tk__tok__sq_bkt_r__18 = "']'"
+showRtkToken L.Tk__tok__sq_bkt_l__17 = "'['"
 showRtkToken L.Tk__tok__symbol__5 = "'@'"
 showRtkToken L.Tk__tok__symbol__56 = "'?'"
 showRtkToken L.Tk__tok__symbol__symbol__symbol__eql__55 = "'>>>='"
@@ -1364,17 +1357,17 @@ data AnnotationDeclaration = Anti_AnnotationDeclaration String |
                              Ctr__AnnotationDeclaration__0 ModifierList String AnnotationTypeElementList
                              deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 data AnnotationElement = Anti_AnnotationElement String |
-                         Ctr__AnnotationElement__0 Rule_15 Expression
+                         Ctr__AnnotationElement__0 String Expression |
+                         Ctr__AnnotationElement__1 Expression
                          deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 type AnnotationList = [Annotation]
 data AnnotationTypeElement = Anti_AnnotationTypeElement String |
-                             Ctr__AnnotationTypeElement__0 ModifierList Type String Rule_28 |
-                             Ctr__AnnotationTypeElement__1 FieldDeclaration
+                             Ctr__AnnotationTypeElement__0 FieldDeclaration
                              deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 type AnnotationTypeElementList = [AnnotationTypeElement]
 data Arglist = Anti_Arglist String |
                Ctr__Arglist__0 |
-               Ctr__Arglist__1 Rule_79
+               Ctr__Arglist__1 Rule_77
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 data AssignmentOp = Anti_AssignmentOp String |
                     Ctr__AssignmentOp__0 |
@@ -1390,18 +1383,18 @@ data AssignmentOp = Anti_AssignmentOp String |
                     Ctr__AssignmentOp__10 |
                     Ctr__AssignmentOp__11
                     deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-type CatchList = [Rule_65]
+type CatchList = [Rule_63]
 data ClassDeclaration = Anti_ClassDeclaration String |
-                        Ctr__ClassDeclaration__0 ModifierList String TypeParameters Rule_25 Rule_26 FieldDeclarationList
+                        Ctr__ClassDeclaration__0 ModifierList String TypeParameters Rule_22 Rule_23 FieldDeclarationList
                         deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 data CompilationUnit = Anti_CompilationUnit String |
                        Ctr__CompilationUnit__0 Rule_4 ImportList Rule_6
                        deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 data CompoundName = Anti_CompoundName String |
-                    Ctr__CompoundName__0 String Rule_92
+                    Ctr__CompoundName__0 String Rule_90
                     deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 data CreationExpression = Anti_CreationExpression String |
-                          Ctr__CreationExpression__0 Type Rule_78
+                          Ctr__CreationExpression__0 Type Rule_76
                           deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 data DoStatement = Anti_DoStatement String |
                    Ctr__DoStatement__0 Statement Expression
@@ -1410,13 +1403,13 @@ data DocComment = Anti_DocComment String |
                   Ctr__DocComment__0 String
                   deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 data EnumConstant = Anti_EnumConstant String |
-                    Ctr__EnumConstant__0 AnnotationList String Rule_30 Rule_32
+                    Ctr__EnumConstant__0 AnnotationList String Rule_26 Rule_28
                     deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 data EnumConstantList = Anti_EnumConstantList String |
-                        Ctr__EnumConstantList__0 EnumConstant Rule_34 Rule_36
+                        Ctr__EnumConstantList__0 EnumConstant Rule_30 Rule_32
                         deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 data EnumDeclaration = Anti_EnumDeclaration String |
-                       Ctr__EnumDeclaration__0 ModifierList String Rule_38 EnumConstantList Rule_39
+                       Ctr__EnumDeclaration__0 ModifierList String Rule_34 EnumConstantList Rule_35
                        deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 data EqualityOp = Anti_EqualityOp String |
                   Ctr__EqualityOp__0 |
@@ -1427,8 +1420,8 @@ data Expression = Anti_Expression String |
                   Ctr__Expression__1 |
                   Ctr__Expression__2 Expression |
                   Ctr__Expression__3 CreationExpression |
-                  Ctr__Expression__4 CompoundName Rule_74 |
-                  Ctr__Expression__5 String Rule_76 |
+                  Ctr__Expression__4 CompoundName Rule_72 |
+                  Ctr__Expression__5 String Rule_74 |
                   Ctr__Expression__6 Expression |
                   Ctr__Expression__7 Expression PostfixOp |
                   Ctr__Expression__8 Expression String |
@@ -1464,33 +1457,32 @@ data Expression = Anti_Expression String |
                   Ctr__Expression__38 Expression Expression |
                   Ctr__Expression__39 Expression |
                   Ctr__Expression__40 Expression Expression Expression |
-                  Ctr__Expression__41 Expression Rule_72 |
+                  Ctr__Expression__41 Expression Rule_70 |
                   Ctr__Expression__42 Expression
                   deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 data ExtendsList = Anti_ExtendsList String |
-                   Ctr__ExtendsList__0 |
-                   Ctr__ExtendsList__1 Rule_20
+                   Ctr__ExtendsList__0 CompoundName Rule_18
                    deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 data FieldDeclaration = Anti_FieldDeclaration String |
-                        Ctr__FieldDeclaration__0 OptDocComment Rule_41 |
+                        Ctr__FieldDeclaration__0 OptDocComment Rule_37 |
                         Ctr__FieldDeclaration__1
                         deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 type FieldDeclarationList = [FieldDeclaration]
 data ForStatement = Anti_ForStatement String |
-                    Ctr__ForStatement__0 Rule_63 OptExpression OptExpression Statement
+                    Ctr__ForStatement__0 Rule_61 OptExpression OptExpression Statement
                     deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 data IfStatement = Anti_IfStatement String |
                    Ctr__IfStatement__0 Expression StatementWithoutIf OptElsePart
                    deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 data ImplementsList = Anti_ImplementsList String |
-                      Ctr__ImplementsList__0 Rule_23
+                      Ctr__ImplementsList__0 Rule_20
                       deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 type ImportList = [Rule_2]
 data ImportStatement = Anti_ImportStatement String |
                        Ctr__ImportStatement__0 Rule_8
                        deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 data InterfaceDeclaration = Anti_InterfaceDeclaration String |
-                            Ctr__InterfaceDeclaration__0 ModifierList String TypeParameters ExtendsList FieldDeclarationList
+                            Ctr__InterfaceDeclaration__0 ModifierList String TypeParameters Rule_24 FieldDeclarationList
                             deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 data Literal = Anti_Literal String |
                Ctr__Literal__0 String |
@@ -1502,7 +1494,7 @@ data Literal = Anti_Literal String |
                Ctr__Literal__6
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 data MemberAfterFirstId = Anti_MemberAfterFirstId String |
-                          Ctr__MemberAfterFirstId__0 Rule_46 StatementBlock |
+                          Ctr__MemberAfterFirstId__0 Rule_42 StatementBlock |
                           Ctr__MemberAfterFirstId__1 MoreTypeSpecifier String MemberRest
                           deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 data MemberDeclaration = Anti_MemberDeclaration String |
@@ -1511,7 +1503,7 @@ data MemberDeclaration = Anti_MemberDeclaration String |
                          Ctr__MemberDeclaration__2 String MemberAfterFirstId
                          deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 data MemberRest = Anti_MemberRest String |
-                  Ctr__MemberRest__0 Rule_47 SquareBracketsList Rule_48 |
+                  Ctr__MemberRest__0 Rule_43 SquareBracketsList Rule_44 |
                   Ctr__MemberRest__1 SquareBracketsList OptVariableInitializer MoreVariableDeclarators
                   deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 data Modifier = Anti_Modifier String |
@@ -1526,12 +1518,12 @@ data Modifier = Anti_Modifier String |
                 Ctr__Modifier__8 |
                 Ctr__Modifier__9
                 deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-type ModifierList = [Rule_18]
+type ModifierList = [Rule_16]
 data MoreTypeSpecifier = Anti_MoreTypeSpecifier String |
                          Ctr__MoreTypeSpecifier__0 String MoreTypeSpecifier |
                          Ctr__MoreTypeSpecifier__1 TypeArguments SquareBracketsList
                          deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-type MoreVariableDeclarators = [Rule_49]
+type MoreVariableDeclarators = [Rule_47]
 data MultiplicativeOp = Anti_MultiplicativeOp String |
                         Ctr__MultiplicativeOp__0 |
                         Ctr__MultiplicativeOp__1 |
@@ -1549,7 +1541,7 @@ data OptDocComment = Anti_OptDocComment String |
                      deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 data OptElsePart = Anti_OptElsePart String |
                    Ctr__OptElsePart__0 |
-                   Ctr__OptElsePart__1 Rule_62
+                   Ctr__OptElsePart__1 Rule_60
                    deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 data OptExpression = Anti_OptExpression String |
                      Ctr__OptExpression__0 |
@@ -1557,7 +1549,7 @@ data OptExpression = Anti_OptExpression String |
                      deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 data OptFinally = Anti_OptFinally String |
                   Ctr__OptFinally__0 |
-                  Ctr__OptFinally__1 Rule_67
+                  Ctr__OptFinally__1 Rule_65
                   deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 data OptId = Anti_OptId String |
              Ctr__OptId__0 |
@@ -1565,7 +1557,7 @@ data OptId = Anti_OptId String |
              deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 data OptVariableInitializer = Anti_OptVariableInitializer String |
                               Ctr__OptVariableInitializer__0 |
-                              Ctr__OptVariableInitializer__1 Rule_53
+                              Ctr__OptVariableInitializer__1 Rule_51
                               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 data Package = Anti_Package String |
                Ctr__Package__0 CompoundName
@@ -1574,7 +1566,7 @@ data Parameter = Anti_Parameter String |
                  Ctr__Parameter__0 Type String SquareBracketsList
                  deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 data ParameterList = Anti_ParameterList String |
-                     Ctr__ParameterList__0 Parameter Rule_59
+                     Ctr__ParameterList__0 Parameter Rule_57
                      deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 data PostfixOp = Anti_PostfixOp String |
                  Ctr__PostfixOp__0 |
@@ -1584,9 +1576,7 @@ data PrefixOp = Anti_PrefixOp String |
                 Ctr__PrefixOp__0 |
                 Ctr__PrefixOp__1 |
                 Ctr__PrefixOp__2 |
-                Ctr__PrefixOp__3 |
-                Ctr__PrefixOp__4 |
-                Ctr__PrefixOp__5
+                Ctr__PrefixOp__3
                 deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 data PrimitiveTypeKeyword = Anti_PrimitiveTypeKeyword String |
                             Ctr__PrimitiveTypeKeyword__0 |
@@ -1623,189 +1613,185 @@ data Rule_12 = Ctr__Rule_12__0 |
 type Rule_13 = [Rule_14]
 data Rule_14 = Ctr__Rule_14__0 AnnotationElement
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_15 = Ctr__Rule_15__0 |
-               Ctr__Rule_15__1 Rule_16
+data Rule_16 = Anti_Rule_16 String |
+               Ctr__Rule_16__1 Modifier |
+               Ctr__Rule_16__2 Annotation
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_16 = Ctr__Rule_16__0 String
-               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_18 = Anti_Rule_18 String |
-               Ctr__Rule_18__1 Modifier |
-               Ctr__Rule_18__2 Annotation
+type Rule_18 = [Rule_19]
+data Rule_19 = Ctr__Rule_19__0 CompoundName
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 data Rule_2 = Anti_Rule_2 String |
               Ctr__Rule_2__1 ImportStatement
               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_20 = Ctr__Rule_20__0 CompoundName Rule_21
+type Rule_20 = [CompoundName]
+data Rule_22 = Ctr__Rule_22__0 |
+               Ctr__Rule_22__1 ExtendsList
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-type Rule_21 = [Rule_22]
-data Rule_22 = Ctr__Rule_22__0 CompoundName
+data Rule_23 = Ctr__Rule_23__0 |
+               Ctr__Rule_23__1 ImplementsList
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-type Rule_23 = [CompoundName]
-data Rule_25 = Ctr__Rule_25__0 |
-               Ctr__Rule_25__1 ExtendsList
+data Rule_24 = Ctr__Rule_24__0 |
+               Ctr__Rule_24__1 ExtendsList
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 data Rule_26 = Ctr__Rule_26__0 |
-               Ctr__Rule_26__1 ImplementsList
+               Ctr__Rule_26__1 Rule_27
+               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+data Rule_27 = Ctr__Rule_27__0 Arglist
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 data Rule_28 = Ctr__Rule_28__0 |
                Ctr__Rule_28__1 Rule_29
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_29 = Ctr__Rule_29__0 Expression
+data Rule_29 = Ctr__Rule_29__0 FieldDeclarationList
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_30 = Ctr__Rule_30__0 |
-               Ctr__Rule_30__1 Rule_31
-               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_31 = Ctr__Rule_31__0 Arglist
+type Rule_30 = [Rule_31]
+data Rule_31 = Ctr__Rule_31__0 EnumConstant
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 data Rule_32 = Ctr__Rule_32__0 |
                Ctr__Rule_32__1 Rule_33
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_33 = Ctr__Rule_33__0 FieldDeclarationList
+data Rule_33 = Ctr__Rule_33__0
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-type Rule_34 = [Rule_35]
-data Rule_35 = Ctr__Rule_35__0 EnumConstant
+data Rule_34 = Ctr__Rule_34__0 |
+               Ctr__Rule_34__1 ImplementsList
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_36 = Ctr__Rule_36__0 |
-               Ctr__Rule_36__1 Rule_37
+data Rule_35 = Ctr__Rule_35__0 |
+               Ctr__Rule_35__1 Rule_36
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_37 = Ctr__Rule_37__0
+data Rule_36 = Ctr__Rule_36__0 FieldDeclarationList
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_38 = Ctr__Rule_38__0 |
-               Ctr__Rule_38__1 ImplementsList
+data Rule_37 = Ctr__Rule_37__0 ModifierList Rule_38
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_39 = Ctr__Rule_39__0 |
-               Ctr__Rule_39__1 Rule_40
+data Rule_38 = Ctr__Rule_38__0 Rule_39 |
+               Ctr__Rule_38__1 StaticInitializer
+               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+data Rule_39 = Ctr__Rule_39__0 MemberDeclaration |
+               Ctr__Rule_39__1 NestedTypeDeclaration
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 data Rule_4 = Ctr__Rule_4__0 |
               Ctr__Rule_4__1 Rule_5
               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_40 = Ctr__Rule_40__0 FieldDeclarationList
+data Rule_40 = Anti_Rule_40 String |
+               Ctr__Rule_40__1 OptExpression
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_41 = Ctr__Rule_41__0 ModifierList Rule_42
+data Rule_42 = Ctr__Rule_42__0 |
+               Ctr__Rule_42__1 ParameterList
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_42 = Ctr__Rule_42__0 Rule_43 |
-               Ctr__Rule_42__1 StaticInitializer
+data Rule_43 = Ctr__Rule_43__0 |
+               Ctr__Rule_43__1 ParameterList
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_43 = Ctr__Rule_43__0 MemberDeclaration |
-               Ctr__Rule_43__1 NestedTypeDeclaration
+data Rule_44 = Ctr__Rule_44__0 StatementBlock |
+               Ctr__Rule_44__1 Rule_45
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_44 = Anti_Rule_44 String |
-               Ctr__Rule_44__1 OptExpression
+data Rule_45 = Ctr__Rule_45__0 |
+               Ctr__Rule_45__1 Rule_46
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_46 = Ctr__Rule_46__0 |
-               Ctr__Rule_46__1 ParameterList
+data Rule_46 = Ctr__Rule_46__0 Expression
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_47 = Ctr__Rule_47__0 |
-               Ctr__Rule_47__1 ParameterList
+data Rule_47 = Anti_Rule_47 String |
+               Ctr__Rule_47__1 VariableDeclarator
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_48 = Ctr__Rule_48__0 StatementBlock |
-               Ctr__Rule_48__1
-               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_49 = Anti_Rule_49 String |
-               Ctr__Rule_49__1 VariableDeclarator
-               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+type Rule_49 = [Rule_50]
 data Rule_5 = Ctr__Rule_5__0 Package
               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-type Rule_51 = [Rule_52]
-data Rule_52 = Ctr__Rule_52__0 VariableDeclarator
+data Rule_50 = Ctr__Rule_50__0 VariableDeclarator
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_53 = Ctr__Rule_53__0 VariableInitializer
+data Rule_51 = Ctr__Rule_51__0 VariableInitializer
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_54 = Ctr__Rule_54__0 VariableInitializer Rule_55 Rule_57
+data Rule_52 = Ctr__Rule_52__0 VariableInitializer Rule_53 Rule_55
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-type Rule_55 = [Rule_56]
-data Rule_56 = Ctr__Rule_56__0 VariableInitializer
+type Rule_53 = [Rule_54]
+data Rule_54 = Ctr__Rule_54__0 VariableInitializer
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_57 = Ctr__Rule_57__0 |
-               Ctr__Rule_57__1 Rule_58
+data Rule_55 = Ctr__Rule_55__0 |
+               Ctr__Rule_55__1 Rule_56
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_58 = Ctr__Rule_58__0
+data Rule_56 = Ctr__Rule_56__0
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-type Rule_59 = [Rule_60]
+type Rule_57 = [Rule_58]
+data Rule_58 = Ctr__Rule_58__0 Parameter
+               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 data Rule_6 = Ctr__Rule_6__0 |
               Ctr__Rule_6__1 Rule_7
               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_60 = Ctr__Rule_60__0 Parameter
+data Rule_60 = Ctr__Rule_60__0 Statement
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_62 = Ctr__Rule_62__0 Statement
+data Rule_61 = Ctr__Rule_61__0 VariableDeclaration |
+               Ctr__Rule_61__1 Rule_62 |
+               Ctr__Rule_61__2
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_63 = Ctr__Rule_63__0 VariableDeclaration |
-               Ctr__Rule_63__1 Rule_64 |
-               Ctr__Rule_63__2
+data Rule_62 = Ctr__Rule_62__0 Expression
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_64 = Ctr__Rule_64__0 Expression
+data Rule_63 = Anti_Rule_63 String |
+               Ctr__Rule_63__1 Parameter Statement
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_65 = Anti_Rule_65 String |
-               Ctr__Rule_65__1 Parameter Statement
+data Rule_65 = Ctr__Rule_65__0 Statement
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_67 = Ctr__Rule_67__0 Statement
+data Rule_66 = Anti_Rule_66 String |
+               Ctr__Rule_66__1 Rule_67 |
+               Ctr__Rule_66__2 Rule_68 |
+               Ctr__Rule_66__3 Statement
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_68 = Anti_Rule_68 String |
-               Ctr__Rule_68__1 Rule_69 |
-               Ctr__Rule_68__2 Rule_70 |
-               Ctr__Rule_68__3 Statement
+data Rule_67 = Ctr__Rule_67__0 Expression
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_69 = Ctr__Rule_69__0 Expression
+data Rule_68 = Ctr__Rule_68__0
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 data Rule_7 = Ctr__Rule_7__0 TypeDeclaration
               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_70 = Ctr__Rule_70__0
+data Rule_70 = Ctr__Rule_70__0 |
+               Ctr__Rule_70__1 Rule_71
+               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+data Rule_71 = Ctr__Rule_71__0 AssignmentOp Expression
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 data Rule_72 = Ctr__Rule_72__0 |
                Ctr__Rule_72__1 Rule_73
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_73 = Ctr__Rule_73__0 AssignmentOp Expression
+data Rule_73 = Ctr__Rule_73__0 Arglist
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 data Rule_74 = Ctr__Rule_74__0 |
                Ctr__Rule_74__1 Rule_75
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 data Rule_75 = Ctr__Rule_75__0 Arglist
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_76 = Ctr__Rule_76__0 |
-               Ctr__Rule_76__1 Rule_77
+data Rule_76 = Ctr__Rule_76__0 Arglist |
+               Ctr__Rule_76__1 SquareBracketsList
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_77 = Ctr__Rule_77__0 Arglist
+data Rule_77 = Ctr__Rule_77__0 Expression Rule_78
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_78 = Ctr__Rule_78__0 Arglist |
-               Ctr__Rule_78__1 SquareBracketsList
-               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_79 = Ctr__Rule_79__0 Expression Rule_80
+type Rule_78 = [Rule_79]
+data Rule_79 = Ctr__Rule_79__0 Expression
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 data Rule_8 = Ctr__Rule_8__0 Rule_9 |
               Ctr__Rule_8__1 CompoundName
               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-type Rule_80 = [Rule_81]
-data Rule_81 = Ctr__Rule_81__0 Expression
+data Rule_80 = Ctr__Rule_80__0 TypeArgument Rule_81
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_82 = Ctr__Rule_82__0 TypeArgument Rule_83
+type Rule_81 = [Rule_82]
+data Rule_82 = Ctr__Rule_82__0 TypeArgument
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-type Rule_83 = [Rule_84]
-data Rule_84 = Ctr__Rule_84__0 TypeArgument
+data Rule_83 = Ctr__Rule_83__0 TypeParameter Rule_84
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_85 = Ctr__Rule_85__0 TypeParameter Rule_86
+type Rule_84 = [Rule_85]
+data Rule_85 = Ctr__Rule_85__0 TypeParameter
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-type Rule_86 = [Rule_87]
-data Rule_87 = Ctr__Rule_87__0 TypeParameter
+data Rule_86 = Ctr__Rule_86__0 |
+               Ctr__Rule_86__1 Rule_87
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_88 = Ctr__Rule_88__0 |
-               Ctr__Rule_88__1 Rule_89
+data Rule_87 = Ctr__Rule_87__0 Type Rule_88
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_89 = Ctr__Rule_89__0 Type Rule_90
+type Rule_88 = [Rule_89]
+data Rule_89 = Ctr__Rule_89__0 Type
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 data Rule_9 = Ctr__Rule_9__0 CompoundName
               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 type Rule_90 = [Rule_91]
-data Rule_91 = Ctr__Rule_91__0 Type
-               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-type Rule_92 = [Rule_93]
-data Rule_93 = Ctr__Rule_93__0 String
+data Rule_91 = Ctr__Rule_91__0 String
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 data ShiftOp = Anti_ShiftOp String |
                Ctr__ShiftOp__0 |
                Ctr__ShiftOp__1 |
                Ctr__ShiftOp__2
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-type SquareBracketsList = [Rule_44]
+type SquareBracketsList = [Rule_40]
 data Statement = Anti_Statement String |
                  Ctr__Statement__0 StatementWithoutIf |
                  Ctr__Statement__1 IfStatement
@@ -1834,7 +1820,7 @@ data StatementWithoutIf = Anti_StatementWithoutIf String |
 data StaticInitializer = Anti_StaticInitializer String |
                          Ctr__StaticInitializer__0 StatementBlock
                          deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-type SwitchCaseList = [Rule_68]
+type SwitchCaseList = [Rule_66]
 data SwitchStatement = Anti_SwitchStatement String |
                        Ctr__SwitchStatement__0 Expression SwitchCaseList
                        deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
@@ -1850,17 +1836,17 @@ data TypeArgument = Anti_TypeArgument String |
                     deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 data TypeArguments = Anti_TypeArguments String |
                      Ctr__TypeArguments__0 |
-                     Ctr__TypeArguments__1 Rule_82
+                     Ctr__TypeArguments__1 Rule_80
                      deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 data TypeDeclaration = Anti_TypeDeclaration String |
                        Ctr__TypeDeclaration__0 OptDocComment Rule_1
                        deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 data TypeParameter = Anti_TypeParameter String |
-                     Ctr__TypeParameter__0 String Rule_88
+                     Ctr__TypeParameter__0 String Rule_86
                      deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 data TypeParameters = Anti_TypeParameters String |
                       Ctr__TypeParameters__0 |
-                      Ctr__TypeParameters__1 Rule_85
+                      Ctr__TypeParameters__1 Rule_83
                       deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 data TypeSpecifier = Anti_TypeSpecifier String |
                      Ctr__TypeSpecifier__0 |
@@ -1881,7 +1867,7 @@ data VariableDeclarator = Anti_VariableDeclarator String |
                           Ctr__VariableDeclarator__0 String SquareBracketsList OptVariableInitializer
                           deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 data VariableDeclaratorList = Anti_VariableDeclaratorList String |
-                              Ctr__VariableDeclaratorList__0 VariableDeclarator Rule_51
+                              Ctr__VariableDeclaratorList__0 VariableDeclarator Rule_49
                               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 data VariableInitializer = Anti_VariableInitializer String |
                            Ctr__VariableInitializer__0 Expression |
@@ -1889,7 +1875,7 @@ data VariableInitializer = Anti_VariableInitializer String |
                            deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 data VariableInitializerList = Anti_VariableInitializerList String |
                                Ctr__VariableInitializerList__0 |
-                               Ctr__VariableInitializerList__1 Rule_54
+                               Ctr__VariableInitializerList__1 Rule_52
                                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 data WhileStatement = Anti_WhileStatement String |
                       Ctr__WhileStatement__0 Expression Statement

--- a/test/golden/java/JavaQQ.hs
+++ b/test/golden/java/JavaQQ.hs
@@ -58,7 +58,7 @@ quoteJavaExp dummy func s = do
            Left err -> fail err
            Right a -> return a
   let expr = func ast
-  dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiRule_2Exp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_18Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiNestedTypeDeclarationExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_49Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiStatementWithoutIfExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_65Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_68Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) expr
+  dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiRule_2Exp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_16Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiNestedTypeDeclarationExp `Generics.extQ` antiRule_40Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_47Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiStatementWithoutIfExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_63Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_66Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) expr
 quoteJavaPat :: Data.Data a => String -> (Java -> a) -> String -> TH.PatQ
 quoteJavaPat dummy func s = do
   s1 <- either fail return (replaceAllPatterns s)
@@ -66,7 +66,7 @@ quoteJavaPat dummy func s = do
            Left err -> fail err
            Right a -> return a
   let expr = func ast
-  dataToPatQ (const Nothing `Generics.extQ` antiJavaPat `Generics.extQ` antiOptDocCommentPat `Generics.extQ` antiTypeDeclarationPat `Generics.extQ` antiRule_2Pat `Generics.extQ` antiCompilationUnitPat `Generics.extQ` antiPackagePat `Generics.extQ` antiImportStatementPat `Generics.extQ` antiDocCommentPat `Generics.extQ` antiAnnotationPat `Generics.extQ` antiAnnotationArgumentsPat `Generics.extQ` antiAnnotationElementPat `Generics.extQ` antiRule_18Pat `Generics.extQ` antiExtendsListPat `Generics.extQ` antiImplementsListPat `Generics.extQ` antiFieldDeclarationPat `Generics.extQ` antiClassDeclarationPat `Generics.extQ` antiInterfaceDeclarationPat `Generics.extQ` antiAnnotationDeclarationPat `Generics.extQ` antiAnnotationTypeElementPat `Generics.extQ` antiEnumConstantPat `Generics.extQ` antiEnumConstantListPat `Generics.extQ` antiEnumDeclarationPat `Generics.extQ` antiNestedTypeDeclarationPat `Generics.extQ` antiRule_44Pat `Generics.extQ` antiMemberDeclarationPat `Generics.extQ` antiPrimitiveTypeKeywordPat `Generics.extQ` antiMemberAfterFirstIdPat `Generics.extQ` antiMoreTypeSpecifierPat `Generics.extQ` antiMemberRestPat `Generics.extQ` antiRule_49Pat `Generics.extQ` antiStatementBlockPat `Generics.extQ` antiVariableDeclaratorListPat `Generics.extQ` antiVariableDeclarationPat `Generics.extQ` antiOptVariableInitializerPat `Generics.extQ` antiVariableDeclaratorPat `Generics.extQ` antiVariableInitializerListPat `Generics.extQ` antiVariableInitializerPat `Generics.extQ` antiStaticInitializerPat `Generics.extQ` antiParameterListPat `Generics.extQ` antiParameterPat `Generics.extQ` antiStatementPat `Generics.extQ` antiOptExpressionPat `Generics.extQ` antiOptIdPat `Generics.extQ` antiStatementWithoutIfPat `Generics.extQ` antiOptElsePartPat `Generics.extQ` antiIfStatementPat `Generics.extQ` antiDoStatementPat `Generics.extQ` antiWhileStatementPat `Generics.extQ` antiForStatementPat `Generics.extQ` antiRule_65Pat `Generics.extQ` antiOptFinallyPat `Generics.extQ` antiTryStatementPat `Generics.extQ` antiRule_68Pat `Generics.extQ` antiSwitchStatementPat `Generics.extQ` antiExpressionPat `Generics.extQ` antiAssignmentOpPat `Generics.extQ` antiEqualityOpPat `Generics.extQ` antiRelationalOpPat `Generics.extQ` antiShiftOpPat `Generics.extQ` antiAdditiveOpPat `Generics.extQ` antiMultiplicativeOpPat `Generics.extQ` antiPrefixOpPat `Generics.extQ` antiPostfixOpPat `Generics.extQ` antiCreationExpressionPat `Generics.extQ` antiLiteralPat `Generics.extQ` antiArglistPat `Generics.extQ` antiTypeArgumentsPat `Generics.extQ` antiTypeArgumentPat `Generics.extQ` antiWildcardTypePat `Generics.extQ` antiTypeParametersPat `Generics.extQ` antiTypeParameterPat `Generics.extQ` antiTypePat `Generics.extQ` antiTypeSpecifierPat `Generics.extQ` antiModifierPat `Generics.extQ` antiCompoundNamePat) expr
+  dataToPatQ (const Nothing `Generics.extQ` antiJavaPat `Generics.extQ` antiOptDocCommentPat `Generics.extQ` antiTypeDeclarationPat `Generics.extQ` antiRule_2Pat `Generics.extQ` antiCompilationUnitPat `Generics.extQ` antiPackagePat `Generics.extQ` antiImportStatementPat `Generics.extQ` antiDocCommentPat `Generics.extQ` antiAnnotationPat `Generics.extQ` antiAnnotationArgumentsPat `Generics.extQ` antiAnnotationElementPat `Generics.extQ` antiRule_16Pat `Generics.extQ` antiExtendsListPat `Generics.extQ` antiImplementsListPat `Generics.extQ` antiFieldDeclarationPat `Generics.extQ` antiClassDeclarationPat `Generics.extQ` antiInterfaceDeclarationPat `Generics.extQ` antiAnnotationDeclarationPat `Generics.extQ` antiAnnotationTypeElementPat `Generics.extQ` antiEnumConstantPat `Generics.extQ` antiEnumConstantListPat `Generics.extQ` antiEnumDeclarationPat `Generics.extQ` antiNestedTypeDeclarationPat `Generics.extQ` antiRule_40Pat `Generics.extQ` antiMemberDeclarationPat `Generics.extQ` antiPrimitiveTypeKeywordPat `Generics.extQ` antiMemberAfterFirstIdPat `Generics.extQ` antiMoreTypeSpecifierPat `Generics.extQ` antiMemberRestPat `Generics.extQ` antiRule_47Pat `Generics.extQ` antiStatementBlockPat `Generics.extQ` antiVariableDeclaratorListPat `Generics.extQ` antiVariableDeclarationPat `Generics.extQ` antiOptVariableInitializerPat `Generics.extQ` antiVariableDeclaratorPat `Generics.extQ` antiVariableInitializerListPat `Generics.extQ` antiVariableInitializerPat `Generics.extQ` antiStaticInitializerPat `Generics.extQ` antiParameterListPat `Generics.extQ` antiParameterPat `Generics.extQ` antiStatementPat `Generics.extQ` antiOptExpressionPat `Generics.extQ` antiOptIdPat `Generics.extQ` antiStatementWithoutIfPat `Generics.extQ` antiOptElsePartPat `Generics.extQ` antiIfStatementPat `Generics.extQ` antiDoStatementPat `Generics.extQ` antiWhileStatementPat `Generics.extQ` antiForStatementPat `Generics.extQ` antiRule_63Pat `Generics.extQ` antiOptFinallyPat `Generics.extQ` antiTryStatementPat `Generics.extQ` antiRule_66Pat `Generics.extQ` antiSwitchStatementPat `Generics.extQ` antiExpressionPat `Generics.extQ` antiAssignmentOpPat `Generics.extQ` antiEqualityOpPat `Generics.extQ` antiRelationalOpPat `Generics.extQ` antiShiftOpPat `Generics.extQ` antiAdditiveOpPat `Generics.extQ` antiMultiplicativeOpPat `Generics.extQ` antiPrefixOpPat `Generics.extQ` antiPostfixOpPat `Generics.extQ` antiCreationExpressionPat `Generics.extQ` antiLiteralPat `Generics.extQ` antiArglistPat `Generics.extQ` antiTypeArgumentsPat `Generics.extQ` antiTypeArgumentPat `Generics.extQ` antiWildcardTypePat `Generics.extQ` antiTypeParametersPat `Generics.extQ` antiTypeParameterPat `Generics.extQ` antiTypePat `Generics.extQ` antiTypeSpecifierPat `Generics.extQ` antiModifierPat `Generics.extQ` antiCompoundNamePat) expr
 
 antiCompoundNameExp :: CompoundName -> Maybe (TH.Q TH.Exp )
 antiCompoundNameExp ( Anti_CompoundName v) = Just $ TH.varE (TH.mkName v)
@@ -178,12 +178,12 @@ antiSwitchStatementExp ( Anti_SwitchStatement v) = Just $ TH.varE (TH.mkName v)
 antiSwitchStatementExp _ = Nothing
 
 
-antiRule_68Exp :: [ Rule_68 ] -> Maybe (TH.Q TH.Exp)
-antiRule_68Exp ((Anti_Rule_68 v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiRule_2Exp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_18Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiNestedTypeDeclarationExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_49Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiStatementWithoutIfExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_65Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_68Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
+antiRule_66Exp :: [ Rule_66 ] -> Maybe (TH.Q TH.Exp)
+antiRule_66Exp ((Anti_Rule_66 v):rest) =
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiRule_2Exp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_16Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiNestedTypeDeclarationExp `Generics.extQ` antiRule_40Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_47Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiStatementWithoutIfExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_63Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_66Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
-antiRule_68Exp _ = Nothing
+antiRule_66Exp _ = Nothing
 
 
 antiTryStatementExp :: TryStatement -> Maybe (TH.Q TH.Exp )
@@ -196,12 +196,12 @@ antiOptFinallyExp ( Anti_OptFinally v) = Just $ TH.varE (TH.mkName v)
 antiOptFinallyExp _ = Nothing
 
 
-antiRule_65Exp :: [ Rule_65 ] -> Maybe (TH.Q TH.Exp)
-antiRule_65Exp ((Anti_Rule_65 v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiRule_2Exp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_18Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiNestedTypeDeclarationExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_49Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiStatementWithoutIfExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_65Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_68Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
+antiRule_63Exp :: [ Rule_63 ] -> Maybe (TH.Q TH.Exp)
+antiRule_63Exp ((Anti_Rule_63 v):rest) =
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiRule_2Exp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_16Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiNestedTypeDeclarationExp `Generics.extQ` antiRule_40Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_47Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiStatementWithoutIfExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_63Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_66Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
-antiRule_65Exp _ = Nothing
+antiRule_63Exp _ = Nothing
 
 
 antiForStatementExp :: ForStatement -> Maybe (TH.Q TH.Exp )
@@ -246,7 +246,7 @@ antiOptExpressionExp _ = Nothing
 
 antiStatementExp :: [ Statement ] -> Maybe (TH.Q TH.Exp)
 antiStatementExp ((Anti_Statement v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiRule_2Exp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_18Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiNestedTypeDeclarationExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_49Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiStatementWithoutIfExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_65Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_68Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiRule_2Exp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_16Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiNestedTypeDeclarationExp `Generics.extQ` antiRule_40Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_47Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiStatementWithoutIfExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_63Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_66Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
 antiStatementExp _ = Nothing
@@ -302,12 +302,12 @@ antiStatementBlockExp ( Anti_StatementBlock v) = Just $ TH.varE (TH.mkName v)
 antiStatementBlockExp _ = Nothing
 
 
-antiRule_49Exp :: [ Rule_49 ] -> Maybe (TH.Q TH.Exp)
-antiRule_49Exp ((Anti_Rule_49 v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiRule_2Exp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_18Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiNestedTypeDeclarationExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_49Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiStatementWithoutIfExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_65Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_68Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
+antiRule_47Exp :: [ Rule_47 ] -> Maybe (TH.Q TH.Exp)
+antiRule_47Exp ((Anti_Rule_47 v):rest) =
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiRule_2Exp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_16Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiNestedTypeDeclarationExp `Generics.extQ` antiRule_40Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_47Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiStatementWithoutIfExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_63Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_66Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
-antiRule_49Exp _ = Nothing
+antiRule_47Exp _ = Nothing
 
 
 antiMemberRestExp :: MemberRest -> Maybe (TH.Q TH.Exp )
@@ -335,12 +335,12 @@ antiMemberDeclarationExp ( Anti_MemberDeclaration v) = Just $ TH.varE (TH.mkName
 antiMemberDeclarationExp _ = Nothing
 
 
-antiRule_44Exp :: [ Rule_44 ] -> Maybe (TH.Q TH.Exp)
-antiRule_44Exp ((Anti_Rule_44 v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiRule_2Exp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_18Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiNestedTypeDeclarationExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_49Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiStatementWithoutIfExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_65Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_68Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
+antiRule_40Exp :: [ Rule_40 ] -> Maybe (TH.Q TH.Exp)
+antiRule_40Exp ((Anti_Rule_40 v):rest) =
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiRule_2Exp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_16Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiNestedTypeDeclarationExp `Generics.extQ` antiRule_40Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_47Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiStatementWithoutIfExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_63Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_66Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
-antiRule_44Exp _ = Nothing
+antiRule_40Exp _ = Nothing
 
 
 antiNestedTypeDeclarationExp :: NestedTypeDeclaration -> Maybe (TH.Q TH.Exp )
@@ -365,7 +365,7 @@ antiEnumConstantExp _ = Nothing
 
 antiAnnotationTypeElementExp :: [ AnnotationTypeElement ] -> Maybe (TH.Q TH.Exp)
 antiAnnotationTypeElementExp ((Anti_AnnotationTypeElement v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiRule_2Exp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_18Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiNestedTypeDeclarationExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_49Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiStatementWithoutIfExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_65Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_68Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiRule_2Exp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_16Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiNestedTypeDeclarationExp `Generics.extQ` antiRule_40Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_47Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiStatementWithoutIfExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_63Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_66Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
 antiAnnotationTypeElementExp _ = Nothing
@@ -388,7 +388,7 @@ antiClassDeclarationExp _ = Nothing
 
 antiFieldDeclarationExp :: [ FieldDeclaration ] -> Maybe (TH.Q TH.Exp)
 antiFieldDeclarationExp ((Anti_FieldDeclaration v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiRule_2Exp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_18Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiNestedTypeDeclarationExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_49Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiStatementWithoutIfExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_65Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_68Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiRule_2Exp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_16Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiNestedTypeDeclarationExp `Generics.extQ` antiRule_40Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_47Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiStatementWithoutIfExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_63Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_66Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
 antiFieldDeclarationExp _ = Nothing
@@ -404,12 +404,12 @@ antiExtendsListExp ( Anti_ExtendsList v) = Just $ TH.varE (TH.mkName v)
 antiExtendsListExp _ = Nothing
 
 
-antiRule_18Exp :: [ Rule_18 ] -> Maybe (TH.Q TH.Exp)
-antiRule_18Exp ((Anti_Rule_18 v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiRule_2Exp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_18Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiNestedTypeDeclarationExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_49Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiStatementWithoutIfExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_65Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_68Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
+antiRule_16Exp :: [ Rule_16 ] -> Maybe (TH.Q TH.Exp)
+antiRule_16Exp ((Anti_Rule_16 v):rest) =
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiRule_2Exp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_16Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiNestedTypeDeclarationExp `Generics.extQ` antiRule_40Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_47Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiStatementWithoutIfExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_63Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_66Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
-antiRule_18Exp _ = Nothing
+antiRule_16Exp _ = Nothing
 
 
 antiAnnotationElementExp :: AnnotationElement -> Maybe (TH.Q TH.Exp )
@@ -449,7 +449,7 @@ antiCompilationUnitExp _ = Nothing
 
 antiRule_2Exp :: [ Rule_2 ] -> Maybe (TH.Q TH.Exp)
 antiRule_2Exp ((Anti_Rule_2 v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiRule_2Exp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_18Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiNestedTypeDeclarationExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_49Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiStatementWithoutIfExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_65Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_68Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiRule_2Exp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_16Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiNestedTypeDeclarationExp `Generics.extQ` antiRule_40Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_47Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiStatementWithoutIfExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_63Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_66Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
 antiRule_2Exp _ = Nothing
@@ -581,9 +581,9 @@ antiSwitchStatementPat ( Anti_SwitchStatement v) = Just $ TH.varP (TH.mkName v)
 antiSwitchStatementPat _ = Nothing
 
 
-antiRule_68Pat :: [ Rule_68 ] -> Maybe (TH.Q TH.Pat)
-antiRule_68Pat [Anti_Rule_68 v] = Just $ TH.varP (TH.mkName v)
-antiRule_68Pat _ = Nothing
+antiRule_66Pat :: [ Rule_66 ] -> Maybe (TH.Q TH.Pat)
+antiRule_66Pat [Anti_Rule_66 v] = Just $ TH.varP (TH.mkName v)
+antiRule_66Pat _ = Nothing
 
 
 antiTryStatementPat :: TryStatement -> Maybe (TH.Q TH.Pat )
@@ -596,9 +596,9 @@ antiOptFinallyPat ( Anti_OptFinally v) = Just $ TH.varP (TH.mkName v)
 antiOptFinallyPat _ = Nothing
 
 
-antiRule_65Pat :: [ Rule_65 ] -> Maybe (TH.Q TH.Pat)
-antiRule_65Pat [Anti_Rule_65 v] = Just $ TH.varP (TH.mkName v)
-antiRule_65Pat _ = Nothing
+antiRule_63Pat :: [ Rule_63 ] -> Maybe (TH.Q TH.Pat)
+antiRule_63Pat [Anti_Rule_63 v] = Just $ TH.varP (TH.mkName v)
+antiRule_63Pat _ = Nothing
 
 
 antiForStatementPat :: ForStatement -> Maybe (TH.Q TH.Pat )
@@ -696,9 +696,9 @@ antiStatementBlockPat ( Anti_StatementBlock v) = Just $ TH.varP (TH.mkName v)
 antiStatementBlockPat _ = Nothing
 
 
-antiRule_49Pat :: [ Rule_49 ] -> Maybe (TH.Q TH.Pat)
-antiRule_49Pat [Anti_Rule_49 v] = Just $ TH.varP (TH.mkName v)
-antiRule_49Pat _ = Nothing
+antiRule_47Pat :: [ Rule_47 ] -> Maybe (TH.Q TH.Pat)
+antiRule_47Pat [Anti_Rule_47 v] = Just $ TH.varP (TH.mkName v)
+antiRule_47Pat _ = Nothing
 
 
 antiMemberRestPat :: MemberRest -> Maybe (TH.Q TH.Pat )
@@ -726,9 +726,9 @@ antiMemberDeclarationPat ( Anti_MemberDeclaration v) = Just $ TH.varP (TH.mkName
 antiMemberDeclarationPat _ = Nothing
 
 
-antiRule_44Pat :: [ Rule_44 ] -> Maybe (TH.Q TH.Pat)
-antiRule_44Pat [Anti_Rule_44 v] = Just $ TH.varP (TH.mkName v)
-antiRule_44Pat _ = Nothing
+antiRule_40Pat :: [ Rule_40 ] -> Maybe (TH.Q TH.Pat)
+antiRule_40Pat [Anti_Rule_40 v] = Just $ TH.varP (TH.mkName v)
+antiRule_40Pat _ = Nothing
 
 
 antiNestedTypeDeclarationPat :: NestedTypeDeclaration -> Maybe (TH.Q TH.Pat )
@@ -786,9 +786,9 @@ antiExtendsListPat ( Anti_ExtendsList v) = Just $ TH.varP (TH.mkName v)
 antiExtendsListPat _ = Nothing
 
 
-antiRule_18Pat :: [ Rule_18 ] -> Maybe (TH.Q TH.Pat)
-antiRule_18Pat [Anti_Rule_18 v] = Just $ TH.varP (TH.mkName v)
-antiRule_18Pat _ = Nothing
+antiRule_16Pat :: [ Rule_16 ] -> Maybe (TH.Q TH.Pat)
+antiRule_16Pat [Anti_Rule_16 v] = Just $ TH.varP (TH.mkName v)
+antiRule_16Pat _ = Nothing
 
 
 antiAnnotationElementPat :: AnnotationElement -> Maybe (TH.Q TH.Pat )
@@ -853,395 +853,395 @@ quoteJavaDecs s = return []
 getJava ( Ctr__Java__0 s) = s
 
 java :: QuasiQuoter
-java = QuasiQuoter (quoteJavaExp "tok_Java_dummy_172" getJava ) (quoteJavaPat "tok_Java_dummy_172" getJava ) quoteJavaType quoteJavaDecs
+java = QuasiQuoter (quoteJavaExp "tok_Java_dummy_170" getJava ) (quoteJavaPat "tok_Java_dummy_170" getJava ) quoteJavaType quoteJavaDecs
 
 getAdditiveOp ( Ctr__Java__1 s) = s
 
 additiveOp :: QuasiQuoter
-additiveOp = QuasiQuoter (quoteJavaExp "tok_AdditiveOp_dummy_171" getAdditiveOp ) (quoteJavaPat "tok_AdditiveOp_dummy_171" getAdditiveOp ) quoteJavaType quoteJavaDecs
+additiveOp = QuasiQuoter (quoteJavaExp "tok_AdditiveOp_dummy_169" getAdditiveOp ) (quoteJavaPat "tok_AdditiveOp_dummy_169" getAdditiveOp ) quoteJavaType quoteJavaDecs
 
 getAnnotation ( Ctr__Java__2 s) = s
 
 annotation :: QuasiQuoter
-annotation = QuasiQuoter (quoteJavaExp "tok_Annotation_dummy_170" getAnnotation ) (quoteJavaPat "tok_Annotation_dummy_170" getAnnotation ) quoteJavaType quoteJavaDecs
+annotation = QuasiQuoter (quoteJavaExp "tok_Annotation_dummy_168" getAnnotation ) (quoteJavaPat "tok_Annotation_dummy_168" getAnnotation ) quoteJavaType quoteJavaDecs
 
 getAnnotationArguments ( Ctr__Java__3 s) = s
 
 annotationArguments :: QuasiQuoter
-annotationArguments = QuasiQuoter (quoteJavaExp "tok_AnnotationArguments_dummy_169" getAnnotationArguments ) (quoteJavaPat "tok_AnnotationArguments_dummy_169" getAnnotationArguments ) quoteJavaType quoteJavaDecs
+annotationArguments = QuasiQuoter (quoteJavaExp "tok_AnnotationArguments_dummy_167" getAnnotationArguments ) (quoteJavaPat "tok_AnnotationArguments_dummy_167" getAnnotationArguments ) quoteJavaType quoteJavaDecs
 
 getAnnotationDeclaration ( Ctr__Java__4 s) = s
 
 annotationDeclaration :: QuasiQuoter
-annotationDeclaration = QuasiQuoter (quoteJavaExp "tok_AnnotationDeclaration_dummy_168" getAnnotationDeclaration ) (quoteJavaPat "tok_AnnotationDeclaration_dummy_168" getAnnotationDeclaration ) quoteJavaType quoteJavaDecs
+annotationDeclaration = QuasiQuoter (quoteJavaExp "tok_AnnotationDeclaration_dummy_166" getAnnotationDeclaration ) (quoteJavaPat "tok_AnnotationDeclaration_dummy_166" getAnnotationDeclaration ) quoteJavaType quoteJavaDecs
 
 getAnnotationElement ( Ctr__Java__5 s) = s
 
 annotationElement :: QuasiQuoter
-annotationElement = QuasiQuoter (quoteJavaExp "tok_AnnotationElement_dummy_167" getAnnotationElement ) (quoteJavaPat "tok_AnnotationElement_dummy_167" getAnnotationElement ) quoteJavaType quoteJavaDecs
+annotationElement = QuasiQuoter (quoteJavaExp "tok_AnnotationElement_dummy_165" getAnnotationElement ) (quoteJavaPat "tok_AnnotationElement_dummy_165" getAnnotationElement ) quoteJavaType quoteJavaDecs
 
 getAnnotationList ( Ctr__Java__6 s) = s
 
 annotationList :: QuasiQuoter
-annotationList = QuasiQuoter (quoteJavaExp "tok_AnnotationList_dummy_166" getAnnotationList ) (quoteJavaPat "tok_AnnotationList_dummy_166" getAnnotationList ) quoteJavaType quoteJavaDecs
+annotationList = QuasiQuoter (quoteJavaExp "tok_AnnotationList_dummy_164" getAnnotationList ) (quoteJavaPat "tok_AnnotationList_dummy_164" getAnnotationList ) quoteJavaType quoteJavaDecs
 
 getAnnotationTypeElement ( Ctr__Java__7 s) = s
 
 annotationTypeElement :: QuasiQuoter
-annotationTypeElement = QuasiQuoter (quoteJavaExp "tok_AnnotationTypeElement_dummy_165" getAnnotationTypeElement ) (quoteJavaPat "tok_AnnotationTypeElement_dummy_165" getAnnotationTypeElement ) quoteJavaType quoteJavaDecs
+annotationTypeElement = QuasiQuoter (quoteJavaExp "tok_AnnotationTypeElement_dummy_163" getAnnotationTypeElement ) (quoteJavaPat "tok_AnnotationTypeElement_dummy_163" getAnnotationTypeElement ) quoteJavaType quoteJavaDecs
 
 getAnnotationTypeElementList ( Ctr__Java__8 s) = s
 
 annotationTypeElementList :: QuasiQuoter
-annotationTypeElementList = QuasiQuoter (quoteJavaExp "tok_AnnotationTypeElementList_dummy_164" getAnnotationTypeElementList ) (quoteJavaPat "tok_AnnotationTypeElementList_dummy_164" getAnnotationTypeElementList ) quoteJavaType quoteJavaDecs
+annotationTypeElementList = QuasiQuoter (quoteJavaExp "tok_AnnotationTypeElementList_dummy_162" getAnnotationTypeElementList ) (quoteJavaPat "tok_AnnotationTypeElementList_dummy_162" getAnnotationTypeElementList ) quoteJavaType quoteJavaDecs
 
 getArglist ( Ctr__Java__9 s) = s
 
 arglist :: QuasiQuoter
-arglist = QuasiQuoter (quoteJavaExp "tok_Arglist_dummy_163" getArglist ) (quoteJavaPat "tok_Arglist_dummy_163" getArglist ) quoteJavaType quoteJavaDecs
+arglist = QuasiQuoter (quoteJavaExp "tok_Arglist_dummy_161" getArglist ) (quoteJavaPat "tok_Arglist_dummy_161" getArglist ) quoteJavaType quoteJavaDecs
 
 getAssignmentOp ( Ctr__Java__10 s) = s
 
 assignmentOp :: QuasiQuoter
-assignmentOp = QuasiQuoter (quoteJavaExp "tok_AssignmentOp_dummy_162" getAssignmentOp ) (quoteJavaPat "tok_AssignmentOp_dummy_162" getAssignmentOp ) quoteJavaType quoteJavaDecs
+assignmentOp = QuasiQuoter (quoteJavaExp "tok_AssignmentOp_dummy_160" getAssignmentOp ) (quoteJavaPat "tok_AssignmentOp_dummy_160" getAssignmentOp ) quoteJavaType quoteJavaDecs
 
 getCatchList ( Ctr__Java__11 s) = s
 
 catchList :: QuasiQuoter
-catchList = QuasiQuoter (quoteJavaExp "tok_CatchList_dummy_161" getCatchList ) (quoteJavaPat "tok_CatchList_dummy_161" getCatchList ) quoteJavaType quoteJavaDecs
+catchList = QuasiQuoter (quoteJavaExp "tok_CatchList_dummy_159" getCatchList ) (quoteJavaPat "tok_CatchList_dummy_159" getCatchList ) quoteJavaType quoteJavaDecs
 
 getClassDeclaration ( Ctr__Java__12 s) = s
 
 classDeclaration :: QuasiQuoter
-classDeclaration = QuasiQuoter (quoteJavaExp "tok_ClassDeclaration_dummy_160" getClassDeclaration ) (quoteJavaPat "tok_ClassDeclaration_dummy_160" getClassDeclaration ) quoteJavaType quoteJavaDecs
+classDeclaration = QuasiQuoter (quoteJavaExp "tok_ClassDeclaration_dummy_158" getClassDeclaration ) (quoteJavaPat "tok_ClassDeclaration_dummy_158" getClassDeclaration ) quoteJavaType quoteJavaDecs
 
 getCompilationUnit ( Ctr__Java__13 s) = s
 
 compilationUnit :: QuasiQuoter
-compilationUnit = QuasiQuoter (quoteJavaExp "tok_CompilationUnit_dummy_159" getCompilationUnit ) (quoteJavaPat "tok_CompilationUnit_dummy_159" getCompilationUnit ) quoteJavaType quoteJavaDecs
+compilationUnit = QuasiQuoter (quoteJavaExp "tok_CompilationUnit_dummy_157" getCompilationUnit ) (quoteJavaPat "tok_CompilationUnit_dummy_157" getCompilationUnit ) quoteJavaType quoteJavaDecs
 
 getCompoundName ( Ctr__Java__14 s) = s
 
 compoundName :: QuasiQuoter
-compoundName = QuasiQuoter (quoteJavaExp "tok_CompoundName_dummy_158" getCompoundName ) (quoteJavaPat "tok_CompoundName_dummy_158" getCompoundName ) quoteJavaType quoteJavaDecs
+compoundName = QuasiQuoter (quoteJavaExp "tok_CompoundName_dummy_156" getCompoundName ) (quoteJavaPat "tok_CompoundName_dummy_156" getCompoundName ) quoteJavaType quoteJavaDecs
 
 getCreationExpression ( Ctr__Java__15 s) = s
 
 creationExpression :: QuasiQuoter
-creationExpression = QuasiQuoter (quoteJavaExp "tok_CreationExpression_dummy_157" getCreationExpression ) (quoteJavaPat "tok_CreationExpression_dummy_157" getCreationExpression ) quoteJavaType quoteJavaDecs
+creationExpression = QuasiQuoter (quoteJavaExp "tok_CreationExpression_dummy_155" getCreationExpression ) (quoteJavaPat "tok_CreationExpression_dummy_155" getCreationExpression ) quoteJavaType quoteJavaDecs
 
 getDoStatement ( Ctr__Java__16 s) = s
 
 doStatement :: QuasiQuoter
-doStatement = QuasiQuoter (quoteJavaExp "tok_DoStatement_dummy_156" getDoStatement ) (quoteJavaPat "tok_DoStatement_dummy_156" getDoStatement ) quoteJavaType quoteJavaDecs
+doStatement = QuasiQuoter (quoteJavaExp "tok_DoStatement_dummy_154" getDoStatement ) (quoteJavaPat "tok_DoStatement_dummy_154" getDoStatement ) quoteJavaType quoteJavaDecs
 
 getDocComment ( Ctr__Java__17 s) = s
 
 docComment :: QuasiQuoter
-docComment = QuasiQuoter (quoteJavaExp "tok_DocComment_dummy_155" getDocComment ) (quoteJavaPat "tok_DocComment_dummy_155" getDocComment ) quoteJavaType quoteJavaDecs
+docComment = QuasiQuoter (quoteJavaExp "tok_DocComment_dummy_153" getDocComment ) (quoteJavaPat "tok_DocComment_dummy_153" getDocComment ) quoteJavaType quoteJavaDecs
 
 getEnumConstant ( Ctr__Java__18 s) = s
 
 enumConstant :: QuasiQuoter
-enumConstant = QuasiQuoter (quoteJavaExp "tok_EnumConstant_dummy_154" getEnumConstant ) (quoteJavaPat "tok_EnumConstant_dummy_154" getEnumConstant ) quoteJavaType quoteJavaDecs
+enumConstant = QuasiQuoter (quoteJavaExp "tok_EnumConstant_dummy_152" getEnumConstant ) (quoteJavaPat "tok_EnumConstant_dummy_152" getEnumConstant ) quoteJavaType quoteJavaDecs
 
 getEnumConstantList ( Ctr__Java__19 s) = s
 
 enumConstantList :: QuasiQuoter
-enumConstantList = QuasiQuoter (quoteJavaExp "tok_EnumConstantList_dummy_153" getEnumConstantList ) (quoteJavaPat "tok_EnumConstantList_dummy_153" getEnumConstantList ) quoteJavaType quoteJavaDecs
+enumConstantList = QuasiQuoter (quoteJavaExp "tok_EnumConstantList_dummy_151" getEnumConstantList ) (quoteJavaPat "tok_EnumConstantList_dummy_151" getEnumConstantList ) quoteJavaType quoteJavaDecs
 
 getEnumDeclaration ( Ctr__Java__20 s) = s
 
 enumDeclaration :: QuasiQuoter
-enumDeclaration = QuasiQuoter (quoteJavaExp "tok_EnumDeclaration_dummy_152" getEnumDeclaration ) (quoteJavaPat "tok_EnumDeclaration_dummy_152" getEnumDeclaration ) quoteJavaType quoteJavaDecs
+enumDeclaration = QuasiQuoter (quoteJavaExp "tok_EnumDeclaration_dummy_150" getEnumDeclaration ) (quoteJavaPat "tok_EnumDeclaration_dummy_150" getEnumDeclaration ) quoteJavaType quoteJavaDecs
 
 getEqualityOp ( Ctr__Java__21 s) = s
 
 equalityOp :: QuasiQuoter
-equalityOp = QuasiQuoter (quoteJavaExp "tok_EqualityOp_dummy_151" getEqualityOp ) (quoteJavaPat "tok_EqualityOp_dummy_151" getEqualityOp ) quoteJavaType quoteJavaDecs
+equalityOp = QuasiQuoter (quoteJavaExp "tok_EqualityOp_dummy_149" getEqualityOp ) (quoteJavaPat "tok_EqualityOp_dummy_149" getEqualityOp ) quoteJavaType quoteJavaDecs
 
 getExpression ( Ctr__Java__22 s) = s
 
 expression :: QuasiQuoter
-expression = QuasiQuoter (quoteJavaExp "tok_Expression_dummy_150" getExpression ) (quoteJavaPat "tok_Expression_dummy_150" getExpression ) quoteJavaType quoteJavaDecs
+expression = QuasiQuoter (quoteJavaExp "tok_Expression_dummy_148" getExpression ) (quoteJavaPat "tok_Expression_dummy_148" getExpression ) quoteJavaType quoteJavaDecs
 
 getExtendsList ( Ctr__Java__23 s) = s
 
 extendsList :: QuasiQuoter
-extendsList = QuasiQuoter (quoteJavaExp "tok_ExtendsList_dummy_149" getExtendsList ) (quoteJavaPat "tok_ExtendsList_dummy_149" getExtendsList ) quoteJavaType quoteJavaDecs
+extendsList = QuasiQuoter (quoteJavaExp "tok_ExtendsList_dummy_147" getExtendsList ) (quoteJavaPat "tok_ExtendsList_dummy_147" getExtendsList ) quoteJavaType quoteJavaDecs
 
 getFieldDeclaration ( Ctr__Java__24 s) = s
 
 fieldDeclaration :: QuasiQuoter
-fieldDeclaration = QuasiQuoter (quoteJavaExp "tok_FieldDeclaration_dummy_148" getFieldDeclaration ) (quoteJavaPat "tok_FieldDeclaration_dummy_148" getFieldDeclaration ) quoteJavaType quoteJavaDecs
+fieldDeclaration = QuasiQuoter (quoteJavaExp "tok_FieldDeclaration_dummy_146" getFieldDeclaration ) (quoteJavaPat "tok_FieldDeclaration_dummy_146" getFieldDeclaration ) quoteJavaType quoteJavaDecs
 
 getFieldDeclarationList ( Ctr__Java__25 s) = s
 
 fieldDeclarationList :: QuasiQuoter
-fieldDeclarationList = QuasiQuoter (quoteJavaExp "tok_FieldDeclarationList_dummy_147" getFieldDeclarationList ) (quoteJavaPat "tok_FieldDeclarationList_dummy_147" getFieldDeclarationList ) quoteJavaType quoteJavaDecs
+fieldDeclarationList = QuasiQuoter (quoteJavaExp "tok_FieldDeclarationList_dummy_145" getFieldDeclarationList ) (quoteJavaPat "tok_FieldDeclarationList_dummy_145" getFieldDeclarationList ) quoteJavaType quoteJavaDecs
 
 getForStatement ( Ctr__Java__26 s) = s
 
 forStatement :: QuasiQuoter
-forStatement = QuasiQuoter (quoteJavaExp "tok_ForStatement_dummy_146" getForStatement ) (quoteJavaPat "tok_ForStatement_dummy_146" getForStatement ) quoteJavaType quoteJavaDecs
+forStatement = QuasiQuoter (quoteJavaExp "tok_ForStatement_dummy_144" getForStatement ) (quoteJavaPat "tok_ForStatement_dummy_144" getForStatement ) quoteJavaType quoteJavaDecs
 
 getIfStatement ( Ctr__Java__27 s) = s
 
 ifStatement :: QuasiQuoter
-ifStatement = QuasiQuoter (quoteJavaExp "tok_IfStatement_dummy_145" getIfStatement ) (quoteJavaPat "tok_IfStatement_dummy_145" getIfStatement ) quoteJavaType quoteJavaDecs
+ifStatement = QuasiQuoter (quoteJavaExp "tok_IfStatement_dummy_143" getIfStatement ) (quoteJavaPat "tok_IfStatement_dummy_143" getIfStatement ) quoteJavaType quoteJavaDecs
 
 getImplementsList ( Ctr__Java__28 s) = s
 
 implementsList :: QuasiQuoter
-implementsList = QuasiQuoter (quoteJavaExp "tok_ImplementsList_dummy_144" getImplementsList ) (quoteJavaPat "tok_ImplementsList_dummy_144" getImplementsList ) quoteJavaType quoteJavaDecs
+implementsList = QuasiQuoter (quoteJavaExp "tok_ImplementsList_dummy_142" getImplementsList ) (quoteJavaPat "tok_ImplementsList_dummy_142" getImplementsList ) quoteJavaType quoteJavaDecs
 
 getImportList ( Ctr__Java__29 s) = s
 
 importList :: QuasiQuoter
-importList = QuasiQuoter (quoteJavaExp "tok_ImportList_dummy_143" getImportList ) (quoteJavaPat "tok_ImportList_dummy_143" getImportList ) quoteJavaType quoteJavaDecs
+importList = QuasiQuoter (quoteJavaExp "tok_ImportList_dummy_141" getImportList ) (quoteJavaPat "tok_ImportList_dummy_141" getImportList ) quoteJavaType quoteJavaDecs
 
 getImportStatement ( Ctr__Java__30 s) = s
 
 importStatement :: QuasiQuoter
-importStatement = QuasiQuoter (quoteJavaExp "tok_ImportStatement_dummy_142" getImportStatement ) (quoteJavaPat "tok_ImportStatement_dummy_142" getImportStatement ) quoteJavaType quoteJavaDecs
+importStatement = QuasiQuoter (quoteJavaExp "tok_ImportStatement_dummy_140" getImportStatement ) (quoteJavaPat "tok_ImportStatement_dummy_140" getImportStatement ) quoteJavaType quoteJavaDecs
 
 getInterfaceDeclaration ( Ctr__Java__31 s) = s
 
 interfaceDeclaration :: QuasiQuoter
-interfaceDeclaration = QuasiQuoter (quoteJavaExp "tok_InterfaceDeclaration_dummy_141" getInterfaceDeclaration ) (quoteJavaPat "tok_InterfaceDeclaration_dummy_141" getInterfaceDeclaration ) quoteJavaType quoteJavaDecs
+interfaceDeclaration = QuasiQuoter (quoteJavaExp "tok_InterfaceDeclaration_dummy_139" getInterfaceDeclaration ) (quoteJavaPat "tok_InterfaceDeclaration_dummy_139" getInterfaceDeclaration ) quoteJavaType quoteJavaDecs
 
 getLiteral ( Ctr__Java__32 s) = s
 
 literal :: QuasiQuoter
-literal = QuasiQuoter (quoteJavaExp "tok_Literal_dummy_140" getLiteral ) (quoteJavaPat "tok_Literal_dummy_140" getLiteral ) quoteJavaType quoteJavaDecs
+literal = QuasiQuoter (quoteJavaExp "tok_Literal_dummy_138" getLiteral ) (quoteJavaPat "tok_Literal_dummy_138" getLiteral ) quoteJavaType quoteJavaDecs
 
 getMemberAfterFirstId ( Ctr__Java__33 s) = s
 
 memberAfterFirstId :: QuasiQuoter
-memberAfterFirstId = QuasiQuoter (quoteJavaExp "tok_MemberAfterFirstId_dummy_139" getMemberAfterFirstId ) (quoteJavaPat "tok_MemberAfterFirstId_dummy_139" getMemberAfterFirstId ) quoteJavaType quoteJavaDecs
+memberAfterFirstId = QuasiQuoter (quoteJavaExp "tok_MemberAfterFirstId_dummy_137" getMemberAfterFirstId ) (quoteJavaPat "tok_MemberAfterFirstId_dummy_137" getMemberAfterFirstId ) quoteJavaType quoteJavaDecs
 
 getMemberDeclaration ( Ctr__Java__34 s) = s
 
 memberDeclaration :: QuasiQuoter
-memberDeclaration = QuasiQuoter (quoteJavaExp "tok_MemberDeclaration_dummy_138" getMemberDeclaration ) (quoteJavaPat "tok_MemberDeclaration_dummy_138" getMemberDeclaration ) quoteJavaType quoteJavaDecs
+memberDeclaration = QuasiQuoter (quoteJavaExp "tok_MemberDeclaration_dummy_136" getMemberDeclaration ) (quoteJavaPat "tok_MemberDeclaration_dummy_136" getMemberDeclaration ) quoteJavaType quoteJavaDecs
 
 getMemberRest ( Ctr__Java__35 s) = s
 
 memberRest :: QuasiQuoter
-memberRest = QuasiQuoter (quoteJavaExp "tok_MemberRest_dummy_137" getMemberRest ) (quoteJavaPat "tok_MemberRest_dummy_137" getMemberRest ) quoteJavaType quoteJavaDecs
+memberRest = QuasiQuoter (quoteJavaExp "tok_MemberRest_dummy_135" getMemberRest ) (quoteJavaPat "tok_MemberRest_dummy_135" getMemberRest ) quoteJavaType quoteJavaDecs
 
 getModifier ( Ctr__Java__36 s) = s
 
 modifier :: QuasiQuoter
-modifier = QuasiQuoter (quoteJavaExp "tok_Modifier_dummy_136" getModifier ) (quoteJavaPat "tok_Modifier_dummy_136" getModifier ) quoteJavaType quoteJavaDecs
+modifier = QuasiQuoter (quoteJavaExp "tok_Modifier_dummy_134" getModifier ) (quoteJavaPat "tok_Modifier_dummy_134" getModifier ) quoteJavaType quoteJavaDecs
 
 getModifierList ( Ctr__Java__37 s) = s
 
 modifierList :: QuasiQuoter
-modifierList = QuasiQuoter (quoteJavaExp "tok_ModifierList_dummy_135" getModifierList ) (quoteJavaPat "tok_ModifierList_dummy_135" getModifierList ) quoteJavaType quoteJavaDecs
+modifierList = QuasiQuoter (quoteJavaExp "tok_ModifierList_dummy_133" getModifierList ) (quoteJavaPat "tok_ModifierList_dummy_133" getModifierList ) quoteJavaType quoteJavaDecs
 
 getMoreTypeSpecifier ( Ctr__Java__38 s) = s
 
 moreTypeSpecifier :: QuasiQuoter
-moreTypeSpecifier = QuasiQuoter (quoteJavaExp "tok_MoreTypeSpecifier_dummy_134" getMoreTypeSpecifier ) (quoteJavaPat "tok_MoreTypeSpecifier_dummy_134" getMoreTypeSpecifier ) quoteJavaType quoteJavaDecs
+moreTypeSpecifier = QuasiQuoter (quoteJavaExp "tok_MoreTypeSpecifier_dummy_132" getMoreTypeSpecifier ) (quoteJavaPat "tok_MoreTypeSpecifier_dummy_132" getMoreTypeSpecifier ) quoteJavaType quoteJavaDecs
 
 getMoreVariableDeclarators ( Ctr__Java__39 s) = s
 
 moreVariableDeclarators :: QuasiQuoter
-moreVariableDeclarators = QuasiQuoter (quoteJavaExp "tok_MoreVariableDeclarators_dummy_133" getMoreVariableDeclarators ) (quoteJavaPat "tok_MoreVariableDeclarators_dummy_133" getMoreVariableDeclarators ) quoteJavaType quoteJavaDecs
+moreVariableDeclarators = QuasiQuoter (quoteJavaExp "tok_MoreVariableDeclarators_dummy_131" getMoreVariableDeclarators ) (quoteJavaPat "tok_MoreVariableDeclarators_dummy_131" getMoreVariableDeclarators ) quoteJavaType quoteJavaDecs
 
 getMultiplicativeOp ( Ctr__Java__40 s) = s
 
 multiplicativeOp :: QuasiQuoter
-multiplicativeOp = QuasiQuoter (quoteJavaExp "tok_MultiplicativeOp_dummy_132" getMultiplicativeOp ) (quoteJavaPat "tok_MultiplicativeOp_dummy_132" getMultiplicativeOp ) quoteJavaType quoteJavaDecs
+multiplicativeOp = QuasiQuoter (quoteJavaExp "tok_MultiplicativeOp_dummy_130" getMultiplicativeOp ) (quoteJavaPat "tok_MultiplicativeOp_dummy_130" getMultiplicativeOp ) quoteJavaType quoteJavaDecs
 
 getNestedTypeDeclaration ( Ctr__Java__41 s) = s
 
 nestedTypeDeclaration :: QuasiQuoter
-nestedTypeDeclaration = QuasiQuoter (quoteJavaExp "tok_NestedTypeDeclaration_dummy_131" getNestedTypeDeclaration ) (quoteJavaPat "tok_NestedTypeDeclaration_dummy_131" getNestedTypeDeclaration ) quoteJavaType quoteJavaDecs
+nestedTypeDeclaration = QuasiQuoter (quoteJavaExp "tok_NestedTypeDeclaration_dummy_129" getNestedTypeDeclaration ) (quoteJavaPat "tok_NestedTypeDeclaration_dummy_129" getNestedTypeDeclaration ) quoteJavaType quoteJavaDecs
 
 getOptDocComment ( Ctr__Java__42 s) = s
 
 optDocComment :: QuasiQuoter
-optDocComment = QuasiQuoter (quoteJavaExp "tok_OptDocComment_dummy_130" getOptDocComment ) (quoteJavaPat "tok_OptDocComment_dummy_130" getOptDocComment ) quoteJavaType quoteJavaDecs
+optDocComment = QuasiQuoter (quoteJavaExp "tok_OptDocComment_dummy_128" getOptDocComment ) (quoteJavaPat "tok_OptDocComment_dummy_128" getOptDocComment ) quoteJavaType quoteJavaDecs
 
 getOptElsePart ( Ctr__Java__43 s) = s
 
 optElsePart :: QuasiQuoter
-optElsePart = QuasiQuoter (quoteJavaExp "tok_OptElsePart_dummy_129" getOptElsePart ) (quoteJavaPat "tok_OptElsePart_dummy_129" getOptElsePart ) quoteJavaType quoteJavaDecs
+optElsePart = QuasiQuoter (quoteJavaExp "tok_OptElsePart_dummy_127" getOptElsePart ) (quoteJavaPat "tok_OptElsePart_dummy_127" getOptElsePart ) quoteJavaType quoteJavaDecs
 
 getOptExpression ( Ctr__Java__44 s) = s
 
 optExpression :: QuasiQuoter
-optExpression = QuasiQuoter (quoteJavaExp "tok_OptExpression_dummy_128" getOptExpression ) (quoteJavaPat "tok_OptExpression_dummy_128" getOptExpression ) quoteJavaType quoteJavaDecs
+optExpression = QuasiQuoter (quoteJavaExp "tok_OptExpression_dummy_126" getOptExpression ) (quoteJavaPat "tok_OptExpression_dummy_126" getOptExpression ) quoteJavaType quoteJavaDecs
 
 getOptFinally ( Ctr__Java__45 s) = s
 
 optFinally :: QuasiQuoter
-optFinally = QuasiQuoter (quoteJavaExp "tok_OptFinally_dummy_127" getOptFinally ) (quoteJavaPat "tok_OptFinally_dummy_127" getOptFinally ) quoteJavaType quoteJavaDecs
+optFinally = QuasiQuoter (quoteJavaExp "tok_OptFinally_dummy_125" getOptFinally ) (quoteJavaPat "tok_OptFinally_dummy_125" getOptFinally ) quoteJavaType quoteJavaDecs
 
 getOptId ( Ctr__Java__46 s) = s
 
 optId :: QuasiQuoter
-optId = QuasiQuoter (quoteJavaExp "tok_OptId_dummy_126" getOptId ) (quoteJavaPat "tok_OptId_dummy_126" getOptId ) quoteJavaType quoteJavaDecs
+optId = QuasiQuoter (quoteJavaExp "tok_OptId_dummy_124" getOptId ) (quoteJavaPat "tok_OptId_dummy_124" getOptId ) quoteJavaType quoteJavaDecs
 
 getOptVariableInitializer ( Ctr__Java__47 s) = s
 
 optVariableInitializer :: QuasiQuoter
-optVariableInitializer = QuasiQuoter (quoteJavaExp "tok_OptVariableInitializer_dummy_125" getOptVariableInitializer ) (quoteJavaPat "tok_OptVariableInitializer_dummy_125" getOptVariableInitializer ) quoteJavaType quoteJavaDecs
+optVariableInitializer = QuasiQuoter (quoteJavaExp "tok_OptVariableInitializer_dummy_123" getOptVariableInitializer ) (quoteJavaPat "tok_OptVariableInitializer_dummy_123" getOptVariableInitializer ) quoteJavaType quoteJavaDecs
 
 getPackage ( Ctr__Java__48 s) = s
 
 package :: QuasiQuoter
-package = QuasiQuoter (quoteJavaExp "tok_Package_dummy_124" getPackage ) (quoteJavaPat "tok_Package_dummy_124" getPackage ) quoteJavaType quoteJavaDecs
+package = QuasiQuoter (quoteJavaExp "tok_Package_dummy_122" getPackage ) (quoteJavaPat "tok_Package_dummy_122" getPackage ) quoteJavaType quoteJavaDecs
 
 getParameter ( Ctr__Java__49 s) = s
 
 parameter :: QuasiQuoter
-parameter = QuasiQuoter (quoteJavaExp "tok_Parameter_dummy_123" getParameter ) (quoteJavaPat "tok_Parameter_dummy_123" getParameter ) quoteJavaType quoteJavaDecs
+parameter = QuasiQuoter (quoteJavaExp "tok_Parameter_dummy_121" getParameter ) (quoteJavaPat "tok_Parameter_dummy_121" getParameter ) quoteJavaType quoteJavaDecs
 
 getParameterList ( Ctr__Java__50 s) = s
 
 parameterList :: QuasiQuoter
-parameterList = QuasiQuoter (quoteJavaExp "tok_ParameterList_dummy_122" getParameterList ) (quoteJavaPat "tok_ParameterList_dummy_122" getParameterList ) quoteJavaType quoteJavaDecs
+parameterList = QuasiQuoter (quoteJavaExp "tok_ParameterList_dummy_120" getParameterList ) (quoteJavaPat "tok_ParameterList_dummy_120" getParameterList ) quoteJavaType quoteJavaDecs
 
 getPostfixOp ( Ctr__Java__51 s) = s
 
 postfixOp :: QuasiQuoter
-postfixOp = QuasiQuoter (quoteJavaExp "tok_PostfixOp_dummy_121" getPostfixOp ) (quoteJavaPat "tok_PostfixOp_dummy_121" getPostfixOp ) quoteJavaType quoteJavaDecs
+postfixOp = QuasiQuoter (quoteJavaExp "tok_PostfixOp_dummy_119" getPostfixOp ) (quoteJavaPat "tok_PostfixOp_dummy_119" getPostfixOp ) quoteJavaType quoteJavaDecs
 
 getPrefixOp ( Ctr__Java__52 s) = s
 
 prefixOp :: QuasiQuoter
-prefixOp = QuasiQuoter (quoteJavaExp "tok_PrefixOp_dummy_120" getPrefixOp ) (quoteJavaPat "tok_PrefixOp_dummy_120" getPrefixOp ) quoteJavaType quoteJavaDecs
+prefixOp = QuasiQuoter (quoteJavaExp "tok_PrefixOp_dummy_118" getPrefixOp ) (quoteJavaPat "tok_PrefixOp_dummy_118" getPrefixOp ) quoteJavaType quoteJavaDecs
 
 getPrimitiveTypeKeyword ( Ctr__Java__53 s) = s
 
 primitiveTypeKeyword :: QuasiQuoter
-primitiveTypeKeyword = QuasiQuoter (quoteJavaExp "tok_PrimitiveTypeKeyword_dummy_119" getPrimitiveTypeKeyword ) (quoteJavaPat "tok_PrimitiveTypeKeyword_dummy_119" getPrimitiveTypeKeyword ) quoteJavaType quoteJavaDecs
+primitiveTypeKeyword = QuasiQuoter (quoteJavaExp "tok_PrimitiveTypeKeyword_dummy_117" getPrimitiveTypeKeyword ) (quoteJavaPat "tok_PrimitiveTypeKeyword_dummy_117" getPrimitiveTypeKeyword ) quoteJavaType quoteJavaDecs
 
 getRelationalOp ( Ctr__Java__54 s) = s
 
 relationalOp :: QuasiQuoter
-relationalOp = QuasiQuoter (quoteJavaExp "tok_RelationalOp_dummy_118" getRelationalOp ) (quoteJavaPat "tok_RelationalOp_dummy_118" getRelationalOp ) quoteJavaType quoteJavaDecs
+relationalOp = QuasiQuoter (quoteJavaExp "tok_RelationalOp_dummy_116" getRelationalOp ) (quoteJavaPat "tok_RelationalOp_dummy_116" getRelationalOp ) quoteJavaType quoteJavaDecs
 
 getShiftOp ( Ctr__Java__55 s) = s
 
 shiftOp :: QuasiQuoter
-shiftOp = QuasiQuoter (quoteJavaExp "tok_ShiftOp_dummy_117" getShiftOp ) (quoteJavaPat "tok_ShiftOp_dummy_117" getShiftOp ) quoteJavaType quoteJavaDecs
+shiftOp = QuasiQuoter (quoteJavaExp "tok_ShiftOp_dummy_115" getShiftOp ) (quoteJavaPat "tok_ShiftOp_dummy_115" getShiftOp ) quoteJavaType quoteJavaDecs
 
 getSquareBracketsList ( Ctr__Java__56 s) = s
 
 squareBracketsList :: QuasiQuoter
-squareBracketsList = QuasiQuoter (quoteJavaExp "tok_SquareBracketsList_dummy_116" getSquareBracketsList ) (quoteJavaPat "tok_SquareBracketsList_dummy_116" getSquareBracketsList ) quoteJavaType quoteJavaDecs
+squareBracketsList = QuasiQuoter (quoteJavaExp "tok_SquareBracketsList_dummy_114" getSquareBracketsList ) (quoteJavaPat "tok_SquareBracketsList_dummy_114" getSquareBracketsList ) quoteJavaType quoteJavaDecs
 
 getStatement ( Ctr__Java__57 s) = s
 
 statement :: QuasiQuoter
-statement = QuasiQuoter (quoteJavaExp "tok_Statement_dummy_115" getStatement ) (quoteJavaPat "tok_Statement_dummy_115" getStatement ) quoteJavaType quoteJavaDecs
+statement = QuasiQuoter (quoteJavaExp "tok_Statement_dummy_113" getStatement ) (quoteJavaPat "tok_Statement_dummy_113" getStatement ) quoteJavaType quoteJavaDecs
 
 getStatementBlock ( Ctr__Java__58 s) = s
 
 statementBlock :: QuasiQuoter
-statementBlock = QuasiQuoter (quoteJavaExp "tok_StatementBlock_dummy_114" getStatementBlock ) (quoteJavaPat "tok_StatementBlock_dummy_114" getStatementBlock ) quoteJavaType quoteJavaDecs
+statementBlock = QuasiQuoter (quoteJavaExp "tok_StatementBlock_dummy_112" getStatementBlock ) (quoteJavaPat "tok_StatementBlock_dummy_112" getStatementBlock ) quoteJavaType quoteJavaDecs
 
 getStatementList ( Ctr__Java__59 s) = s
 
 statementList :: QuasiQuoter
-statementList = QuasiQuoter (quoteJavaExp "tok_StatementList_dummy_113" getStatementList ) (quoteJavaPat "tok_StatementList_dummy_113" getStatementList ) quoteJavaType quoteJavaDecs
+statementList = QuasiQuoter (quoteJavaExp "tok_StatementList_dummy_111" getStatementList ) (quoteJavaPat "tok_StatementList_dummy_111" getStatementList ) quoteJavaType quoteJavaDecs
 
 getStatementWithoutIf ( Ctr__Java__60 s) = s
 
 statementWithoutIf :: QuasiQuoter
-statementWithoutIf = QuasiQuoter (quoteJavaExp "tok_StatementWithoutIf_dummy_112" getStatementWithoutIf ) (quoteJavaPat "tok_StatementWithoutIf_dummy_112" getStatementWithoutIf ) quoteJavaType quoteJavaDecs
+statementWithoutIf = QuasiQuoter (quoteJavaExp "tok_StatementWithoutIf_dummy_110" getStatementWithoutIf ) (quoteJavaPat "tok_StatementWithoutIf_dummy_110" getStatementWithoutIf ) quoteJavaType quoteJavaDecs
 
 getStaticInitializer ( Ctr__Java__61 s) = s
 
 staticInitializer :: QuasiQuoter
-staticInitializer = QuasiQuoter (quoteJavaExp "tok_StaticInitializer_dummy_111" getStaticInitializer ) (quoteJavaPat "tok_StaticInitializer_dummy_111" getStaticInitializer ) quoteJavaType quoteJavaDecs
+staticInitializer = QuasiQuoter (quoteJavaExp "tok_StaticInitializer_dummy_109" getStaticInitializer ) (quoteJavaPat "tok_StaticInitializer_dummy_109" getStaticInitializer ) quoteJavaType quoteJavaDecs
 
 getSwitchCaseList ( Ctr__Java__62 s) = s
 
 switchCaseList :: QuasiQuoter
-switchCaseList = QuasiQuoter (quoteJavaExp "tok_SwitchCaseList_dummy_110" getSwitchCaseList ) (quoteJavaPat "tok_SwitchCaseList_dummy_110" getSwitchCaseList ) quoteJavaType quoteJavaDecs
+switchCaseList = QuasiQuoter (quoteJavaExp "tok_SwitchCaseList_dummy_108" getSwitchCaseList ) (quoteJavaPat "tok_SwitchCaseList_dummy_108" getSwitchCaseList ) quoteJavaType quoteJavaDecs
 
 getSwitchStatement ( Ctr__Java__63 s) = s
 
 switchStatement :: QuasiQuoter
-switchStatement = QuasiQuoter (quoteJavaExp "tok_SwitchStatement_dummy_109" getSwitchStatement ) (quoteJavaPat "tok_SwitchStatement_dummy_109" getSwitchStatement ) quoteJavaType quoteJavaDecs
+switchStatement = QuasiQuoter (quoteJavaExp "tok_SwitchStatement_dummy_107" getSwitchStatement ) (quoteJavaPat "tok_SwitchStatement_dummy_107" getSwitchStatement ) quoteJavaType quoteJavaDecs
 
 getTryStatement ( Ctr__Java__64 s) = s
 
 tryStatement :: QuasiQuoter
-tryStatement = QuasiQuoter (quoteJavaExp "tok_TryStatement_dummy_108" getTryStatement ) (quoteJavaPat "tok_TryStatement_dummy_108" getTryStatement ) quoteJavaType quoteJavaDecs
+tryStatement = QuasiQuoter (quoteJavaExp "tok_TryStatement_dummy_106" getTryStatement ) (quoteJavaPat "tok_TryStatement_dummy_106" getTryStatement ) quoteJavaType quoteJavaDecs
 
 getType ( Ctr__Java__65 s) = s
 
 __type :: QuasiQuoter
-__type = QuasiQuoter (quoteJavaExp "tok_Type_dummy_107" getType ) (quoteJavaPat "tok_Type_dummy_107" getType ) quoteJavaType quoteJavaDecs
+__type = QuasiQuoter (quoteJavaExp "tok_Type_dummy_105" getType ) (quoteJavaPat "tok_Type_dummy_105" getType ) quoteJavaType quoteJavaDecs
 
 getTypeArgument ( Ctr__Java__66 s) = s
 
 typeArgument :: QuasiQuoter
-typeArgument = QuasiQuoter (quoteJavaExp "tok_TypeArgument_dummy_106" getTypeArgument ) (quoteJavaPat "tok_TypeArgument_dummy_106" getTypeArgument ) quoteJavaType quoteJavaDecs
+typeArgument = QuasiQuoter (quoteJavaExp "tok_TypeArgument_dummy_104" getTypeArgument ) (quoteJavaPat "tok_TypeArgument_dummy_104" getTypeArgument ) quoteJavaType quoteJavaDecs
 
 getTypeArguments ( Ctr__Java__67 s) = s
 
 typeArguments :: QuasiQuoter
-typeArguments = QuasiQuoter (quoteJavaExp "tok_TypeArguments_dummy_105" getTypeArguments ) (quoteJavaPat "tok_TypeArguments_dummy_105" getTypeArguments ) quoteJavaType quoteJavaDecs
+typeArguments = QuasiQuoter (quoteJavaExp "tok_TypeArguments_dummy_103" getTypeArguments ) (quoteJavaPat "tok_TypeArguments_dummy_103" getTypeArguments ) quoteJavaType quoteJavaDecs
 
 getTypeDeclaration ( Ctr__Java__68 s) = s
 
 typeDeclaration :: QuasiQuoter
-typeDeclaration = QuasiQuoter (quoteJavaExp "tok_TypeDeclaration_dummy_104" getTypeDeclaration ) (quoteJavaPat "tok_TypeDeclaration_dummy_104" getTypeDeclaration ) quoteJavaType quoteJavaDecs
+typeDeclaration = QuasiQuoter (quoteJavaExp "tok_TypeDeclaration_dummy_102" getTypeDeclaration ) (quoteJavaPat "tok_TypeDeclaration_dummy_102" getTypeDeclaration ) quoteJavaType quoteJavaDecs
 
 getTypeParameter ( Ctr__Java__69 s) = s
 
 typeParameter :: QuasiQuoter
-typeParameter = QuasiQuoter (quoteJavaExp "tok_TypeParameter_dummy_103" getTypeParameter ) (quoteJavaPat "tok_TypeParameter_dummy_103" getTypeParameter ) quoteJavaType quoteJavaDecs
+typeParameter = QuasiQuoter (quoteJavaExp "tok_TypeParameter_dummy_101" getTypeParameter ) (quoteJavaPat "tok_TypeParameter_dummy_101" getTypeParameter ) quoteJavaType quoteJavaDecs
 
 getTypeParameters ( Ctr__Java__70 s) = s
 
 typeParameters :: QuasiQuoter
-typeParameters = QuasiQuoter (quoteJavaExp "tok_TypeParameters_dummy_102" getTypeParameters ) (quoteJavaPat "tok_TypeParameters_dummy_102" getTypeParameters ) quoteJavaType quoteJavaDecs
+typeParameters = QuasiQuoter (quoteJavaExp "tok_TypeParameters_dummy_100" getTypeParameters ) (quoteJavaPat "tok_TypeParameters_dummy_100" getTypeParameters ) quoteJavaType quoteJavaDecs
 
 getTypeSpecifier ( Ctr__Java__71 s) = s
 
 typeSpecifier :: QuasiQuoter
-typeSpecifier = QuasiQuoter (quoteJavaExp "tok_TypeSpecifier_dummy_101" getTypeSpecifier ) (quoteJavaPat "tok_TypeSpecifier_dummy_101" getTypeSpecifier ) quoteJavaType quoteJavaDecs
+typeSpecifier = QuasiQuoter (quoteJavaExp "tok_TypeSpecifier_dummy_99" getTypeSpecifier ) (quoteJavaPat "tok_TypeSpecifier_dummy_99" getTypeSpecifier ) quoteJavaType quoteJavaDecs
 
 getVariableDeclaration ( Ctr__Java__72 s) = s
 
 variableDeclaration :: QuasiQuoter
-variableDeclaration = QuasiQuoter (quoteJavaExp "tok_VariableDeclaration_dummy_100" getVariableDeclaration ) (quoteJavaPat "tok_VariableDeclaration_dummy_100" getVariableDeclaration ) quoteJavaType quoteJavaDecs
+variableDeclaration = QuasiQuoter (quoteJavaExp "tok_VariableDeclaration_dummy_98" getVariableDeclaration ) (quoteJavaPat "tok_VariableDeclaration_dummy_98" getVariableDeclaration ) quoteJavaType quoteJavaDecs
 
 getVariableDeclarator ( Ctr__Java__73 s) = s
 
 variableDeclarator :: QuasiQuoter
-variableDeclarator = QuasiQuoter (quoteJavaExp "tok_VariableDeclarator_dummy_99" getVariableDeclarator ) (quoteJavaPat "tok_VariableDeclarator_dummy_99" getVariableDeclarator ) quoteJavaType quoteJavaDecs
+variableDeclarator = QuasiQuoter (quoteJavaExp "tok_VariableDeclarator_dummy_97" getVariableDeclarator ) (quoteJavaPat "tok_VariableDeclarator_dummy_97" getVariableDeclarator ) quoteJavaType quoteJavaDecs
 
 getVariableDeclaratorList ( Ctr__Java__74 s) = s
 
 variableDeclaratorList :: QuasiQuoter
-variableDeclaratorList = QuasiQuoter (quoteJavaExp "tok_VariableDeclaratorList_dummy_98" getVariableDeclaratorList ) (quoteJavaPat "tok_VariableDeclaratorList_dummy_98" getVariableDeclaratorList ) quoteJavaType quoteJavaDecs
+variableDeclaratorList = QuasiQuoter (quoteJavaExp "tok_VariableDeclaratorList_dummy_96" getVariableDeclaratorList ) (quoteJavaPat "tok_VariableDeclaratorList_dummy_96" getVariableDeclaratorList ) quoteJavaType quoteJavaDecs
 
 getVariableInitializer ( Ctr__Java__75 s) = s
 
 variableInitializer :: QuasiQuoter
-variableInitializer = QuasiQuoter (quoteJavaExp "tok_VariableInitializer_dummy_97" getVariableInitializer ) (quoteJavaPat "tok_VariableInitializer_dummy_97" getVariableInitializer ) quoteJavaType quoteJavaDecs
+variableInitializer = QuasiQuoter (quoteJavaExp "tok_VariableInitializer_dummy_95" getVariableInitializer ) (quoteJavaPat "tok_VariableInitializer_dummy_95" getVariableInitializer ) quoteJavaType quoteJavaDecs
 
 getVariableInitializerList ( Ctr__Java__76 s) = s
 
 variableInitializerList :: QuasiQuoter
-variableInitializerList = QuasiQuoter (quoteJavaExp "tok_VariableInitializerList_dummy_96" getVariableInitializerList ) (quoteJavaPat "tok_VariableInitializerList_dummy_96" getVariableInitializerList ) quoteJavaType quoteJavaDecs
+variableInitializerList = QuasiQuoter (quoteJavaExp "tok_VariableInitializerList_dummy_94" getVariableInitializerList ) (quoteJavaPat "tok_VariableInitializerList_dummy_94" getVariableInitializerList ) quoteJavaType quoteJavaDecs
 
 getWhileStatement ( Ctr__Java__77 s) = s
 
 whileStatement :: QuasiQuoter
-whileStatement = QuasiQuoter (quoteJavaExp "tok_WhileStatement_dummy_95" getWhileStatement ) (quoteJavaPat "tok_WhileStatement_dummy_95" getWhileStatement ) quoteJavaType quoteJavaDecs
+whileStatement = QuasiQuoter (quoteJavaExp "tok_WhileStatement_dummy_93" getWhileStatement ) (quoteJavaPat "tok_WhileStatement_dummy_93" getWhileStatement ) quoteJavaType quoteJavaDecs
 
 getWildcardType ( Ctr__Java__78 s) = s
 
 wildcardType :: QuasiQuoter
-wildcardType = QuasiQuoter (quoteJavaExp "tok_WildcardType_dummy_94" getWildcardType ) (quoteJavaPat "tok_WildcardType_dummy_94" getWildcardType ) quoteJavaType quoteJavaDecs
+wildcardType = QuasiQuoter (quoteJavaExp "tok_WildcardType_dummy_92" getWildcardType ) (quoteJavaPat "tok_WildcardType_dummy_92" getWildcardType ) quoteJavaType quoteJavaDecs
 


### PR DESCRIPTION
Mechanical cleanups found by analyzing happy's info file for the
generated JavaParser.y; two of these made the parser reject valid Java:

- Remove '~' and '!' from PrefixOp: they already exist as alternatives
  in UnaryExpressionNotPlusMinus (JLS 15.15), so ~x derived two ways
  (46 shift/reduce conflicts).

- Make ExtendsList non-optional and use ExtendsList? at use sites:
  the optional list under another '?' gave two derivations of "no
  extends clause" (3 reduce/reduce conflicts).

- Split AnnotationElement into explicit alternatives
  id '=' ConditionalExpression | ConditionalExpression: the factored
  (id '=')? Expression form committed to the named form on lookahead
  id, so values starting with an identifier
  (@Retention(RetentionPolicy.RUNTIME)) could never parse.
  ConditionalExpression is the JLS ElementValue level; full Expression
  would make @Foo(a = b) genuinely ambiguous.

- Reduce AnnotationTypeElement to FieldDeclaration and let MemberRest
  accept an optional 'default' Expression before ';': the dedicated
  annotation-method alternative raced its nullable ModifierList against
  FieldDeclaration's nullable OptDocComment (72 reduce/reduce
  conflicts), losing every time, so int value() default 5; inside
  @interface could never parse. Accepting 'default' on ordinary
  methods too is deliberate parser-level tolerance.

https://claude.ai/code/session_0133jNpDjcpJQfaQAXtLcMhc