### PR TITLE
Resolve the Java grammar's type-vs-expression LALR ambiguity (JLS-style)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,6 +154,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   printed an error
 
 ### Fixed
+- The Java grammar's last structural LALR ambiguity - deciding between a
+  type and an expression after a `CompoundName` at statement start or after
+  `(` - is resolved JLS-style (`happy` now reports 0 reduce/reduce
+  conflicts on the generated `JavaParser.y`, down from 2). Types and
+  declarators take only empty bracket pairs (`Dims`/`NonEmptyDims`,
+  anchored on the unreduced name so `[` is a plain shift); only array
+  creation takes sizing expressions; `CastExpression` uses the JLS trick
+  (`'(' Expression ')' UnaryExpressionNotPlusMinus` for reference casts
+  plus explicit primitive/generic/array alternatives); and array access is
+  anchored on `CompoundName` in `PrimaryNoPostfix`. `a[0] = 1;`,
+  `x = (a);`, `x = (Foo) y;`, `x = (List<String>) y;`, `((Map) c).get(k);`
+  and `new int[3][];` now parse; JLS-invalid `int[3] x;` declarations are
+  now rejected. Known residual limitation (shared by LALR Java parsers
+  generally): `(a < b)` as a parenthesized primary mis-commits to a
+  generic cast on `<` (conditions like `if (a < b)` are unaffected)
 - `make test-p` works again: the target had a hand-rolled recipe that
   compiled the driver with bare `ghc` outside the cabal package environment,
   failing with `Could not find module 'Data.Generics'` in clean

--- a/test-grammars/java.pg
+++ b/test-grammars/java.pg
@@ -99,7 +99,19 @@ FieldDeclaration  =
  OptDocComment (ModifierList ((MemberDeclaration | NestedTypeDeclaration) | StaticInitializer))
  |  ';'  ;
 
-SquareBracketsList = ('[' OptExpression ']')* ;
+# Array brackets (JLS-style split): types and declarators may only contain
+# EMPTY bracket pairs; sizing expressions are only allowed in array creation
+# (see CreationExpression). Keeping expressions out of type brackets is what
+# lets one token after 'name [' decide between a type (']') and an array
+# access (expression start), so 'a[0] = 1;' and 'Foo[] x;' both parse.
+#
+# NOTE: RTK expands X* into a LEFT-recursive list with an empty base case, so
+# a nullable Dims placed directly after CompoundName would demand an
+# epsilon-reduce on '[' - exactly the early commitment we must avoid. Where
+# the brackets compete with an expression interpretation (Type, casts) we
+# therefore use NonEmptyDims, whose first '[' is a plain shift.
+Dims = ('[' ']')* ;
+NonEmptyDims = ('[' ']')+ ;
 
 # MemberDeclaration unifies constructors, methods, and fields
 # Strategy: Disambiguate early by checking what comes first
@@ -107,7 +119,7 @@ SquareBracketsList = ('[' OptExpression ']')* ;
 # - TypeParameters → definitely method (generic)
 # - id → could be constructor or reference type method/field
 MemberDeclaration =
- PrimitiveTypeKeyword SquareBracketsList id MemberRest         # Primitive type method/field
+ PrimitiveTypeKeyword Dims id MemberRest                       # Primitive type method/field
  | TypeParameters id MoreTypeSpecifier id MemberRest           # Generic method with any type
  | id MemberAfterFirstId ;                                     # Constructor or reference type
 
@@ -124,7 +136,7 @@ MemberAfterFirstId =
 # Could be: empty (simple type), '.' id (qualified), '<' ... '>' (generics), '[' ']' (array)
 MoreTypeSpecifier =
  '.' id MoreTypeSpecifier                                       # Qualified name
- | TypeArguments SquareBracketsList ;                            # Generics + array brackets
+ | TypeArguments Dims ;                                          # Generics + array brackets
 
 # MemberRest branches on what follows "Type id":
 # - '(' indicates a method declaration
@@ -133,8 +145,8 @@ MoreTypeSpecifier =
 # (int value() default 5;). Accepting it on ordinary methods too is
 # parser-level tolerance; rejecting it there is a semantic check (javac's job).
 MemberRest =
- '(' ParameterList? ')' SquareBracketsList ( StatementBlock | ('default' Expression)? ';' )
- | SquareBracketsList OptVariableInitializer MoreVariableDeclarators ';' ;
+ '(' ParameterList? ')' Dims ( StatementBlock | ('default' Expression)? ';' )
+ | Dims OptVariableInitializer MoreVariableDeclarators ';' ;
 
 MoreVariableDeclarators = (',' VariableDeclarator)* ;
 
@@ -164,7 +176,7 @@ VariableDeclaration  =
 OptVariableInitializer = ('=' VariableInitializer)? ;
 
 VariableDeclarator  =
- id  SquareBracketsList  OptVariableInitializer  ;
+ id  Dims  OptVariableInitializer  ;
 
 VariableInitializerList = (VariableInitializer (',' VariableInitializer)* (',')?)? ;
 
@@ -179,7 +191,7 @@ ParameterList  =
 Parameter (',' Parameter)* ;
 
 Parameter  =
-Type id SquareBracketsList ;
+Type id Dims ;
 
 StatementList = Statement *;
 
@@ -316,7 +328,50 @@ MultiplicativeOp = '*' | '/' | '%' ;
 
 Expression : MultiplicativeExpression = UnaryExpression | MultiplicativeExpression MultiplicativeOp UnaryExpression ;
 
-Expression : CastExpression = '(' Type ')' UnaryExpression ;
+# JLS cast trick (JLS 19, CastExpression): no alternative needs a reduce
+# before its first distinguishing token, so LALR(1) never has to decide
+# "type or expression?" early:
+#  - a primitive keyword after '(' can only be a cast;
+#  - '(' CompoundName '<' commits to a generic cast (NonEmptyTypeArguments);
+#  - '(' CompoundName '[' is decided one token later: ']' means an array
+#    cast (NonEmptyDims), an expression start means an array access inside
+#    a parenthesized expression;
+#  - every other reference cast is parsed as '(' Expression ')' with the
+#    type-as-expression, e.g. (Foo) x or (java.util.List) x. Whether
+#    '(' Expression ')' is a cast or a parenthesized expression is decided
+#    one token after ')': an operand start means cast. '(a) + b' stays an
+#    addition precisely because '+'/'-' are excluded from
+#    UnaryExpressionNotPlusMinus (which is why the JLS has that nonterminal).
+#
+# KNOWN LIMITATION: '(a < b)' as a primary expression mis-commits on '<'
+# (the shift prefers a generic cast '(a<...>) ...'), so e.g. 'x = (a < b);'
+# is rejected. This is the standard trade-off of LALR Java parsers. In
+# conditions (if/while/for) and argument lists there is no cast context, so
+# 'if (a < b)' and 'f(a < b)' are unaffected.
+#
+# Shift/reduce inventory after this restructure (happy: 32 s/r, 0 r/r; the
+# two reduce/reduce conflicts of the previous grammar are gone). The 8
+# java-specific conflicts beyond the long-standing ones (dangling else,
+# catch/finally repetition, ModifierList stop, compound-name '.', member
+# id-vs-TypeParameters, bootstrap dummy token) are all intended
+# shift-preferences:
+#   on '[' (5 states): after CompoundName in expression, statement-start,
+#     cast, and after DimExprs/NonEmptyDims in creation - shifting '[' just
+#     defers the type-vs-access decision to the next token (']' vs
+#     expression start) or extends the bracket list; no input is lost.
+#   on '<' (3 states): after CompoundName at statement start, in casts, and
+#     after 'instanceof' - shift prefers type arguments. Only the cast state
+#     loses input ('(a < b)' above); the other two reject only semantically
+#     invalid Java ('a < b;' as a bare statement-expression,
+#     'x instanceof T < y').
+# The cast-vs-paren decision after ')' is conflict-FREE: operand-start
+# tokens can never follow a complete parenthesized expression, so the
+# lookahead sets are disjoint.
+Expression : CastExpression =
+ '(' PrimitiveTypeKeyword Dims ')' UnaryExpression
+ | '(' CompoundName NonEmptyTypeArguments Dims ')' UnaryExpressionNotPlusMinus
+ | '(' CompoundName NonEmptyDims ')' UnaryExpressionNotPlusMinus
+ | '(' Expression ')' UnaryExpressionNotPlusMinus ;
 
 # '~' and '!' live in UnaryExpressionNotPlusMinus (JLS 15.15), not here:
 # keeping them in both derives ~x two ways, and they must stay in
@@ -342,26 +397,49 @@ Expression : PostfixExpression =
  | PostfixExpression '.' id '(' Arglist ')'
  | PostfixExpression '[' Expression ']' ;
 
+# The 'CompoundName '[' Expression ']'' alternative anchors array access on
+# the unreduced name (JLS ArrayAccess: Name [ Expression ]). It must sit here
+# and not only on PostfixExpression: reaching PostfixExpression first would
+# reduce CompoundName on lookahead '[', committing against the type
+# interpretation ('Foo[] x;', '(Foo[]) x') one token too early. With the
+# anchored alternative both interpretations shift '[' and the NEXT token
+# decides. 'a[0]' is still derivable through PostfixExpression too; the
+# resulting shift/reduce conflicts on '[' prefer the shift, i.e. exactly this
+# anchored production (the PostfixExpression production still applies to
+# non-name bases such as 'f()[0]' or 'this.x[0]').
 Expression : PrimaryNoPostfix =
  Literal
  | 'this'
  | '(' Expression ')'
  | CreationExpression
  | CompoundName ('(' Arglist ')')?
+ | CompoundName '[' Expression ']'
  | 'super' '.' id ('(' Arglist ')')? ;
 
-CreationExpression = 'new' Type ( '(' Arglist ')' | SquareBracketsList );
+# Only array creation takes sizing expressions (DimExprs); trailing empty
+# pairs allow 'new int[3][]'. Uses TypeSpecifier, not Type, so the dims are
+# not consumed twice. 'new int[] {1,2}' (initializer syntax) is a separate
+# feature (Phase 4g).
+CreationExpression = 'new' TypeSpecifier ( '(' Arglist ')' | DimExprs (NonEmptyDims)? );
+
+DimExprs = ('[' Expression ']')+ ;
 
 Literal = integerLiteral | floatLiteral | 'true' | 'false' | char | string | 'null' ;
 
 Arglist = (Expression (',' Expression)*)? ;
 
 # Generics support
-# NOTE: The '<' and '>' symbols create shift/reduce conflicts (~60) because they are used for both:
-#   - Type arguments: List<String>
-#   - Comparison operators: x < y
-# These conflicts resolve correctly with default shift behavior (standard for Java parsers).
-TypeArguments = ('<' TypeArgument (',' TypeArgument)* '>')? ;
+# NOTE: '<' is both the type-argument opener (List<String>) and the
+# comparison operator (x < y). Wherever a CompoundName can be followed by
+# either, the parser shifts '<' into NonEmptyTypeArguments (standard for
+# Java parsers); see the shift/reduce inventory at CastExpression for the
+# three states where this surfaces.
+TypeArguments = NonEmptyTypeArguments? ;
+
+# Non-optional variant: Type and CastExpression need the '<' to be a plain
+# shift from CompoundName (an optional TypeArguments would interpose an
+# epsilon-reduce and recreate the type-vs-expression conflict).
+NonEmptyTypeArguments = '<' TypeArgument (',' TypeArgument)* '>' ;
 
 TypeArgument =
  Type
@@ -376,9 +454,22 @@ TypeParameters = ('<' TypeParameter (',' TypeParameter)* '>')? ;
 
 TypeParameter = id ('extends' Type ('&' Type)*)? ;
 
+# Type is spelled out by alternatives (instead of 'TypeSpecifier Dims') so
+# that in positions where both a type and an expression may start (statement
+# start, for-init) every alternative either shifts its next token directly
+# from CompoundName ('<' for generics, '[' for array types) or reduces bare
+# CompoundName only on lookahead 'id' (the declared variable's name), which
+# no expression interpretation shares. This is what removes the
+# PrimaryNoPostfix-vs-TypeSpecifier reduce/reduce conflict: the parser no
+# longer has to pick type-or-expression while staring at '['.
 Type  =
-TypeSpecifier  SquareBracketsList  ;
+ PrimitiveTypeKeyword Dims
+ | CompoundName NonEmptyTypeArguments Dims
+ | CompoundName NonEmptyDims
+ | CompoundName ;
 
+# Only used by CreationExpression nowadays (Type spells out its own
+# alternatives, see above).
 TypeSpecifier =
  'boolean'
  |  'byte'

--- a/test/golden/java/JavaLexer.x
+++ b/test/golden/java/JavaLexer.x
@@ -10,85 +10,88 @@ import Data.Data (Data)
 @exponentPart = ([eE]  ("+"| "-") ?  [0-9]  ([0-9_]*  [0-9]) ?)
 @floatTypeSuffix = ([fFdD])
 
-tokens :- "tok_AdditiveOp_dummy_169" { simple Tk__tok_AdditiveOp_dummy_169 }
-          "tok_Annotation_dummy_168" { simple Tk__tok_Annotation_dummy_168 }
-          "tok_AnnotationArguments_dummy_167" { simple Tk__tok_AnnotationArguments_dummy_167 }
-          "tok_AnnotationDeclaration_dummy_166" { simple Tk__tok_AnnotationDeclaration_dummy_166 }
-          "tok_AnnotationElement_dummy_165" { simple Tk__tok_AnnotationElement_dummy_165 }
-          "tok_AnnotationList_dummy_164" { simple Tk__tok_AnnotationList_dummy_164 }
-          "tok_AnnotationTypeElement_dummy_163" { simple Tk__tok_AnnotationTypeElement_dummy_163 }
-          "tok_AnnotationTypeElementList_dummy_162" { simple Tk__tok_AnnotationTypeElementList_dummy_162 }
-          "tok_Arglist_dummy_161" { simple Tk__tok_Arglist_dummy_161 }
-          "tok_AssignmentOp_dummy_160" { simple Tk__tok_AssignmentOp_dummy_160 }
-          "tok_CatchList_dummy_159" { simple Tk__tok_CatchList_dummy_159 }
-          "tok_ClassDeclaration_dummy_158" { simple Tk__tok_ClassDeclaration_dummy_158 }
-          "tok_CompilationUnit_dummy_157" { simple Tk__tok_CompilationUnit_dummy_157 }
-          "tok_CompoundName_dummy_156" { simple Tk__tok_CompoundName_dummy_156 }
-          "tok_CreationExpression_dummy_155" { simple Tk__tok_CreationExpression_dummy_155 }
-          "tok_DoStatement_dummy_154" { simple Tk__tok_DoStatement_dummy_154 }
-          "tok_DocComment_dummy_153" { simple Tk__tok_DocComment_dummy_153 }
-          "tok_EnumConstant_dummy_152" { simple Tk__tok_EnumConstant_dummy_152 }
-          "tok_EnumConstantList_dummy_151" { simple Tk__tok_EnumConstantList_dummy_151 }
-          "tok_EnumDeclaration_dummy_150" { simple Tk__tok_EnumDeclaration_dummy_150 }
-          "tok_EqualityOp_dummy_149" { simple Tk__tok_EqualityOp_dummy_149 }
-          "tok_Expression_dummy_148" { simple Tk__tok_Expression_dummy_148 }
-          "tok_ExtendsList_dummy_147" { simple Tk__tok_ExtendsList_dummy_147 }
-          "tok_FieldDeclaration_dummy_146" { simple Tk__tok_FieldDeclaration_dummy_146 }
-          "tok_FieldDeclarationList_dummy_145" { simple Tk__tok_FieldDeclarationList_dummy_145 }
-          "tok_ForStatement_dummy_144" { simple Tk__tok_ForStatement_dummy_144 }
-          "tok_IfStatement_dummy_143" { simple Tk__tok_IfStatement_dummy_143 }
-          "tok_ImplementsList_dummy_142" { simple Tk__tok_ImplementsList_dummy_142 }
-          "tok_ImportList_dummy_141" { simple Tk__tok_ImportList_dummy_141 }
-          "tok_ImportStatement_dummy_140" { simple Tk__tok_ImportStatement_dummy_140 }
-          "tok_InterfaceDeclaration_dummy_139" { simple Tk__tok_InterfaceDeclaration_dummy_139 }
-          "tok_Java_dummy_170" { simple Tk__tok_Java_dummy_170 }
-          "tok_Literal_dummy_138" { simple Tk__tok_Literal_dummy_138 }
-          "tok_MemberAfterFirstId_dummy_137" { simple Tk__tok_MemberAfterFirstId_dummy_137 }
-          "tok_MemberDeclaration_dummy_136" { simple Tk__tok_MemberDeclaration_dummy_136 }
-          "tok_MemberRest_dummy_135" { simple Tk__tok_MemberRest_dummy_135 }
-          "tok_Modifier_dummy_134" { simple Tk__tok_Modifier_dummy_134 }
-          "tok_ModifierList_dummy_133" { simple Tk__tok_ModifierList_dummy_133 }
-          "tok_MoreTypeSpecifier_dummy_132" { simple Tk__tok_MoreTypeSpecifier_dummy_132 }
-          "tok_MoreVariableDeclarators_dummy_131" { simple Tk__tok_MoreVariableDeclarators_dummy_131 }
-          "tok_MultiplicativeOp_dummy_130" { simple Tk__tok_MultiplicativeOp_dummy_130 }
-          "tok_NestedTypeDeclaration_dummy_129" { simple Tk__tok_NestedTypeDeclaration_dummy_129 }
-          "tok_OptDocComment_dummy_128" { simple Tk__tok_OptDocComment_dummy_128 }
-          "tok_OptElsePart_dummy_127" { simple Tk__tok_OptElsePart_dummy_127 }
-          "tok_OptExpression_dummy_126" { simple Tk__tok_OptExpression_dummy_126 }
-          "tok_OptFinally_dummy_125" { simple Tk__tok_OptFinally_dummy_125 }
-          "tok_OptId_dummy_124" { simple Tk__tok_OptId_dummy_124 }
-          "tok_OptVariableInitializer_dummy_123" { simple Tk__tok_OptVariableInitializer_dummy_123 }
-          "tok_Package_dummy_122" { simple Tk__tok_Package_dummy_122 }
-          "tok_Parameter_dummy_121" { simple Tk__tok_Parameter_dummy_121 }
-          "tok_ParameterList_dummy_120" { simple Tk__tok_ParameterList_dummy_120 }
-          "tok_PostfixOp_dummy_119" { simple Tk__tok_PostfixOp_dummy_119 }
-          "tok_PrefixOp_dummy_118" { simple Tk__tok_PrefixOp_dummy_118 }
-          "tok_PrimitiveTypeKeyword_dummy_117" { simple Tk__tok_PrimitiveTypeKeyword_dummy_117 }
-          "tok_RelationalOp_dummy_116" { simple Tk__tok_RelationalOp_dummy_116 }
-          "tok_ShiftOp_dummy_115" { simple Tk__tok_ShiftOp_dummy_115 }
-          "tok_SquareBracketsList_dummy_114" { simple Tk__tok_SquareBracketsList_dummy_114 }
-          "tok_Statement_dummy_113" { simple Tk__tok_Statement_dummy_113 }
-          "tok_StatementBlock_dummy_112" { simple Tk__tok_StatementBlock_dummy_112 }
-          "tok_StatementList_dummy_111" { simple Tk__tok_StatementList_dummy_111 }
-          "tok_StatementWithoutIf_dummy_110" { simple Tk__tok_StatementWithoutIf_dummy_110 }
-          "tok_StaticInitializer_dummy_109" { simple Tk__tok_StaticInitializer_dummy_109 }
-          "tok_SwitchCaseList_dummy_108" { simple Tk__tok_SwitchCaseList_dummy_108 }
-          "tok_SwitchStatement_dummy_107" { simple Tk__tok_SwitchStatement_dummy_107 }
-          "tok_TryStatement_dummy_106" { simple Tk__tok_TryStatement_dummy_106 }
-          "tok_Type_dummy_105" { simple Tk__tok_Type_dummy_105 }
-          "tok_TypeArgument_dummy_104" { simple Tk__tok_TypeArgument_dummy_104 }
-          "tok_TypeArguments_dummy_103" { simple Tk__tok_TypeArguments_dummy_103 }
-          "tok_TypeDeclaration_dummy_102" { simple Tk__tok_TypeDeclaration_dummy_102 }
-          "tok_TypeParameter_dummy_101" { simple Tk__tok_TypeParameter_dummy_101 }
-          "tok_TypeParameters_dummy_100" { simple Tk__tok_TypeParameters_dummy_100 }
-          "tok_TypeSpecifier_dummy_99" { simple Tk__tok_TypeSpecifier_dummy_99 }
-          "tok_VariableDeclaration_dummy_98" { simple Tk__tok_VariableDeclaration_dummy_98 }
-          "tok_VariableDeclarator_dummy_97" { simple Tk__tok_VariableDeclarator_dummy_97 }
-          "tok_VariableDeclaratorList_dummy_96" { simple Tk__tok_VariableDeclaratorList_dummy_96 }
-          "tok_VariableInitializer_dummy_95" { simple Tk__tok_VariableInitializer_dummy_95 }
-          "tok_VariableInitializerList_dummy_94" { simple Tk__tok_VariableInitializerList_dummy_94 }
-          "tok_WhileStatement_dummy_93" { simple Tk__tok_WhileStatement_dummy_93 }
-          "tok_WildcardType_dummy_92" { simple Tk__tok_WildcardType_dummy_92 }
+tokens :- "tok_AdditiveOp_dummy_177" { simple Tk__tok_AdditiveOp_dummy_177 }
+          "tok_Annotation_dummy_176" { simple Tk__tok_Annotation_dummy_176 }
+          "tok_AnnotationArguments_dummy_175" { simple Tk__tok_AnnotationArguments_dummy_175 }
+          "tok_AnnotationDeclaration_dummy_174" { simple Tk__tok_AnnotationDeclaration_dummy_174 }
+          "tok_AnnotationElement_dummy_173" { simple Tk__tok_AnnotationElement_dummy_173 }
+          "tok_AnnotationList_dummy_172" { simple Tk__tok_AnnotationList_dummy_172 }
+          "tok_AnnotationTypeElement_dummy_171" { simple Tk__tok_AnnotationTypeElement_dummy_171 }
+          "tok_AnnotationTypeElementList_dummy_170" { simple Tk__tok_AnnotationTypeElementList_dummy_170 }
+          "tok_Arglist_dummy_169" { simple Tk__tok_Arglist_dummy_169 }
+          "tok_AssignmentOp_dummy_168" { simple Tk__tok_AssignmentOp_dummy_168 }
+          "tok_CatchList_dummy_167" { simple Tk__tok_CatchList_dummy_167 }
+          "tok_ClassDeclaration_dummy_166" { simple Tk__tok_ClassDeclaration_dummy_166 }
+          "tok_CompilationUnit_dummy_165" { simple Tk__tok_CompilationUnit_dummy_165 }
+          "tok_CompoundName_dummy_164" { simple Tk__tok_CompoundName_dummy_164 }
+          "tok_CreationExpression_dummy_163" { simple Tk__tok_CreationExpression_dummy_163 }
+          "tok_DimExprs_dummy_162" { simple Tk__tok_DimExprs_dummy_162 }
+          "tok_Dims_dummy_161" { simple Tk__tok_Dims_dummy_161 }
+          "tok_DoStatement_dummy_160" { simple Tk__tok_DoStatement_dummy_160 }
+          "tok_DocComment_dummy_159" { simple Tk__tok_DocComment_dummy_159 }
+          "tok_EnumConstant_dummy_158" { simple Tk__tok_EnumConstant_dummy_158 }
+          "tok_EnumConstantList_dummy_157" { simple Tk__tok_EnumConstantList_dummy_157 }
+          "tok_EnumDeclaration_dummy_156" { simple Tk__tok_EnumDeclaration_dummy_156 }
+          "tok_EqualityOp_dummy_155" { simple Tk__tok_EqualityOp_dummy_155 }
+          "tok_Expression_dummy_154" { simple Tk__tok_Expression_dummy_154 }
+          "tok_ExtendsList_dummy_153" { simple Tk__tok_ExtendsList_dummy_153 }
+          "tok_FieldDeclaration_dummy_152" { simple Tk__tok_FieldDeclaration_dummy_152 }
+          "tok_FieldDeclarationList_dummy_151" { simple Tk__tok_FieldDeclarationList_dummy_151 }
+          "tok_ForStatement_dummy_150" { simple Tk__tok_ForStatement_dummy_150 }
+          "tok_IfStatement_dummy_149" { simple Tk__tok_IfStatement_dummy_149 }
+          "tok_ImplementsList_dummy_148" { simple Tk__tok_ImplementsList_dummy_148 }
+          "tok_ImportList_dummy_147" { simple Tk__tok_ImportList_dummy_147 }
+          "tok_ImportStatement_dummy_146" { simple Tk__tok_ImportStatement_dummy_146 }
+          "tok_InterfaceDeclaration_dummy_145" { simple Tk__tok_InterfaceDeclaration_dummy_145 }
+          "tok_Java_dummy_178" { simple Tk__tok_Java_dummy_178 }
+          "tok_Literal_dummy_144" { simple Tk__tok_Literal_dummy_144 }
+          "tok_MemberAfterFirstId_dummy_143" { simple Tk__tok_MemberAfterFirstId_dummy_143 }
+          "tok_MemberDeclaration_dummy_142" { simple Tk__tok_MemberDeclaration_dummy_142 }
+          "tok_MemberRest_dummy_141" { simple Tk__tok_MemberRest_dummy_141 }
+          "tok_Modifier_dummy_140" { simple Tk__tok_Modifier_dummy_140 }
+          "tok_ModifierList_dummy_139" { simple Tk__tok_ModifierList_dummy_139 }
+          "tok_MoreTypeSpecifier_dummy_138" { simple Tk__tok_MoreTypeSpecifier_dummy_138 }
+          "tok_MoreVariableDeclarators_dummy_137" { simple Tk__tok_MoreVariableDeclarators_dummy_137 }
+          "tok_MultiplicativeOp_dummy_136" { simple Tk__tok_MultiplicativeOp_dummy_136 }
+          "tok_NestedTypeDeclaration_dummy_135" { simple Tk__tok_NestedTypeDeclaration_dummy_135 }
+          "tok_NonEmptyDims_dummy_134" { simple Tk__tok_NonEmptyDims_dummy_134 }
+          "tok_NonEmptyTypeArguments_dummy_133" { simple Tk__tok_NonEmptyTypeArguments_dummy_133 }
+          "tok_OptDocComment_dummy_132" { simple Tk__tok_OptDocComment_dummy_132 }
+          "tok_OptElsePart_dummy_131" { simple Tk__tok_OptElsePart_dummy_131 }
+          "tok_OptExpression_dummy_130" { simple Tk__tok_OptExpression_dummy_130 }
+          "tok_OptFinally_dummy_129" { simple Tk__tok_OptFinally_dummy_129 }
+          "tok_OptId_dummy_128" { simple Tk__tok_OptId_dummy_128 }
+          "tok_OptVariableInitializer_dummy_127" { simple Tk__tok_OptVariableInitializer_dummy_127 }
+          "tok_Package_dummy_126" { simple Tk__tok_Package_dummy_126 }
+          "tok_Parameter_dummy_125" { simple Tk__tok_Parameter_dummy_125 }
+          "tok_ParameterList_dummy_124" { simple Tk__tok_ParameterList_dummy_124 }
+          "tok_PostfixOp_dummy_123" { simple Tk__tok_PostfixOp_dummy_123 }
+          "tok_PrefixOp_dummy_122" { simple Tk__tok_PrefixOp_dummy_122 }
+          "tok_PrimitiveTypeKeyword_dummy_121" { simple Tk__tok_PrimitiveTypeKeyword_dummy_121 }
+          "tok_RelationalOp_dummy_120" { simple Tk__tok_RelationalOp_dummy_120 }
+          "tok_ShiftOp_dummy_119" { simple Tk__tok_ShiftOp_dummy_119 }
+          "tok_Statement_dummy_118" { simple Tk__tok_Statement_dummy_118 }
+          "tok_StatementBlock_dummy_117" { simple Tk__tok_StatementBlock_dummy_117 }
+          "tok_StatementList_dummy_116" { simple Tk__tok_StatementList_dummy_116 }
+          "tok_StatementWithoutIf_dummy_115" { simple Tk__tok_StatementWithoutIf_dummy_115 }
+          "tok_StaticInitializer_dummy_114" { simple Tk__tok_StaticInitializer_dummy_114 }
+          "tok_SwitchCaseList_dummy_113" { simple Tk__tok_SwitchCaseList_dummy_113 }
+          "tok_SwitchStatement_dummy_112" { simple Tk__tok_SwitchStatement_dummy_112 }
+          "tok_TryStatement_dummy_111" { simple Tk__tok_TryStatement_dummy_111 }
+          "tok_Type_dummy_110" { simple Tk__tok_Type_dummy_110 }
+          "tok_TypeArgument_dummy_109" { simple Tk__tok_TypeArgument_dummy_109 }
+          "tok_TypeArguments_dummy_108" { simple Tk__tok_TypeArguments_dummy_108 }
+          "tok_TypeDeclaration_dummy_107" { simple Tk__tok_TypeDeclaration_dummy_107 }
+          "tok_TypeParameter_dummy_106" { simple Tk__tok_TypeParameter_dummy_106 }
+          "tok_TypeParameters_dummy_105" { simple Tk__tok_TypeParameters_dummy_105 }
+          "tok_TypeSpecifier_dummy_104" { simple Tk__tok_TypeSpecifier_dummy_104 }
+          "tok_VariableDeclaration_dummy_103" { simple Tk__tok_VariableDeclaration_dummy_103 }
+          "tok_VariableDeclarator_dummy_102" { simple Tk__tok_VariableDeclarator_dummy_102 }
+          "tok_VariableDeclaratorList_dummy_101" { simple Tk__tok_VariableDeclaratorList_dummy_101 }
+          "tok_VariableInitializer_dummy_100" { simple Tk__tok_VariableInitializer_dummy_100 }
+          "tok_VariableInitializerList_dummy_99" { simple Tk__tok_VariableInitializerList_dummy_99 }
+          "tok_WhileStatement_dummy_98" { simple Tk__tok_WhileStatement_dummy_98 }
+          "tok_WildcardType_dummy_97" { simple Tk__tok_WildcardType_dummy_97 }
           "~" { simple Tk__tok__tilde__78 }
           "}" { simple Tk__tok__symbol__14 }
           "||" { simple Tk__tok__pipe__pipe__57 }
@@ -203,9 +206,11 @@ tokens :- "tok_AdditiveOp_dummy_169" { simple Tk__tok_AdditiveOp_dummy_169 }
           ("$"  "TypeParameters"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_TypeParameters . ((tail . dropWhile (/= ':'))) }
           ("$"  "WildcardType"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_WildcardType . ((tail . dropWhile (/= ':'))) }
           ("$"  "TypeArgument"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_TypeArgument . ((tail . dropWhile (/= ':'))) }
+          ("$"  "NonEmptyTypeArguments"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_NonEmptyTypeArguments . ((tail . dropWhile (/= ':'))) }
           ("$"  "TypeArguments"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_TypeArguments . ((tail . dropWhile (/= ':'))) }
           ("$"  "Arglist"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_Arglist . ((tail . dropWhile (/= ':'))) }
           ("$"  "Literal"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_Literal . ((tail . dropWhile (/= ':'))) }
+          ("$"  "DimExprs"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_DimExprs . ((tail . dropWhile (/= ':'))) }
           ("$"  "CreationExpression"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_CreationExpression . ((tail . dropWhile (/= ':'))) }
           ("$"  "PostfixOp"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_PostfixOp . ((tail . dropWhile (/= ':'))) }
           ("$"  "PrefixOp"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_PrefixOp . ((tail . dropWhile (/= ':'))) }
@@ -247,7 +252,8 @@ tokens :- "tok_AdditiveOp_dummy_169" { simple Tk__tok_AdditiveOp_dummy_169 }
           ("$"  "MemberAfterFirstId"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_MemberAfterFirstId . ((tail . dropWhile (/= ':'))) }
           ("$"  "PrimitiveTypeKeyword"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_PrimitiveTypeKeyword . ((tail . dropWhile (/= ':'))) }
           ("$"  "MemberDeclaration"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_MemberDeclaration . ((tail . dropWhile (/= ':'))) }
-          ("$"  "SquareBracketsList"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_SquareBracketsList . ((tail . dropWhile (/= ':'))) }
+          ("$"  "NonEmptyDims"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_NonEmptyDims . ((tail . dropWhile (/= ':'))) }
+          ("$"  "Dims"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_Dims . ((tail . dropWhile (/= ':'))) }
           ("$"  "FieldDeclaration"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_FieldDeclaration . ((tail . dropWhile (/= ':'))) }
           ("$"  "NestedTypeDeclaration"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_NestedTypeDeclaration . ((tail . dropWhile (/= ':'))) }
           ("$"  "EnumDeclaration"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_EnumDeclaration . ((tail . dropWhile (/= ':'))) }
@@ -278,85 +284,88 @@ tokens :- "tok_AdditiveOp_dummy_169" { simple Tk__tok_AdditiveOp_dummy_169 }
 
 {
 data Token = EndOfFile |
-             Tk__tok_AdditiveOp_dummy_169 |
-             Tk__tok_Annotation_dummy_168 |
-             Tk__tok_AnnotationArguments_dummy_167 |
-             Tk__tok_AnnotationDeclaration_dummy_166 |
-             Tk__tok_AnnotationElement_dummy_165 |
-             Tk__tok_AnnotationList_dummy_164 |
-             Tk__tok_AnnotationTypeElement_dummy_163 |
-             Tk__tok_AnnotationTypeElementList_dummy_162 |
-             Tk__tok_Arglist_dummy_161 |
-             Tk__tok_AssignmentOp_dummy_160 |
-             Tk__tok_CatchList_dummy_159 |
-             Tk__tok_ClassDeclaration_dummy_158 |
-             Tk__tok_CompilationUnit_dummy_157 |
-             Tk__tok_CompoundName_dummy_156 |
-             Tk__tok_CreationExpression_dummy_155 |
-             Tk__tok_DoStatement_dummy_154 |
-             Tk__tok_DocComment_dummy_153 |
-             Tk__tok_EnumConstant_dummy_152 |
-             Tk__tok_EnumConstantList_dummy_151 |
-             Tk__tok_EnumDeclaration_dummy_150 |
-             Tk__tok_EqualityOp_dummy_149 |
-             Tk__tok_Expression_dummy_148 |
-             Tk__tok_ExtendsList_dummy_147 |
-             Tk__tok_FieldDeclaration_dummy_146 |
-             Tk__tok_FieldDeclarationList_dummy_145 |
-             Tk__tok_ForStatement_dummy_144 |
-             Tk__tok_IfStatement_dummy_143 |
-             Tk__tok_ImplementsList_dummy_142 |
-             Tk__tok_ImportList_dummy_141 |
-             Tk__tok_ImportStatement_dummy_140 |
-             Tk__tok_InterfaceDeclaration_dummy_139 |
-             Tk__tok_Java_dummy_170 |
-             Tk__tok_Literal_dummy_138 |
-             Tk__tok_MemberAfterFirstId_dummy_137 |
-             Tk__tok_MemberDeclaration_dummy_136 |
-             Tk__tok_MemberRest_dummy_135 |
-             Tk__tok_Modifier_dummy_134 |
-             Tk__tok_ModifierList_dummy_133 |
-             Tk__tok_MoreTypeSpecifier_dummy_132 |
-             Tk__tok_MoreVariableDeclarators_dummy_131 |
-             Tk__tok_MultiplicativeOp_dummy_130 |
-             Tk__tok_NestedTypeDeclaration_dummy_129 |
-             Tk__tok_OptDocComment_dummy_128 |
-             Tk__tok_OptElsePart_dummy_127 |
-             Tk__tok_OptExpression_dummy_126 |
-             Tk__tok_OptFinally_dummy_125 |
-             Tk__tok_OptId_dummy_124 |
-             Tk__tok_OptVariableInitializer_dummy_123 |
-             Tk__tok_Package_dummy_122 |
-             Tk__tok_Parameter_dummy_121 |
-             Tk__tok_ParameterList_dummy_120 |
-             Tk__tok_PostfixOp_dummy_119 |
-             Tk__tok_PrefixOp_dummy_118 |
-             Tk__tok_PrimitiveTypeKeyword_dummy_117 |
-             Tk__tok_RelationalOp_dummy_116 |
-             Tk__tok_ShiftOp_dummy_115 |
-             Tk__tok_SquareBracketsList_dummy_114 |
-             Tk__tok_Statement_dummy_113 |
-             Tk__tok_StatementBlock_dummy_112 |
-             Tk__tok_StatementList_dummy_111 |
-             Tk__tok_StatementWithoutIf_dummy_110 |
-             Tk__tok_StaticInitializer_dummy_109 |
-             Tk__tok_SwitchCaseList_dummy_108 |
-             Tk__tok_SwitchStatement_dummy_107 |
-             Tk__tok_TryStatement_dummy_106 |
-             Tk__tok_Type_dummy_105 |
-             Tk__tok_TypeArgument_dummy_104 |
-             Tk__tok_TypeArguments_dummy_103 |
-             Tk__tok_TypeDeclaration_dummy_102 |
-             Tk__tok_TypeParameter_dummy_101 |
-             Tk__tok_TypeParameters_dummy_100 |
-             Tk__tok_TypeSpecifier_dummy_99 |
-             Tk__tok_VariableDeclaration_dummy_98 |
-             Tk__tok_VariableDeclarator_dummy_97 |
-             Tk__tok_VariableDeclaratorList_dummy_96 |
-             Tk__tok_VariableInitializer_dummy_95 |
-             Tk__tok_VariableInitializerList_dummy_94 |
-             Tk__tok_WhileStatement_dummy_93 |
-             Tk__tok_WildcardType_dummy_92 |
+             Tk__tok_AdditiveOp_dummy_177 |
+             Tk__tok_Annotation_dummy_176 |
+             Tk__tok_AnnotationArguments_dummy_175 |
+             Tk__tok_AnnotationDeclaration_dummy_174 |
+             Tk__tok_AnnotationElement_dummy_173 |
+             Tk__tok_AnnotationList_dummy_172 |
+             Tk__tok_AnnotationTypeElement_dummy_171 |
+             Tk__tok_AnnotationTypeElementList_dummy_170 |
+             Tk__tok_Arglist_dummy_169 |
+             Tk__tok_AssignmentOp_dummy_168 |
+             Tk__tok_CatchList_dummy_167 |
+             Tk__tok_ClassDeclaration_dummy_166 |
+             Tk__tok_CompilationUnit_dummy_165 |
+             Tk__tok_CompoundName_dummy_164 |
+             Tk__tok_CreationExpression_dummy_163 |
+             Tk__tok_DimExprs_dummy_162 |
+             Tk__tok_Dims_dummy_161 |
+             Tk__tok_DoStatement_dummy_160 |
+             Tk__tok_DocComment_dummy_159 |
+             Tk__tok_EnumConstant_dummy_158 |
+             Tk__tok_EnumConstantList_dummy_157 |
+             Tk__tok_EnumDeclaration_dummy_156 |
+             Tk__tok_EqualityOp_dummy_155 |
+             Tk__tok_Expression_dummy_154 |
+             Tk__tok_ExtendsList_dummy_153 |
+             Tk__tok_FieldDeclaration_dummy_152 |
+             Tk__tok_FieldDeclarationList_dummy_151 |
+             Tk__tok_ForStatement_dummy_150 |
+             Tk__tok_IfStatement_dummy_149 |
+             Tk__tok_ImplementsList_dummy_148 |
+             Tk__tok_ImportList_dummy_147 |
+             Tk__tok_ImportStatement_dummy_146 |
+             Tk__tok_InterfaceDeclaration_dummy_145 |
+             Tk__tok_Java_dummy_178 |
+             Tk__tok_Literal_dummy_144 |
+             Tk__tok_MemberAfterFirstId_dummy_143 |
+             Tk__tok_MemberDeclaration_dummy_142 |
+             Tk__tok_MemberRest_dummy_141 |
+             Tk__tok_Modifier_dummy_140 |
+             Tk__tok_ModifierList_dummy_139 |
+             Tk__tok_MoreTypeSpecifier_dummy_138 |
+             Tk__tok_MoreVariableDeclarators_dummy_137 |
+             Tk__tok_MultiplicativeOp_dummy_136 |
+             Tk__tok_NestedTypeDeclaration_dummy_135 |
+             Tk__tok_NonEmptyDims_dummy_134 |
+             Tk__tok_NonEmptyTypeArguments_dummy_133 |
+             Tk__tok_OptDocComment_dummy_132 |
+             Tk__tok_OptElsePart_dummy_131 |
+             Tk__tok_OptExpression_dummy_130 |
+             Tk__tok_OptFinally_dummy_129 |
+             Tk__tok_OptId_dummy_128 |
+             Tk__tok_OptVariableInitializer_dummy_127 |
+             Tk__tok_Package_dummy_126 |
+             Tk__tok_Parameter_dummy_125 |
+             Tk__tok_ParameterList_dummy_124 |
+             Tk__tok_PostfixOp_dummy_123 |
+             Tk__tok_PrefixOp_dummy_122 |
+             Tk__tok_PrimitiveTypeKeyword_dummy_121 |
+             Tk__tok_RelationalOp_dummy_120 |
+             Tk__tok_ShiftOp_dummy_119 |
+             Tk__tok_Statement_dummy_118 |
+             Tk__tok_StatementBlock_dummy_117 |
+             Tk__tok_StatementList_dummy_116 |
+             Tk__tok_StatementWithoutIf_dummy_115 |
+             Tk__tok_StaticInitializer_dummy_114 |
+             Tk__tok_SwitchCaseList_dummy_113 |
+             Tk__tok_SwitchStatement_dummy_112 |
+             Tk__tok_TryStatement_dummy_111 |
+             Tk__tok_Type_dummy_110 |
+             Tk__tok_TypeArgument_dummy_109 |
+             Tk__tok_TypeArguments_dummy_108 |
+             Tk__tok_TypeDeclaration_dummy_107 |
+             Tk__tok_TypeParameter_dummy_106 |
+             Tk__tok_TypeParameters_dummy_105 |
+             Tk__tok_TypeSpecifier_dummy_104 |
+             Tk__tok_VariableDeclaration_dummy_103 |
+             Tk__tok_VariableDeclarator_dummy_102 |
+             Tk__tok_VariableDeclaratorList_dummy_101 |
+             Tk__tok_VariableInitializer_dummy_100 |
+             Tk__tok_VariableInitializerList_dummy_99 |
+             Tk__tok_WhileStatement_dummy_98 |
+             Tk__tok_WildcardType_dummy_97 |
              Tk__tok__tilde__78 |
              Tk__tok__symbol__14 |
              Tk__tok__pipe__pipe__57 |
@@ -468,9 +477,11 @@ data Token = EndOfFile |
              Tk__qq_TypeParameters String |
              Tk__qq_WildcardType String |
              Tk__qq_TypeArgument String |
+             Tk__qq_NonEmptyTypeArguments String |
              Tk__qq_TypeArguments String |
              Tk__qq_Arglist String |
              Tk__qq_Literal String |
+             Tk__qq_DimExprs String |
              Tk__qq_CreationExpression String |
              Tk__qq_PostfixOp String |
              Tk__qq_PrefixOp String |
@@ -512,7 +523,8 @@ data Token = EndOfFile |
              Tk__qq_MemberAfterFirstId String |
              Tk__qq_PrimitiveTypeKeyword String |
              Tk__qq_MemberDeclaration String |
-             Tk__qq_SquareBracketsList String |
+             Tk__qq_NonEmptyDims String |
+             Tk__qq_Dims String |
              Tk__qq_FieldDeclaration String |
              Tk__qq_NestedTypeDeclaration String |
              Tk__qq_EnumDeclaration String |

--- a/test/golden/java/JavaParser.y
+++ b/test/golden/java/JavaParser.y
@@ -13,85 +13,88 @@ import qualified JavaLexer as L (Token(..), PosToken(..), AlexPosn(..), alexScan
 %token
 
 rtk__eof { L.PosToken _ L.EndOfFile }
-tok_AdditiveOp_dummy_169 { L.PosToken _ L.Tk__tok_AdditiveOp_dummy_169 }
-tok_Annotation_dummy_168 { L.PosToken _ L.Tk__tok_Annotation_dummy_168 }
-tok_AnnotationArguments_dummy_167 { L.PosToken _ L.Tk__tok_AnnotationArguments_dummy_167 }
-tok_AnnotationDeclaration_dummy_166 { L.PosToken _ L.Tk__tok_AnnotationDeclaration_dummy_166 }
-tok_AnnotationElement_dummy_165 { L.PosToken _ L.Tk__tok_AnnotationElement_dummy_165 }
-tok_AnnotationList_dummy_164 { L.PosToken _ L.Tk__tok_AnnotationList_dummy_164 }
-tok_AnnotationTypeElement_dummy_163 { L.PosToken _ L.Tk__tok_AnnotationTypeElement_dummy_163 }
-tok_AnnotationTypeElementList_dummy_162 { L.PosToken _ L.Tk__tok_AnnotationTypeElementList_dummy_162 }
-tok_Arglist_dummy_161 { L.PosToken _ L.Tk__tok_Arglist_dummy_161 }
-tok_AssignmentOp_dummy_160 { L.PosToken _ L.Tk__tok_AssignmentOp_dummy_160 }
-tok_CatchList_dummy_159 { L.PosToken _ L.Tk__tok_CatchList_dummy_159 }
-tok_ClassDeclaration_dummy_158 { L.PosToken _ L.Tk__tok_ClassDeclaration_dummy_158 }
-tok_CompilationUnit_dummy_157 { L.PosToken _ L.Tk__tok_CompilationUnit_dummy_157 }
-tok_CompoundName_dummy_156 { L.PosToken _ L.Tk__tok_CompoundName_dummy_156 }
-tok_CreationExpression_dummy_155 { L.PosToken _ L.Tk__tok_CreationExpression_dummy_155 }
-tok_DoStatement_dummy_154 { L.PosToken _ L.Tk__tok_DoStatement_dummy_154 }
-tok_DocComment_dummy_153 { L.PosToken _ L.Tk__tok_DocComment_dummy_153 }
-tok_EnumConstant_dummy_152 { L.PosToken _ L.Tk__tok_EnumConstant_dummy_152 }
-tok_EnumConstantList_dummy_151 { L.PosToken _ L.Tk__tok_EnumConstantList_dummy_151 }
-tok_EnumDeclaration_dummy_150 { L.PosToken _ L.Tk__tok_EnumDeclaration_dummy_150 }
-tok_EqualityOp_dummy_149 { L.PosToken _ L.Tk__tok_EqualityOp_dummy_149 }
-tok_Expression_dummy_148 { L.PosToken _ L.Tk__tok_Expression_dummy_148 }
-tok_ExtendsList_dummy_147 { L.PosToken _ L.Tk__tok_ExtendsList_dummy_147 }
-tok_FieldDeclaration_dummy_146 { L.PosToken _ L.Tk__tok_FieldDeclaration_dummy_146 }
-tok_FieldDeclarationList_dummy_145 { L.PosToken _ L.Tk__tok_FieldDeclarationList_dummy_145 }
-tok_ForStatement_dummy_144 { L.PosToken _ L.Tk__tok_ForStatement_dummy_144 }
-tok_IfStatement_dummy_143 { L.PosToken _ L.Tk__tok_IfStatement_dummy_143 }
-tok_ImplementsList_dummy_142 { L.PosToken _ L.Tk__tok_ImplementsList_dummy_142 }
-tok_ImportList_dummy_141 { L.PosToken _ L.Tk__tok_ImportList_dummy_141 }
-tok_ImportStatement_dummy_140 { L.PosToken _ L.Tk__tok_ImportStatement_dummy_140 }
-tok_InterfaceDeclaration_dummy_139 { L.PosToken _ L.Tk__tok_InterfaceDeclaration_dummy_139 }
-tok_Java_dummy_170 { L.PosToken _ L.Tk__tok_Java_dummy_170 }
-tok_Literal_dummy_138 { L.PosToken _ L.Tk__tok_Literal_dummy_138 }
-tok_MemberAfterFirstId_dummy_137 { L.PosToken _ L.Tk__tok_MemberAfterFirstId_dummy_137 }
-tok_MemberDeclaration_dummy_136 { L.PosToken _ L.Tk__tok_MemberDeclaration_dummy_136 }
-tok_MemberRest_dummy_135 { L.PosToken _ L.Tk__tok_MemberRest_dummy_135 }
-tok_Modifier_dummy_134 { L.PosToken _ L.Tk__tok_Modifier_dummy_134 }
-tok_ModifierList_dummy_133 { L.PosToken _ L.Tk__tok_ModifierList_dummy_133 }
-tok_MoreTypeSpecifier_dummy_132 { L.PosToken _ L.Tk__tok_MoreTypeSpecifier_dummy_132 }
-tok_MoreVariableDeclarators_dummy_131 { L.PosToken _ L.Tk__tok_MoreVariableDeclarators_dummy_131 }
-tok_MultiplicativeOp_dummy_130 { L.PosToken _ L.Tk__tok_MultiplicativeOp_dummy_130 }
-tok_NestedTypeDeclaration_dummy_129 { L.PosToken _ L.Tk__tok_NestedTypeDeclaration_dummy_129 }
-tok_OptDocComment_dummy_128 { L.PosToken _ L.Tk__tok_OptDocComment_dummy_128 }
-tok_OptElsePart_dummy_127 { L.PosToken _ L.Tk__tok_OptElsePart_dummy_127 }
-tok_OptExpression_dummy_126 { L.PosToken _ L.Tk__tok_OptExpression_dummy_126 }
-tok_OptFinally_dummy_125 { L.PosToken _ L.Tk__tok_OptFinally_dummy_125 }
-tok_OptId_dummy_124 { L.PosToken _ L.Tk__tok_OptId_dummy_124 }
-tok_OptVariableInitializer_dummy_123 { L.PosToken _ L.Tk__tok_OptVariableInitializer_dummy_123 }
-tok_Package_dummy_122 { L.PosToken _ L.Tk__tok_Package_dummy_122 }
-tok_Parameter_dummy_121 { L.PosToken _ L.Tk__tok_Parameter_dummy_121 }
-tok_ParameterList_dummy_120 { L.PosToken _ L.Tk__tok_ParameterList_dummy_120 }
-tok_PostfixOp_dummy_119 { L.PosToken _ L.Tk__tok_PostfixOp_dummy_119 }
-tok_PrefixOp_dummy_118 { L.PosToken _ L.Tk__tok_PrefixOp_dummy_118 }
-tok_PrimitiveTypeKeyword_dummy_117 { L.PosToken _ L.Tk__tok_PrimitiveTypeKeyword_dummy_117 }
-tok_RelationalOp_dummy_116 { L.PosToken _ L.Tk__tok_RelationalOp_dummy_116 }
-tok_ShiftOp_dummy_115 { L.PosToken _ L.Tk__tok_ShiftOp_dummy_115 }
-tok_SquareBracketsList_dummy_114 { L.PosToken _ L.Tk__tok_SquareBracketsList_dummy_114 }
-tok_Statement_dummy_113 { L.PosToken _ L.Tk__tok_Statement_dummy_113 }
-tok_StatementBlock_dummy_112 { L.PosToken _ L.Tk__tok_StatementBlock_dummy_112 }
-tok_StatementList_dummy_111 { L.PosToken _ L.Tk__tok_StatementList_dummy_111 }
-tok_StatementWithoutIf_dummy_110 { L.PosToken _ L.Tk__tok_StatementWithoutIf_dummy_110 }
-tok_StaticInitializer_dummy_109 { L.PosToken _ L.Tk__tok_StaticInitializer_dummy_109 }
-tok_SwitchCaseList_dummy_108 { L.PosToken _ L.Tk__tok_SwitchCaseList_dummy_108 }
-tok_SwitchStatement_dummy_107 { L.PosToken _ L.Tk__tok_SwitchStatement_dummy_107 }
-tok_TryStatement_dummy_106 { L.PosToken _ L.Tk__tok_TryStatement_dummy_106 }
-tok_Type_dummy_105 { L.PosToken _ L.Tk__tok_Type_dummy_105 }
-tok_TypeArgument_dummy_104 { L.PosToken _ L.Tk__tok_TypeArgument_dummy_104 }
-tok_TypeArguments_dummy_103 { L.PosToken _ L.Tk__tok_TypeArguments_dummy_103 }
-tok_TypeDeclaration_dummy_102 { L.PosToken _ L.Tk__tok_TypeDeclaration_dummy_102 }
-tok_TypeParameter_dummy_101 { L.PosToken _ L.Tk__tok_TypeParameter_dummy_101 }
-tok_TypeParameters_dummy_100 { L.PosToken _ L.Tk__tok_TypeParameters_dummy_100 }
-tok_TypeSpecifier_dummy_99 { L.PosToken _ L.Tk__tok_TypeSpecifier_dummy_99 }
-tok_VariableDeclaration_dummy_98 { L.PosToken _ L.Tk__tok_VariableDeclaration_dummy_98 }
-tok_VariableDeclarator_dummy_97 { L.PosToken _ L.Tk__tok_VariableDeclarator_dummy_97 }
-tok_VariableDeclaratorList_dummy_96 { L.PosToken _ L.Tk__tok_VariableDeclaratorList_dummy_96 }
-tok_VariableInitializer_dummy_95 { L.PosToken _ L.Tk__tok_VariableInitializer_dummy_95 }
-tok_VariableInitializerList_dummy_94 { L.PosToken _ L.Tk__tok_VariableInitializerList_dummy_94 }
-tok_WhileStatement_dummy_93 { L.PosToken _ L.Tk__tok_WhileStatement_dummy_93 }
-tok_WildcardType_dummy_92 { L.PosToken _ L.Tk__tok_WildcardType_dummy_92 }
+tok_AdditiveOp_dummy_177 { L.PosToken _ L.Tk__tok_AdditiveOp_dummy_177 }
+tok_Annotation_dummy_176 { L.PosToken _ L.Tk__tok_Annotation_dummy_176 }
+tok_AnnotationArguments_dummy_175 { L.PosToken _ L.Tk__tok_AnnotationArguments_dummy_175 }
+tok_AnnotationDeclaration_dummy_174 { L.PosToken _ L.Tk__tok_AnnotationDeclaration_dummy_174 }
+tok_AnnotationElement_dummy_173 { L.PosToken _ L.Tk__tok_AnnotationElement_dummy_173 }
+tok_AnnotationList_dummy_172 { L.PosToken _ L.Tk__tok_AnnotationList_dummy_172 }
+tok_AnnotationTypeElement_dummy_171 { L.PosToken _ L.Tk__tok_AnnotationTypeElement_dummy_171 }
+tok_AnnotationTypeElementList_dummy_170 { L.PosToken _ L.Tk__tok_AnnotationTypeElementList_dummy_170 }
+tok_Arglist_dummy_169 { L.PosToken _ L.Tk__tok_Arglist_dummy_169 }
+tok_AssignmentOp_dummy_168 { L.PosToken _ L.Tk__tok_AssignmentOp_dummy_168 }
+tok_CatchList_dummy_167 { L.PosToken _ L.Tk__tok_CatchList_dummy_167 }
+tok_ClassDeclaration_dummy_166 { L.PosToken _ L.Tk__tok_ClassDeclaration_dummy_166 }
+tok_CompilationUnit_dummy_165 { L.PosToken _ L.Tk__tok_CompilationUnit_dummy_165 }
+tok_CompoundName_dummy_164 { L.PosToken _ L.Tk__tok_CompoundName_dummy_164 }
+tok_CreationExpression_dummy_163 { L.PosToken _ L.Tk__tok_CreationExpression_dummy_163 }
+tok_DimExprs_dummy_162 { L.PosToken _ L.Tk__tok_DimExprs_dummy_162 }
+tok_Dims_dummy_161 { L.PosToken _ L.Tk__tok_Dims_dummy_161 }
+tok_DoStatement_dummy_160 { L.PosToken _ L.Tk__tok_DoStatement_dummy_160 }
+tok_DocComment_dummy_159 { L.PosToken _ L.Tk__tok_DocComment_dummy_159 }
+tok_EnumConstant_dummy_158 { L.PosToken _ L.Tk__tok_EnumConstant_dummy_158 }
+tok_EnumConstantList_dummy_157 { L.PosToken _ L.Tk__tok_EnumConstantList_dummy_157 }
+tok_EnumDeclaration_dummy_156 { L.PosToken _ L.Tk__tok_EnumDeclaration_dummy_156 }
+tok_EqualityOp_dummy_155 { L.PosToken _ L.Tk__tok_EqualityOp_dummy_155 }
+tok_Expression_dummy_154 { L.PosToken _ L.Tk__tok_Expression_dummy_154 }
+tok_ExtendsList_dummy_153 { L.PosToken _ L.Tk__tok_ExtendsList_dummy_153 }
+tok_FieldDeclaration_dummy_152 { L.PosToken _ L.Tk__tok_FieldDeclaration_dummy_152 }
+tok_FieldDeclarationList_dummy_151 { L.PosToken _ L.Tk__tok_FieldDeclarationList_dummy_151 }
+tok_ForStatement_dummy_150 { L.PosToken _ L.Tk__tok_ForStatement_dummy_150 }
+tok_IfStatement_dummy_149 { L.PosToken _ L.Tk__tok_IfStatement_dummy_149 }
+tok_ImplementsList_dummy_148 { L.PosToken _ L.Tk__tok_ImplementsList_dummy_148 }
+tok_ImportList_dummy_147 { L.PosToken _ L.Tk__tok_ImportList_dummy_147 }
+tok_ImportStatement_dummy_146 { L.PosToken _ L.Tk__tok_ImportStatement_dummy_146 }
+tok_InterfaceDeclaration_dummy_145 { L.PosToken _ L.Tk__tok_InterfaceDeclaration_dummy_145 }
+tok_Java_dummy_178 { L.PosToken _ L.Tk__tok_Java_dummy_178 }
+tok_Literal_dummy_144 { L.PosToken _ L.Tk__tok_Literal_dummy_144 }
+tok_MemberAfterFirstId_dummy_143 { L.PosToken _ L.Tk__tok_MemberAfterFirstId_dummy_143 }
+tok_MemberDeclaration_dummy_142 { L.PosToken _ L.Tk__tok_MemberDeclaration_dummy_142 }
+tok_MemberRest_dummy_141 { L.PosToken _ L.Tk__tok_MemberRest_dummy_141 }
+tok_Modifier_dummy_140 { L.PosToken _ L.Tk__tok_Modifier_dummy_140 }
+tok_ModifierList_dummy_139 { L.PosToken _ L.Tk__tok_ModifierList_dummy_139 }
+tok_MoreTypeSpecifier_dummy_138 { L.PosToken _ L.Tk__tok_MoreTypeSpecifier_dummy_138 }
+tok_MoreVariableDeclarators_dummy_137 { L.PosToken _ L.Tk__tok_MoreVariableDeclarators_dummy_137 }
+tok_MultiplicativeOp_dummy_136 { L.PosToken _ L.Tk__tok_MultiplicativeOp_dummy_136 }
+tok_NestedTypeDeclaration_dummy_135 { L.PosToken _ L.Tk__tok_NestedTypeDeclaration_dummy_135 }
+tok_NonEmptyDims_dummy_134 { L.PosToken _ L.Tk__tok_NonEmptyDims_dummy_134 }
+tok_NonEmptyTypeArguments_dummy_133 { L.PosToken _ L.Tk__tok_NonEmptyTypeArguments_dummy_133 }
+tok_OptDocComment_dummy_132 { L.PosToken _ L.Tk__tok_OptDocComment_dummy_132 }
+tok_OptElsePart_dummy_131 { L.PosToken _ L.Tk__tok_OptElsePart_dummy_131 }
+tok_OptExpression_dummy_130 { L.PosToken _ L.Tk__tok_OptExpression_dummy_130 }
+tok_OptFinally_dummy_129 { L.PosToken _ L.Tk__tok_OptFinally_dummy_129 }
+tok_OptId_dummy_128 { L.PosToken _ L.Tk__tok_OptId_dummy_128 }
+tok_OptVariableInitializer_dummy_127 { L.PosToken _ L.Tk__tok_OptVariableInitializer_dummy_127 }
+tok_Package_dummy_126 { L.PosToken _ L.Tk__tok_Package_dummy_126 }
+tok_Parameter_dummy_125 { L.PosToken _ L.Tk__tok_Parameter_dummy_125 }
+tok_ParameterList_dummy_124 { L.PosToken _ L.Tk__tok_ParameterList_dummy_124 }
+tok_PostfixOp_dummy_123 { L.PosToken _ L.Tk__tok_PostfixOp_dummy_123 }
+tok_PrefixOp_dummy_122 { L.PosToken _ L.Tk__tok_PrefixOp_dummy_122 }
+tok_PrimitiveTypeKeyword_dummy_121 { L.PosToken _ L.Tk__tok_PrimitiveTypeKeyword_dummy_121 }
+tok_RelationalOp_dummy_120 { L.PosToken _ L.Tk__tok_RelationalOp_dummy_120 }
+tok_ShiftOp_dummy_119 { L.PosToken _ L.Tk__tok_ShiftOp_dummy_119 }
+tok_Statement_dummy_118 { L.PosToken _ L.Tk__tok_Statement_dummy_118 }
+tok_StatementBlock_dummy_117 { L.PosToken _ L.Tk__tok_StatementBlock_dummy_117 }
+tok_StatementList_dummy_116 { L.PosToken _ L.Tk__tok_StatementList_dummy_116 }
+tok_StatementWithoutIf_dummy_115 { L.PosToken _ L.Tk__tok_StatementWithoutIf_dummy_115 }
+tok_StaticInitializer_dummy_114 { L.PosToken _ L.Tk__tok_StaticInitializer_dummy_114 }
+tok_SwitchCaseList_dummy_113 { L.PosToken _ L.Tk__tok_SwitchCaseList_dummy_113 }
+tok_SwitchStatement_dummy_112 { L.PosToken _ L.Tk__tok_SwitchStatement_dummy_112 }
+tok_TryStatement_dummy_111 { L.PosToken _ L.Tk__tok_TryStatement_dummy_111 }
+tok_Type_dummy_110 { L.PosToken _ L.Tk__tok_Type_dummy_110 }
+tok_TypeArgument_dummy_109 { L.PosToken _ L.Tk__tok_TypeArgument_dummy_109 }
+tok_TypeArguments_dummy_108 { L.PosToken _ L.Tk__tok_TypeArguments_dummy_108 }
+tok_TypeDeclaration_dummy_107 { L.PosToken _ L.Tk__tok_TypeDeclaration_dummy_107 }
+tok_TypeParameter_dummy_106 { L.PosToken _ L.Tk__tok_TypeParameter_dummy_106 }
+tok_TypeParameters_dummy_105 { L.PosToken _ L.Tk__tok_TypeParameters_dummy_105 }
+tok_TypeSpecifier_dummy_104 { L.PosToken _ L.Tk__tok_TypeSpecifier_dummy_104 }
+tok_VariableDeclaration_dummy_103 { L.PosToken _ L.Tk__tok_VariableDeclaration_dummy_103 }
+tok_VariableDeclarator_dummy_102 { L.PosToken _ L.Tk__tok_VariableDeclarator_dummy_102 }
+tok_VariableDeclaratorList_dummy_101 { L.PosToken _ L.Tk__tok_VariableDeclaratorList_dummy_101 }
+tok_VariableInitializer_dummy_100 { L.PosToken _ L.Tk__tok_VariableInitializer_dummy_100 }
+tok_VariableInitializerList_dummy_99 { L.PosToken _ L.Tk__tok_VariableInitializerList_dummy_99 }
+tok_WhileStatement_dummy_98 { L.PosToken _ L.Tk__tok_WhileStatement_dummy_98 }
+tok_WildcardType_dummy_97 { L.PosToken _ L.Tk__tok_WildcardType_dummy_97 }
 tok__tilde__78 { L.PosToken _ L.Tk__tok__tilde__78 }
 tok__symbol__14 { L.PosToken _ L.Tk__tok__symbol__14 }
 tok__pipe__pipe__57 { L.PosToken _ L.Tk__tok__pipe__pipe__57 }
@@ -203,9 +206,11 @@ qq_TypeParameter { L.PosToken _ (L.Tk__qq_TypeParameter _) }
 qq_TypeParameters { L.PosToken _ (L.Tk__qq_TypeParameters _) }
 qq_WildcardType { L.PosToken _ (L.Tk__qq_WildcardType _) }
 qq_TypeArgument { L.PosToken _ (L.Tk__qq_TypeArgument _) }
+qq_NonEmptyTypeArguments { L.PosToken _ (L.Tk__qq_NonEmptyTypeArguments _) }
 qq_TypeArguments { L.PosToken _ (L.Tk__qq_TypeArguments _) }
 qq_Arglist { L.PosToken _ (L.Tk__qq_Arglist _) }
 qq_Literal { L.PosToken _ (L.Tk__qq_Literal _) }
+qq_DimExprs { L.PosToken _ (L.Tk__qq_DimExprs _) }
 qq_CreationExpression { L.PosToken _ (L.Tk__qq_CreationExpression _) }
 qq_PostfixOp { L.PosToken _ (L.Tk__qq_PostfixOp _) }
 qq_PrefixOp { L.PosToken _ (L.Tk__qq_PrefixOp _) }
@@ -247,7 +252,8 @@ qq_MoreTypeSpecifier { L.PosToken _ (L.Tk__qq_MoreTypeSpecifier _) }
 qq_MemberAfterFirstId { L.PosToken _ (L.Tk__qq_MemberAfterFirstId _) }
 qq_PrimitiveTypeKeyword { L.PosToken _ (L.Tk__qq_PrimitiveTypeKeyword _) }
 qq_MemberDeclaration { L.PosToken _ (L.Tk__qq_MemberDeclaration _) }
-qq_SquareBracketsList { L.PosToken _ (L.Tk__qq_SquareBracketsList _) }
+qq_NonEmptyDims { L.PosToken _ (L.Tk__qq_NonEmptyDims _) }
+qq_Dims { L.PosToken _ (L.Tk__qq_Dims _) }
 qq_FieldDeclaration { L.PosToken _ (L.Tk__qq_FieldDeclaration _) }
 qq_NestedTypeDeclaration { L.PosToken _ (L.Tk__qq_NestedTypeDeclaration _) }
 qq_EnumDeclaration { L.PosToken _ (L.Tk__qq_EnumDeclaration _) }
@@ -279,88 +285,91 @@ qq_Java { L.PosToken _ (L.Tk__qq_Java _) }
 
 Java__top : Java rtk__eof { $1 }
 
-Java : tok_Java_dummy_170 Java tok_Java_dummy_170 { Ctr__Java__0 (rtkPosOf $1) $2 } |
-       tok_AdditiveOp_dummy_169 AdditiveOp tok_AdditiveOp_dummy_169 { Ctr__Java__1 (rtkPosOf $1) $2 } |
-       tok_Annotation_dummy_168 Annotation tok_Annotation_dummy_168 { Ctr__Java__2 (rtkPosOf $1) $2 } |
-       tok_AnnotationArguments_dummy_167 AnnotationArguments tok_AnnotationArguments_dummy_167 { Ctr__Java__3 (rtkPosOf $1) $2 } |
-       tok_AnnotationDeclaration_dummy_166 AnnotationDeclaration tok_AnnotationDeclaration_dummy_166 { Ctr__Java__4 (rtkPosOf $1) $2 } |
-       tok_AnnotationElement_dummy_165 AnnotationElement tok_AnnotationElement_dummy_165 { Ctr__Java__5 (rtkPosOf $1) $2 } |
-       tok_AnnotationList_dummy_164 AnnotationList tok_AnnotationList_dummy_164 { Ctr__Java__6 (rtkPosOf $1) (reverse $2) } |
-       tok_AnnotationTypeElement_dummy_163 AnnotationTypeElement tok_AnnotationTypeElement_dummy_163 { Ctr__Java__7 (rtkPosOf $1) $2 } |
-       tok_AnnotationTypeElementList_dummy_162 AnnotationTypeElementList tok_AnnotationTypeElementList_dummy_162 { Ctr__Java__8 (rtkPosOf $1) (reverse $2) } |
-       tok_Arglist_dummy_161 Arglist tok_Arglist_dummy_161 { Ctr__Java__9 (rtkPosOf $1) $2 } |
-       tok_AssignmentOp_dummy_160 AssignmentOp tok_AssignmentOp_dummy_160 { Ctr__Java__10 (rtkPosOf $1) $2 } |
-       tok_CatchList_dummy_159 CatchList tok_CatchList_dummy_159 { Ctr__Java__11 (rtkPosOf $1) (reverse $2) } |
-       tok_ClassDeclaration_dummy_158 ClassDeclaration tok_ClassDeclaration_dummy_158 { Ctr__Java__12 (rtkPosOf $1) $2 } |
-       tok_CompilationUnit_dummy_157 CompilationUnit tok_CompilationUnit_dummy_157 { Ctr__Java__13 (rtkPosOf $1) $2 } |
-       tok_CompoundName_dummy_156 CompoundName tok_CompoundName_dummy_156 { Ctr__Java__14 (rtkPosOf $1) $2 } |
-       tok_CreationExpression_dummy_155 CreationExpression tok_CreationExpression_dummy_155 { Ctr__Java__15 (rtkPosOf $1) $2 } |
-       tok_DoStatement_dummy_154 DoStatement tok_DoStatement_dummy_154 { Ctr__Java__16 (rtkPosOf $1) $2 } |
-       tok_DocComment_dummy_153 DocComment tok_DocComment_dummy_153 { Ctr__Java__17 (rtkPosOf $1) $2 } |
-       tok_EnumConstant_dummy_152 EnumConstant tok_EnumConstant_dummy_152 { Ctr__Java__18 (rtkPosOf $1) $2 } |
-       tok_EnumConstantList_dummy_151 EnumConstantList tok_EnumConstantList_dummy_151 { Ctr__Java__19 (rtkPosOf $1) $2 } |
-       tok_EnumDeclaration_dummy_150 EnumDeclaration tok_EnumDeclaration_dummy_150 { Ctr__Java__20 (rtkPosOf $1) $2 } |
-       tok_EqualityOp_dummy_149 EqualityOp tok_EqualityOp_dummy_149 { Ctr__Java__21 (rtkPosOf $1) $2 } |
-       tok_Expression_dummy_148 Expression tok_Expression_dummy_148 { Ctr__Java__22 (rtkPosOf $1) $2 } |
-       tok_ExtendsList_dummy_147 ExtendsList tok_ExtendsList_dummy_147 { Ctr__Java__23 (rtkPosOf $1) $2 } |
-       tok_FieldDeclaration_dummy_146 FieldDeclaration tok_FieldDeclaration_dummy_146 { Ctr__Java__24 (rtkPosOf $1) $2 } |
-       tok_FieldDeclarationList_dummy_145 FieldDeclarationList tok_FieldDeclarationList_dummy_145 { Ctr__Java__25 (rtkPosOf $1) (reverse $2) } |
-       tok_ForStatement_dummy_144 ForStatement tok_ForStatement_dummy_144 { Ctr__Java__26 (rtkPosOf $1) $2 } |
-       tok_IfStatement_dummy_143 IfStatement tok_IfStatement_dummy_143 { Ctr__Java__27 (rtkPosOf $1) $2 } |
-       tok_ImplementsList_dummy_142 ImplementsList tok_ImplementsList_dummy_142 { Ctr__Java__28 (rtkPosOf $1) $2 } |
-       tok_ImportList_dummy_141 ImportList tok_ImportList_dummy_141 { Ctr__Java__29 (rtkPosOf $1) (reverse $2) } |
-       tok_ImportStatement_dummy_140 ImportStatement tok_ImportStatement_dummy_140 { Ctr__Java__30 (rtkPosOf $1) $2 } |
-       tok_InterfaceDeclaration_dummy_139 InterfaceDeclaration tok_InterfaceDeclaration_dummy_139 { Ctr__Java__31 (rtkPosOf $1) $2 } |
-       tok_Literal_dummy_138 Literal tok_Literal_dummy_138 { Ctr__Java__32 (rtkPosOf $1) $2 } |
-       tok_MemberAfterFirstId_dummy_137 MemberAfterFirstId tok_MemberAfterFirstId_dummy_137 { Ctr__Java__33 (rtkPosOf $1) $2 } |
-       tok_MemberDeclaration_dummy_136 MemberDeclaration tok_MemberDeclaration_dummy_136 { Ctr__Java__34 (rtkPosOf $1) $2 } |
-       tok_MemberRest_dummy_135 MemberRest tok_MemberRest_dummy_135 { Ctr__Java__35 (rtkPosOf $1) $2 } |
-       tok_Modifier_dummy_134 Modifier tok_Modifier_dummy_134 { Ctr__Java__36 (rtkPosOf $1) $2 } |
-       tok_ModifierList_dummy_133 ModifierList tok_ModifierList_dummy_133 { Ctr__Java__37 (rtkPosOf $1) (reverse $2) } |
-       tok_MoreTypeSpecifier_dummy_132 MoreTypeSpecifier tok_MoreTypeSpecifier_dummy_132 { Ctr__Java__38 (rtkPosOf $1) $2 } |
-       tok_MoreVariableDeclarators_dummy_131 MoreVariableDeclarators tok_MoreVariableDeclarators_dummy_131 { Ctr__Java__39 (rtkPosOf $1) (reverse $2) } |
-       tok_MultiplicativeOp_dummy_130 MultiplicativeOp tok_MultiplicativeOp_dummy_130 { Ctr__Java__40 (rtkPosOf $1) $2 } |
-       tok_NestedTypeDeclaration_dummy_129 NestedTypeDeclaration tok_NestedTypeDeclaration_dummy_129 { Ctr__Java__41 (rtkPosOf $1) $2 } |
-       tok_OptDocComment_dummy_128 OptDocComment tok_OptDocComment_dummy_128 { Ctr__Java__42 (rtkPosOf $1) $2 } |
-       tok_OptElsePart_dummy_127 OptElsePart tok_OptElsePart_dummy_127 { Ctr__Java__43 (rtkPosOf $1) $2 } |
-       tok_OptExpression_dummy_126 OptExpression tok_OptExpression_dummy_126 { Ctr__Java__44 (rtkPosOf $1) $2 } |
-       tok_OptFinally_dummy_125 OptFinally tok_OptFinally_dummy_125 { Ctr__Java__45 (rtkPosOf $1) $2 } |
-       tok_OptId_dummy_124 OptId tok_OptId_dummy_124 { Ctr__Java__46 (rtkPosOf $1) $2 } |
-       tok_OptVariableInitializer_dummy_123 OptVariableInitializer tok_OptVariableInitializer_dummy_123 { Ctr__Java__47 (rtkPosOf $1) $2 } |
-       tok_Package_dummy_122 Package tok_Package_dummy_122 { Ctr__Java__48 (rtkPosOf $1) $2 } |
-       tok_Parameter_dummy_121 Parameter tok_Parameter_dummy_121 { Ctr__Java__49 (rtkPosOf $1) $2 } |
-       tok_ParameterList_dummy_120 ParameterList tok_ParameterList_dummy_120 { Ctr__Java__50 (rtkPosOf $1) $2 } |
-       tok_PostfixOp_dummy_119 PostfixOp tok_PostfixOp_dummy_119 { Ctr__Java__51 (rtkPosOf $1) $2 } |
-       tok_PrefixOp_dummy_118 PrefixOp tok_PrefixOp_dummy_118 { Ctr__Java__52 (rtkPosOf $1) $2 } |
-       tok_PrimitiveTypeKeyword_dummy_117 PrimitiveTypeKeyword tok_PrimitiveTypeKeyword_dummy_117 { Ctr__Java__53 (rtkPosOf $1) $2 } |
-       tok_RelationalOp_dummy_116 RelationalOp tok_RelationalOp_dummy_116 { Ctr__Java__54 (rtkPosOf $1) $2 } |
-       tok_ShiftOp_dummy_115 ShiftOp tok_ShiftOp_dummy_115 { Ctr__Java__55 (rtkPosOf $1) $2 } |
-       tok_SquareBracketsList_dummy_114 SquareBracketsList tok_SquareBracketsList_dummy_114 { Ctr__Java__56 (rtkPosOf $1) (reverse $2) } |
-       tok_Statement_dummy_113 Statement tok_Statement_dummy_113 { Ctr__Java__57 (rtkPosOf $1) $2 } |
-       tok_StatementBlock_dummy_112 StatementBlock tok_StatementBlock_dummy_112 { Ctr__Java__58 (rtkPosOf $1) $2 } |
-       tok_StatementList_dummy_111 StatementList tok_StatementList_dummy_111 { Ctr__Java__59 (rtkPosOf $1) (reverse $2) } |
-       tok_StatementWithoutIf_dummy_110 StatementWithoutIf tok_StatementWithoutIf_dummy_110 { Ctr__Java__60 (rtkPosOf $1) $2 } |
-       tok_StaticInitializer_dummy_109 StaticInitializer tok_StaticInitializer_dummy_109 { Ctr__Java__61 (rtkPosOf $1) $2 } |
-       tok_SwitchCaseList_dummy_108 SwitchCaseList tok_SwitchCaseList_dummy_108 { Ctr__Java__62 (rtkPosOf $1) (reverse $2) } |
-       tok_SwitchStatement_dummy_107 SwitchStatement tok_SwitchStatement_dummy_107 { Ctr__Java__63 (rtkPosOf $1) $2 } |
-       tok_TryStatement_dummy_106 TryStatement tok_TryStatement_dummy_106 { Ctr__Java__64 (rtkPosOf $1) $2 } |
-       tok_Type_dummy_105 Type tok_Type_dummy_105 { Ctr__Java__65 (rtkPosOf $1) $2 } |
-       tok_TypeArgument_dummy_104 TypeArgument tok_TypeArgument_dummy_104 { Ctr__Java__66 (rtkPosOf $1) $2 } |
-       tok_TypeArguments_dummy_103 TypeArguments tok_TypeArguments_dummy_103 { Ctr__Java__67 (rtkPosOf $1) $2 } |
-       tok_TypeDeclaration_dummy_102 TypeDeclaration tok_TypeDeclaration_dummy_102 { Ctr__Java__68 (rtkPosOf $1) $2 } |
-       tok_TypeParameter_dummy_101 TypeParameter tok_TypeParameter_dummy_101 { Ctr__Java__69 (rtkPosOf $1) $2 } |
-       tok_TypeParameters_dummy_100 TypeParameters tok_TypeParameters_dummy_100 { Ctr__Java__70 (rtkPosOf $1) $2 } |
-       tok_TypeSpecifier_dummy_99 TypeSpecifier tok_TypeSpecifier_dummy_99 { Ctr__Java__71 (rtkPosOf $1) $2 } |
-       tok_VariableDeclaration_dummy_98 VariableDeclaration tok_VariableDeclaration_dummy_98 { Ctr__Java__72 (rtkPosOf $1) $2 } |
-       tok_VariableDeclarator_dummy_97 VariableDeclarator tok_VariableDeclarator_dummy_97 { Ctr__Java__73 (rtkPosOf $1) $2 } |
-       tok_VariableDeclaratorList_dummy_96 VariableDeclaratorList tok_VariableDeclaratorList_dummy_96 { Ctr__Java__74 (rtkPosOf $1) $2 } |
-       tok_VariableInitializer_dummy_95 VariableInitializer tok_VariableInitializer_dummy_95 { Ctr__Java__75 (rtkPosOf $1) $2 } |
-       tok_VariableInitializerList_dummy_94 VariableInitializerList tok_VariableInitializerList_dummy_94 { Ctr__Java__76 (rtkPosOf $1) $2 } |
-       tok_WhileStatement_dummy_93 WhileStatement tok_WhileStatement_dummy_93 { Ctr__Java__77 (rtkPosOf $1) $2 } |
-       tok_WildcardType_dummy_92 WildcardType tok_WildcardType_dummy_92 { Ctr__Java__78 (rtkPosOf $1) $2 }
+Java : tok_Java_dummy_178 Java tok_Java_dummy_178 { Ctr__Java__0 (rtkPosOf $1) $2 } |
+       tok_AdditiveOp_dummy_177 AdditiveOp tok_AdditiveOp_dummy_177 { Ctr__Java__1 (rtkPosOf $1) $2 } |
+       tok_Annotation_dummy_176 Annotation tok_Annotation_dummy_176 { Ctr__Java__2 (rtkPosOf $1) $2 } |
+       tok_AnnotationArguments_dummy_175 AnnotationArguments tok_AnnotationArguments_dummy_175 { Ctr__Java__3 (rtkPosOf $1) $2 } |
+       tok_AnnotationDeclaration_dummy_174 AnnotationDeclaration tok_AnnotationDeclaration_dummy_174 { Ctr__Java__4 (rtkPosOf $1) $2 } |
+       tok_AnnotationElement_dummy_173 AnnotationElement tok_AnnotationElement_dummy_173 { Ctr__Java__5 (rtkPosOf $1) $2 } |
+       tok_AnnotationList_dummy_172 AnnotationList tok_AnnotationList_dummy_172 { Ctr__Java__6 (rtkPosOf $1) (reverse $2) } |
+       tok_AnnotationTypeElement_dummy_171 AnnotationTypeElement tok_AnnotationTypeElement_dummy_171 { Ctr__Java__7 (rtkPosOf $1) $2 } |
+       tok_AnnotationTypeElementList_dummy_170 AnnotationTypeElementList tok_AnnotationTypeElementList_dummy_170 { Ctr__Java__8 (rtkPosOf $1) (reverse $2) } |
+       tok_Arglist_dummy_169 Arglist tok_Arglist_dummy_169 { Ctr__Java__9 (rtkPosOf $1) $2 } |
+       tok_AssignmentOp_dummy_168 AssignmentOp tok_AssignmentOp_dummy_168 { Ctr__Java__10 (rtkPosOf $1) $2 } |
+       tok_CatchList_dummy_167 CatchList tok_CatchList_dummy_167 { Ctr__Java__11 (rtkPosOf $1) (reverse $2) } |
+       tok_ClassDeclaration_dummy_166 ClassDeclaration tok_ClassDeclaration_dummy_166 { Ctr__Java__12 (rtkPosOf $1) $2 } |
+       tok_CompilationUnit_dummy_165 CompilationUnit tok_CompilationUnit_dummy_165 { Ctr__Java__13 (rtkPosOf $1) $2 } |
+       tok_CompoundName_dummy_164 CompoundName tok_CompoundName_dummy_164 { Ctr__Java__14 (rtkPosOf $1) $2 } |
+       tok_CreationExpression_dummy_163 CreationExpression tok_CreationExpression_dummy_163 { Ctr__Java__15 (rtkPosOf $1) $2 } |
+       tok_DimExprs_dummy_162 DimExprs tok_DimExprs_dummy_162 { Ctr__Java__16 (rtkPosOf $1) (reverse $2) } |
+       tok_Dims_dummy_161 Dims tok_Dims_dummy_161 { Ctr__Java__17 (rtkPosOf $1) (reverse $2) } |
+       tok_DoStatement_dummy_160 DoStatement tok_DoStatement_dummy_160 { Ctr__Java__18 (rtkPosOf $1) $2 } |
+       tok_DocComment_dummy_159 DocComment tok_DocComment_dummy_159 { Ctr__Java__19 (rtkPosOf $1) $2 } |
+       tok_EnumConstant_dummy_158 EnumConstant tok_EnumConstant_dummy_158 { Ctr__Java__20 (rtkPosOf $1) $2 } |
+       tok_EnumConstantList_dummy_157 EnumConstantList tok_EnumConstantList_dummy_157 { Ctr__Java__21 (rtkPosOf $1) $2 } |
+       tok_EnumDeclaration_dummy_156 EnumDeclaration tok_EnumDeclaration_dummy_156 { Ctr__Java__22 (rtkPosOf $1) $2 } |
+       tok_EqualityOp_dummy_155 EqualityOp tok_EqualityOp_dummy_155 { Ctr__Java__23 (rtkPosOf $1) $2 } |
+       tok_Expression_dummy_154 Expression tok_Expression_dummy_154 { Ctr__Java__24 (rtkPosOf $1) $2 } |
+       tok_ExtendsList_dummy_153 ExtendsList tok_ExtendsList_dummy_153 { Ctr__Java__25 (rtkPosOf $1) $2 } |
+       tok_FieldDeclaration_dummy_152 FieldDeclaration tok_FieldDeclaration_dummy_152 { Ctr__Java__26 (rtkPosOf $1) $2 } |
+       tok_FieldDeclarationList_dummy_151 FieldDeclarationList tok_FieldDeclarationList_dummy_151 { Ctr__Java__27 (rtkPosOf $1) (reverse $2) } |
+       tok_ForStatement_dummy_150 ForStatement tok_ForStatement_dummy_150 { Ctr__Java__28 (rtkPosOf $1) $2 } |
+       tok_IfStatement_dummy_149 IfStatement tok_IfStatement_dummy_149 { Ctr__Java__29 (rtkPosOf $1) $2 } |
+       tok_ImplementsList_dummy_148 ImplementsList tok_ImplementsList_dummy_148 { Ctr__Java__30 (rtkPosOf $1) $2 } |
+       tok_ImportList_dummy_147 ImportList tok_ImportList_dummy_147 { Ctr__Java__31 (rtkPosOf $1) (reverse $2) } |
+       tok_ImportStatement_dummy_146 ImportStatement tok_ImportStatement_dummy_146 { Ctr__Java__32 (rtkPosOf $1) $2 } |
+       tok_InterfaceDeclaration_dummy_145 InterfaceDeclaration tok_InterfaceDeclaration_dummy_145 { Ctr__Java__33 (rtkPosOf $1) $2 } |
+       tok_Literal_dummy_144 Literal tok_Literal_dummy_144 { Ctr__Java__34 (rtkPosOf $1) $2 } |
+       tok_MemberAfterFirstId_dummy_143 MemberAfterFirstId tok_MemberAfterFirstId_dummy_143 { Ctr__Java__35 (rtkPosOf $1) $2 } |
+       tok_MemberDeclaration_dummy_142 MemberDeclaration tok_MemberDeclaration_dummy_142 { Ctr__Java__36 (rtkPosOf $1) $2 } |
+       tok_MemberRest_dummy_141 MemberRest tok_MemberRest_dummy_141 { Ctr__Java__37 (rtkPosOf $1) $2 } |
+       tok_Modifier_dummy_140 Modifier tok_Modifier_dummy_140 { Ctr__Java__38 (rtkPosOf $1) $2 } |
+       tok_ModifierList_dummy_139 ModifierList tok_ModifierList_dummy_139 { Ctr__Java__39 (rtkPosOf $1) (reverse $2) } |
+       tok_MoreTypeSpecifier_dummy_138 MoreTypeSpecifier tok_MoreTypeSpecifier_dummy_138 { Ctr__Java__40 (rtkPosOf $1) $2 } |
+       tok_MoreVariableDeclarators_dummy_137 MoreVariableDeclarators tok_MoreVariableDeclarators_dummy_137 { Ctr__Java__41 (rtkPosOf $1) (reverse $2) } |
+       tok_MultiplicativeOp_dummy_136 MultiplicativeOp tok_MultiplicativeOp_dummy_136 { Ctr__Java__42 (rtkPosOf $1) $2 } |
+       tok_NestedTypeDeclaration_dummy_135 NestedTypeDeclaration tok_NestedTypeDeclaration_dummy_135 { Ctr__Java__43 (rtkPosOf $1) $2 } |
+       tok_NonEmptyDims_dummy_134 NonEmptyDims tok_NonEmptyDims_dummy_134 { Ctr__Java__44 (rtkPosOf $1) (reverse $2) } |
+       tok_NonEmptyTypeArguments_dummy_133 NonEmptyTypeArguments tok_NonEmptyTypeArguments_dummy_133 { Ctr__Java__45 (rtkPosOf $1) $2 } |
+       tok_OptDocComment_dummy_132 OptDocComment tok_OptDocComment_dummy_132 { Ctr__Java__46 (rtkPosOf $1) $2 } |
+       tok_OptElsePart_dummy_131 OptElsePart tok_OptElsePart_dummy_131 { Ctr__Java__47 (rtkPosOf $1) $2 } |
+       tok_OptExpression_dummy_130 OptExpression tok_OptExpression_dummy_130 { Ctr__Java__48 (rtkPosOf $1) $2 } |
+       tok_OptFinally_dummy_129 OptFinally tok_OptFinally_dummy_129 { Ctr__Java__49 (rtkPosOf $1) $2 } |
+       tok_OptId_dummy_128 OptId tok_OptId_dummy_128 { Ctr__Java__50 (rtkPosOf $1) $2 } |
+       tok_OptVariableInitializer_dummy_127 OptVariableInitializer tok_OptVariableInitializer_dummy_127 { Ctr__Java__51 (rtkPosOf $1) $2 } |
+       tok_Package_dummy_126 Package tok_Package_dummy_126 { Ctr__Java__52 (rtkPosOf $1) $2 } |
+       tok_Parameter_dummy_125 Parameter tok_Parameter_dummy_125 { Ctr__Java__53 (rtkPosOf $1) $2 } |
+       tok_ParameterList_dummy_124 ParameterList tok_ParameterList_dummy_124 { Ctr__Java__54 (rtkPosOf $1) $2 } |
+       tok_PostfixOp_dummy_123 PostfixOp tok_PostfixOp_dummy_123 { Ctr__Java__55 (rtkPosOf $1) $2 } |
+       tok_PrefixOp_dummy_122 PrefixOp tok_PrefixOp_dummy_122 { Ctr__Java__56 (rtkPosOf $1) $2 } |
+       tok_PrimitiveTypeKeyword_dummy_121 PrimitiveTypeKeyword tok_PrimitiveTypeKeyword_dummy_121 { Ctr__Java__57 (rtkPosOf $1) $2 } |
+       tok_RelationalOp_dummy_120 RelationalOp tok_RelationalOp_dummy_120 { Ctr__Java__58 (rtkPosOf $1) $2 } |
+       tok_ShiftOp_dummy_119 ShiftOp tok_ShiftOp_dummy_119 { Ctr__Java__59 (rtkPosOf $1) $2 } |
+       tok_Statement_dummy_118 Statement tok_Statement_dummy_118 { Ctr__Java__60 (rtkPosOf $1) $2 } |
+       tok_StatementBlock_dummy_117 StatementBlock tok_StatementBlock_dummy_117 { Ctr__Java__61 (rtkPosOf $1) $2 } |
+       tok_StatementList_dummy_116 StatementList tok_StatementList_dummy_116 { Ctr__Java__62 (rtkPosOf $1) (reverse $2) } |
+       tok_StatementWithoutIf_dummy_115 StatementWithoutIf tok_StatementWithoutIf_dummy_115 { Ctr__Java__63 (rtkPosOf $1) $2 } |
+       tok_StaticInitializer_dummy_114 StaticInitializer tok_StaticInitializer_dummy_114 { Ctr__Java__64 (rtkPosOf $1) $2 } |
+       tok_SwitchCaseList_dummy_113 SwitchCaseList tok_SwitchCaseList_dummy_113 { Ctr__Java__65 (rtkPosOf $1) (reverse $2) } |
+       tok_SwitchStatement_dummy_112 SwitchStatement tok_SwitchStatement_dummy_112 { Ctr__Java__66 (rtkPosOf $1) $2 } |
+       tok_TryStatement_dummy_111 TryStatement tok_TryStatement_dummy_111 { Ctr__Java__67 (rtkPosOf $1) $2 } |
+       tok_Type_dummy_110 Type tok_Type_dummy_110 { Ctr__Java__68 (rtkPosOf $1) $2 } |
+       tok_TypeArgument_dummy_109 TypeArgument tok_TypeArgument_dummy_109 { Ctr__Java__69 (rtkPosOf $1) $2 } |
+       tok_TypeArguments_dummy_108 TypeArguments tok_TypeArguments_dummy_108 { Ctr__Java__70 (rtkPosOf $1) $2 } |
+       tok_TypeDeclaration_dummy_107 TypeDeclaration tok_TypeDeclaration_dummy_107 { Ctr__Java__71 (rtkPosOf $1) $2 } |
+       tok_TypeParameter_dummy_106 TypeParameter tok_TypeParameter_dummy_106 { Ctr__Java__72 (rtkPosOf $1) $2 } |
+       tok_TypeParameters_dummy_105 TypeParameters tok_TypeParameters_dummy_105 { Ctr__Java__73 (rtkPosOf $1) $2 } |
+       tok_TypeSpecifier_dummy_104 TypeSpecifier tok_TypeSpecifier_dummy_104 { Ctr__Java__74 (rtkPosOf $1) $2 } |
+       tok_VariableDeclaration_dummy_103 VariableDeclaration tok_VariableDeclaration_dummy_103 { Ctr__Java__75 (rtkPosOf $1) $2 } |
+       tok_VariableDeclarator_dummy_102 VariableDeclarator tok_VariableDeclarator_dummy_102 { Ctr__Java__76 (rtkPosOf $1) $2 } |
+       tok_VariableDeclaratorList_dummy_101 VariableDeclaratorList tok_VariableDeclaratorList_dummy_101 { Ctr__Java__77 (rtkPosOf $1) $2 } |
+       tok_VariableInitializer_dummy_100 VariableInitializer tok_VariableInitializer_dummy_100 { Ctr__Java__78 (rtkPosOf $1) $2 } |
+       tok_VariableInitializerList_dummy_99 VariableInitializerList tok_VariableInitializerList_dummy_99 { Ctr__Java__79 (rtkPosOf $1) $2 } |
+       tok_WhileStatement_dummy_98 WhileStatement tok_WhileStatement_dummy_98 { Ctr__Java__80 (rtkPosOf $1) $2 } |
+       tok_WildcardType_dummy_97 WildcardType tok_WildcardType_dummy_97 { Ctr__Java__81 (rtkPosOf $1) $2 }
 
 Java : qq_Java { Anti_Java (tkVal_qq_Java $1) } |
-       CompilationUnit { Ctr__Java__79 (rtkPosOf $1) $1 }
+       CompilationUnit { Ctr__Java__82 (rtkPosOf $1) $1 }
 
 AdditiveOp : qq_AdditiveOp { Anti_AdditiveOp (tkVal_qq_AdditiveOp $1) } |
              tok__plus__72 { Ctr__AdditiveOp__0 (rtkPosOf $1) } |
@@ -396,7 +405,7 @@ AnnotationTypeElementList : {- empty -} { [] } |
 
 Arglist : qq_Arglist { Anti_Arglist (tkVal_qq_Arglist $1) } |
           { Ctr__Arglist__0 rtkNoPos } |
-          Rule_77 { Ctr__Arglist__1 (rtkPosOf $1) $1 }
+          Rule_83 { Ctr__Arglist__1 (rtkPosOf $1) $1 }
 
 AssignmentOp : qq_AssignmentOp { Anti_AssignmentOp (tkVal_qq_AssignmentOp $1) } |
                tok__eql__9 { Ctr__AssignmentOp__0 (rtkPosOf $1) } |
@@ -413,7 +422,7 @@ AssignmentOp : qq_AssignmentOp { Anti_AssignmentOp (tkVal_qq_AssignmentOp $1) } 
                tok__symbol__symbol__symbol__eql__55 { Ctr__AssignmentOp__11 (rtkPosOf $1) }
 
 CatchList : {- empty -} { [] } |
-            CatchList ListElem_CatchList64 { $2 : $1 }
+            CatchList ListElem_CatchList66 { $2 : $1 }
 
 ClassDeclaration : qq_ClassDeclaration { Anti_ClassDeclaration (tkVal_qq_ClassDeclaration $1) } |
                    ModifierList tok_class_12 id TypeParameters Rule_22 Rule_23 tok__symbol__13 FieldDeclarationList tok__symbol__14 { Ctr__ClassDeclaration__0 (rtkPosOf (reverse $1)) (reverse $1) (tkVal_id $3) $4 $5 $6 (reverse $8) }
@@ -422,10 +431,16 @@ CompilationUnit : qq_CompilationUnit { Anti_CompilationUnit (tkVal_qq_Compilatio
                   Rule_4 ImportList Rule_6 { Ctr__CompilationUnit__0 (rtkPosOf $1) $1 (reverse $2) $3 }
 
 CompoundName : qq_CompoundName { Anti_CompoundName (tkVal_qq_CompoundName $1) } |
-               id Rule_90 { Ctr__CompoundName__0 (rtkPosOf $1) (tkVal_id $1) (reverse $2) }
+               id Rule_95 { Ctr__CompoundName__0 (rtkPosOf $1) (tkVal_id $1) (reverse $2) }
 
 CreationExpression : qq_CreationExpression { Anti_CreationExpression (tkVal_qq_CreationExpression $1) } |
-                     tok_new_82 Type Rule_76 { Ctr__CreationExpression__0 (rtkPosOf $1) $2 $3 }
+                     tok_new_82 TypeSpecifier Rule_78 { Ctr__CreationExpression__0 (rtkPosOf $1) $2 $3 }
+
+DimExprs : ListElem_DimExprs82 { [$1] } |
+           DimExprs ListElem_DimExprs82 { $2 : $1 }
+
+Dims : {- empty -} { [] } |
+       Dims ListElem_Dims41 { $2 : $1 }
 
 DoStatement : qq_DoStatement { Anti_DoStatement (tkVal_qq_DoStatement $1) } |
               tok_do_37 Statement tok_while_38 tok__lparen__6 Expression tok__rparen__7 tok__semi__1 { Ctr__DoStatement__0 (rtkPosOf $1) $2 $5 }
@@ -451,62 +466,66 @@ PrimaryNoPostfix : qq_Expression { Anti_Expression (tkVal_qq_Expression $1) } |
                    tok_this_80 { Ctr__Expression__1 (rtkPosOf $1) } |
                    tok__lparen__6 Expression tok__rparen__7 { Ctr__Expression__2 (rtkPosOf $1) $2 } |
                    CreationExpression { Ctr__Expression__3 (rtkPosOf $1) $1 } |
-                   CompoundName Rule_72 { Ctr__Expression__4 (rtkPosOf $1) $1 $2 } |
-                   tok_super_81 tok__dot__3 id Rule_74 { Ctr__Expression__5 (rtkPosOf $1) (tkVal_id $3) $4 }
+                   CompoundName Rule_74 { Ctr__Expression__4 (rtkPosOf $1) $1 $2 } |
+                   CompoundName tok__sq_bkt_l__17 Expression tok__sq_bkt_r__18 { Ctr__Expression__5 (rtkPosOf $1) $1 $3 } |
+                   tok_super_81 tok__dot__3 id Rule_76 { Ctr__Expression__6 (rtkPosOf $1) (tkVal_id $3) $4 }
 
-PostfixExpression : PrimaryNoPostfix { Ctr__Expression__6 (rtkPosOf $1) $1 } |
-                    PostfixExpression PostfixOp { Ctr__Expression__7 (rtkPosOf $1) $1 $2 } |
-                    PostfixExpression tok__dot__3 id { Ctr__Expression__8 (rtkPosOf $1) $1 (tkVal_id $3) } |
-                    PostfixExpression tok__dot__3 id tok__lparen__6 Arglist tok__rparen__7 { Ctr__Expression__9 (rtkPosOf $1) $1 (tkVal_id $3) $5 } |
-                    PostfixExpression tok__sq_bkt_l__17 Expression tok__sq_bkt_r__18 { Ctr__Expression__10 (rtkPosOf $1) $1 $3 }
+PostfixExpression : PrimaryNoPostfix { Ctr__Expression__7 (rtkPosOf $1) $1 } |
+                    PostfixExpression PostfixOp { Ctr__Expression__8 (rtkPosOf $1) $1 $2 } |
+                    PostfixExpression tok__dot__3 id { Ctr__Expression__9 (rtkPosOf $1) $1 (tkVal_id $3) } |
+                    PostfixExpression tok__dot__3 id tok__lparen__6 Arglist tok__rparen__7 { Ctr__Expression__10 (rtkPosOf $1) $1 (tkVal_id $3) $5 } |
+                    PostfixExpression tok__sq_bkt_l__17 Expression tok__sq_bkt_r__18 { Ctr__Expression__11 (rtkPosOf $1) $1 $3 }
 
-UnaryExpressionNotPlusMinus : PostfixExpression { Ctr__Expression__11 (rtkPosOf $1) $1 } |
-                              tok__tilde__78 UnaryExpression { Ctr__Expression__12 (rtkPosOf $1) $2 } |
-                              tok__exclamation__79 UnaryExpression { Ctr__Expression__13 (rtkPosOf $1) $2 } |
-                              CastExpression { Ctr__Expression__14 (rtkPosOf $1) $1 }
+UnaryExpressionNotPlusMinus : PostfixExpression { Ctr__Expression__12 (rtkPosOf $1) $1 } |
+                              tok__tilde__78 UnaryExpression { Ctr__Expression__13 (rtkPosOf $1) $2 } |
+                              tok__exclamation__79 UnaryExpression { Ctr__Expression__14 (rtkPosOf $1) $2 } |
+                              CastExpression { Ctr__Expression__15 (rtkPosOf $1) $1 }
 
-UnaryExpression : PrefixOp UnaryExpression { Ctr__Expression__15 (rtkPosOf $1) $1 $2 } |
-                  UnaryExpressionNotPlusMinus { Ctr__Expression__16 (rtkPosOf $1) $1 }
+UnaryExpression : PrefixOp UnaryExpression { Ctr__Expression__16 (rtkPosOf $1) $1 $2 } |
+                  UnaryExpressionNotPlusMinus { Ctr__Expression__17 (rtkPosOf $1) $1 }
 
-CastExpression : tok__lparen__6 Type tok__rparen__7 UnaryExpression { Ctr__Expression__17 (rtkPosOf $1) $2 $4 }
+CastExpression : tok__lparen__6 PrimitiveTypeKeyword Dims tok__rparen__7 UnaryExpression { Ctr__Expression__18 (rtkPosOf $1) $2 (reverse $3) $5 } |
+                 tok__lparen__6 CompoundName NonEmptyTypeArguments Dims tok__rparen__7 UnaryExpressionNotPlusMinus { Ctr__Expression__19 (rtkPosOf $1) $2 $3 (reverse $4) $6 } |
+                 tok__lparen__6 CompoundName NonEmptyDims tok__rparen__7 UnaryExpressionNotPlusMinus { Ctr__Expression__20 (rtkPosOf $1) $2 (reverse $3) $5 } |
+                 tok__lparen__6 Expression tok__rparen__7 UnaryExpressionNotPlusMinus { Ctr__Expression__21 (rtkPosOf $1) $2 $4 }
 
-MultiplicativeExpression : UnaryExpression { Ctr__Expression__18 (rtkPosOf $1) $1 } |
-                           MultiplicativeExpression MultiplicativeOp UnaryExpression { Ctr__Expression__19 (rtkPosOf $1) $1 $2 $3 }
+MultiplicativeExpression : UnaryExpression { Ctr__Expression__22 (rtkPosOf $1) $1 } |
+                           MultiplicativeExpression MultiplicativeOp UnaryExpression { Ctr__Expression__23 (rtkPosOf $1) $1 $2 $3 }
 
-AdditiveExpression : MultiplicativeExpression { Ctr__Expression__20 (rtkPosOf $1) $1 } |
-                     AdditiveExpression AdditiveOp MultiplicativeExpression { Ctr__Expression__21 (rtkPosOf $1) $1 $2 $3 }
+AdditiveExpression : MultiplicativeExpression { Ctr__Expression__24 (rtkPosOf $1) $1 } |
+                     AdditiveExpression AdditiveOp MultiplicativeExpression { Ctr__Expression__25 (rtkPosOf $1) $1 $2 $3 }
 
-ShiftExpression : AdditiveExpression { Ctr__Expression__22 (rtkPosOf $1) $1 } |
-                  ShiftExpression ShiftOp AdditiveExpression { Ctr__Expression__23 (rtkPosOf $1) $1 $2 $3 }
+ShiftExpression : AdditiveExpression { Ctr__Expression__26 (rtkPosOf $1) $1 } |
+                  ShiftExpression ShiftOp AdditiveExpression { Ctr__Expression__27 (rtkPosOf $1) $1 $2 $3 }
 
-RelationalExpression : ShiftExpression { Ctr__Expression__24 (rtkPosOf $1) $1 } |
-                       RelationalExpression RelationalOp ShiftExpression { Ctr__Expression__25 (rtkPosOf $1) $1 $2 $3 } |
-                       RelationalExpression tok_instanceof_68 Type { Ctr__Expression__26 (rtkPosOf $1) $1 $3 }
+RelationalExpression : ShiftExpression { Ctr__Expression__28 (rtkPosOf $1) $1 } |
+                       RelationalExpression RelationalOp ShiftExpression { Ctr__Expression__29 (rtkPosOf $1) $1 $2 $3 } |
+                       RelationalExpression tok_instanceof_68 Type { Ctr__Expression__30 (rtkPosOf $1) $1 $3 }
 
-EqualityExpression : RelationalExpression { Ctr__Expression__27 (rtkPosOf $1) $1 } |
-                     EqualityExpression EqualityOp RelationalExpression { Ctr__Expression__28 (rtkPosOf $1) $1 $2 $3 }
+EqualityExpression : RelationalExpression { Ctr__Expression__31 (rtkPosOf $1) $1 } |
+                     EqualityExpression EqualityOp RelationalExpression { Ctr__Expression__32 (rtkPosOf $1) $1 $2 $3 }
 
-AndExpression : EqualityExpression { Ctr__Expression__29 (rtkPosOf $1) $1 } |
-                AndExpression tok__symbol__61 EqualityExpression { Ctr__Expression__30 (rtkPosOf $1) $1 $3 }
+AndExpression : EqualityExpression { Ctr__Expression__33 (rtkPosOf $1) $1 } |
+                AndExpression tok__symbol__61 EqualityExpression { Ctr__Expression__34 (rtkPosOf $1) $1 $3 }
 
-ExclusiveOrExpression : AndExpression { Ctr__Expression__31 (rtkPosOf $1) $1 } |
-                        ExclusiveOrExpression tok__symbol__60 AndExpression { Ctr__Expression__32 (rtkPosOf $1) $1 $3 }
+ExclusiveOrExpression : AndExpression { Ctr__Expression__35 (rtkPosOf $1) $1 } |
+                        ExclusiveOrExpression tok__symbol__60 AndExpression { Ctr__Expression__36 (rtkPosOf $1) $1 $3 }
 
-InclusiveOrEpression : ExclusiveOrExpression { Ctr__Expression__33 (rtkPosOf $1) $1 } |
-                       InclusiveOrEpression tok__pipe__59 ExclusiveOrExpression { Ctr__Expression__34 (rtkPosOf $1) $1 $3 }
+InclusiveOrEpression : ExclusiveOrExpression { Ctr__Expression__37 (rtkPosOf $1) $1 } |
+                       InclusiveOrEpression tok__pipe__59 ExclusiveOrExpression { Ctr__Expression__38 (rtkPosOf $1) $1 $3 }
 
-ConditionalAndExpression : InclusiveOrEpression { Ctr__Expression__35 (rtkPosOf $1) $1 } |
-                           ConditionalAndExpression tok__symbol__symbol__58 InclusiveOrEpression { Ctr__Expression__36 (rtkPosOf $1) $1 $3 }
+ConditionalAndExpression : InclusiveOrEpression { Ctr__Expression__39 (rtkPosOf $1) $1 } |
+                           ConditionalAndExpression tok__symbol__symbol__58 InclusiveOrEpression { Ctr__Expression__40 (rtkPosOf $1) $1 $3 }
 
-ConditionalOrExpression : ConditionalAndExpression { Ctr__Expression__37 (rtkPosOf $1) $1 } |
-                          ConditionalOrExpression tok__pipe__pipe__57 ConditionalAndExpression { Ctr__Expression__38 (rtkPosOf $1) $1 $3 }
+ConditionalOrExpression : ConditionalAndExpression { Ctr__Expression__41 (rtkPosOf $1) $1 } |
+                          ConditionalOrExpression tok__pipe__pipe__57 ConditionalAndExpression { Ctr__Expression__42 (rtkPosOf $1) $1 $3 }
 
-ConditionalExpression : ConditionalOrExpression { Ctr__Expression__39 (rtkPosOf $1) $1 } |
-                        ConditionalOrExpression tok__symbol__56 Expression tok__colon__32 ConditionalExpression { Ctr__Expression__40 (rtkPosOf $1) $1 $3 $5 }
+ConditionalExpression : ConditionalOrExpression { Ctr__Expression__43 (rtkPosOf $1) $1 } |
+                        ConditionalOrExpression tok__symbol__56 Expression tok__colon__32 ConditionalExpression { Ctr__Expression__44 (rtkPosOf $1) $1 $3 $5 }
 
-AssignmentExpression : ConditionalExpression Rule_70 { Ctr__Expression__41 (rtkPosOf $1) $1 $2 }
+AssignmentExpression : ConditionalExpression Rule_72 { Ctr__Expression__45 (rtkPosOf $1) $1 $2 }
 
-Expression : AssignmentExpression { Ctr__Expression__42 (rtkPosOf $1) $1 }
+Expression : AssignmentExpression { Ctr__Expression__46 (rtkPosOf $1) $1 }
 
 ExtendsList : qq_ExtendsList { Anti_ExtendsList (tkVal_qq_ExtendsList $1) } |
               tok_extends_10 CompoundName Rule_18 { Ctr__ExtendsList__0 (rtkPosOf $1) $2 (reverse $3) }
@@ -522,7 +541,7 @@ FieldDeclarationList : {- empty -} { [] } |
                        FieldDeclarationList ListElem_FieldDeclarationList21 { $2 : $1 }
 
 ForStatement : qq_ForStatement { Anti_ForStatement (tkVal_qq_ForStatement $1) } |
-               tok_for_39 tok__lparen__6 Rule_61 OptExpression tok__semi__1 OptExpression tok__rparen__7 Statement { Ctr__ForStatement__0 (rtkPosOf $1) $3 $4 $6 $8 }
+               tok_for_39 tok__lparen__6 Rule_63 OptExpression tok__semi__1 OptExpression tok__rparen__7 Statement { Ctr__ForStatement__0 (rtkPosOf $1) $3 $4 $6 $8 }
 
 IfStatement : qq_IfStatement { Anti_IfStatement (tkVal_qq_IfStatement $1) } |
               tok_if_36 tok__lparen__6 Expression tok__rparen__7 StatementWithoutIf OptElsePart { Ctr__IfStatement__0 (rtkPosOf $1) $3 $5 $6 }
@@ -549,17 +568,17 @@ Literal : qq_Literal { Anti_Literal (tkVal_qq_Literal $1) } |
           tok_null_85 { Ctr__Literal__6 (rtkPosOf $1) }
 
 MemberAfterFirstId : qq_MemberAfterFirstId { Anti_MemberAfterFirstId (tkVal_qq_MemberAfterFirstId $1) } |
-                     tok__lparen__6 Rule_42 tok__rparen__7 StatementBlock { Ctr__MemberAfterFirstId__0 (rtkPosOf $1) $2 $4 } |
+                     tok__lparen__6 Rule_44 tok__rparen__7 StatementBlock { Ctr__MemberAfterFirstId__0 (rtkPosOf $1) $2 $4 } |
                      MoreTypeSpecifier id MemberRest { Ctr__MemberAfterFirstId__1 (rtkPosOf $1) $1 (tkVal_id $2) $3 }
 
 MemberDeclaration : qq_MemberDeclaration { Anti_MemberDeclaration (tkVal_qq_MemberDeclaration $1) } |
-                    PrimitiveTypeKeyword SquareBracketsList id MemberRest { Ctr__MemberDeclaration__0 (rtkPosOf $1) $1 (reverse $2) (tkVal_id $3) $4 } |
+                    PrimitiveTypeKeyword Dims id MemberRest { Ctr__MemberDeclaration__0 (rtkPosOf $1) $1 (reverse $2) (tkVal_id $3) $4 } |
                     TypeParameters id MoreTypeSpecifier id MemberRest { Ctr__MemberDeclaration__1 (rtkPosOf $1) $1 (tkVal_id $2) $3 (tkVal_id $4) $5 } |
                     id MemberAfterFirstId { Ctr__MemberDeclaration__2 (rtkPosOf $1) (tkVal_id $1) $2 }
 
 MemberRest : qq_MemberRest { Anti_MemberRest (tkVal_qq_MemberRest $1) } |
-             tok__lparen__6 Rule_43 tok__rparen__7 SquareBracketsList Rule_44 { Ctr__MemberRest__0 (rtkPosOf $1) $2 (reverse $4) $5 } |
-             SquareBracketsList OptVariableInitializer MoreVariableDeclarators tok__semi__1 { Ctr__MemberRest__1 (rtkPosOf (reverse $1)) (reverse $1) $2 (reverse $3) }
+             tok__lparen__6 Rule_45 tok__rparen__7 Dims Rule_46 { Ctr__MemberRest__0 (rtkPosOf $1) $2 (reverse $4) $5 } |
+             Dims OptVariableInitializer MoreVariableDeclarators tok__semi__1 { Ctr__MemberRest__1 (rtkPosOf (reverse $1)) (reverse $1) $2 (reverse $3) }
 
 Modifier : qq_Modifier { Anti_Modifier (tkVal_qq_Modifier $1) } |
            tok_public_86 { Ctr__Modifier__0 (rtkPosOf $1) } |
@@ -578,10 +597,10 @@ ModifierList : {- empty -} { [] } |
 
 MoreTypeSpecifier : qq_MoreTypeSpecifier { Anti_MoreTypeSpecifier (tkVal_qq_MoreTypeSpecifier $1) } |
                     tok__dot__3 id MoreTypeSpecifier { Ctr__MoreTypeSpecifier__0 (rtkPosOf $1) (tkVal_id $2) $3 } |
-                    TypeArguments SquareBracketsList { Ctr__MoreTypeSpecifier__1 (rtkPosOf $1) $1 (reverse $2) }
+                    TypeArguments Dims { Ctr__MoreTypeSpecifier__1 (rtkPosOf $1) $1 (reverse $2) }
 
 MoreVariableDeclarators : {- empty -} { [] } |
-                          MoreVariableDeclarators ListElem_MoreVariableDeclarators48 { $2 : $1 }
+                          MoreVariableDeclarators ListElem_MoreVariableDeclarators50 { $2 : $1 }
 
 MultiplicativeOp : qq_MultiplicativeOp { Anti_MultiplicativeOp (tkVal_qq_MultiplicativeOp $1) } |
                    tok__star__4 { Ctr__MultiplicativeOp__0 (rtkPosOf $1) } |
@@ -594,13 +613,19 @@ NestedTypeDeclaration : qq_NestedTypeDeclaration { Anti_NestedTypeDeclaration (t
                         EnumDeclaration { Ctr__NestedTypeDeclaration__2 (rtkPosOf $1) $1 } |
                         AnnotationDeclaration { Ctr__NestedTypeDeclaration__3 (rtkPosOf $1) $1 }
 
+NonEmptyDims : ListElem_NonEmptyDims43 { [$1] } |
+               NonEmptyDims ListElem_NonEmptyDims43 { $2 : $1 }
+
+NonEmptyTypeArguments : qq_NonEmptyTypeArguments { Anti_NonEmptyTypeArguments (tkVal_qq_NonEmptyTypeArguments $1) } |
+                        tok__symbol__64 TypeArgument Rule_86 tok__symbol__65 { Ctr__NonEmptyTypeArguments__0 (rtkPosOf $1) $2 (reverse $3) }
+
 OptDocComment : qq_OptDocComment { Anti_OptDocComment (tkVal_qq_OptDocComment $1) } |
                 { Ctr__OptDocComment__0 rtkNoPos } |
                 Rule_0 { Ctr__OptDocComment__1 (rtkPosOf $1) $1 }
 
 OptElsePart : qq_OptElsePart { Anti_OptElsePart (tkVal_qq_OptElsePart $1) } |
               { Ctr__OptElsePart__0 rtkNoPos } |
-              Rule_60 { Ctr__OptElsePart__1 (rtkPosOf $1) $1 }
+              Rule_62 { Ctr__OptElsePart__1 (rtkPosOf $1) $1 }
 
 OptExpression : qq_OptExpression { Anti_OptExpression (tkVal_qq_OptExpression $1) } |
                 { Ctr__OptExpression__0 rtkNoPos } |
@@ -608,7 +633,7 @@ OptExpression : qq_OptExpression { Anti_OptExpression (tkVal_qq_OptExpression $1
 
 OptFinally : qq_OptFinally { Anti_OptFinally (tkVal_qq_OptFinally $1) } |
              { Ctr__OptFinally__0 rtkNoPos } |
-             Rule_65 { Ctr__OptFinally__1 (rtkPosOf $1) $1 }
+             Rule_67 { Ctr__OptFinally__1 (rtkPosOf $1) $1 }
 
 OptId : qq_OptId { Anti_OptId (tkVal_qq_OptId $1) } |
         { Ctr__OptId__0 rtkNoPos } |
@@ -616,16 +641,16 @@ OptId : qq_OptId { Anti_OptId (tkVal_qq_OptId $1) } |
 
 OptVariableInitializer : qq_OptVariableInitializer { Anti_OptVariableInitializer (tkVal_qq_OptVariableInitializer $1) } |
                          { Ctr__OptVariableInitializer__0 rtkNoPos } |
-                         Rule_51 { Ctr__OptVariableInitializer__1 (rtkPosOf $1) $1 }
+                         Rule_53 { Ctr__OptVariableInitializer__1 (rtkPosOf $1) $1 }
 
 Package : qq_Package { Anti_Package (tkVal_qq_Package $1) } |
           tok_package_0 CompoundName tok__semi__1 { Ctr__Package__0 (rtkPosOf $1) $2 }
 
 Parameter : qq_Parameter { Anti_Parameter (tkVal_qq_Parameter $1) } |
-            Type id SquareBracketsList { Ctr__Parameter__0 (rtkPosOf $1) $1 (tkVal_id $2) (reverse $3) }
+            Type id Dims { Ctr__Parameter__0 (rtkPosOf $1) $1 (tkVal_id $2) (reverse $3) }
 
 ParameterList : qq_ParameterList { Anti_ParameterList (tkVal_qq_ParameterList $1) } |
-                Parameter Rule_57 { Ctr__ParameterList__0 (rtkPosOf $1) $1 (reverse $2) }
+                Parameter Rule_59 { Ctr__ParameterList__0 (rtkPosOf $1) $1 (reverse $2) }
 
 PostfixOp : qq_PostfixOp { Anti_PostfixOp (tkVal_qq_PostfixOp $1) } |
             tok__plus__plus__76 { Ctr__PostfixOp__0 (rtkPosOf $1) } |
@@ -741,166 +766,176 @@ Rule_39 : MemberDeclaration { Ctr__Rule_39__0 (rtkPosOf $1) $1 } |
 Rule_4 : { Ctr__Rule_4__0 rtkNoPos } |
          Rule_5 { Ctr__Rule_4__1 (rtkPosOf $1) $1 }
 
-ListElem_SquareBracketsList41 : qq_SquareBracketsList { Anti_Rule_40 (tkVal_qq_SquareBracketsList $1) } |
-                                Rule_40 { $1 }
+ListElem_Dims41 : qq_Dims { Anti_Rule_40 (tkVal_qq_Dims $1) } |
+                  Rule_40 { $1 }
 
-Rule_40 : tok__sq_bkt_l__17 OptExpression tok__sq_bkt_r__18 { Ctr__Rule_40__1 (rtkPosOf $1) $2 }
+Rule_40 : tok__sq_bkt_l__17 tok__sq_bkt_r__18 { Ctr__Rule_40__1 (rtkPosOf $1) }
 
-Rule_42 : { Ctr__Rule_42__0 rtkNoPos } |
-          ParameterList { Ctr__Rule_42__1 (rtkPosOf $1) $1 }
+ListElem_NonEmptyDims43 : qq_NonEmptyDims { Anti_Rule_42 (tkVal_qq_NonEmptyDims $1) } |
+                          Rule_42 { $1 }
 
-Rule_43 : { Ctr__Rule_43__0 rtkNoPos } |
-          ParameterList { Ctr__Rule_43__1 (rtkPosOf $1) $1 }
+Rule_42 : tok__sq_bkt_l__17 tok__sq_bkt_r__18 { Ctr__Rule_42__1 (rtkPosOf $1) }
 
-Rule_44 : StatementBlock { Ctr__Rule_44__0 (rtkPosOf $1) $1 } |
-          Rule_45 tok__semi__1 { Ctr__Rule_44__1 (rtkPosOf $1) $1 }
+Rule_44 : { Ctr__Rule_44__0 rtkNoPos } |
+          ParameterList { Ctr__Rule_44__1 (rtkPosOf $1) $1 }
 
 Rule_45 : { Ctr__Rule_45__0 rtkNoPos } |
-          Rule_46 { Ctr__Rule_45__1 (rtkPosOf $1) $1 }
+          ParameterList { Ctr__Rule_45__1 (rtkPosOf $1) $1 }
 
-Rule_46 : tok_default_28 Expression { Ctr__Rule_46__0 (rtkPosOf $1) $2 }
+Rule_46 : StatementBlock { Ctr__Rule_46__0 (rtkPosOf $1) $1 } |
+          Rule_47 tok__semi__1 { Ctr__Rule_46__1 (rtkPosOf $1) $1 }
 
-ListElem_MoreVariableDeclarators48 : qq_MoreVariableDeclarators { Anti_Rule_47 (tkVal_qq_MoreVariableDeclarators $1) } |
-                                     Rule_47 { $1 }
+Rule_47 : { Ctr__Rule_47__0 rtkNoPos } |
+          Rule_48 { Ctr__Rule_47__1 (rtkPosOf $1) $1 }
 
-Rule_47 : tok__coma__8 VariableDeclarator { Ctr__Rule_47__1 (rtkPosOf $1) $2 }
+Rule_48 : tok_default_28 Expression { Ctr__Rule_48__0 (rtkPosOf $1) $2 }
 
-Rule_49 : {- empty -} { [] } |
-          Rule_49 Rule_50 { $2 : $1 }
+ListElem_MoreVariableDeclarators50 : qq_MoreVariableDeclarators { Anti_Rule_49 (tkVal_qq_MoreVariableDeclarators $1) } |
+                                     Rule_49 { $1 }
+
+Rule_49 : tok__coma__8 VariableDeclarator { Ctr__Rule_49__1 (rtkPosOf $1) $2 }
 
 Rule_5 : Package { Ctr__Rule_5__0 (rtkPosOf $1) $1 }
 
-Rule_50 : tok__coma__8 VariableDeclarator { Ctr__Rule_50__0 (rtkPosOf $1) $2 }
+Rule_51 : {- empty -} { [] } |
+          Rule_51 Rule_52 { $2 : $1 }
 
-Rule_51 : tok__eql__9 VariableInitializer { Ctr__Rule_51__0 (rtkPosOf $1) $2 }
+Rule_52 : tok__coma__8 VariableDeclarator { Ctr__Rule_52__0 (rtkPosOf $1) $2 }
 
-Rule_52 : VariableInitializer Rule_53 Rule_55 { Ctr__Rule_52__0 (rtkPosOf $1) $1 (reverse $2) $3 }
+Rule_53 : tok__eql__9 VariableInitializer { Ctr__Rule_53__0 (rtkPosOf $1) $2 }
 
-Rule_53 : {- empty -} { [] } |
-          Rule_53 Rule_54 { $2 : $1 }
+Rule_54 : VariableInitializer Rule_55 Rule_57 { Ctr__Rule_54__0 (rtkPosOf $1) $1 (reverse $2) $3 }
 
-Rule_54 : tok__coma__8 VariableInitializer { Ctr__Rule_54__0 (rtkPosOf $1) $2 }
+Rule_55 : {- empty -} { [] } |
+          Rule_55 Rule_56 { $2 : $1 }
 
-Rule_55 : { Ctr__Rule_55__0 rtkNoPos } |
-          Rule_56 { Ctr__Rule_55__1 (rtkPosOf $1) $1 }
+Rule_56 : tok__coma__8 VariableInitializer { Ctr__Rule_56__0 (rtkPosOf $1) $2 }
 
-Rule_56 : tok__coma__8 { Ctr__Rule_56__0 (rtkPosOf $1) }
+Rule_57 : { Ctr__Rule_57__0 rtkNoPos } |
+          Rule_58 { Ctr__Rule_57__1 (rtkPosOf $1) $1 }
 
-Rule_57 : {- empty -} { [] } |
-          Rule_57 Rule_58 { $2 : $1 }
+Rule_58 : tok__coma__8 { Ctr__Rule_58__0 (rtkPosOf $1) }
 
-Rule_58 : tok__coma__8 Parameter { Ctr__Rule_58__0 (rtkPosOf $1) $2 }
+Rule_59 : {- empty -} { [] } |
+          Rule_59 Rule_60 { $2 : $1 }
 
 Rule_6 : { Ctr__Rule_6__0 rtkNoPos } |
          Rule_7 { Ctr__Rule_6__1 (rtkPosOf $1) $1 }
 
-Rule_60 : tok_else_35 Statement { Ctr__Rule_60__0 (rtkPosOf $1) $2 }
+Rule_60 : tok__coma__8 Parameter { Ctr__Rule_60__0 (rtkPosOf $1) $2 }
 
-Rule_61 : VariableDeclaration { Ctr__Rule_61__0 (rtkPosOf $1) $1 } |
-          Rule_62 { Ctr__Rule_61__1 (rtkPosOf $1) $1 } |
-          tok__semi__1 { Ctr__Rule_61__2 (rtkPosOf $1) }
+Rule_62 : tok_else_35 Statement { Ctr__Rule_62__0 (rtkPosOf $1) $2 }
 
-Rule_62 : Expression tok__semi__1 { Ctr__Rule_62__0 (rtkPosOf $1) $1 }
+Rule_63 : VariableDeclaration { Ctr__Rule_63__0 (rtkPosOf $1) $1 } |
+          Rule_64 { Ctr__Rule_63__1 (rtkPosOf $1) $1 } |
+          tok__semi__1 { Ctr__Rule_63__2 (rtkPosOf $1) }
 
-ListElem_CatchList64 : qq_CatchList { Anti_Rule_63 (tkVal_qq_CatchList $1) } |
-                       Rule_63 { $1 }
+Rule_64 : Expression tok__semi__1 { Ctr__Rule_64__0 (rtkPosOf $1) $1 }
 
-Rule_63 : tok_catch_40 tok__lparen__6 Parameter tok__rparen__7 Statement { Ctr__Rule_63__1 (rtkPosOf $1) $3 $5 }
+ListElem_CatchList66 : qq_CatchList { Anti_Rule_65 (tkVal_qq_CatchList $1) } |
+                       Rule_65 { $1 }
 
-Rule_65 : tok_finally_41 Statement { Ctr__Rule_65__0 (rtkPosOf $1) $2 }
+Rule_65 : tok_catch_40 tok__lparen__6 Parameter tok__rparen__7 Statement { Ctr__Rule_65__1 (rtkPosOf $1) $3 $5 }
 
-ListElem_SwitchCaseList69 : qq_SwitchCaseList { Anti_Rule_66 (tkVal_qq_SwitchCaseList $1) } |
-                            Rule_66 { $1 }
+Rule_67 : tok_finally_41 Statement { Ctr__Rule_67__0 (rtkPosOf $1) $2 }
 
-Rule_66 : Rule_67 { Ctr__Rule_66__1 (rtkPosOf $1) $1 } |
-          Rule_68 { Ctr__Rule_66__2 (rtkPosOf $1) $1 } |
-          Statement { Ctr__Rule_66__3 (rtkPosOf $1) $1 }
+ListElem_SwitchCaseList71 : qq_SwitchCaseList { Anti_Rule_68 (tkVal_qq_SwitchCaseList $1) } |
+                            Rule_68 { $1 }
 
-Rule_67 : tok_case_43 Expression tok__colon__32 { Ctr__Rule_67__0 (rtkPosOf $1) $2 }
+Rule_68 : Rule_69 { Ctr__Rule_68__1 (rtkPosOf $1) $1 } |
+          Rule_70 { Ctr__Rule_68__2 (rtkPosOf $1) $1 } |
+          Statement { Ctr__Rule_68__3 (rtkPosOf $1) $1 }
 
-Rule_68 : tok_default_28 tok__colon__32 { Ctr__Rule_68__0 (rtkPosOf $1) }
+Rule_69 : tok_case_43 Expression tok__colon__32 { Ctr__Rule_69__0 (rtkPosOf $1) $2 }
 
 Rule_7 : TypeDeclaration { Ctr__Rule_7__0 (rtkPosOf $1) $1 }
 
-Rule_70 : { Ctr__Rule_70__0 rtkNoPos } |
-          Rule_71 { Ctr__Rule_70__1 (rtkPosOf $1) $1 }
-
-Rule_71 : AssignmentOp AssignmentExpression { Ctr__Rule_71__0 (rtkPosOf $1) $1 $2 }
+Rule_70 : tok_default_28 tok__colon__32 { Ctr__Rule_70__0 (rtkPosOf $1) }
 
 Rule_72 : { Ctr__Rule_72__0 rtkNoPos } |
           Rule_73 { Ctr__Rule_72__1 (rtkPosOf $1) $1 }
 
-Rule_73 : tok__lparen__6 Arglist tok__rparen__7 { Ctr__Rule_73__0 (rtkPosOf $1) $2 }
+Rule_73 : AssignmentOp AssignmentExpression { Ctr__Rule_73__0 (rtkPosOf $1) $1 $2 }
 
 Rule_74 : { Ctr__Rule_74__0 rtkNoPos } |
           Rule_75 { Ctr__Rule_74__1 (rtkPosOf $1) $1 }
 
 Rule_75 : tok__lparen__6 Arglist tok__rparen__7 { Ctr__Rule_75__0 (rtkPosOf $1) $2 }
 
-Rule_76 : tok__lparen__6 Arglist tok__rparen__7 { Ctr__Rule_76__0 (rtkPosOf $1) $2 } |
-          SquareBracketsList { Ctr__Rule_76__1 (rtkPosOf (reverse $1)) (reverse $1) }
+Rule_76 : { Ctr__Rule_76__0 rtkNoPos } |
+          Rule_77 { Ctr__Rule_76__1 (rtkPosOf $1) $1 }
 
-Rule_77 : Expression Rule_78 { Ctr__Rule_77__0 (rtkPosOf $1) $1 (reverse $2) }
+Rule_77 : tok__lparen__6 Arglist tok__rparen__7 { Ctr__Rule_77__0 (rtkPosOf $1) $2 }
 
-Rule_78 : {- empty -} { [] } |
-          Rule_78 Rule_79 { $2 : $1 }
+Rule_78 : tok__lparen__6 Arglist tok__rparen__7 { Ctr__Rule_78__0 (rtkPosOf $1) $2 } |
+          DimExprs Rule_79 { Ctr__Rule_78__1 (rtkPosOf (reverse $1)) (reverse $1) $2 }
 
-Rule_79 : tok__coma__8 Expression { Ctr__Rule_79__0 (rtkPosOf $1) $2 }
+Rule_79 : { Ctr__Rule_79__0 rtkNoPos } |
+          Rule_80 { Ctr__Rule_79__1 (rtkPosOf $1) $1 }
 
 Rule_8 : Rule_9 { Ctr__Rule_8__0 (rtkPosOf $1) $1 } |
          CompoundName { Ctr__Rule_8__1 (rtkPosOf $1) $1 }
 
-Rule_80 : tok__symbol__64 TypeArgument Rule_81 tok__symbol__65 { Ctr__Rule_80__0 (rtkPosOf $1) $2 (reverse $3) }
+Rule_80 : NonEmptyDims { Ctr__Rule_80__0 (rtkPosOf (reverse $1)) (reverse $1) }
 
-Rule_81 : {- empty -} { [] } |
-          Rule_81 Rule_82 { $2 : $1 }
+ListElem_DimExprs82 : qq_DimExprs { Anti_Rule_81 (tkVal_qq_DimExprs $1) } |
+                      Rule_81 { $1 }
 
-Rule_82 : tok__coma__8 TypeArgument { Ctr__Rule_82__0 (rtkPosOf $1) $2 }
+Rule_81 : tok__sq_bkt_l__17 Expression tok__sq_bkt_r__18 { Ctr__Rule_81__1 (rtkPosOf $1) $2 }
 
-Rule_83 : tok__symbol__64 TypeParameter Rule_84 tok__symbol__65 { Ctr__Rule_83__0 (rtkPosOf $1) $2 (reverse $3) }
+Rule_83 : Expression Rule_84 { Ctr__Rule_83__0 (rtkPosOf $1) $1 (reverse $2) }
 
 Rule_84 : {- empty -} { [] } |
           Rule_84 Rule_85 { $2 : $1 }
 
-Rule_85 : tok__coma__8 TypeParameter { Ctr__Rule_85__0 (rtkPosOf $1) $2 }
+Rule_85 : tok__coma__8 Expression { Ctr__Rule_85__0 (rtkPosOf $1) $2 }
 
-Rule_86 : { Ctr__Rule_86__0 rtkNoPos } |
-          Rule_87 { Ctr__Rule_86__1 (rtkPosOf $1) $1 }
+Rule_86 : {- empty -} { [] } |
+          Rule_86 Rule_87 { $2 : $1 }
 
-Rule_87 : tok_extends_10 Type Rule_88 { Ctr__Rule_87__0 (rtkPosOf $1) $2 (reverse $3) }
+Rule_87 : tok__coma__8 TypeArgument { Ctr__Rule_87__0 (rtkPosOf $1) $2 }
 
-Rule_88 : {- empty -} { [] } |
-          Rule_88 Rule_89 { $2 : $1 }
+Rule_88 : tok__symbol__64 TypeParameter Rule_89 tok__symbol__65 { Ctr__Rule_88__0 (rtkPosOf $1) $2 (reverse $3) }
 
-Rule_89 : tok__symbol__61 Type { Ctr__Rule_89__0 (rtkPosOf $1) $2 }
+Rule_89 : {- empty -} { [] } |
+          Rule_89 Rule_90 { $2 : $1 }
 
 Rule_9 : CompoundName tok__dot__3 tok__star__4 { Ctr__Rule_9__0 (rtkPosOf $1) $1 }
 
-Rule_90 : {- empty -} { [] } |
-          Rule_90 Rule_91 { $2 : $1 }
+Rule_90 : tok__coma__8 TypeParameter { Ctr__Rule_90__0 (rtkPosOf $1) $2 }
 
-Rule_91 : tok__dot__3 id { Ctr__Rule_91__0 (rtkPosOf $1) (tkVal_id $2) }
+Rule_91 : { Ctr__Rule_91__0 rtkNoPos } |
+          Rule_92 { Ctr__Rule_91__1 (rtkPosOf $1) $1 }
+
+Rule_92 : tok_extends_10 Type Rule_93 { Ctr__Rule_92__0 (rtkPosOf $1) $2 (reverse $3) }
+
+Rule_93 : {- empty -} { [] } |
+          Rule_93 Rule_94 { $2 : $1 }
+
+Rule_94 : tok__symbol__61 Type { Ctr__Rule_94__0 (rtkPosOf $1) $2 }
+
+Rule_95 : {- empty -} { [] } |
+          Rule_95 Rule_96 { $2 : $1 }
+
+Rule_96 : tok__dot__3 id { Ctr__Rule_96__0 (rtkPosOf $1) (tkVal_id $2) }
 
 ShiftOp : qq_ShiftOp { Anti_ShiftOp (tkVal_qq_ShiftOp $1) } |
           tok__symbol__symbol__69 { Ctr__ShiftOp__0 (rtkPosOf $1) } |
           tok__symbol__symbol__70 { Ctr__ShiftOp__1 (rtkPosOf $1) } |
           tok__symbol__symbol__symbol__71 { Ctr__ShiftOp__2 (rtkPosOf $1) }
 
-SquareBracketsList : {- empty -} { [] } |
-                     SquareBracketsList ListElem_SquareBracketsList41 { $2 : $1 }
-
 Statement : qq_Statement { Anti_Statement (tkVal_qq_Statement $1) } |
             StatementWithoutIf { Ctr__Statement__0 (rtkPosOf $1) $1 } |
             IfStatement { Ctr__Statement__1 (rtkPosOf $1) $1 }
 
-ListElem_StatementList59 : qq_StatementList { Anti_Statement (tkVal_qq_StatementList $1) } |
+ListElem_StatementList61 : qq_StatementList { Anti_Statement (tkVal_qq_StatementList $1) } |
                            Statement { $1 }
 
 StatementBlock : qq_StatementBlock { Anti_StatementBlock (tkVal_qq_StatementBlock $1) } |
                  tok__symbol__13 StatementList tok__symbol__14 { Ctr__StatementBlock__0 (rtkPosOf $1) (reverse $2) }
 
 StatementList : {- empty -} { [] } |
-                StatementList ListElem_StatementList59 { $2 : $1 }
+                StatementList ListElem_StatementList61 { $2 : $1 }
 
 StatementWithoutIf : qq_StatementWithoutIf { Anti_StatementWithoutIf (tkVal_qq_StatementWithoutIf $1) } |
                      VariableDeclaration { Ctr__StatementWithoutIf__0 (rtkPosOf $1) $1 } |
@@ -923,7 +958,7 @@ StaticInitializer : qq_StaticInitializer { Anti_StaticInitializer (tkVal_qq_Stat
                     StatementBlock { Ctr__StaticInitializer__0 (rtkPosOf $1) $1 }
 
 SwitchCaseList : {- empty -} { [] } |
-                 SwitchCaseList ListElem_SwitchCaseList69 { $2 : $1 }
+                 SwitchCaseList ListElem_SwitchCaseList71 { $2 : $1 }
 
 SwitchStatement : qq_SwitchStatement { Anti_SwitchStatement (tkVal_qq_SwitchStatement $1) } |
                   tok_switch_44 tok__lparen__6 Expression tok__rparen__7 tok__symbol__13 SwitchCaseList tok__symbol__14 { Ctr__SwitchStatement__0 (rtkPosOf $1) $3 (reverse $6) }
@@ -932,7 +967,10 @@ TryStatement : qq_TryStatement { Anti_TryStatement (tkVal_qq_TryStatement $1) } 
                tok_try_42 Statement CatchList OptFinally { Ctr__TryStatement__0 (rtkPosOf $1) $2 (reverse $3) $4 }
 
 Type : qq_Type { Anti_Type (tkVal_qq_Type $1) } |
-       TypeSpecifier SquareBracketsList { Ctr__Type__0 (rtkPosOf $1) $1 (reverse $2) }
+       PrimitiveTypeKeyword Dims { Ctr__Type__0 (rtkPosOf $1) $1 (reverse $2) } |
+       CompoundName NonEmptyTypeArguments Dims { Ctr__Type__1 (rtkPosOf $1) $1 $2 (reverse $3) } |
+       CompoundName NonEmptyDims { Ctr__Type__2 (rtkPosOf $1) $1 (reverse $2) } |
+       CompoundName { Ctr__Type__3 (rtkPosOf $1) $1 }
 
 TypeArgument : qq_TypeArgument { Anti_TypeArgument (tkVal_qq_TypeArgument $1) } |
                Type { Ctr__TypeArgument__0 (rtkPosOf $1) $1 } |
@@ -940,17 +978,17 @@ TypeArgument : qq_TypeArgument { Anti_TypeArgument (tkVal_qq_TypeArgument $1) } 
 
 TypeArguments : qq_TypeArguments { Anti_TypeArguments (tkVal_qq_TypeArguments $1) } |
                 { Ctr__TypeArguments__0 rtkNoPos } |
-                Rule_80 { Ctr__TypeArguments__1 (rtkPosOf $1) $1 }
+                NonEmptyTypeArguments { Ctr__TypeArguments__1 (rtkPosOf $1) $1 }
 
 TypeDeclaration : qq_TypeDeclaration { Anti_TypeDeclaration (tkVal_qq_TypeDeclaration $1) } |
                   OptDocComment Rule_1 { Ctr__TypeDeclaration__0 (rtkPosOf $1) $1 $2 }
 
 TypeParameter : qq_TypeParameter { Anti_TypeParameter (tkVal_qq_TypeParameter $1) } |
-                id Rule_86 { Ctr__TypeParameter__0 (rtkPosOf $1) (tkVal_id $1) $2 }
+                id Rule_91 { Ctr__TypeParameter__0 (rtkPosOf $1) (tkVal_id $1) $2 }
 
 TypeParameters : qq_TypeParameters { Anti_TypeParameters (tkVal_qq_TypeParameters $1) } |
                  { Ctr__TypeParameters__0 rtkNoPos } |
-                 Rule_83 { Ctr__TypeParameters__1 (rtkPosOf $1) $1 }
+                 Rule_88 { Ctr__TypeParameters__1 (rtkPosOf $1) $1 }
 
 TypeSpecifier : qq_TypeSpecifier { Anti_TypeSpecifier (tkVal_qq_TypeSpecifier $1) } |
                 tok_boolean_19 { Ctr__TypeSpecifier__0 (rtkPosOf $1) } |
@@ -968,10 +1006,10 @@ VariableDeclaration : qq_VariableDeclaration { Anti_VariableDeclaration (tkVal_q
                       Type VariableDeclaratorList tok__semi__1 { Ctr__VariableDeclaration__0 (rtkPosOf $1) $1 $2 }
 
 VariableDeclarator : qq_VariableDeclarator { Anti_VariableDeclarator (tkVal_qq_VariableDeclarator $1) } |
-                     id SquareBracketsList OptVariableInitializer { Ctr__VariableDeclarator__0 (rtkPosOf $1) (tkVal_id $1) (reverse $2) $3 }
+                     id Dims OptVariableInitializer { Ctr__VariableDeclarator__0 (rtkPosOf $1) (tkVal_id $1) (reverse $2) $3 }
 
 VariableDeclaratorList : qq_VariableDeclaratorList { Anti_VariableDeclaratorList (tkVal_qq_VariableDeclaratorList $1) } |
-                         VariableDeclarator Rule_49 { Ctr__VariableDeclaratorList__0 (rtkPosOf $1) $1 (reverse $2) }
+                         VariableDeclarator Rule_51 { Ctr__VariableDeclaratorList__0 (rtkPosOf $1) $1 (reverse $2) }
 
 VariableInitializer : qq_VariableInitializer { Anti_VariableInitializer (tkVal_qq_VariableInitializer $1) } |
                       Expression { Ctr__VariableInitializer__0 (rtkPosOf $1) $1 } |
@@ -979,7 +1017,7 @@ VariableInitializer : qq_VariableInitializer { Anti_VariableInitializer (tkVal_q
 
 VariableInitializerList : qq_VariableInitializerList { Anti_VariableInitializerList (tkVal_qq_VariableInitializerList $1) } |
                           { Ctr__VariableInitializerList__0 rtkNoPos } |
-                          Rule_52 { Ctr__VariableInitializerList__1 (rtkPosOf $1) $1 }
+                          Rule_54 { Ctr__VariableInitializerList__1 (rtkPosOf $1) $1 }
 
 WhileStatement : qq_WhileStatement { Anti_WhileStatement (tkVal_qq_WhileStatement $1) } |
                  tok_while_38 tok__lparen__6 Expression tok__rparen__7 Statement { Ctr__WhileStatement__0 (rtkPosOf $1) $3 $5 }
@@ -999,85 +1037,88 @@ parseError (L.PosToken (L.AlexPn _ line col) tok : _) =
 -- Render a token the way it appears in the source, for error messages
 showRtkToken :: L.Token -> String
 showRtkToken L.EndOfFile = "end of input"
-showRtkToken L.Tk__tok_AdditiveOp_dummy_169 = "'tok_AdditiveOp_dummy_169'"
-showRtkToken L.Tk__tok_Annotation_dummy_168 = "'tok_Annotation_dummy_168'"
-showRtkToken L.Tk__tok_AnnotationArguments_dummy_167 = "'tok_AnnotationArguments_dummy_167'"
-showRtkToken L.Tk__tok_AnnotationDeclaration_dummy_166 = "'tok_AnnotationDeclaration_dummy_166'"
-showRtkToken L.Tk__tok_AnnotationElement_dummy_165 = "'tok_AnnotationElement_dummy_165'"
-showRtkToken L.Tk__tok_AnnotationList_dummy_164 = "'tok_AnnotationList_dummy_164'"
-showRtkToken L.Tk__tok_AnnotationTypeElement_dummy_163 = "'tok_AnnotationTypeElement_dummy_163'"
-showRtkToken L.Tk__tok_AnnotationTypeElementList_dummy_162 = "'tok_AnnotationTypeElementList_dummy_162'"
-showRtkToken L.Tk__tok_Arglist_dummy_161 = "'tok_Arglist_dummy_161'"
-showRtkToken L.Tk__tok_AssignmentOp_dummy_160 = "'tok_AssignmentOp_dummy_160'"
-showRtkToken L.Tk__tok_CatchList_dummy_159 = "'tok_CatchList_dummy_159'"
-showRtkToken L.Tk__tok_ClassDeclaration_dummy_158 = "'tok_ClassDeclaration_dummy_158'"
-showRtkToken L.Tk__tok_CompilationUnit_dummy_157 = "'tok_CompilationUnit_dummy_157'"
-showRtkToken L.Tk__tok_CompoundName_dummy_156 = "'tok_CompoundName_dummy_156'"
-showRtkToken L.Tk__tok_CreationExpression_dummy_155 = "'tok_CreationExpression_dummy_155'"
-showRtkToken L.Tk__tok_DoStatement_dummy_154 = "'tok_DoStatement_dummy_154'"
-showRtkToken L.Tk__tok_DocComment_dummy_153 = "'tok_DocComment_dummy_153'"
-showRtkToken L.Tk__tok_EnumConstant_dummy_152 = "'tok_EnumConstant_dummy_152'"
-showRtkToken L.Tk__tok_EnumConstantList_dummy_151 = "'tok_EnumConstantList_dummy_151'"
-showRtkToken L.Tk__tok_EnumDeclaration_dummy_150 = "'tok_EnumDeclaration_dummy_150'"
-showRtkToken L.Tk__tok_EqualityOp_dummy_149 = "'tok_EqualityOp_dummy_149'"
-showRtkToken L.Tk__tok_Expression_dummy_148 = "'tok_Expression_dummy_148'"
-showRtkToken L.Tk__tok_ExtendsList_dummy_147 = "'tok_ExtendsList_dummy_147'"
-showRtkToken L.Tk__tok_FieldDeclaration_dummy_146 = "'tok_FieldDeclaration_dummy_146'"
-showRtkToken L.Tk__tok_FieldDeclarationList_dummy_145 = "'tok_FieldDeclarationList_dummy_145'"
-showRtkToken L.Tk__tok_ForStatement_dummy_144 = "'tok_ForStatement_dummy_144'"
-showRtkToken L.Tk__tok_IfStatement_dummy_143 = "'tok_IfStatement_dummy_143'"
-showRtkToken L.Tk__tok_ImplementsList_dummy_142 = "'tok_ImplementsList_dummy_142'"
-showRtkToken L.Tk__tok_ImportList_dummy_141 = "'tok_ImportList_dummy_141'"
-showRtkToken L.Tk__tok_ImportStatement_dummy_140 = "'tok_ImportStatement_dummy_140'"
-showRtkToken L.Tk__tok_InterfaceDeclaration_dummy_139 = "'tok_InterfaceDeclaration_dummy_139'"
-showRtkToken L.Tk__tok_Java_dummy_170 = "'tok_Java_dummy_170'"
-showRtkToken L.Tk__tok_Literal_dummy_138 = "'tok_Literal_dummy_138'"
-showRtkToken L.Tk__tok_MemberAfterFirstId_dummy_137 = "'tok_MemberAfterFirstId_dummy_137'"
-showRtkToken L.Tk__tok_MemberDeclaration_dummy_136 = "'tok_MemberDeclaration_dummy_136'"
-showRtkToken L.Tk__tok_MemberRest_dummy_135 = "'tok_MemberRest_dummy_135'"
-showRtkToken L.Tk__tok_Modifier_dummy_134 = "'tok_Modifier_dummy_134'"
-showRtkToken L.Tk__tok_ModifierList_dummy_133 = "'tok_ModifierList_dummy_133'"
-showRtkToken L.Tk__tok_MoreTypeSpecifier_dummy_132 = "'tok_MoreTypeSpecifier_dummy_132'"
-showRtkToken L.Tk__tok_MoreVariableDeclarators_dummy_131 = "'tok_MoreVariableDeclarators_dummy_131'"
-showRtkToken L.Tk__tok_MultiplicativeOp_dummy_130 = "'tok_MultiplicativeOp_dummy_130'"
-showRtkToken L.Tk__tok_NestedTypeDeclaration_dummy_129 = "'tok_NestedTypeDeclaration_dummy_129'"
-showRtkToken L.Tk__tok_OptDocComment_dummy_128 = "'tok_OptDocComment_dummy_128'"
-showRtkToken L.Tk__tok_OptElsePart_dummy_127 = "'tok_OptElsePart_dummy_127'"
-showRtkToken L.Tk__tok_OptExpression_dummy_126 = "'tok_OptExpression_dummy_126'"
-showRtkToken L.Tk__tok_OptFinally_dummy_125 = "'tok_OptFinally_dummy_125'"
-showRtkToken L.Tk__tok_OptId_dummy_124 = "'tok_OptId_dummy_124'"
-showRtkToken L.Tk__tok_OptVariableInitializer_dummy_123 = "'tok_OptVariableInitializer_dummy_123'"
-showRtkToken L.Tk__tok_Package_dummy_122 = "'tok_Package_dummy_122'"
-showRtkToken L.Tk__tok_Parameter_dummy_121 = "'tok_Parameter_dummy_121'"
-showRtkToken L.Tk__tok_ParameterList_dummy_120 = "'tok_ParameterList_dummy_120'"
-showRtkToken L.Tk__tok_PostfixOp_dummy_119 = "'tok_PostfixOp_dummy_119'"
-showRtkToken L.Tk__tok_PrefixOp_dummy_118 = "'tok_PrefixOp_dummy_118'"
-showRtkToken L.Tk__tok_PrimitiveTypeKeyword_dummy_117 = "'tok_PrimitiveTypeKeyword_dummy_117'"
-showRtkToken L.Tk__tok_RelationalOp_dummy_116 = "'tok_RelationalOp_dummy_116'"
-showRtkToken L.Tk__tok_ShiftOp_dummy_115 = "'tok_ShiftOp_dummy_115'"
-showRtkToken L.Tk__tok_SquareBracketsList_dummy_114 = "'tok_SquareBracketsList_dummy_114'"
-showRtkToken L.Tk__tok_Statement_dummy_113 = "'tok_Statement_dummy_113'"
-showRtkToken L.Tk__tok_StatementBlock_dummy_112 = "'tok_StatementBlock_dummy_112'"
-showRtkToken L.Tk__tok_StatementList_dummy_111 = "'tok_StatementList_dummy_111'"
-showRtkToken L.Tk__tok_StatementWithoutIf_dummy_110 = "'tok_StatementWithoutIf_dummy_110'"
-showRtkToken L.Tk__tok_StaticInitializer_dummy_109 = "'tok_StaticInitializer_dummy_109'"
-showRtkToken L.Tk__tok_SwitchCaseList_dummy_108 = "'tok_SwitchCaseList_dummy_108'"
-showRtkToken L.Tk__tok_SwitchStatement_dummy_107 = "'tok_SwitchStatement_dummy_107'"
-showRtkToken L.Tk__tok_TryStatement_dummy_106 = "'tok_TryStatement_dummy_106'"
-showRtkToken L.Tk__tok_Type_dummy_105 = "'tok_Type_dummy_105'"
-showRtkToken L.Tk__tok_TypeArgument_dummy_104 = "'tok_TypeArgument_dummy_104'"
-showRtkToken L.Tk__tok_TypeArguments_dummy_103 = "'tok_TypeArguments_dummy_103'"
-showRtkToken L.Tk__tok_TypeDeclaration_dummy_102 = "'tok_TypeDeclaration_dummy_102'"
-showRtkToken L.Tk__tok_TypeParameter_dummy_101 = "'tok_TypeParameter_dummy_101'"
-showRtkToken L.Tk__tok_TypeParameters_dummy_100 = "'tok_TypeParameters_dummy_100'"
-showRtkToken L.Tk__tok_TypeSpecifier_dummy_99 = "'tok_TypeSpecifier_dummy_99'"
-showRtkToken L.Tk__tok_VariableDeclaration_dummy_98 = "'tok_VariableDeclaration_dummy_98'"
-showRtkToken L.Tk__tok_VariableDeclarator_dummy_97 = "'tok_VariableDeclarator_dummy_97'"
-showRtkToken L.Tk__tok_VariableDeclaratorList_dummy_96 = "'tok_VariableDeclaratorList_dummy_96'"
-showRtkToken L.Tk__tok_VariableInitializer_dummy_95 = "'tok_VariableInitializer_dummy_95'"
-showRtkToken L.Tk__tok_VariableInitializerList_dummy_94 = "'tok_VariableInitializerList_dummy_94'"
-showRtkToken L.Tk__tok_WhileStatement_dummy_93 = "'tok_WhileStatement_dummy_93'"
-showRtkToken L.Tk__tok_WildcardType_dummy_92 = "'tok_WildcardType_dummy_92'"
+showRtkToken L.Tk__tok_AdditiveOp_dummy_177 = "'tok_AdditiveOp_dummy_177'"
+showRtkToken L.Tk__tok_Annotation_dummy_176 = "'tok_Annotation_dummy_176'"
+showRtkToken L.Tk__tok_AnnotationArguments_dummy_175 = "'tok_AnnotationArguments_dummy_175'"
+showRtkToken L.Tk__tok_AnnotationDeclaration_dummy_174 = "'tok_AnnotationDeclaration_dummy_174'"
+showRtkToken L.Tk__tok_AnnotationElement_dummy_173 = "'tok_AnnotationElement_dummy_173'"
+showRtkToken L.Tk__tok_AnnotationList_dummy_172 = "'tok_AnnotationList_dummy_172'"
+showRtkToken L.Tk__tok_AnnotationTypeElement_dummy_171 = "'tok_AnnotationTypeElement_dummy_171'"
+showRtkToken L.Tk__tok_AnnotationTypeElementList_dummy_170 = "'tok_AnnotationTypeElementList_dummy_170'"
+showRtkToken L.Tk__tok_Arglist_dummy_169 = "'tok_Arglist_dummy_169'"
+showRtkToken L.Tk__tok_AssignmentOp_dummy_168 = "'tok_AssignmentOp_dummy_168'"
+showRtkToken L.Tk__tok_CatchList_dummy_167 = "'tok_CatchList_dummy_167'"
+showRtkToken L.Tk__tok_ClassDeclaration_dummy_166 = "'tok_ClassDeclaration_dummy_166'"
+showRtkToken L.Tk__tok_CompilationUnit_dummy_165 = "'tok_CompilationUnit_dummy_165'"
+showRtkToken L.Tk__tok_CompoundName_dummy_164 = "'tok_CompoundName_dummy_164'"
+showRtkToken L.Tk__tok_CreationExpression_dummy_163 = "'tok_CreationExpression_dummy_163'"
+showRtkToken L.Tk__tok_DimExprs_dummy_162 = "'tok_DimExprs_dummy_162'"
+showRtkToken L.Tk__tok_Dims_dummy_161 = "'tok_Dims_dummy_161'"
+showRtkToken L.Tk__tok_DoStatement_dummy_160 = "'tok_DoStatement_dummy_160'"
+showRtkToken L.Tk__tok_DocComment_dummy_159 = "'tok_DocComment_dummy_159'"
+showRtkToken L.Tk__tok_EnumConstant_dummy_158 = "'tok_EnumConstant_dummy_158'"
+showRtkToken L.Tk__tok_EnumConstantList_dummy_157 = "'tok_EnumConstantList_dummy_157'"
+showRtkToken L.Tk__tok_EnumDeclaration_dummy_156 = "'tok_EnumDeclaration_dummy_156'"
+showRtkToken L.Tk__tok_EqualityOp_dummy_155 = "'tok_EqualityOp_dummy_155'"
+showRtkToken L.Tk__tok_Expression_dummy_154 = "'tok_Expression_dummy_154'"
+showRtkToken L.Tk__tok_ExtendsList_dummy_153 = "'tok_ExtendsList_dummy_153'"
+showRtkToken L.Tk__tok_FieldDeclaration_dummy_152 = "'tok_FieldDeclaration_dummy_152'"
+showRtkToken L.Tk__tok_FieldDeclarationList_dummy_151 = "'tok_FieldDeclarationList_dummy_151'"
+showRtkToken L.Tk__tok_ForStatement_dummy_150 = "'tok_ForStatement_dummy_150'"
+showRtkToken L.Tk__tok_IfStatement_dummy_149 = "'tok_IfStatement_dummy_149'"
+showRtkToken L.Tk__tok_ImplementsList_dummy_148 = "'tok_ImplementsList_dummy_148'"
+showRtkToken L.Tk__tok_ImportList_dummy_147 = "'tok_ImportList_dummy_147'"
+showRtkToken L.Tk__tok_ImportStatement_dummy_146 = "'tok_ImportStatement_dummy_146'"
+showRtkToken L.Tk__tok_InterfaceDeclaration_dummy_145 = "'tok_InterfaceDeclaration_dummy_145'"
+showRtkToken L.Tk__tok_Java_dummy_178 = "'tok_Java_dummy_178'"
+showRtkToken L.Tk__tok_Literal_dummy_144 = "'tok_Literal_dummy_144'"
+showRtkToken L.Tk__tok_MemberAfterFirstId_dummy_143 = "'tok_MemberAfterFirstId_dummy_143'"
+showRtkToken L.Tk__tok_MemberDeclaration_dummy_142 = "'tok_MemberDeclaration_dummy_142'"
+showRtkToken L.Tk__tok_MemberRest_dummy_141 = "'tok_MemberRest_dummy_141'"
+showRtkToken L.Tk__tok_Modifier_dummy_140 = "'tok_Modifier_dummy_140'"
+showRtkToken L.Tk__tok_ModifierList_dummy_139 = "'tok_ModifierList_dummy_139'"
+showRtkToken L.Tk__tok_MoreTypeSpecifier_dummy_138 = "'tok_MoreTypeSpecifier_dummy_138'"
+showRtkToken L.Tk__tok_MoreVariableDeclarators_dummy_137 = "'tok_MoreVariableDeclarators_dummy_137'"
+showRtkToken L.Tk__tok_MultiplicativeOp_dummy_136 = "'tok_MultiplicativeOp_dummy_136'"
+showRtkToken L.Tk__tok_NestedTypeDeclaration_dummy_135 = "'tok_NestedTypeDeclaration_dummy_135'"
+showRtkToken L.Tk__tok_NonEmptyDims_dummy_134 = "'tok_NonEmptyDims_dummy_134'"
+showRtkToken L.Tk__tok_NonEmptyTypeArguments_dummy_133 = "'tok_NonEmptyTypeArguments_dummy_133'"
+showRtkToken L.Tk__tok_OptDocComment_dummy_132 = "'tok_OptDocComment_dummy_132'"
+showRtkToken L.Tk__tok_OptElsePart_dummy_131 = "'tok_OptElsePart_dummy_131'"
+showRtkToken L.Tk__tok_OptExpression_dummy_130 = "'tok_OptExpression_dummy_130'"
+showRtkToken L.Tk__tok_OptFinally_dummy_129 = "'tok_OptFinally_dummy_129'"
+showRtkToken L.Tk__tok_OptId_dummy_128 = "'tok_OptId_dummy_128'"
+showRtkToken L.Tk__tok_OptVariableInitializer_dummy_127 = "'tok_OptVariableInitializer_dummy_127'"
+showRtkToken L.Tk__tok_Package_dummy_126 = "'tok_Package_dummy_126'"
+showRtkToken L.Tk__tok_Parameter_dummy_125 = "'tok_Parameter_dummy_125'"
+showRtkToken L.Tk__tok_ParameterList_dummy_124 = "'tok_ParameterList_dummy_124'"
+showRtkToken L.Tk__tok_PostfixOp_dummy_123 = "'tok_PostfixOp_dummy_123'"
+showRtkToken L.Tk__tok_PrefixOp_dummy_122 = "'tok_PrefixOp_dummy_122'"
+showRtkToken L.Tk__tok_PrimitiveTypeKeyword_dummy_121 = "'tok_PrimitiveTypeKeyword_dummy_121'"
+showRtkToken L.Tk__tok_RelationalOp_dummy_120 = "'tok_RelationalOp_dummy_120'"
+showRtkToken L.Tk__tok_ShiftOp_dummy_119 = "'tok_ShiftOp_dummy_119'"
+showRtkToken L.Tk__tok_Statement_dummy_118 = "'tok_Statement_dummy_118'"
+showRtkToken L.Tk__tok_StatementBlock_dummy_117 = "'tok_StatementBlock_dummy_117'"
+showRtkToken L.Tk__tok_StatementList_dummy_116 = "'tok_StatementList_dummy_116'"
+showRtkToken L.Tk__tok_StatementWithoutIf_dummy_115 = "'tok_StatementWithoutIf_dummy_115'"
+showRtkToken L.Tk__tok_StaticInitializer_dummy_114 = "'tok_StaticInitializer_dummy_114'"
+showRtkToken L.Tk__tok_SwitchCaseList_dummy_113 = "'tok_SwitchCaseList_dummy_113'"
+showRtkToken L.Tk__tok_SwitchStatement_dummy_112 = "'tok_SwitchStatement_dummy_112'"
+showRtkToken L.Tk__tok_TryStatement_dummy_111 = "'tok_TryStatement_dummy_111'"
+showRtkToken L.Tk__tok_Type_dummy_110 = "'tok_Type_dummy_110'"
+showRtkToken L.Tk__tok_TypeArgument_dummy_109 = "'tok_TypeArgument_dummy_109'"
+showRtkToken L.Tk__tok_TypeArguments_dummy_108 = "'tok_TypeArguments_dummy_108'"
+showRtkToken L.Tk__tok_TypeDeclaration_dummy_107 = "'tok_TypeDeclaration_dummy_107'"
+showRtkToken L.Tk__tok_TypeParameter_dummy_106 = "'tok_TypeParameter_dummy_106'"
+showRtkToken L.Tk__tok_TypeParameters_dummy_105 = "'tok_TypeParameters_dummy_105'"
+showRtkToken L.Tk__tok_TypeSpecifier_dummy_104 = "'tok_TypeSpecifier_dummy_104'"
+showRtkToken L.Tk__tok_VariableDeclaration_dummy_103 = "'tok_VariableDeclaration_dummy_103'"
+showRtkToken L.Tk__tok_VariableDeclarator_dummy_102 = "'tok_VariableDeclarator_dummy_102'"
+showRtkToken L.Tk__tok_VariableDeclaratorList_dummy_101 = "'tok_VariableDeclaratorList_dummy_101'"
+showRtkToken L.Tk__tok_VariableInitializer_dummy_100 = "'tok_VariableInitializer_dummy_100'"
+showRtkToken L.Tk__tok_VariableInitializerList_dummy_99 = "'tok_VariableInitializerList_dummy_99'"
+showRtkToken L.Tk__tok_WhileStatement_dummy_98 = "'tok_WhileStatement_dummy_98'"
+showRtkToken L.Tk__tok_WildcardType_dummy_97 = "'tok_WildcardType_dummy_97'"
 showRtkToken L.Tk__tok__tilde__78 = "'~'"
 showRtkToken L.Tk__tok__symbol__14 = "'}'"
 showRtkToken L.Tk__tok__pipe__pipe__57 = "'||'"
@@ -1189,9 +1230,11 @@ showRtkToken (L.Tk__qq_TypeParameter v) = "qq_TypeParameter " ++ show v
 showRtkToken (L.Tk__qq_TypeParameters v) = "qq_TypeParameters " ++ show v
 showRtkToken (L.Tk__qq_WildcardType v) = "qq_WildcardType " ++ show v
 showRtkToken (L.Tk__qq_TypeArgument v) = "qq_TypeArgument " ++ show v
+showRtkToken (L.Tk__qq_NonEmptyTypeArguments v) = "qq_NonEmptyTypeArguments " ++ show v
 showRtkToken (L.Tk__qq_TypeArguments v) = "qq_TypeArguments " ++ show v
 showRtkToken (L.Tk__qq_Arglist v) = "qq_Arglist " ++ show v
 showRtkToken (L.Tk__qq_Literal v) = "qq_Literal " ++ show v
+showRtkToken (L.Tk__qq_DimExprs v) = "qq_DimExprs " ++ show v
 showRtkToken (L.Tk__qq_CreationExpression v) = "qq_CreationExpression " ++ show v
 showRtkToken (L.Tk__qq_PostfixOp v) = "qq_PostfixOp " ++ show v
 showRtkToken (L.Tk__qq_PrefixOp v) = "qq_PrefixOp " ++ show v
@@ -1233,7 +1276,8 @@ showRtkToken (L.Tk__qq_MoreTypeSpecifier v) = "qq_MoreTypeSpecifier " ++ show v
 showRtkToken (L.Tk__qq_MemberAfterFirstId v) = "qq_MemberAfterFirstId " ++ show v
 showRtkToken (L.Tk__qq_PrimitiveTypeKeyword v) = "qq_PrimitiveTypeKeyword " ++ show v
 showRtkToken (L.Tk__qq_MemberDeclaration v) = "qq_MemberDeclaration " ++ show v
-showRtkToken (L.Tk__qq_SquareBracketsList v) = "qq_SquareBracketsList " ++ show v
+showRtkToken (L.Tk__qq_NonEmptyDims v) = "qq_NonEmptyDims " ++ show v
+showRtkToken (L.Tk__qq_Dims v) = "qq_Dims " ++ show v
 showRtkToken (L.Tk__qq_FieldDeclaration v) = "qq_FieldDeclaration " ++ show v
 showRtkToken (L.Tk__qq_NestedTypeDeclaration v) = "qq_NestedTypeDeclaration " ++ show v
 showRtkToken (L.Tk__qq_EnumDeclaration v) = "qq_EnumDeclaration " ++ show v
@@ -1339,6 +1383,9 @@ tkVal_qq_WildcardType t = error ("rtk internal error: token qq_WildcardType expe
 tkVal_qq_TypeArgument :: L.PosToken -> String
 tkVal_qq_TypeArgument (L.PosToken _ (L.Tk__qq_TypeArgument v)) = v
 tkVal_qq_TypeArgument t = error ("rtk internal error: token qq_TypeArgument expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_NonEmptyTypeArguments :: L.PosToken -> String
+tkVal_qq_NonEmptyTypeArguments (L.PosToken _ (L.Tk__qq_NonEmptyTypeArguments v)) = v
+tkVal_qq_NonEmptyTypeArguments t = error ("rtk internal error: token qq_NonEmptyTypeArguments expected, got " ++ showRtkToken (L.ptToken t))
 tkVal_qq_TypeArguments :: L.PosToken -> String
 tkVal_qq_TypeArguments (L.PosToken _ (L.Tk__qq_TypeArguments v)) = v
 tkVal_qq_TypeArguments t = error ("rtk internal error: token qq_TypeArguments expected, got " ++ showRtkToken (L.ptToken t))
@@ -1348,6 +1395,9 @@ tkVal_qq_Arglist t = error ("rtk internal error: token qq_Arglist expected, got 
 tkVal_qq_Literal :: L.PosToken -> String
 tkVal_qq_Literal (L.PosToken _ (L.Tk__qq_Literal v)) = v
 tkVal_qq_Literal t = error ("rtk internal error: token qq_Literal expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_DimExprs :: L.PosToken -> String
+tkVal_qq_DimExprs (L.PosToken _ (L.Tk__qq_DimExprs v)) = v
+tkVal_qq_DimExprs t = error ("rtk internal error: token qq_DimExprs expected, got " ++ showRtkToken (L.ptToken t))
 tkVal_qq_CreationExpression :: L.PosToken -> String
 tkVal_qq_CreationExpression (L.PosToken _ (L.Tk__qq_CreationExpression v)) = v
 tkVal_qq_CreationExpression t = error ("rtk internal error: token qq_CreationExpression expected, got " ++ showRtkToken (L.ptToken t))
@@ -1471,9 +1521,12 @@ tkVal_qq_PrimitiveTypeKeyword t = error ("rtk internal error: token qq_Primitive
 tkVal_qq_MemberDeclaration :: L.PosToken -> String
 tkVal_qq_MemberDeclaration (L.PosToken _ (L.Tk__qq_MemberDeclaration v)) = v
 tkVal_qq_MemberDeclaration t = error ("rtk internal error: token qq_MemberDeclaration expected, got " ++ showRtkToken (L.ptToken t))
-tkVal_qq_SquareBracketsList :: L.PosToken -> String
-tkVal_qq_SquareBracketsList (L.PosToken _ (L.Tk__qq_SquareBracketsList v)) = v
-tkVal_qq_SquareBracketsList t = error ("rtk internal error: token qq_SquareBracketsList expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_NonEmptyDims :: L.PosToken -> String
+tkVal_qq_NonEmptyDims (L.PosToken _ (L.Tk__qq_NonEmptyDims v)) = v
+tkVal_qq_NonEmptyDims t = error ("rtk internal error: token qq_NonEmptyDims expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_Dims :: L.PosToken -> String
+tkVal_qq_Dims (L.PosToken _ (L.Tk__qq_Dims v)) = v
+tkVal_qq_Dims t = error ("rtk internal error: token qq_Dims expected, got " ++ showRtkToken (L.ptToken t))
 tkVal_qq_FieldDeclaration :: L.PosToken -> String
 tkVal_qq_FieldDeclaration (L.PosToken _ (L.Tk__qq_FieldDeclaration v)) = v
 tkVal_qq_FieldDeclaration t = error ("rtk internal error: token qq_FieldDeclaration expected, got " ++ showRtkToken (L.ptToken t))
@@ -1569,71 +1622,74 @@ data Java = Ctr__Java__0 RtkPos Java |
             Ctr__Java__13 RtkPos CompilationUnit |
             Ctr__Java__14 RtkPos CompoundName |
             Ctr__Java__15 RtkPos CreationExpression |
-            Ctr__Java__16 RtkPos DoStatement |
-            Ctr__Java__17 RtkPos DocComment |
-            Ctr__Java__18 RtkPos EnumConstant |
-            Ctr__Java__19 RtkPos EnumConstantList |
-            Ctr__Java__20 RtkPos EnumDeclaration |
-            Ctr__Java__21 RtkPos EqualityOp |
-            Ctr__Java__22 RtkPos Expression |
-            Ctr__Java__23 RtkPos ExtendsList |
-            Ctr__Java__24 RtkPos FieldDeclaration |
-            Ctr__Java__25 RtkPos FieldDeclarationList |
-            Ctr__Java__26 RtkPos ForStatement |
-            Ctr__Java__27 RtkPos IfStatement |
-            Ctr__Java__28 RtkPos ImplementsList |
-            Ctr__Java__29 RtkPos ImportList |
-            Ctr__Java__30 RtkPos ImportStatement |
-            Ctr__Java__31 RtkPos InterfaceDeclaration |
-            Ctr__Java__32 RtkPos Literal |
-            Ctr__Java__33 RtkPos MemberAfterFirstId |
-            Ctr__Java__34 RtkPos MemberDeclaration |
-            Ctr__Java__35 RtkPos MemberRest |
-            Ctr__Java__36 RtkPos Modifier |
-            Ctr__Java__37 RtkPos ModifierList |
-            Ctr__Java__38 RtkPos MoreTypeSpecifier |
-            Ctr__Java__39 RtkPos MoreVariableDeclarators |
-            Ctr__Java__40 RtkPos MultiplicativeOp |
-            Ctr__Java__41 RtkPos NestedTypeDeclaration |
-            Ctr__Java__42 RtkPos OptDocComment |
-            Ctr__Java__43 RtkPos OptElsePart |
-            Ctr__Java__44 RtkPos OptExpression |
-            Ctr__Java__45 RtkPos OptFinally |
-            Ctr__Java__46 RtkPos OptId |
-            Ctr__Java__47 RtkPos OptVariableInitializer |
-            Ctr__Java__48 RtkPos Package |
-            Ctr__Java__49 RtkPos Parameter |
-            Ctr__Java__50 RtkPos ParameterList |
-            Ctr__Java__51 RtkPos PostfixOp |
-            Ctr__Java__52 RtkPos PrefixOp |
-            Ctr__Java__53 RtkPos PrimitiveTypeKeyword |
-            Ctr__Java__54 RtkPos RelationalOp |
-            Ctr__Java__55 RtkPos ShiftOp |
-            Ctr__Java__56 RtkPos SquareBracketsList |
-            Ctr__Java__57 RtkPos Statement |
-            Ctr__Java__58 RtkPos StatementBlock |
-            Ctr__Java__59 RtkPos StatementList |
-            Ctr__Java__60 RtkPos StatementWithoutIf |
-            Ctr__Java__61 RtkPos StaticInitializer |
-            Ctr__Java__62 RtkPos SwitchCaseList |
-            Ctr__Java__63 RtkPos SwitchStatement |
-            Ctr__Java__64 RtkPos TryStatement |
-            Ctr__Java__65 RtkPos Type |
-            Ctr__Java__66 RtkPos TypeArgument |
-            Ctr__Java__67 RtkPos TypeArguments |
-            Ctr__Java__68 RtkPos TypeDeclaration |
-            Ctr__Java__69 RtkPos TypeParameter |
-            Ctr__Java__70 RtkPos TypeParameters |
-            Ctr__Java__71 RtkPos TypeSpecifier |
-            Ctr__Java__72 RtkPos VariableDeclaration |
-            Ctr__Java__73 RtkPos VariableDeclarator |
-            Ctr__Java__74 RtkPos VariableDeclaratorList |
-            Ctr__Java__75 RtkPos VariableInitializer |
-            Ctr__Java__76 RtkPos VariableInitializerList |
-            Ctr__Java__77 RtkPos WhileStatement |
-            Ctr__Java__78 RtkPos WildcardType |
+            Ctr__Java__16 RtkPos DimExprs |
+            Ctr__Java__17 RtkPos Dims |
+            Ctr__Java__18 RtkPos DoStatement |
+            Ctr__Java__19 RtkPos DocComment |
+            Ctr__Java__20 RtkPos EnumConstant |
+            Ctr__Java__21 RtkPos EnumConstantList |
+            Ctr__Java__22 RtkPos EnumDeclaration |
+            Ctr__Java__23 RtkPos EqualityOp |
+            Ctr__Java__24 RtkPos Expression |
+            Ctr__Java__25 RtkPos ExtendsList |
+            Ctr__Java__26 RtkPos FieldDeclaration |
+            Ctr__Java__27 RtkPos FieldDeclarationList |
+            Ctr__Java__28 RtkPos ForStatement |
+            Ctr__Java__29 RtkPos IfStatement |
+            Ctr__Java__30 RtkPos ImplementsList |
+            Ctr__Java__31 RtkPos ImportList |
+            Ctr__Java__32 RtkPos ImportStatement |
+            Ctr__Java__33 RtkPos InterfaceDeclaration |
+            Ctr__Java__34 RtkPos Literal |
+            Ctr__Java__35 RtkPos MemberAfterFirstId |
+            Ctr__Java__36 RtkPos MemberDeclaration |
+            Ctr__Java__37 RtkPos MemberRest |
+            Ctr__Java__38 RtkPos Modifier |
+            Ctr__Java__39 RtkPos ModifierList |
+            Ctr__Java__40 RtkPos MoreTypeSpecifier |
+            Ctr__Java__41 RtkPos MoreVariableDeclarators |
+            Ctr__Java__42 RtkPos MultiplicativeOp |
+            Ctr__Java__43 RtkPos NestedTypeDeclaration |
+            Ctr__Java__44 RtkPos NonEmptyDims |
+            Ctr__Java__45 RtkPos NonEmptyTypeArguments |
+            Ctr__Java__46 RtkPos OptDocComment |
+            Ctr__Java__47 RtkPos OptElsePart |
+            Ctr__Java__48 RtkPos OptExpression |
+            Ctr__Java__49 RtkPos OptFinally |
+            Ctr__Java__50 RtkPos OptId |
+            Ctr__Java__51 RtkPos OptVariableInitializer |
+            Ctr__Java__52 RtkPos Package |
+            Ctr__Java__53 RtkPos Parameter |
+            Ctr__Java__54 RtkPos ParameterList |
+            Ctr__Java__55 RtkPos PostfixOp |
+            Ctr__Java__56 RtkPos PrefixOp |
+            Ctr__Java__57 RtkPos PrimitiveTypeKeyword |
+            Ctr__Java__58 RtkPos RelationalOp |
+            Ctr__Java__59 RtkPos ShiftOp |
+            Ctr__Java__60 RtkPos Statement |
+            Ctr__Java__61 RtkPos StatementBlock |
+            Ctr__Java__62 RtkPos StatementList |
+            Ctr__Java__63 RtkPos StatementWithoutIf |
+            Ctr__Java__64 RtkPos StaticInitializer |
+            Ctr__Java__65 RtkPos SwitchCaseList |
+            Ctr__Java__66 RtkPos SwitchStatement |
+            Ctr__Java__67 RtkPos TryStatement |
+            Ctr__Java__68 RtkPos Type |
+            Ctr__Java__69 RtkPos TypeArgument |
+            Ctr__Java__70 RtkPos TypeArguments |
+            Ctr__Java__71 RtkPos TypeDeclaration |
+            Ctr__Java__72 RtkPos TypeParameter |
+            Ctr__Java__73 RtkPos TypeParameters |
+            Ctr__Java__74 RtkPos TypeSpecifier |
+            Ctr__Java__75 RtkPos VariableDeclaration |
+            Ctr__Java__76 RtkPos VariableDeclarator |
+            Ctr__Java__77 RtkPos VariableDeclaratorList |
+            Ctr__Java__78 RtkPos VariableInitializer |
+            Ctr__Java__79 RtkPos VariableInitializerList |
+            Ctr__Java__80 RtkPos WhileStatement |
+            Ctr__Java__81 RtkPos WildcardType |
             Anti_Java String |
-            Ctr__Java__79 RtkPos CompilationUnit
+            Ctr__Java__82 RtkPos CompilationUnit
             deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Java where
     rtkPosOf (Ctr__Java__0 p _) = p
@@ -1715,8 +1771,11 @@ instance RtkPosOf Java where
     rtkPosOf (Ctr__Java__76 p _) = p
     rtkPosOf (Ctr__Java__77 p _) = p
     rtkPosOf (Ctr__Java__78 p _) = p
-    rtkPosOf (Anti_Java _) = rtkNoPos
     rtkPosOf (Ctr__Java__79 p _) = p
+    rtkPosOf (Ctr__Java__80 p _) = p
+    rtkPosOf (Ctr__Java__81 p _) = p
+    rtkPosOf (Anti_Java _) = rtkNoPos
+    rtkPosOf (Ctr__Java__82 p _) = p
 data AdditiveOp = Anti_AdditiveOp String |
                   Ctr__AdditiveOp__0 RtkPos |
                   Ctr__AdditiveOp__1 RtkPos
@@ -1761,7 +1820,7 @@ instance RtkPosOf AnnotationTypeElement where
 type AnnotationTypeElementList = [AnnotationTypeElement]
 data Arglist = Anti_Arglist String |
                Ctr__Arglist__0 RtkPos |
-               Ctr__Arglist__1 RtkPos Rule_77
+               Ctr__Arglist__1 RtkPos Rule_83
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Arglist where
     rtkPosOf (Anti_Arglist _) = rtkNoPos
@@ -1795,7 +1854,7 @@ instance RtkPosOf AssignmentOp where
     rtkPosOf (Ctr__AssignmentOp__9 p) = p
     rtkPosOf (Ctr__AssignmentOp__10 p) = p
     rtkPosOf (Ctr__AssignmentOp__11 p) = p
-type CatchList = [Rule_63]
+type CatchList = [Rule_65]
 data ClassDeclaration = Anti_ClassDeclaration String |
                         Ctr__ClassDeclaration__0 RtkPos ModifierList String TypeParameters Rule_22 Rule_23 FieldDeclarationList
                         deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
@@ -1809,17 +1868,19 @@ instance RtkPosOf CompilationUnit where
     rtkPosOf (Anti_CompilationUnit _) = rtkNoPos
     rtkPosOf (Ctr__CompilationUnit__0 p _ _ _) = p
 data CompoundName = Anti_CompoundName String |
-                    Ctr__CompoundName__0 RtkPos String Rule_90
+                    Ctr__CompoundName__0 RtkPos String Rule_95
                     deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf CompoundName where
     rtkPosOf (Anti_CompoundName _) = rtkNoPos
     rtkPosOf (Ctr__CompoundName__0 p _ _) = p
 data CreationExpression = Anti_CreationExpression String |
-                          Ctr__CreationExpression__0 RtkPos Type Rule_76
+                          Ctr__CreationExpression__0 RtkPos TypeSpecifier Rule_78
                           deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf CreationExpression where
     rtkPosOf (Anti_CreationExpression _) = rtkNoPos
     rtkPosOf (Ctr__CreationExpression__0 p _ _) = p
+type DimExprs = [Rule_81]
+type Dims = [Rule_40]
 data DoStatement = Anti_DoStatement String |
                    Ctr__DoStatement__0 RtkPos Statement Expression
                    deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
@@ -1863,35 +1924,35 @@ data Expression = Anti_Expression String |
                   Ctr__Expression__1 RtkPos |
                   Ctr__Expression__2 RtkPos Expression |
                   Ctr__Expression__3 RtkPos CreationExpression |
-                  Ctr__Expression__4 RtkPos CompoundName Rule_72 |
-                  Ctr__Expression__5 RtkPos String Rule_74 |
-                  Ctr__Expression__6 RtkPos Expression |
-                  Ctr__Expression__7 RtkPos Expression PostfixOp |
-                  Ctr__Expression__8 RtkPos Expression String |
-                  Ctr__Expression__9 RtkPos Expression String Arglist |
-                  Ctr__Expression__10 RtkPos Expression Expression |
-                  Ctr__Expression__11 RtkPos Expression |
+                  Ctr__Expression__4 RtkPos CompoundName Rule_74 |
+                  Ctr__Expression__5 RtkPos CompoundName Expression |
+                  Ctr__Expression__6 RtkPos String Rule_76 |
+                  Ctr__Expression__7 RtkPos Expression |
+                  Ctr__Expression__8 RtkPos Expression PostfixOp |
+                  Ctr__Expression__9 RtkPos Expression String |
+                  Ctr__Expression__10 RtkPos Expression String Arglist |
+                  Ctr__Expression__11 RtkPos Expression Expression |
                   Ctr__Expression__12 RtkPos Expression |
                   Ctr__Expression__13 RtkPos Expression |
                   Ctr__Expression__14 RtkPos Expression |
-                  Ctr__Expression__15 RtkPos PrefixOp Expression |
-                  Ctr__Expression__16 RtkPos Expression |
-                  Ctr__Expression__17 RtkPos Type Expression |
-                  Ctr__Expression__18 RtkPos Expression |
-                  Ctr__Expression__19 RtkPos Expression MultiplicativeOp Expression |
-                  Ctr__Expression__20 RtkPos Expression |
-                  Ctr__Expression__21 RtkPos Expression AdditiveOp Expression |
+                  Ctr__Expression__15 RtkPos Expression |
+                  Ctr__Expression__16 RtkPos PrefixOp Expression |
+                  Ctr__Expression__17 RtkPos Expression |
+                  Ctr__Expression__18 RtkPos PrimitiveTypeKeyword Dims Expression |
+                  Ctr__Expression__19 RtkPos CompoundName NonEmptyTypeArguments Dims Expression |
+                  Ctr__Expression__20 RtkPos CompoundName NonEmptyDims Expression |
+                  Ctr__Expression__21 RtkPos Expression Expression |
                   Ctr__Expression__22 RtkPos Expression |
-                  Ctr__Expression__23 RtkPos Expression ShiftOp Expression |
+                  Ctr__Expression__23 RtkPos Expression MultiplicativeOp Expression |
                   Ctr__Expression__24 RtkPos Expression |
-                  Ctr__Expression__25 RtkPos Expression RelationalOp Expression |
-                  Ctr__Expression__26 RtkPos Expression Type |
-                  Ctr__Expression__27 RtkPos Expression |
-                  Ctr__Expression__28 RtkPos Expression EqualityOp Expression |
-                  Ctr__Expression__29 RtkPos Expression |
-                  Ctr__Expression__30 RtkPos Expression Expression |
+                  Ctr__Expression__25 RtkPos Expression AdditiveOp Expression |
+                  Ctr__Expression__26 RtkPos Expression |
+                  Ctr__Expression__27 RtkPos Expression ShiftOp Expression |
+                  Ctr__Expression__28 RtkPos Expression |
+                  Ctr__Expression__29 RtkPos Expression RelationalOp Expression |
+                  Ctr__Expression__30 RtkPos Expression Type |
                   Ctr__Expression__31 RtkPos Expression |
-                  Ctr__Expression__32 RtkPos Expression Expression |
+                  Ctr__Expression__32 RtkPos Expression EqualityOp Expression |
                   Ctr__Expression__33 RtkPos Expression |
                   Ctr__Expression__34 RtkPos Expression Expression |
                   Ctr__Expression__35 RtkPos Expression |
@@ -1899,9 +1960,13 @@ data Expression = Anti_Expression String |
                   Ctr__Expression__37 RtkPos Expression |
                   Ctr__Expression__38 RtkPos Expression Expression |
                   Ctr__Expression__39 RtkPos Expression |
-                  Ctr__Expression__40 RtkPos Expression Expression Expression |
-                  Ctr__Expression__41 RtkPos Expression Rule_70 |
-                  Ctr__Expression__42 RtkPos Expression
+                  Ctr__Expression__40 RtkPos Expression Expression |
+                  Ctr__Expression__41 RtkPos Expression |
+                  Ctr__Expression__42 RtkPos Expression Expression |
+                  Ctr__Expression__43 RtkPos Expression |
+                  Ctr__Expression__44 RtkPos Expression Expression Expression |
+                  Ctr__Expression__45 RtkPos Expression Rule_72 |
+                  Ctr__Expression__46 RtkPos Expression
                   deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Expression where
     rtkPosOf (Anti_Expression _) = rtkNoPos
@@ -1911,33 +1976,33 @@ instance RtkPosOf Expression where
     rtkPosOf (Ctr__Expression__3 p _) = p
     rtkPosOf (Ctr__Expression__4 p _ _) = p
     rtkPosOf (Ctr__Expression__5 p _ _) = p
-    rtkPosOf (Ctr__Expression__6 p _) = p
-    rtkPosOf (Ctr__Expression__7 p _ _) = p
+    rtkPosOf (Ctr__Expression__6 p _ _) = p
+    rtkPosOf (Ctr__Expression__7 p _) = p
     rtkPosOf (Ctr__Expression__8 p _ _) = p
-    rtkPosOf (Ctr__Expression__9 p _ _ _) = p
-    rtkPosOf (Ctr__Expression__10 p _ _) = p
-    rtkPosOf (Ctr__Expression__11 p _) = p
+    rtkPosOf (Ctr__Expression__9 p _ _) = p
+    rtkPosOf (Ctr__Expression__10 p _ _ _) = p
+    rtkPosOf (Ctr__Expression__11 p _ _) = p
     rtkPosOf (Ctr__Expression__12 p _) = p
     rtkPosOf (Ctr__Expression__13 p _) = p
     rtkPosOf (Ctr__Expression__14 p _) = p
-    rtkPosOf (Ctr__Expression__15 p _ _) = p
-    rtkPosOf (Ctr__Expression__16 p _) = p
-    rtkPosOf (Ctr__Expression__17 p _ _) = p
-    rtkPosOf (Ctr__Expression__18 p _) = p
-    rtkPosOf (Ctr__Expression__19 p _ _ _) = p
-    rtkPosOf (Ctr__Expression__20 p _) = p
-    rtkPosOf (Ctr__Expression__21 p _ _ _) = p
+    rtkPosOf (Ctr__Expression__15 p _) = p
+    rtkPosOf (Ctr__Expression__16 p _ _) = p
+    rtkPosOf (Ctr__Expression__17 p _) = p
+    rtkPosOf (Ctr__Expression__18 p _ _ _) = p
+    rtkPosOf (Ctr__Expression__19 p _ _ _ _) = p
+    rtkPosOf (Ctr__Expression__20 p _ _ _) = p
+    rtkPosOf (Ctr__Expression__21 p _ _) = p
     rtkPosOf (Ctr__Expression__22 p _) = p
     rtkPosOf (Ctr__Expression__23 p _ _ _) = p
     rtkPosOf (Ctr__Expression__24 p _) = p
     rtkPosOf (Ctr__Expression__25 p _ _ _) = p
-    rtkPosOf (Ctr__Expression__26 p _ _) = p
-    rtkPosOf (Ctr__Expression__27 p _) = p
-    rtkPosOf (Ctr__Expression__28 p _ _ _) = p
-    rtkPosOf (Ctr__Expression__29 p _) = p
+    rtkPosOf (Ctr__Expression__26 p _) = p
+    rtkPosOf (Ctr__Expression__27 p _ _ _) = p
+    rtkPosOf (Ctr__Expression__28 p _) = p
+    rtkPosOf (Ctr__Expression__29 p _ _ _) = p
     rtkPosOf (Ctr__Expression__30 p _ _) = p
     rtkPosOf (Ctr__Expression__31 p _) = p
-    rtkPosOf (Ctr__Expression__32 p _ _) = p
+    rtkPosOf (Ctr__Expression__32 p _ _ _) = p
     rtkPosOf (Ctr__Expression__33 p _) = p
     rtkPosOf (Ctr__Expression__34 p _ _) = p
     rtkPosOf (Ctr__Expression__35 p _) = p
@@ -1945,9 +2010,13 @@ instance RtkPosOf Expression where
     rtkPosOf (Ctr__Expression__37 p _) = p
     rtkPosOf (Ctr__Expression__38 p _ _) = p
     rtkPosOf (Ctr__Expression__39 p _) = p
-    rtkPosOf (Ctr__Expression__40 p _ _ _) = p
-    rtkPosOf (Ctr__Expression__41 p _ _) = p
-    rtkPosOf (Ctr__Expression__42 p _) = p
+    rtkPosOf (Ctr__Expression__40 p _ _) = p
+    rtkPosOf (Ctr__Expression__41 p _) = p
+    rtkPosOf (Ctr__Expression__42 p _ _) = p
+    rtkPosOf (Ctr__Expression__43 p _) = p
+    rtkPosOf (Ctr__Expression__44 p _ _ _) = p
+    rtkPosOf (Ctr__Expression__45 p _ _) = p
+    rtkPosOf (Ctr__Expression__46 p _) = p
 data ExtendsList = Anti_ExtendsList String |
                    Ctr__ExtendsList__0 RtkPos CompoundName Rule_18
                    deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
@@ -1964,7 +2033,7 @@ instance RtkPosOf FieldDeclaration where
     rtkPosOf (Ctr__FieldDeclaration__1 p) = p
 type FieldDeclarationList = [FieldDeclaration]
 data ForStatement = Anti_ForStatement String |
-                    Ctr__ForStatement__0 RtkPos Rule_61 OptExpression OptExpression Statement
+                    Ctr__ForStatement__0 RtkPos Rule_63 OptExpression OptExpression Statement
                     deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf ForStatement where
     rtkPosOf (Anti_ForStatement _) = rtkNoPos
@@ -2013,7 +2082,7 @@ instance RtkPosOf Literal where
     rtkPosOf (Ctr__Literal__5 p _) = p
     rtkPosOf (Ctr__Literal__6 p) = p
 data MemberAfterFirstId = Anti_MemberAfterFirstId String |
-                          Ctr__MemberAfterFirstId__0 RtkPos Rule_42 StatementBlock |
+                          Ctr__MemberAfterFirstId__0 RtkPos Rule_44 StatementBlock |
                           Ctr__MemberAfterFirstId__1 RtkPos MoreTypeSpecifier String MemberRest
                           deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf MemberAfterFirstId where
@@ -2021,7 +2090,7 @@ instance RtkPosOf MemberAfterFirstId where
     rtkPosOf (Ctr__MemberAfterFirstId__0 p _ _) = p
     rtkPosOf (Ctr__MemberAfterFirstId__1 p _ _ _) = p
 data MemberDeclaration = Anti_MemberDeclaration String |
-                         Ctr__MemberDeclaration__0 RtkPos PrimitiveTypeKeyword SquareBracketsList String MemberRest |
+                         Ctr__MemberDeclaration__0 RtkPos PrimitiveTypeKeyword Dims String MemberRest |
                          Ctr__MemberDeclaration__1 RtkPos TypeParameters String MoreTypeSpecifier String MemberRest |
                          Ctr__MemberDeclaration__2 RtkPos String MemberAfterFirstId
                          deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
@@ -2031,8 +2100,8 @@ instance RtkPosOf MemberDeclaration where
     rtkPosOf (Ctr__MemberDeclaration__1 p _ _ _ _ _) = p
     rtkPosOf (Ctr__MemberDeclaration__2 p _ _) = p
 data MemberRest = Anti_MemberRest String |
-                  Ctr__MemberRest__0 RtkPos Rule_43 SquareBracketsList Rule_44 |
-                  Ctr__MemberRest__1 RtkPos SquareBracketsList OptVariableInitializer MoreVariableDeclarators
+                  Ctr__MemberRest__0 RtkPos Rule_45 Dims Rule_46 |
+                  Ctr__MemberRest__1 RtkPos Dims OptVariableInitializer MoreVariableDeclarators
                   deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf MemberRest where
     rtkPosOf (Anti_MemberRest _) = rtkNoPos
@@ -2065,13 +2134,13 @@ instance RtkPosOf Modifier where
 type ModifierList = [Rule_16]
 data MoreTypeSpecifier = Anti_MoreTypeSpecifier String |
                          Ctr__MoreTypeSpecifier__0 RtkPos String MoreTypeSpecifier |
-                         Ctr__MoreTypeSpecifier__1 RtkPos TypeArguments SquareBracketsList
+                         Ctr__MoreTypeSpecifier__1 RtkPos TypeArguments Dims
                          deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf MoreTypeSpecifier where
     rtkPosOf (Anti_MoreTypeSpecifier _) = rtkNoPos
     rtkPosOf (Ctr__MoreTypeSpecifier__0 p _ _) = p
     rtkPosOf (Ctr__MoreTypeSpecifier__1 p _ _) = p
-type MoreVariableDeclarators = [Rule_47]
+type MoreVariableDeclarators = [Rule_49]
 data MultiplicativeOp = Anti_MultiplicativeOp String |
                         Ctr__MultiplicativeOp__0 RtkPos |
                         Ctr__MultiplicativeOp__1 RtkPos |
@@ -2094,6 +2163,13 @@ instance RtkPosOf NestedTypeDeclaration where
     rtkPosOf (Ctr__NestedTypeDeclaration__1 p _) = p
     rtkPosOf (Ctr__NestedTypeDeclaration__2 p _) = p
     rtkPosOf (Ctr__NestedTypeDeclaration__3 p _) = p
+type NonEmptyDims = [Rule_42]
+data NonEmptyTypeArguments = Anti_NonEmptyTypeArguments String |
+                             Ctr__NonEmptyTypeArguments__0 RtkPos TypeArgument Rule_86
+                             deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf NonEmptyTypeArguments where
+    rtkPosOf (Anti_NonEmptyTypeArguments _) = rtkNoPos
+    rtkPosOf (Ctr__NonEmptyTypeArguments__0 p _ _) = p
 data OptDocComment = Anti_OptDocComment String |
                      Ctr__OptDocComment__0 RtkPos |
                      Ctr__OptDocComment__1 RtkPos Rule_0
@@ -2104,7 +2180,7 @@ instance RtkPosOf OptDocComment where
     rtkPosOf (Ctr__OptDocComment__1 p _) = p
 data OptElsePart = Anti_OptElsePart String |
                    Ctr__OptElsePart__0 RtkPos |
-                   Ctr__OptElsePart__1 RtkPos Rule_60
+                   Ctr__OptElsePart__1 RtkPos Rule_62
                    deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf OptElsePart where
     rtkPosOf (Anti_OptElsePart _) = rtkNoPos
@@ -2120,7 +2196,7 @@ instance RtkPosOf OptExpression where
     rtkPosOf (Ctr__OptExpression__1 p _) = p
 data OptFinally = Anti_OptFinally String |
                   Ctr__OptFinally__0 RtkPos |
-                  Ctr__OptFinally__1 RtkPos Rule_65
+                  Ctr__OptFinally__1 RtkPos Rule_67
                   deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf OptFinally where
     rtkPosOf (Anti_OptFinally _) = rtkNoPos
@@ -2136,7 +2212,7 @@ instance RtkPosOf OptId where
     rtkPosOf (Ctr__OptId__1 p _) = p
 data OptVariableInitializer = Anti_OptVariableInitializer String |
                               Ctr__OptVariableInitializer__0 RtkPos |
-                              Ctr__OptVariableInitializer__1 RtkPos Rule_51
+                              Ctr__OptVariableInitializer__1 RtkPos Rule_53
                               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf OptVariableInitializer where
     rtkPosOf (Anti_OptVariableInitializer _) = rtkNoPos
@@ -2149,13 +2225,13 @@ instance RtkPosOf Package where
     rtkPosOf (Anti_Package _) = rtkNoPos
     rtkPosOf (Ctr__Package__0 p _) = p
 data Parameter = Anti_Parameter String |
-                 Ctr__Parameter__0 RtkPos Type String SquareBracketsList
+                 Ctr__Parameter__0 RtkPos Type String Dims
                  deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Parameter where
     rtkPosOf (Anti_Parameter _) = rtkNoPos
     rtkPosOf (Ctr__Parameter__0 p _ _ _) = p
 data ParameterList = Anti_ParameterList String |
-                     Ctr__ParameterList__0 RtkPos Parameter Rule_57
+                     Ctr__ParameterList__0 RtkPos Parameter Rule_59
                      deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf ParameterList where
     rtkPosOf (Anti_ParameterList _) = rtkNoPos
@@ -2361,156 +2437,152 @@ instance RtkPosOf Rule_4 where
     rtkPosOf (Ctr__Rule_4__0 p) = p
     rtkPosOf (Ctr__Rule_4__1 p _) = p
 data Rule_40 = Anti_Rule_40 String |
-               Ctr__Rule_40__1 RtkPos OptExpression
+               Ctr__Rule_40__1 RtkPos
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_40 where
     rtkPosOf (Anti_Rule_40 _) = rtkNoPos
-    rtkPosOf (Ctr__Rule_40__1 p _) = p
-data Rule_42 = Ctr__Rule_42__0 RtkPos |
-               Ctr__Rule_42__1 RtkPos ParameterList
+    rtkPosOf (Ctr__Rule_40__1 p) = p
+data Rule_42 = Anti_Rule_42 String |
+               Ctr__Rule_42__1 RtkPos
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_42 where
-    rtkPosOf (Ctr__Rule_42__0 p) = p
-    rtkPosOf (Ctr__Rule_42__1 p _) = p
-data Rule_43 = Ctr__Rule_43__0 RtkPos |
-               Ctr__Rule_43__1 RtkPos ParameterList
-               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-instance RtkPosOf Rule_43 where
-    rtkPosOf (Ctr__Rule_43__0 p) = p
-    rtkPosOf (Ctr__Rule_43__1 p _) = p
-data Rule_44 = Ctr__Rule_44__0 RtkPos StatementBlock |
-               Ctr__Rule_44__1 RtkPos Rule_45
+    rtkPosOf (Anti_Rule_42 _) = rtkNoPos
+    rtkPosOf (Ctr__Rule_42__1 p) = p
+data Rule_44 = Ctr__Rule_44__0 RtkPos |
+               Ctr__Rule_44__1 RtkPos ParameterList
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_44 where
-    rtkPosOf (Ctr__Rule_44__0 p _) = p
+    rtkPosOf (Ctr__Rule_44__0 p) = p
     rtkPosOf (Ctr__Rule_44__1 p _) = p
 data Rule_45 = Ctr__Rule_45__0 RtkPos |
-               Ctr__Rule_45__1 RtkPos Rule_46
+               Ctr__Rule_45__1 RtkPos ParameterList
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_45 where
     rtkPosOf (Ctr__Rule_45__0 p) = p
     rtkPosOf (Ctr__Rule_45__1 p _) = p
-data Rule_46 = Ctr__Rule_46__0 RtkPos Expression
+data Rule_46 = Ctr__Rule_46__0 RtkPos StatementBlock |
+               Ctr__Rule_46__1 RtkPos Rule_47
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_46 where
     rtkPosOf (Ctr__Rule_46__0 p _) = p
-data Rule_47 = Anti_Rule_47 String |
-               Ctr__Rule_47__1 RtkPos VariableDeclarator
+    rtkPosOf (Ctr__Rule_46__1 p _) = p
+data Rule_47 = Ctr__Rule_47__0 RtkPos |
+               Ctr__Rule_47__1 RtkPos Rule_48
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_47 where
-    rtkPosOf (Anti_Rule_47 _) = rtkNoPos
+    rtkPosOf (Ctr__Rule_47__0 p) = p
     rtkPosOf (Ctr__Rule_47__1 p _) = p
-type Rule_49 = [Rule_50]
+data Rule_48 = Ctr__Rule_48__0 RtkPos Expression
+               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_48 where
+    rtkPosOf (Ctr__Rule_48__0 p _) = p
+data Rule_49 = Anti_Rule_49 String |
+               Ctr__Rule_49__1 RtkPos VariableDeclarator
+               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_49 where
+    rtkPosOf (Anti_Rule_49 _) = rtkNoPos
+    rtkPosOf (Ctr__Rule_49__1 p _) = p
 data Rule_5 = Ctr__Rule_5__0 RtkPos Package
               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_5 where
     rtkPosOf (Ctr__Rule_5__0 p _) = p
-data Rule_50 = Ctr__Rule_50__0 RtkPos VariableDeclarator
-               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-instance RtkPosOf Rule_50 where
-    rtkPosOf (Ctr__Rule_50__0 p _) = p
-data Rule_51 = Ctr__Rule_51__0 RtkPos VariableInitializer
-               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-instance RtkPosOf Rule_51 where
-    rtkPosOf (Ctr__Rule_51__0 p _) = p
-data Rule_52 = Ctr__Rule_52__0 RtkPos VariableInitializer Rule_53 Rule_55
+type Rule_51 = [Rule_52]
+data Rule_52 = Ctr__Rule_52__0 RtkPos VariableDeclarator
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_52 where
-    rtkPosOf (Ctr__Rule_52__0 p _ _ _) = p
-type Rule_53 = [Rule_54]
-data Rule_54 = Ctr__Rule_54__0 RtkPos VariableInitializer
+    rtkPosOf (Ctr__Rule_52__0 p _) = p
+data Rule_53 = Ctr__Rule_53__0 RtkPos VariableInitializer
+               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_53 where
+    rtkPosOf (Ctr__Rule_53__0 p _) = p
+data Rule_54 = Ctr__Rule_54__0 RtkPos VariableInitializer Rule_55 Rule_57
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_54 where
-    rtkPosOf (Ctr__Rule_54__0 p _) = p
-data Rule_55 = Ctr__Rule_55__0 RtkPos |
-               Ctr__Rule_55__1 RtkPos Rule_56
-               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-instance RtkPosOf Rule_55 where
-    rtkPosOf (Ctr__Rule_55__0 p) = p
-    rtkPosOf (Ctr__Rule_55__1 p _) = p
-data Rule_56 = Ctr__Rule_56__0 RtkPos
+    rtkPosOf (Ctr__Rule_54__0 p _ _ _) = p
+type Rule_55 = [Rule_56]
+data Rule_56 = Ctr__Rule_56__0 RtkPos VariableInitializer
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_56 where
-    rtkPosOf (Ctr__Rule_56__0 p) = p
-type Rule_57 = [Rule_58]
-data Rule_58 = Ctr__Rule_58__0 RtkPos Parameter
+    rtkPosOf (Ctr__Rule_56__0 p _) = p
+data Rule_57 = Ctr__Rule_57__0 RtkPos |
+               Ctr__Rule_57__1 RtkPos Rule_58
+               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_57 where
+    rtkPosOf (Ctr__Rule_57__0 p) = p
+    rtkPosOf (Ctr__Rule_57__1 p _) = p
+data Rule_58 = Ctr__Rule_58__0 RtkPos
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_58 where
-    rtkPosOf (Ctr__Rule_58__0 p _) = p
+    rtkPosOf (Ctr__Rule_58__0 p) = p
+type Rule_59 = [Rule_60]
 data Rule_6 = Ctr__Rule_6__0 RtkPos |
               Ctr__Rule_6__1 RtkPos Rule_7
               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_6 where
     rtkPosOf (Ctr__Rule_6__0 p) = p
     rtkPosOf (Ctr__Rule_6__1 p _) = p
-data Rule_60 = Ctr__Rule_60__0 RtkPos Statement
+data Rule_60 = Ctr__Rule_60__0 RtkPos Parameter
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_60 where
     rtkPosOf (Ctr__Rule_60__0 p _) = p
-data Rule_61 = Ctr__Rule_61__0 RtkPos VariableDeclaration |
-               Ctr__Rule_61__1 RtkPos Rule_62 |
-               Ctr__Rule_61__2 RtkPos
-               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-instance RtkPosOf Rule_61 where
-    rtkPosOf (Ctr__Rule_61__0 p _) = p
-    rtkPosOf (Ctr__Rule_61__1 p _) = p
-    rtkPosOf (Ctr__Rule_61__2 p) = p
-data Rule_62 = Ctr__Rule_62__0 RtkPos Expression
+data Rule_62 = Ctr__Rule_62__0 RtkPos Statement
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_62 where
     rtkPosOf (Ctr__Rule_62__0 p _) = p
-data Rule_63 = Anti_Rule_63 String |
-               Ctr__Rule_63__1 RtkPos Parameter Statement
+data Rule_63 = Ctr__Rule_63__0 RtkPos VariableDeclaration |
+               Ctr__Rule_63__1 RtkPos Rule_64 |
+               Ctr__Rule_63__2 RtkPos
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_63 where
-    rtkPosOf (Anti_Rule_63 _) = rtkNoPos
-    rtkPosOf (Ctr__Rule_63__1 p _ _) = p
-data Rule_65 = Ctr__Rule_65__0 RtkPos Statement
+    rtkPosOf (Ctr__Rule_63__0 p _) = p
+    rtkPosOf (Ctr__Rule_63__1 p _) = p
+    rtkPosOf (Ctr__Rule_63__2 p) = p
+data Rule_64 = Ctr__Rule_64__0 RtkPos Expression
+               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_64 where
+    rtkPosOf (Ctr__Rule_64__0 p _) = p
+data Rule_65 = Anti_Rule_65 String |
+               Ctr__Rule_65__1 RtkPos Parameter Statement
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_65 where
-    rtkPosOf (Ctr__Rule_65__0 p _) = p
-data Rule_66 = Anti_Rule_66 String |
-               Ctr__Rule_66__1 RtkPos Rule_67 |
-               Ctr__Rule_66__2 RtkPos Rule_68 |
-               Ctr__Rule_66__3 RtkPos Statement
-               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-instance RtkPosOf Rule_66 where
-    rtkPosOf (Anti_Rule_66 _) = rtkNoPos
-    rtkPosOf (Ctr__Rule_66__1 p _) = p
-    rtkPosOf (Ctr__Rule_66__2 p _) = p
-    rtkPosOf (Ctr__Rule_66__3 p _) = p
-data Rule_67 = Ctr__Rule_67__0 RtkPos Expression
+    rtkPosOf (Anti_Rule_65 _) = rtkNoPos
+    rtkPosOf (Ctr__Rule_65__1 p _ _) = p
+data Rule_67 = Ctr__Rule_67__0 RtkPos Statement
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_67 where
     rtkPosOf (Ctr__Rule_67__0 p _) = p
-data Rule_68 = Ctr__Rule_68__0 RtkPos
+data Rule_68 = Anti_Rule_68 String |
+               Ctr__Rule_68__1 RtkPos Rule_69 |
+               Ctr__Rule_68__2 RtkPos Rule_70 |
+               Ctr__Rule_68__3 RtkPos Statement
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_68 where
-    rtkPosOf (Ctr__Rule_68__0 p) = p
+    rtkPosOf (Anti_Rule_68 _) = rtkNoPos
+    rtkPosOf (Ctr__Rule_68__1 p _) = p
+    rtkPosOf (Ctr__Rule_68__2 p _) = p
+    rtkPosOf (Ctr__Rule_68__3 p _) = p
+data Rule_69 = Ctr__Rule_69__0 RtkPos Expression
+               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_69 where
+    rtkPosOf (Ctr__Rule_69__0 p _) = p
 data Rule_7 = Ctr__Rule_7__0 RtkPos TypeDeclaration
               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_7 where
     rtkPosOf (Ctr__Rule_7__0 p _) = p
-data Rule_70 = Ctr__Rule_70__0 RtkPos |
-               Ctr__Rule_70__1 RtkPos Rule_71
+data Rule_70 = Ctr__Rule_70__0 RtkPos
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_70 where
     rtkPosOf (Ctr__Rule_70__0 p) = p
-    rtkPosOf (Ctr__Rule_70__1 p _) = p
-data Rule_71 = Ctr__Rule_71__0 RtkPos AssignmentOp Expression
-               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-instance RtkPosOf Rule_71 where
-    rtkPosOf (Ctr__Rule_71__0 p _ _) = p
 data Rule_72 = Ctr__Rule_72__0 RtkPos |
                Ctr__Rule_72__1 RtkPos Rule_73
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_72 where
     rtkPosOf (Ctr__Rule_72__0 p) = p
     rtkPosOf (Ctr__Rule_72__1 p _) = p
-data Rule_73 = Ctr__Rule_73__0 RtkPos Arglist
+data Rule_73 = Ctr__Rule_73__0 RtkPos AssignmentOp Expression
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_73 where
-    rtkPosOf (Ctr__Rule_73__0 p _) = p
+    rtkPosOf (Ctr__Rule_73__0 p _ _) = p
 data Rule_74 = Ctr__Rule_74__0 RtkPos |
                Ctr__Rule_74__1 RtkPos Rule_75
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
@@ -2521,69 +2593,91 @@ data Rule_75 = Ctr__Rule_75__0 RtkPos Arglist
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_75 where
     rtkPosOf (Ctr__Rule_75__0 p _) = p
-data Rule_76 = Ctr__Rule_76__0 RtkPos Arglist |
-               Ctr__Rule_76__1 RtkPos SquareBracketsList
+data Rule_76 = Ctr__Rule_76__0 RtkPos |
+               Ctr__Rule_76__1 RtkPos Rule_77
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_76 where
-    rtkPosOf (Ctr__Rule_76__0 p _) = p
+    rtkPosOf (Ctr__Rule_76__0 p) = p
     rtkPosOf (Ctr__Rule_76__1 p _) = p
-data Rule_77 = Ctr__Rule_77__0 RtkPos Expression Rule_78
+data Rule_77 = Ctr__Rule_77__0 RtkPos Arglist
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_77 where
-    rtkPosOf (Ctr__Rule_77__0 p _ _) = p
-type Rule_78 = [Rule_79]
-data Rule_79 = Ctr__Rule_79__0 RtkPos Expression
+    rtkPosOf (Ctr__Rule_77__0 p _) = p
+data Rule_78 = Ctr__Rule_78__0 RtkPos Arglist |
+               Ctr__Rule_78__1 RtkPos DimExprs Rule_79
+               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_78 where
+    rtkPosOf (Ctr__Rule_78__0 p _) = p
+    rtkPosOf (Ctr__Rule_78__1 p _ _) = p
+data Rule_79 = Ctr__Rule_79__0 RtkPos |
+               Ctr__Rule_79__1 RtkPos Rule_80
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_79 where
-    rtkPosOf (Ctr__Rule_79__0 p _) = p
+    rtkPosOf (Ctr__Rule_79__0 p) = p
+    rtkPosOf (Ctr__Rule_79__1 p _) = p
 data Rule_8 = Ctr__Rule_8__0 RtkPos Rule_9 |
               Ctr__Rule_8__1 RtkPos CompoundName
               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_8 where
     rtkPosOf (Ctr__Rule_8__0 p _) = p
     rtkPosOf (Ctr__Rule_8__1 p _) = p
-data Rule_80 = Ctr__Rule_80__0 RtkPos TypeArgument Rule_81
+data Rule_80 = Ctr__Rule_80__0 RtkPos NonEmptyDims
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_80 where
-    rtkPosOf (Ctr__Rule_80__0 p _ _) = p
-type Rule_81 = [Rule_82]
-data Rule_82 = Ctr__Rule_82__0 RtkPos TypeArgument
+    rtkPosOf (Ctr__Rule_80__0 p _) = p
+data Rule_81 = Anti_Rule_81 String |
+               Ctr__Rule_81__1 RtkPos Expression
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-instance RtkPosOf Rule_82 where
-    rtkPosOf (Ctr__Rule_82__0 p _) = p
-data Rule_83 = Ctr__Rule_83__0 RtkPos TypeParameter Rule_84
+instance RtkPosOf Rule_81 where
+    rtkPosOf (Anti_Rule_81 _) = rtkNoPos
+    rtkPosOf (Ctr__Rule_81__1 p _) = p
+data Rule_83 = Ctr__Rule_83__0 RtkPos Expression Rule_84
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_83 where
     rtkPosOf (Ctr__Rule_83__0 p _ _) = p
 type Rule_84 = [Rule_85]
-data Rule_85 = Ctr__Rule_85__0 RtkPos TypeParameter
+data Rule_85 = Ctr__Rule_85__0 RtkPos Expression
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_85 where
     rtkPosOf (Ctr__Rule_85__0 p _) = p
-data Rule_86 = Ctr__Rule_86__0 RtkPos |
-               Ctr__Rule_86__1 RtkPos Rule_87
-               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-instance RtkPosOf Rule_86 where
-    rtkPosOf (Ctr__Rule_86__0 p) = p
-    rtkPosOf (Ctr__Rule_86__1 p _) = p
-data Rule_87 = Ctr__Rule_87__0 RtkPos Type Rule_88
+type Rule_86 = [Rule_87]
+data Rule_87 = Ctr__Rule_87__0 RtkPos TypeArgument
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_87 where
-    rtkPosOf (Ctr__Rule_87__0 p _ _) = p
-type Rule_88 = [Rule_89]
-data Rule_89 = Ctr__Rule_89__0 RtkPos Type
+    rtkPosOf (Ctr__Rule_87__0 p _) = p
+data Rule_88 = Ctr__Rule_88__0 RtkPos TypeParameter Rule_89
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-instance RtkPosOf Rule_89 where
-    rtkPosOf (Ctr__Rule_89__0 p _) = p
+instance RtkPosOf Rule_88 where
+    rtkPosOf (Ctr__Rule_88__0 p _ _) = p
+type Rule_89 = [Rule_90]
 data Rule_9 = Ctr__Rule_9__0 RtkPos CompoundName
               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_9 where
     rtkPosOf (Ctr__Rule_9__0 p _) = p
-type Rule_90 = [Rule_91]
-data Rule_91 = Ctr__Rule_91__0 RtkPos String
+data Rule_90 = Ctr__Rule_90__0 RtkPos TypeParameter
+               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_90 where
+    rtkPosOf (Ctr__Rule_90__0 p _) = p
+data Rule_91 = Ctr__Rule_91__0 RtkPos |
+               Ctr__Rule_91__1 RtkPos Rule_92
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_91 where
-    rtkPosOf (Ctr__Rule_91__0 p _) = p
+    rtkPosOf (Ctr__Rule_91__0 p) = p
+    rtkPosOf (Ctr__Rule_91__1 p _) = p
+data Rule_92 = Ctr__Rule_92__0 RtkPos Type Rule_93
+               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_92 where
+    rtkPosOf (Ctr__Rule_92__0 p _ _) = p
+type Rule_93 = [Rule_94]
+data Rule_94 = Ctr__Rule_94__0 RtkPos Type
+               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_94 where
+    rtkPosOf (Ctr__Rule_94__0 p _) = p
+type Rule_95 = [Rule_96]
+data Rule_96 = Ctr__Rule_96__0 RtkPos String
+               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_96 where
+    rtkPosOf (Ctr__Rule_96__0 p _) = p
 data ShiftOp = Anti_ShiftOp String |
                Ctr__ShiftOp__0 RtkPos |
                Ctr__ShiftOp__1 RtkPos |
@@ -2594,7 +2688,6 @@ instance RtkPosOf ShiftOp where
     rtkPosOf (Ctr__ShiftOp__0 p) = p
     rtkPosOf (Ctr__ShiftOp__1 p) = p
     rtkPosOf (Ctr__ShiftOp__2 p) = p
-type SquareBracketsList = [Rule_40]
 data Statement = Anti_Statement String |
                  Ctr__Statement__0 RtkPos StatementWithoutIf |
                  Ctr__Statement__1 RtkPos IfStatement
@@ -2650,7 +2743,7 @@ data StaticInitializer = Anti_StaticInitializer String |
 instance RtkPosOf StaticInitializer where
     rtkPosOf (Anti_StaticInitializer _) = rtkNoPos
     rtkPosOf (Ctr__StaticInitializer__0 p _) = p
-type SwitchCaseList = [Rule_66]
+type SwitchCaseList = [Rule_68]
 data SwitchStatement = Anti_SwitchStatement String |
                        Ctr__SwitchStatement__0 RtkPos Expression SwitchCaseList
                        deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
@@ -2664,11 +2757,17 @@ instance RtkPosOf TryStatement where
     rtkPosOf (Anti_TryStatement _) = rtkNoPos
     rtkPosOf (Ctr__TryStatement__0 p _ _ _) = p
 data Type = Anti_Type String |
-            Ctr__Type__0 RtkPos TypeSpecifier SquareBracketsList
+            Ctr__Type__0 RtkPos PrimitiveTypeKeyword Dims |
+            Ctr__Type__1 RtkPos CompoundName NonEmptyTypeArguments Dims |
+            Ctr__Type__2 RtkPos CompoundName NonEmptyDims |
+            Ctr__Type__3 RtkPos CompoundName
             deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Type where
     rtkPosOf (Anti_Type _) = rtkNoPos
     rtkPosOf (Ctr__Type__0 p _ _) = p
+    rtkPosOf (Ctr__Type__1 p _ _ _) = p
+    rtkPosOf (Ctr__Type__2 p _ _) = p
+    rtkPosOf (Ctr__Type__3 p _) = p
 data TypeArgument = Anti_TypeArgument String |
                     Ctr__TypeArgument__0 RtkPos Type |
                     Ctr__TypeArgument__1 RtkPos WildcardType
@@ -2679,7 +2778,7 @@ instance RtkPosOf TypeArgument where
     rtkPosOf (Ctr__TypeArgument__1 p _) = p
 data TypeArguments = Anti_TypeArguments String |
                      Ctr__TypeArguments__0 RtkPos |
-                     Ctr__TypeArguments__1 RtkPos Rule_80
+                     Ctr__TypeArguments__1 RtkPos NonEmptyTypeArguments
                      deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf TypeArguments where
     rtkPosOf (Anti_TypeArguments _) = rtkNoPos
@@ -2692,14 +2791,14 @@ instance RtkPosOf TypeDeclaration where
     rtkPosOf (Anti_TypeDeclaration _) = rtkNoPos
     rtkPosOf (Ctr__TypeDeclaration__0 p _ _) = p
 data TypeParameter = Anti_TypeParameter String |
-                     Ctr__TypeParameter__0 RtkPos String Rule_86
+                     Ctr__TypeParameter__0 RtkPos String Rule_91
                      deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf TypeParameter where
     rtkPosOf (Anti_TypeParameter _) = rtkNoPos
     rtkPosOf (Ctr__TypeParameter__0 p _ _) = p
 data TypeParameters = Anti_TypeParameters String |
                       Ctr__TypeParameters__0 RtkPos |
-                      Ctr__TypeParameters__1 RtkPos Rule_83
+                      Ctr__TypeParameters__1 RtkPos Rule_88
                       deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf TypeParameters where
     rtkPosOf (Anti_TypeParameters _) = rtkNoPos
@@ -2736,13 +2835,13 @@ instance RtkPosOf VariableDeclaration where
     rtkPosOf (Anti_VariableDeclaration _) = rtkNoPos
     rtkPosOf (Ctr__VariableDeclaration__0 p _ _) = p
 data VariableDeclarator = Anti_VariableDeclarator String |
-                          Ctr__VariableDeclarator__0 RtkPos String SquareBracketsList OptVariableInitializer
+                          Ctr__VariableDeclarator__0 RtkPos String Dims OptVariableInitializer
                           deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf VariableDeclarator where
     rtkPosOf (Anti_VariableDeclarator _) = rtkNoPos
     rtkPosOf (Ctr__VariableDeclarator__0 p _ _ _) = p
 data VariableDeclaratorList = Anti_VariableDeclaratorList String |
-                              Ctr__VariableDeclaratorList__0 RtkPos VariableDeclarator Rule_49
+                              Ctr__VariableDeclaratorList__0 RtkPos VariableDeclarator Rule_51
                               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf VariableDeclaratorList where
     rtkPosOf (Anti_VariableDeclaratorList _) = rtkNoPos
@@ -2757,7 +2856,7 @@ instance RtkPosOf VariableInitializer where
     rtkPosOf (Ctr__VariableInitializer__1 p _) = p
 data VariableInitializerList = Anti_VariableInitializerList String |
                                Ctr__VariableInitializerList__0 RtkPos |
-                               Ctr__VariableInitializerList__1 RtkPos Rule_52
+                               Ctr__VariableInitializerList__1 RtkPos Rule_54
                                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf VariableInitializerList where
     rtkPosOf (Anti_VariableInitializerList _) = rtkNoPos

--- a/test/golden/java/JavaQQ.hs
+++ b/test/golden/java/JavaQQ.hs
@@ -49,7 +49,7 @@ replaceAllPatterns1 str = let (pre, match, post) = str =~ qqPattern :: (String, 
 replaceAllPatterns :: String -> Either String String
 replaceAllPatterns str = init <$> replaceAllPatterns1 (str ++ " ")
 
-qqShortcuts = M.fromList [ ("java","Java"),("additiveOp","AdditiveOp"),("annotation","Annotation"),("annotationArguments","AnnotationArguments"),("annotationDeclaration","AnnotationDeclaration"),("annotationElement","AnnotationElement"),("annotationList","AnnotationList"),("annotationTypeElement","AnnotationTypeElement"),("annotationTypeElementList","AnnotationTypeElementList"),("arglist","Arglist"),("assignmentOp","AssignmentOp"),("catchList","CatchList"),("classDeclaration","ClassDeclaration"),("compilationUnit","CompilationUnit"),("compoundName","CompoundName"),("creationExpression","CreationExpression"),("doStatement","DoStatement"),("docComment","DocComment"),("enumConstant","EnumConstant"),("enumConstantList","EnumConstantList"),("enumDeclaration","EnumDeclaration"),("equalityOp","EqualityOp"),("expression","Expression"),("extendsList","ExtendsList"),("fieldDeclaration","FieldDeclaration"),("fieldDeclarationList","FieldDeclarationList"),("forStatement","ForStatement"),("ifStatement","IfStatement"),("implementsList","ImplementsList"),("importList","ImportList"),("importStatement","ImportStatement"),("interfaceDeclaration","InterfaceDeclaration"),("literal","Literal"),("memberAfterFirstId","MemberAfterFirstId"),("memberDeclaration","MemberDeclaration"),("memberRest","MemberRest"),("modifier","Modifier"),("modifierList","ModifierList"),("moreTypeSpecifier","MoreTypeSpecifier"),("moreVariableDeclarators","MoreVariableDeclarators"),("multiplicativeOp","MultiplicativeOp"),("nestedTypeDeclaration","NestedTypeDeclaration"),("optDocComment","OptDocComment"),("optElsePart","OptElsePart"),("optExpression","OptExpression"),("optFinally","OptFinally"),("optId","OptId"),("optVariableInitializer","OptVariableInitializer"),("package","Package"),("parameter","Parameter"),("parameterList","ParameterList"),("postfixOp","PostfixOp"),("prefixOp","PrefixOp"),("primitiveTypeKeyword","PrimitiveTypeKeyword"),("relationalOp","RelationalOp"),("shiftOp","ShiftOp"),("squareBracketsList","SquareBracketsList"),("statement","Statement"),("statementBlock","StatementBlock"),("statementList","StatementList"),("statementWithoutIf","StatementWithoutIf"),("staticInitializer","StaticInitializer"),("switchCaseList","SwitchCaseList"),("switchStatement","SwitchStatement"),("tryStatement","TryStatement"),("type","Type"),("typeArgument","TypeArgument"),("typeArguments","TypeArguments"),("typeDeclaration","TypeDeclaration"),("typeParameter","TypeParameter"),("typeParameters","TypeParameters"),("typeSpecifier","TypeSpecifier"),("variableDeclaration","VariableDeclaration"),("variableDeclarator","VariableDeclarator"),("variableDeclaratorList","VariableDeclaratorList"),("variableInitializer","VariableInitializer"),("variableInitializerList","VariableInitializerList"),("whileStatement","WhileStatement"),("wildcardType","WildcardType")]
+qqShortcuts = M.fromList [ ("java","Java"),("additiveOp","AdditiveOp"),("annotation","Annotation"),("annotationArguments","AnnotationArguments"),("annotationDeclaration","AnnotationDeclaration"),("annotationElement","AnnotationElement"),("annotationList","AnnotationList"),("annotationTypeElement","AnnotationTypeElement"),("annotationTypeElementList","AnnotationTypeElementList"),("arglist","Arglist"),("assignmentOp","AssignmentOp"),("catchList","CatchList"),("classDeclaration","ClassDeclaration"),("compilationUnit","CompilationUnit"),("compoundName","CompoundName"),("creationExpression","CreationExpression"),("dimExprs","DimExprs"),("dims","Dims"),("doStatement","DoStatement"),("docComment","DocComment"),("enumConstant","EnumConstant"),("enumConstantList","EnumConstantList"),("enumDeclaration","EnumDeclaration"),("equalityOp","EqualityOp"),("expression","Expression"),("extendsList","ExtendsList"),("fieldDeclaration","FieldDeclaration"),("fieldDeclarationList","FieldDeclarationList"),("forStatement","ForStatement"),("ifStatement","IfStatement"),("implementsList","ImplementsList"),("importList","ImportList"),("importStatement","ImportStatement"),("interfaceDeclaration","InterfaceDeclaration"),("literal","Literal"),("memberAfterFirstId","MemberAfterFirstId"),("memberDeclaration","MemberDeclaration"),("memberRest","MemberRest"),("modifier","Modifier"),("modifierList","ModifierList"),("moreTypeSpecifier","MoreTypeSpecifier"),("moreVariableDeclarators","MoreVariableDeclarators"),("multiplicativeOp","MultiplicativeOp"),("nestedTypeDeclaration","NestedTypeDeclaration"),("nonEmptyDims","NonEmptyDims"),("nonEmptyTypeArguments","NonEmptyTypeArguments"),("optDocComment","OptDocComment"),("optElsePart","OptElsePart"),("optExpression","OptExpression"),("optFinally","OptFinally"),("optId","OptId"),("optVariableInitializer","OptVariableInitializer"),("package","Package"),("parameter","Parameter"),("parameterList","ParameterList"),("postfixOp","PostfixOp"),("prefixOp","PrefixOp"),("primitiveTypeKeyword","PrimitiveTypeKeyword"),("relationalOp","RelationalOp"),("shiftOp","ShiftOp"),("statement","Statement"),("statementBlock","StatementBlock"),("statementList","StatementList"),("statementWithoutIf","StatementWithoutIf"),("staticInitializer","StaticInitializer"),("switchCaseList","SwitchCaseList"),("switchStatement","SwitchStatement"),("tryStatement","TryStatement"),("type","Type"),("typeArgument","TypeArgument"),("typeArguments","TypeArguments"),("typeDeclaration","TypeDeclaration"),("typeParameter","TypeParameter"),("typeParameters","TypeParameters"),("typeSpecifier","TypeSpecifier"),("variableDeclaration","VariableDeclaration"),("variableDeclarator","VariableDeclarator"),("variableDeclaratorList","VariableDeclaratorList"),("variableInitializer","VariableInitializer"),("variableInitializerList","VariableInitializerList"),("whileStatement","WhileStatement"),("wildcardType","WildcardType")]
 
 -- A quasi-quote pattern must match an AST parsed from anywhere in a source
 -- file, while the pattern itself was parsed from the quote body - so every
@@ -66,7 +66,7 @@ quoteJavaExp dummy func s = do
            Left err -> fail err
            Right a -> return a
   let expr = func ast
-  dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiRule_2Exp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_16Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiNestedTypeDeclarationExp `Generics.extQ` antiRule_40Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_47Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiStatementWithoutIfExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_63Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_66Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) expr
+  dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiRule_2Exp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_16Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiNestedTypeDeclarationExp `Generics.extQ` antiRule_40Exp `Generics.extQ` antiRule_42Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_49Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiStatementWithoutIfExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_65Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_68Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_81Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) expr
 quoteJavaPat :: Data.Data a => String -> (Java -> a) -> String -> TH.PatQ
 quoteJavaPat dummy func s = do
   s1 <- either fail return (replaceAllPatterns s)
@@ -74,7 +74,7 @@ quoteJavaPat dummy func s = do
            Left err -> fail err
            Right a -> return a
   let expr = func ast
-  dataToPatQ (const Nothing `Generics.extQ` rtkPosWildPat `Generics.extQ` antiJavaPat `Generics.extQ` antiOptDocCommentPat `Generics.extQ` antiTypeDeclarationPat `Generics.extQ` antiRule_2Pat `Generics.extQ` antiCompilationUnitPat `Generics.extQ` antiPackagePat `Generics.extQ` antiImportStatementPat `Generics.extQ` antiDocCommentPat `Generics.extQ` antiAnnotationPat `Generics.extQ` antiAnnotationArgumentsPat `Generics.extQ` antiAnnotationElementPat `Generics.extQ` antiRule_16Pat `Generics.extQ` antiExtendsListPat `Generics.extQ` antiImplementsListPat `Generics.extQ` antiFieldDeclarationPat `Generics.extQ` antiClassDeclarationPat `Generics.extQ` antiInterfaceDeclarationPat `Generics.extQ` antiAnnotationDeclarationPat `Generics.extQ` antiAnnotationTypeElementPat `Generics.extQ` antiEnumConstantPat `Generics.extQ` antiEnumConstantListPat `Generics.extQ` antiEnumDeclarationPat `Generics.extQ` antiNestedTypeDeclarationPat `Generics.extQ` antiRule_40Pat `Generics.extQ` antiMemberDeclarationPat `Generics.extQ` antiPrimitiveTypeKeywordPat `Generics.extQ` antiMemberAfterFirstIdPat `Generics.extQ` antiMoreTypeSpecifierPat `Generics.extQ` antiMemberRestPat `Generics.extQ` antiRule_47Pat `Generics.extQ` antiStatementBlockPat `Generics.extQ` antiVariableDeclaratorListPat `Generics.extQ` antiVariableDeclarationPat `Generics.extQ` antiOptVariableInitializerPat `Generics.extQ` antiVariableDeclaratorPat `Generics.extQ` antiVariableInitializerListPat `Generics.extQ` antiVariableInitializerPat `Generics.extQ` antiStaticInitializerPat `Generics.extQ` antiParameterListPat `Generics.extQ` antiParameterPat `Generics.extQ` antiStatementPat `Generics.extQ` antiOptExpressionPat `Generics.extQ` antiOptIdPat `Generics.extQ` antiStatementWithoutIfPat `Generics.extQ` antiOptElsePartPat `Generics.extQ` antiIfStatementPat `Generics.extQ` antiDoStatementPat `Generics.extQ` antiWhileStatementPat `Generics.extQ` antiForStatementPat `Generics.extQ` antiRule_63Pat `Generics.extQ` antiOptFinallyPat `Generics.extQ` antiTryStatementPat `Generics.extQ` antiRule_66Pat `Generics.extQ` antiSwitchStatementPat `Generics.extQ` antiExpressionPat `Generics.extQ` antiAssignmentOpPat `Generics.extQ` antiEqualityOpPat `Generics.extQ` antiRelationalOpPat `Generics.extQ` antiShiftOpPat `Generics.extQ` antiAdditiveOpPat `Generics.extQ` antiMultiplicativeOpPat `Generics.extQ` antiPrefixOpPat `Generics.extQ` antiPostfixOpPat `Generics.extQ` antiCreationExpressionPat `Generics.extQ` antiLiteralPat `Generics.extQ` antiArglistPat `Generics.extQ` antiTypeArgumentsPat `Generics.extQ` antiTypeArgumentPat `Generics.extQ` antiWildcardTypePat `Generics.extQ` antiTypeParametersPat `Generics.extQ` antiTypeParameterPat `Generics.extQ` antiTypePat `Generics.extQ` antiTypeSpecifierPat `Generics.extQ` antiModifierPat `Generics.extQ` antiCompoundNamePat) expr
+  dataToPatQ (const Nothing `Generics.extQ` rtkPosWildPat `Generics.extQ` antiJavaPat `Generics.extQ` antiOptDocCommentPat `Generics.extQ` antiTypeDeclarationPat `Generics.extQ` antiRule_2Pat `Generics.extQ` antiCompilationUnitPat `Generics.extQ` antiPackagePat `Generics.extQ` antiImportStatementPat `Generics.extQ` antiDocCommentPat `Generics.extQ` antiAnnotationPat `Generics.extQ` antiAnnotationArgumentsPat `Generics.extQ` antiAnnotationElementPat `Generics.extQ` antiRule_16Pat `Generics.extQ` antiExtendsListPat `Generics.extQ` antiImplementsListPat `Generics.extQ` antiFieldDeclarationPat `Generics.extQ` antiClassDeclarationPat `Generics.extQ` antiInterfaceDeclarationPat `Generics.extQ` antiAnnotationDeclarationPat `Generics.extQ` antiAnnotationTypeElementPat `Generics.extQ` antiEnumConstantPat `Generics.extQ` antiEnumConstantListPat `Generics.extQ` antiEnumDeclarationPat `Generics.extQ` antiNestedTypeDeclarationPat `Generics.extQ` antiRule_40Pat `Generics.extQ` antiRule_42Pat `Generics.extQ` antiMemberDeclarationPat `Generics.extQ` antiPrimitiveTypeKeywordPat `Generics.extQ` antiMemberAfterFirstIdPat `Generics.extQ` antiMoreTypeSpecifierPat `Generics.extQ` antiMemberRestPat `Generics.extQ` antiRule_49Pat `Generics.extQ` antiStatementBlockPat `Generics.extQ` antiVariableDeclaratorListPat `Generics.extQ` antiVariableDeclarationPat `Generics.extQ` antiOptVariableInitializerPat `Generics.extQ` antiVariableDeclaratorPat `Generics.extQ` antiVariableInitializerListPat `Generics.extQ` antiVariableInitializerPat `Generics.extQ` antiStaticInitializerPat `Generics.extQ` antiParameterListPat `Generics.extQ` antiParameterPat `Generics.extQ` antiStatementPat `Generics.extQ` antiOptExpressionPat `Generics.extQ` antiOptIdPat `Generics.extQ` antiStatementWithoutIfPat `Generics.extQ` antiOptElsePartPat `Generics.extQ` antiIfStatementPat `Generics.extQ` antiDoStatementPat `Generics.extQ` antiWhileStatementPat `Generics.extQ` antiForStatementPat `Generics.extQ` antiRule_65Pat `Generics.extQ` antiOptFinallyPat `Generics.extQ` antiTryStatementPat `Generics.extQ` antiRule_68Pat `Generics.extQ` antiSwitchStatementPat `Generics.extQ` antiExpressionPat `Generics.extQ` antiAssignmentOpPat `Generics.extQ` antiEqualityOpPat `Generics.extQ` antiRelationalOpPat `Generics.extQ` antiShiftOpPat `Generics.extQ` antiAdditiveOpPat `Generics.extQ` antiMultiplicativeOpPat `Generics.extQ` antiPrefixOpPat `Generics.extQ` antiPostfixOpPat `Generics.extQ` antiCreationExpressionPat `Generics.extQ` antiRule_81Pat `Generics.extQ` antiLiteralPat `Generics.extQ` antiArglistPat `Generics.extQ` antiTypeArgumentsPat `Generics.extQ` antiNonEmptyTypeArgumentsPat `Generics.extQ` antiTypeArgumentPat `Generics.extQ` antiWildcardTypePat `Generics.extQ` antiTypeParametersPat `Generics.extQ` antiTypeParameterPat `Generics.extQ` antiTypePat `Generics.extQ` antiTypeSpecifierPat `Generics.extQ` antiModifierPat `Generics.extQ` antiCompoundNamePat) expr
 
 antiCompoundNameExp :: CompoundName -> Maybe (TH.Q TH.Exp )
 antiCompoundNameExp ( Anti_CompoundName v) = Just $ TH.varE (TH.mkName v)
@@ -116,6 +116,11 @@ antiTypeArgumentExp ( Anti_TypeArgument v) = Just $ TH.varE (TH.mkName v)
 antiTypeArgumentExp _ = Nothing
 
 
+antiNonEmptyTypeArgumentsExp :: NonEmptyTypeArguments -> Maybe (TH.Q TH.Exp )
+antiNonEmptyTypeArgumentsExp ( Anti_NonEmptyTypeArguments v) = Just $ TH.varE (TH.mkName v)
+antiNonEmptyTypeArgumentsExp _ = Nothing
+
+
 antiTypeArgumentsExp :: TypeArguments -> Maybe (TH.Q TH.Exp )
 antiTypeArgumentsExp ( Anti_TypeArguments v) = Just $ TH.varE (TH.mkName v)
 antiTypeArgumentsExp _ = Nothing
@@ -129,6 +134,14 @@ antiArglistExp _ = Nothing
 antiLiteralExp :: Literal -> Maybe (TH.Q TH.Exp )
 antiLiteralExp ( Anti_Literal v) = Just $ TH.varE (TH.mkName v)
 antiLiteralExp _ = Nothing
+
+
+antiRule_81Exp :: [ Rule_81 ] -> Maybe (TH.Q TH.Exp)
+antiRule_81Exp ((Anti_Rule_81 v):rest) =
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiRule_2Exp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_16Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiNestedTypeDeclarationExp `Generics.extQ` antiRule_40Exp `Generics.extQ` antiRule_42Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_49Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiStatementWithoutIfExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_65Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_68Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_81Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
+     lvar = TH.varE $ TH.mkName v
+   in Just [| $lvar ++ $restExp |]
+antiRule_81Exp _ = Nothing
 
 
 antiCreationExpressionExp :: CreationExpression -> Maybe (TH.Q TH.Exp )
@@ -186,12 +199,12 @@ antiSwitchStatementExp ( Anti_SwitchStatement v) = Just $ TH.varE (TH.mkName v)
 antiSwitchStatementExp _ = Nothing
 
 
-antiRule_66Exp :: [ Rule_66 ] -> Maybe (TH.Q TH.Exp)
-antiRule_66Exp ((Anti_Rule_66 v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiRule_2Exp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_16Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiNestedTypeDeclarationExp `Generics.extQ` antiRule_40Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_47Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiStatementWithoutIfExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_63Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_66Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
+antiRule_68Exp :: [ Rule_68 ] -> Maybe (TH.Q TH.Exp)
+antiRule_68Exp ((Anti_Rule_68 v):rest) =
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiRule_2Exp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_16Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiNestedTypeDeclarationExp `Generics.extQ` antiRule_40Exp `Generics.extQ` antiRule_42Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_49Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiStatementWithoutIfExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_65Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_68Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_81Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
-antiRule_66Exp _ = Nothing
+antiRule_68Exp _ = Nothing
 
 
 antiTryStatementExp :: TryStatement -> Maybe (TH.Q TH.Exp )
@@ -204,12 +217,12 @@ antiOptFinallyExp ( Anti_OptFinally v) = Just $ TH.varE (TH.mkName v)
 antiOptFinallyExp _ = Nothing
 
 
-antiRule_63Exp :: [ Rule_63 ] -> Maybe (TH.Q TH.Exp)
-antiRule_63Exp ((Anti_Rule_63 v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiRule_2Exp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_16Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiNestedTypeDeclarationExp `Generics.extQ` antiRule_40Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_47Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiStatementWithoutIfExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_63Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_66Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
+antiRule_65Exp :: [ Rule_65 ] -> Maybe (TH.Q TH.Exp)
+antiRule_65Exp ((Anti_Rule_65 v):rest) =
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiRule_2Exp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_16Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiNestedTypeDeclarationExp `Generics.extQ` antiRule_40Exp `Generics.extQ` antiRule_42Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_49Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiStatementWithoutIfExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_65Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_68Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_81Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
-antiRule_63Exp _ = Nothing
+antiRule_65Exp _ = Nothing
 
 
 antiForStatementExp :: ForStatement -> Maybe (TH.Q TH.Exp )
@@ -254,7 +267,7 @@ antiOptExpressionExp _ = Nothing
 
 antiStatementExp :: [ Statement ] -> Maybe (TH.Q TH.Exp)
 antiStatementExp ((Anti_Statement v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiRule_2Exp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_16Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiNestedTypeDeclarationExp `Generics.extQ` antiRule_40Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_47Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiStatementWithoutIfExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_63Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_66Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiRule_2Exp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_16Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiNestedTypeDeclarationExp `Generics.extQ` antiRule_40Exp `Generics.extQ` antiRule_42Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_49Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiStatementWithoutIfExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_65Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_68Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_81Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
 antiStatementExp _ = Nothing
@@ -310,12 +323,12 @@ antiStatementBlockExp ( Anti_StatementBlock v) = Just $ TH.varE (TH.mkName v)
 antiStatementBlockExp _ = Nothing
 
 
-antiRule_47Exp :: [ Rule_47 ] -> Maybe (TH.Q TH.Exp)
-antiRule_47Exp ((Anti_Rule_47 v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiRule_2Exp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_16Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiNestedTypeDeclarationExp `Generics.extQ` antiRule_40Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_47Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiStatementWithoutIfExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_63Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_66Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
+antiRule_49Exp :: [ Rule_49 ] -> Maybe (TH.Q TH.Exp)
+antiRule_49Exp ((Anti_Rule_49 v):rest) =
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiRule_2Exp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_16Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiNestedTypeDeclarationExp `Generics.extQ` antiRule_40Exp `Generics.extQ` antiRule_42Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_49Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiStatementWithoutIfExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_65Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_68Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_81Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
-antiRule_47Exp _ = Nothing
+antiRule_49Exp _ = Nothing
 
 
 antiMemberRestExp :: MemberRest -> Maybe (TH.Q TH.Exp )
@@ -343,9 +356,17 @@ antiMemberDeclarationExp ( Anti_MemberDeclaration v) = Just $ TH.varE (TH.mkName
 antiMemberDeclarationExp _ = Nothing
 
 
+antiRule_42Exp :: [ Rule_42 ] -> Maybe (TH.Q TH.Exp)
+antiRule_42Exp ((Anti_Rule_42 v):rest) =
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiRule_2Exp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_16Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiNestedTypeDeclarationExp `Generics.extQ` antiRule_40Exp `Generics.extQ` antiRule_42Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_49Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiStatementWithoutIfExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_65Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_68Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_81Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
+     lvar = TH.varE $ TH.mkName v
+   in Just [| $lvar ++ $restExp |]
+antiRule_42Exp _ = Nothing
+
+
 antiRule_40Exp :: [ Rule_40 ] -> Maybe (TH.Q TH.Exp)
 antiRule_40Exp ((Anti_Rule_40 v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiRule_2Exp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_16Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiNestedTypeDeclarationExp `Generics.extQ` antiRule_40Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_47Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiStatementWithoutIfExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_63Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_66Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiRule_2Exp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_16Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiNestedTypeDeclarationExp `Generics.extQ` antiRule_40Exp `Generics.extQ` antiRule_42Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_49Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiStatementWithoutIfExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_65Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_68Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_81Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
 antiRule_40Exp _ = Nothing
@@ -373,7 +394,7 @@ antiEnumConstantExp _ = Nothing
 
 antiAnnotationTypeElementExp :: [ AnnotationTypeElement ] -> Maybe (TH.Q TH.Exp)
 antiAnnotationTypeElementExp ((Anti_AnnotationTypeElement v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiRule_2Exp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_16Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiNestedTypeDeclarationExp `Generics.extQ` antiRule_40Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_47Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiStatementWithoutIfExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_63Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_66Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiRule_2Exp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_16Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiNestedTypeDeclarationExp `Generics.extQ` antiRule_40Exp `Generics.extQ` antiRule_42Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_49Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiStatementWithoutIfExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_65Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_68Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_81Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
 antiAnnotationTypeElementExp _ = Nothing
@@ -396,7 +417,7 @@ antiClassDeclarationExp _ = Nothing
 
 antiFieldDeclarationExp :: [ FieldDeclaration ] -> Maybe (TH.Q TH.Exp)
 antiFieldDeclarationExp ((Anti_FieldDeclaration v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiRule_2Exp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_16Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiNestedTypeDeclarationExp `Generics.extQ` antiRule_40Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_47Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiStatementWithoutIfExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_63Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_66Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiRule_2Exp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_16Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiNestedTypeDeclarationExp `Generics.extQ` antiRule_40Exp `Generics.extQ` antiRule_42Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_49Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiStatementWithoutIfExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_65Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_68Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_81Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
 antiFieldDeclarationExp _ = Nothing
@@ -414,7 +435,7 @@ antiExtendsListExp _ = Nothing
 
 antiRule_16Exp :: [ Rule_16 ] -> Maybe (TH.Q TH.Exp)
 antiRule_16Exp ((Anti_Rule_16 v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiRule_2Exp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_16Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiNestedTypeDeclarationExp `Generics.extQ` antiRule_40Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_47Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiStatementWithoutIfExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_63Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_66Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiRule_2Exp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_16Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiNestedTypeDeclarationExp `Generics.extQ` antiRule_40Exp `Generics.extQ` antiRule_42Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_49Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiStatementWithoutIfExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_65Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_68Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_81Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
 antiRule_16Exp _ = Nothing
@@ -457,7 +478,7 @@ antiCompilationUnitExp _ = Nothing
 
 antiRule_2Exp :: [ Rule_2 ] -> Maybe (TH.Q TH.Exp)
 antiRule_2Exp ((Anti_Rule_2 v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiRule_2Exp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_16Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiNestedTypeDeclarationExp `Generics.extQ` antiRule_40Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_47Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiStatementWithoutIfExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_63Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_66Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiRule_2Exp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_16Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiNestedTypeDeclarationExp `Generics.extQ` antiRule_40Exp `Generics.extQ` antiRule_42Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_49Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiStatementWithoutIfExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_65Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_68Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_81Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
 antiRule_2Exp _ = Nothing
@@ -519,6 +540,11 @@ antiTypeArgumentPat ( Anti_TypeArgument v) = Just $ TH.varP (TH.mkName v)
 antiTypeArgumentPat _ = Nothing
 
 
+antiNonEmptyTypeArgumentsPat :: NonEmptyTypeArguments -> Maybe (TH.Q TH.Pat )
+antiNonEmptyTypeArgumentsPat ( Anti_NonEmptyTypeArguments v) = Just $ TH.varP (TH.mkName v)
+antiNonEmptyTypeArgumentsPat _ = Nothing
+
+
 antiTypeArgumentsPat :: TypeArguments -> Maybe (TH.Q TH.Pat )
 antiTypeArgumentsPat ( Anti_TypeArguments v) = Just $ TH.varP (TH.mkName v)
 antiTypeArgumentsPat _ = Nothing
@@ -532,6 +558,11 @@ antiArglistPat _ = Nothing
 antiLiteralPat :: Literal -> Maybe (TH.Q TH.Pat )
 antiLiteralPat ( Anti_Literal v) = Just $ TH.varP (TH.mkName v)
 antiLiteralPat _ = Nothing
+
+
+antiRule_81Pat :: [ Rule_81 ] -> Maybe (TH.Q TH.Pat)
+antiRule_81Pat [Anti_Rule_81 v] = Just $ TH.varP (TH.mkName v)
+antiRule_81Pat _ = Nothing
 
 
 antiCreationExpressionPat :: CreationExpression -> Maybe (TH.Q TH.Pat )
@@ -589,9 +620,9 @@ antiSwitchStatementPat ( Anti_SwitchStatement v) = Just $ TH.varP (TH.mkName v)
 antiSwitchStatementPat _ = Nothing
 
 
-antiRule_66Pat :: [ Rule_66 ] -> Maybe (TH.Q TH.Pat)
-antiRule_66Pat [Anti_Rule_66 v] = Just $ TH.varP (TH.mkName v)
-antiRule_66Pat _ = Nothing
+antiRule_68Pat :: [ Rule_68 ] -> Maybe (TH.Q TH.Pat)
+antiRule_68Pat [Anti_Rule_68 v] = Just $ TH.varP (TH.mkName v)
+antiRule_68Pat _ = Nothing
 
 
 antiTryStatementPat :: TryStatement -> Maybe (TH.Q TH.Pat )
@@ -604,9 +635,9 @@ antiOptFinallyPat ( Anti_OptFinally v) = Just $ TH.varP (TH.mkName v)
 antiOptFinallyPat _ = Nothing
 
 
-antiRule_63Pat :: [ Rule_63 ] -> Maybe (TH.Q TH.Pat)
-antiRule_63Pat [Anti_Rule_63 v] = Just $ TH.varP (TH.mkName v)
-antiRule_63Pat _ = Nothing
+antiRule_65Pat :: [ Rule_65 ] -> Maybe (TH.Q TH.Pat)
+antiRule_65Pat [Anti_Rule_65 v] = Just $ TH.varP (TH.mkName v)
+antiRule_65Pat _ = Nothing
 
 
 antiForStatementPat :: ForStatement -> Maybe (TH.Q TH.Pat )
@@ -704,9 +735,9 @@ antiStatementBlockPat ( Anti_StatementBlock v) = Just $ TH.varP (TH.mkName v)
 antiStatementBlockPat _ = Nothing
 
 
-antiRule_47Pat :: [ Rule_47 ] -> Maybe (TH.Q TH.Pat)
-antiRule_47Pat [Anti_Rule_47 v] = Just $ TH.varP (TH.mkName v)
-antiRule_47Pat _ = Nothing
+antiRule_49Pat :: [ Rule_49 ] -> Maybe (TH.Q TH.Pat)
+antiRule_49Pat [Anti_Rule_49 v] = Just $ TH.varP (TH.mkName v)
+antiRule_49Pat _ = Nothing
 
 
 antiMemberRestPat :: MemberRest -> Maybe (TH.Q TH.Pat )
@@ -732,6 +763,11 @@ antiPrimitiveTypeKeywordPat _ = Nothing
 antiMemberDeclarationPat :: MemberDeclaration -> Maybe (TH.Q TH.Pat )
 antiMemberDeclarationPat ( Anti_MemberDeclaration v) = Just $ TH.varP (TH.mkName v)
 antiMemberDeclarationPat _ = Nothing
+
+
+antiRule_42Pat :: [ Rule_42 ] -> Maybe (TH.Q TH.Pat)
+antiRule_42Pat [Anti_Rule_42 v] = Just $ TH.varP (TH.mkName v)
+antiRule_42Pat _ = Nothing
 
 
 antiRule_40Pat :: [ Rule_40 ] -> Maybe (TH.Q TH.Pat)
@@ -861,395 +897,410 @@ quoteJavaDecs s = return []
 getJava ( Ctr__Java__0 _ s) = s
 
 java :: QuasiQuoter
-java = QuasiQuoter (quoteJavaExp "tok_Java_dummy_170" getJava ) (quoteJavaPat "tok_Java_dummy_170" getJava ) quoteJavaType quoteJavaDecs
+java = QuasiQuoter (quoteJavaExp "tok_Java_dummy_178" getJava ) (quoteJavaPat "tok_Java_dummy_178" getJava ) quoteJavaType quoteJavaDecs
 
 getAdditiveOp ( Ctr__Java__1 _ s) = s
 
 additiveOp :: QuasiQuoter
-additiveOp = QuasiQuoter (quoteJavaExp "tok_AdditiveOp_dummy_169" getAdditiveOp ) (quoteJavaPat "tok_AdditiveOp_dummy_169" getAdditiveOp ) quoteJavaType quoteJavaDecs
+additiveOp = QuasiQuoter (quoteJavaExp "tok_AdditiveOp_dummy_177" getAdditiveOp ) (quoteJavaPat "tok_AdditiveOp_dummy_177" getAdditiveOp ) quoteJavaType quoteJavaDecs
 
 getAnnotation ( Ctr__Java__2 _ s) = s
 
 annotation :: QuasiQuoter
-annotation = QuasiQuoter (quoteJavaExp "tok_Annotation_dummy_168" getAnnotation ) (quoteJavaPat "tok_Annotation_dummy_168" getAnnotation ) quoteJavaType quoteJavaDecs
+annotation = QuasiQuoter (quoteJavaExp "tok_Annotation_dummy_176" getAnnotation ) (quoteJavaPat "tok_Annotation_dummy_176" getAnnotation ) quoteJavaType quoteJavaDecs
 
 getAnnotationArguments ( Ctr__Java__3 _ s) = s
 
 annotationArguments :: QuasiQuoter
-annotationArguments = QuasiQuoter (quoteJavaExp "tok_AnnotationArguments_dummy_167" getAnnotationArguments ) (quoteJavaPat "tok_AnnotationArguments_dummy_167" getAnnotationArguments ) quoteJavaType quoteJavaDecs
+annotationArguments = QuasiQuoter (quoteJavaExp "tok_AnnotationArguments_dummy_175" getAnnotationArguments ) (quoteJavaPat "tok_AnnotationArguments_dummy_175" getAnnotationArguments ) quoteJavaType quoteJavaDecs
 
 getAnnotationDeclaration ( Ctr__Java__4 _ s) = s
 
 annotationDeclaration :: QuasiQuoter
-annotationDeclaration = QuasiQuoter (quoteJavaExp "tok_AnnotationDeclaration_dummy_166" getAnnotationDeclaration ) (quoteJavaPat "tok_AnnotationDeclaration_dummy_166" getAnnotationDeclaration ) quoteJavaType quoteJavaDecs
+annotationDeclaration = QuasiQuoter (quoteJavaExp "tok_AnnotationDeclaration_dummy_174" getAnnotationDeclaration ) (quoteJavaPat "tok_AnnotationDeclaration_dummy_174" getAnnotationDeclaration ) quoteJavaType quoteJavaDecs
 
 getAnnotationElement ( Ctr__Java__5 _ s) = s
 
 annotationElement :: QuasiQuoter
-annotationElement = QuasiQuoter (quoteJavaExp "tok_AnnotationElement_dummy_165" getAnnotationElement ) (quoteJavaPat "tok_AnnotationElement_dummy_165" getAnnotationElement ) quoteJavaType quoteJavaDecs
+annotationElement = QuasiQuoter (quoteJavaExp "tok_AnnotationElement_dummy_173" getAnnotationElement ) (quoteJavaPat "tok_AnnotationElement_dummy_173" getAnnotationElement ) quoteJavaType quoteJavaDecs
 
 getAnnotationList ( Ctr__Java__6 _ s) = s
 
 annotationList :: QuasiQuoter
-annotationList = QuasiQuoter (quoteJavaExp "tok_AnnotationList_dummy_164" getAnnotationList ) (quoteJavaPat "tok_AnnotationList_dummy_164" getAnnotationList ) quoteJavaType quoteJavaDecs
+annotationList = QuasiQuoter (quoteJavaExp "tok_AnnotationList_dummy_172" getAnnotationList ) (quoteJavaPat "tok_AnnotationList_dummy_172" getAnnotationList ) quoteJavaType quoteJavaDecs
 
 getAnnotationTypeElement ( Ctr__Java__7 _ s) = s
 
 annotationTypeElement :: QuasiQuoter
-annotationTypeElement = QuasiQuoter (quoteJavaExp "tok_AnnotationTypeElement_dummy_163" getAnnotationTypeElement ) (quoteJavaPat "tok_AnnotationTypeElement_dummy_163" getAnnotationTypeElement ) quoteJavaType quoteJavaDecs
+annotationTypeElement = QuasiQuoter (quoteJavaExp "tok_AnnotationTypeElement_dummy_171" getAnnotationTypeElement ) (quoteJavaPat "tok_AnnotationTypeElement_dummy_171" getAnnotationTypeElement ) quoteJavaType quoteJavaDecs
 
 getAnnotationTypeElementList ( Ctr__Java__8 _ s) = s
 
 annotationTypeElementList :: QuasiQuoter
-annotationTypeElementList = QuasiQuoter (quoteJavaExp "tok_AnnotationTypeElementList_dummy_162" getAnnotationTypeElementList ) (quoteJavaPat "tok_AnnotationTypeElementList_dummy_162" getAnnotationTypeElementList ) quoteJavaType quoteJavaDecs
+annotationTypeElementList = QuasiQuoter (quoteJavaExp "tok_AnnotationTypeElementList_dummy_170" getAnnotationTypeElementList ) (quoteJavaPat "tok_AnnotationTypeElementList_dummy_170" getAnnotationTypeElementList ) quoteJavaType quoteJavaDecs
 
 getArglist ( Ctr__Java__9 _ s) = s
 
 arglist :: QuasiQuoter
-arglist = QuasiQuoter (quoteJavaExp "tok_Arglist_dummy_161" getArglist ) (quoteJavaPat "tok_Arglist_dummy_161" getArglist ) quoteJavaType quoteJavaDecs
+arglist = QuasiQuoter (quoteJavaExp "tok_Arglist_dummy_169" getArglist ) (quoteJavaPat "tok_Arglist_dummy_169" getArglist ) quoteJavaType quoteJavaDecs
 
 getAssignmentOp ( Ctr__Java__10 _ s) = s
 
 assignmentOp :: QuasiQuoter
-assignmentOp = QuasiQuoter (quoteJavaExp "tok_AssignmentOp_dummy_160" getAssignmentOp ) (quoteJavaPat "tok_AssignmentOp_dummy_160" getAssignmentOp ) quoteJavaType quoteJavaDecs
+assignmentOp = QuasiQuoter (quoteJavaExp "tok_AssignmentOp_dummy_168" getAssignmentOp ) (quoteJavaPat "tok_AssignmentOp_dummy_168" getAssignmentOp ) quoteJavaType quoteJavaDecs
 
 getCatchList ( Ctr__Java__11 _ s) = s
 
 catchList :: QuasiQuoter
-catchList = QuasiQuoter (quoteJavaExp "tok_CatchList_dummy_159" getCatchList ) (quoteJavaPat "tok_CatchList_dummy_159" getCatchList ) quoteJavaType quoteJavaDecs
+catchList = QuasiQuoter (quoteJavaExp "tok_CatchList_dummy_167" getCatchList ) (quoteJavaPat "tok_CatchList_dummy_167" getCatchList ) quoteJavaType quoteJavaDecs
 
 getClassDeclaration ( Ctr__Java__12 _ s) = s
 
 classDeclaration :: QuasiQuoter
-classDeclaration = QuasiQuoter (quoteJavaExp "tok_ClassDeclaration_dummy_158" getClassDeclaration ) (quoteJavaPat "tok_ClassDeclaration_dummy_158" getClassDeclaration ) quoteJavaType quoteJavaDecs
+classDeclaration = QuasiQuoter (quoteJavaExp "tok_ClassDeclaration_dummy_166" getClassDeclaration ) (quoteJavaPat "tok_ClassDeclaration_dummy_166" getClassDeclaration ) quoteJavaType quoteJavaDecs
 
 getCompilationUnit ( Ctr__Java__13 _ s) = s
 
 compilationUnit :: QuasiQuoter
-compilationUnit = QuasiQuoter (quoteJavaExp "tok_CompilationUnit_dummy_157" getCompilationUnit ) (quoteJavaPat "tok_CompilationUnit_dummy_157" getCompilationUnit ) quoteJavaType quoteJavaDecs
+compilationUnit = QuasiQuoter (quoteJavaExp "tok_CompilationUnit_dummy_165" getCompilationUnit ) (quoteJavaPat "tok_CompilationUnit_dummy_165" getCompilationUnit ) quoteJavaType quoteJavaDecs
 
 getCompoundName ( Ctr__Java__14 _ s) = s
 
 compoundName :: QuasiQuoter
-compoundName = QuasiQuoter (quoteJavaExp "tok_CompoundName_dummy_156" getCompoundName ) (quoteJavaPat "tok_CompoundName_dummy_156" getCompoundName ) quoteJavaType quoteJavaDecs
+compoundName = QuasiQuoter (quoteJavaExp "tok_CompoundName_dummy_164" getCompoundName ) (quoteJavaPat "tok_CompoundName_dummy_164" getCompoundName ) quoteJavaType quoteJavaDecs
 
 getCreationExpression ( Ctr__Java__15 _ s) = s
 
 creationExpression :: QuasiQuoter
-creationExpression = QuasiQuoter (quoteJavaExp "tok_CreationExpression_dummy_155" getCreationExpression ) (quoteJavaPat "tok_CreationExpression_dummy_155" getCreationExpression ) quoteJavaType quoteJavaDecs
+creationExpression = QuasiQuoter (quoteJavaExp "tok_CreationExpression_dummy_163" getCreationExpression ) (quoteJavaPat "tok_CreationExpression_dummy_163" getCreationExpression ) quoteJavaType quoteJavaDecs
 
-getDoStatement ( Ctr__Java__16 _ s) = s
+getDimExprs ( Ctr__Java__16 _ s) = s
+
+dimExprs :: QuasiQuoter
+dimExprs = QuasiQuoter (quoteJavaExp "tok_DimExprs_dummy_162" getDimExprs ) (quoteJavaPat "tok_DimExprs_dummy_162" getDimExprs ) quoteJavaType quoteJavaDecs
+
+getDims ( Ctr__Java__17 _ s) = s
+
+dims :: QuasiQuoter
+dims = QuasiQuoter (quoteJavaExp "tok_Dims_dummy_161" getDims ) (quoteJavaPat "tok_Dims_dummy_161" getDims ) quoteJavaType quoteJavaDecs
+
+getDoStatement ( Ctr__Java__18 _ s) = s
 
 doStatement :: QuasiQuoter
-doStatement = QuasiQuoter (quoteJavaExp "tok_DoStatement_dummy_154" getDoStatement ) (quoteJavaPat "tok_DoStatement_dummy_154" getDoStatement ) quoteJavaType quoteJavaDecs
+doStatement = QuasiQuoter (quoteJavaExp "tok_DoStatement_dummy_160" getDoStatement ) (quoteJavaPat "tok_DoStatement_dummy_160" getDoStatement ) quoteJavaType quoteJavaDecs
 
-getDocComment ( Ctr__Java__17 _ s) = s
+getDocComment ( Ctr__Java__19 _ s) = s
 
 docComment :: QuasiQuoter
-docComment = QuasiQuoter (quoteJavaExp "tok_DocComment_dummy_153" getDocComment ) (quoteJavaPat "tok_DocComment_dummy_153" getDocComment ) quoteJavaType quoteJavaDecs
+docComment = QuasiQuoter (quoteJavaExp "tok_DocComment_dummy_159" getDocComment ) (quoteJavaPat "tok_DocComment_dummy_159" getDocComment ) quoteJavaType quoteJavaDecs
 
-getEnumConstant ( Ctr__Java__18 _ s) = s
+getEnumConstant ( Ctr__Java__20 _ s) = s
 
 enumConstant :: QuasiQuoter
-enumConstant = QuasiQuoter (quoteJavaExp "tok_EnumConstant_dummy_152" getEnumConstant ) (quoteJavaPat "tok_EnumConstant_dummy_152" getEnumConstant ) quoteJavaType quoteJavaDecs
+enumConstant = QuasiQuoter (quoteJavaExp "tok_EnumConstant_dummy_158" getEnumConstant ) (quoteJavaPat "tok_EnumConstant_dummy_158" getEnumConstant ) quoteJavaType quoteJavaDecs
 
-getEnumConstantList ( Ctr__Java__19 _ s) = s
+getEnumConstantList ( Ctr__Java__21 _ s) = s
 
 enumConstantList :: QuasiQuoter
-enumConstantList = QuasiQuoter (quoteJavaExp "tok_EnumConstantList_dummy_151" getEnumConstantList ) (quoteJavaPat "tok_EnumConstantList_dummy_151" getEnumConstantList ) quoteJavaType quoteJavaDecs
+enumConstantList = QuasiQuoter (quoteJavaExp "tok_EnumConstantList_dummy_157" getEnumConstantList ) (quoteJavaPat "tok_EnumConstantList_dummy_157" getEnumConstantList ) quoteJavaType quoteJavaDecs
 
-getEnumDeclaration ( Ctr__Java__20 _ s) = s
+getEnumDeclaration ( Ctr__Java__22 _ s) = s
 
 enumDeclaration :: QuasiQuoter
-enumDeclaration = QuasiQuoter (quoteJavaExp "tok_EnumDeclaration_dummy_150" getEnumDeclaration ) (quoteJavaPat "tok_EnumDeclaration_dummy_150" getEnumDeclaration ) quoteJavaType quoteJavaDecs
+enumDeclaration = QuasiQuoter (quoteJavaExp "tok_EnumDeclaration_dummy_156" getEnumDeclaration ) (quoteJavaPat "tok_EnumDeclaration_dummy_156" getEnumDeclaration ) quoteJavaType quoteJavaDecs
 
-getEqualityOp ( Ctr__Java__21 _ s) = s
+getEqualityOp ( Ctr__Java__23 _ s) = s
 
 equalityOp :: QuasiQuoter
-equalityOp = QuasiQuoter (quoteJavaExp "tok_EqualityOp_dummy_149" getEqualityOp ) (quoteJavaPat "tok_EqualityOp_dummy_149" getEqualityOp ) quoteJavaType quoteJavaDecs
+equalityOp = QuasiQuoter (quoteJavaExp "tok_EqualityOp_dummy_155" getEqualityOp ) (quoteJavaPat "tok_EqualityOp_dummy_155" getEqualityOp ) quoteJavaType quoteJavaDecs
 
-getExpression ( Ctr__Java__22 _ s) = s
+getExpression ( Ctr__Java__24 _ s) = s
 
 expression :: QuasiQuoter
-expression = QuasiQuoter (quoteJavaExp "tok_Expression_dummy_148" getExpression ) (quoteJavaPat "tok_Expression_dummy_148" getExpression ) quoteJavaType quoteJavaDecs
+expression = QuasiQuoter (quoteJavaExp "tok_Expression_dummy_154" getExpression ) (quoteJavaPat "tok_Expression_dummy_154" getExpression ) quoteJavaType quoteJavaDecs
 
-getExtendsList ( Ctr__Java__23 _ s) = s
+getExtendsList ( Ctr__Java__25 _ s) = s
 
 extendsList :: QuasiQuoter
-extendsList = QuasiQuoter (quoteJavaExp "tok_ExtendsList_dummy_147" getExtendsList ) (quoteJavaPat "tok_ExtendsList_dummy_147" getExtendsList ) quoteJavaType quoteJavaDecs
+extendsList = QuasiQuoter (quoteJavaExp "tok_ExtendsList_dummy_153" getExtendsList ) (quoteJavaPat "tok_ExtendsList_dummy_153" getExtendsList ) quoteJavaType quoteJavaDecs
 
-getFieldDeclaration ( Ctr__Java__24 _ s) = s
+getFieldDeclaration ( Ctr__Java__26 _ s) = s
 
 fieldDeclaration :: QuasiQuoter
-fieldDeclaration = QuasiQuoter (quoteJavaExp "tok_FieldDeclaration_dummy_146" getFieldDeclaration ) (quoteJavaPat "tok_FieldDeclaration_dummy_146" getFieldDeclaration ) quoteJavaType quoteJavaDecs
+fieldDeclaration = QuasiQuoter (quoteJavaExp "tok_FieldDeclaration_dummy_152" getFieldDeclaration ) (quoteJavaPat "tok_FieldDeclaration_dummy_152" getFieldDeclaration ) quoteJavaType quoteJavaDecs
 
-getFieldDeclarationList ( Ctr__Java__25 _ s) = s
+getFieldDeclarationList ( Ctr__Java__27 _ s) = s
 
 fieldDeclarationList :: QuasiQuoter
-fieldDeclarationList = QuasiQuoter (quoteJavaExp "tok_FieldDeclarationList_dummy_145" getFieldDeclarationList ) (quoteJavaPat "tok_FieldDeclarationList_dummy_145" getFieldDeclarationList ) quoteJavaType quoteJavaDecs
+fieldDeclarationList = QuasiQuoter (quoteJavaExp "tok_FieldDeclarationList_dummy_151" getFieldDeclarationList ) (quoteJavaPat "tok_FieldDeclarationList_dummy_151" getFieldDeclarationList ) quoteJavaType quoteJavaDecs
 
-getForStatement ( Ctr__Java__26 _ s) = s
+getForStatement ( Ctr__Java__28 _ s) = s
 
 forStatement :: QuasiQuoter
-forStatement = QuasiQuoter (quoteJavaExp "tok_ForStatement_dummy_144" getForStatement ) (quoteJavaPat "tok_ForStatement_dummy_144" getForStatement ) quoteJavaType quoteJavaDecs
+forStatement = QuasiQuoter (quoteJavaExp "tok_ForStatement_dummy_150" getForStatement ) (quoteJavaPat "tok_ForStatement_dummy_150" getForStatement ) quoteJavaType quoteJavaDecs
 
-getIfStatement ( Ctr__Java__27 _ s) = s
+getIfStatement ( Ctr__Java__29 _ s) = s
 
 ifStatement :: QuasiQuoter
-ifStatement = QuasiQuoter (quoteJavaExp "tok_IfStatement_dummy_143" getIfStatement ) (quoteJavaPat "tok_IfStatement_dummy_143" getIfStatement ) quoteJavaType quoteJavaDecs
+ifStatement = QuasiQuoter (quoteJavaExp "tok_IfStatement_dummy_149" getIfStatement ) (quoteJavaPat "tok_IfStatement_dummy_149" getIfStatement ) quoteJavaType quoteJavaDecs
 
-getImplementsList ( Ctr__Java__28 _ s) = s
+getImplementsList ( Ctr__Java__30 _ s) = s
 
 implementsList :: QuasiQuoter
-implementsList = QuasiQuoter (quoteJavaExp "tok_ImplementsList_dummy_142" getImplementsList ) (quoteJavaPat "tok_ImplementsList_dummy_142" getImplementsList ) quoteJavaType quoteJavaDecs
+implementsList = QuasiQuoter (quoteJavaExp "tok_ImplementsList_dummy_148" getImplementsList ) (quoteJavaPat "tok_ImplementsList_dummy_148" getImplementsList ) quoteJavaType quoteJavaDecs
 
-getImportList ( Ctr__Java__29 _ s) = s
+getImportList ( Ctr__Java__31 _ s) = s
 
 importList :: QuasiQuoter
-importList = QuasiQuoter (quoteJavaExp "tok_ImportList_dummy_141" getImportList ) (quoteJavaPat "tok_ImportList_dummy_141" getImportList ) quoteJavaType quoteJavaDecs
+importList = QuasiQuoter (quoteJavaExp "tok_ImportList_dummy_147" getImportList ) (quoteJavaPat "tok_ImportList_dummy_147" getImportList ) quoteJavaType quoteJavaDecs
 
-getImportStatement ( Ctr__Java__30 _ s) = s
+getImportStatement ( Ctr__Java__32 _ s) = s
 
 importStatement :: QuasiQuoter
-importStatement = QuasiQuoter (quoteJavaExp "tok_ImportStatement_dummy_140" getImportStatement ) (quoteJavaPat "tok_ImportStatement_dummy_140" getImportStatement ) quoteJavaType quoteJavaDecs
+importStatement = QuasiQuoter (quoteJavaExp "tok_ImportStatement_dummy_146" getImportStatement ) (quoteJavaPat "tok_ImportStatement_dummy_146" getImportStatement ) quoteJavaType quoteJavaDecs
 
-getInterfaceDeclaration ( Ctr__Java__31 _ s) = s
+getInterfaceDeclaration ( Ctr__Java__33 _ s) = s
 
 interfaceDeclaration :: QuasiQuoter
-interfaceDeclaration = QuasiQuoter (quoteJavaExp "tok_InterfaceDeclaration_dummy_139" getInterfaceDeclaration ) (quoteJavaPat "tok_InterfaceDeclaration_dummy_139" getInterfaceDeclaration ) quoteJavaType quoteJavaDecs
+interfaceDeclaration = QuasiQuoter (quoteJavaExp "tok_InterfaceDeclaration_dummy_145" getInterfaceDeclaration ) (quoteJavaPat "tok_InterfaceDeclaration_dummy_145" getInterfaceDeclaration ) quoteJavaType quoteJavaDecs
 
-getLiteral ( Ctr__Java__32 _ s) = s
+getLiteral ( Ctr__Java__34 _ s) = s
 
 literal :: QuasiQuoter
-literal = QuasiQuoter (quoteJavaExp "tok_Literal_dummy_138" getLiteral ) (quoteJavaPat "tok_Literal_dummy_138" getLiteral ) quoteJavaType quoteJavaDecs
+literal = QuasiQuoter (quoteJavaExp "tok_Literal_dummy_144" getLiteral ) (quoteJavaPat "tok_Literal_dummy_144" getLiteral ) quoteJavaType quoteJavaDecs
 
-getMemberAfterFirstId ( Ctr__Java__33 _ s) = s
+getMemberAfterFirstId ( Ctr__Java__35 _ s) = s
 
 memberAfterFirstId :: QuasiQuoter
-memberAfterFirstId = QuasiQuoter (quoteJavaExp "tok_MemberAfterFirstId_dummy_137" getMemberAfterFirstId ) (quoteJavaPat "tok_MemberAfterFirstId_dummy_137" getMemberAfterFirstId ) quoteJavaType quoteJavaDecs
+memberAfterFirstId = QuasiQuoter (quoteJavaExp "tok_MemberAfterFirstId_dummy_143" getMemberAfterFirstId ) (quoteJavaPat "tok_MemberAfterFirstId_dummy_143" getMemberAfterFirstId ) quoteJavaType quoteJavaDecs
 
-getMemberDeclaration ( Ctr__Java__34 _ s) = s
+getMemberDeclaration ( Ctr__Java__36 _ s) = s
 
 memberDeclaration :: QuasiQuoter
-memberDeclaration = QuasiQuoter (quoteJavaExp "tok_MemberDeclaration_dummy_136" getMemberDeclaration ) (quoteJavaPat "tok_MemberDeclaration_dummy_136" getMemberDeclaration ) quoteJavaType quoteJavaDecs
+memberDeclaration = QuasiQuoter (quoteJavaExp "tok_MemberDeclaration_dummy_142" getMemberDeclaration ) (quoteJavaPat "tok_MemberDeclaration_dummy_142" getMemberDeclaration ) quoteJavaType quoteJavaDecs
 
-getMemberRest ( Ctr__Java__35 _ s) = s
+getMemberRest ( Ctr__Java__37 _ s) = s
 
 memberRest :: QuasiQuoter
-memberRest = QuasiQuoter (quoteJavaExp "tok_MemberRest_dummy_135" getMemberRest ) (quoteJavaPat "tok_MemberRest_dummy_135" getMemberRest ) quoteJavaType quoteJavaDecs
+memberRest = QuasiQuoter (quoteJavaExp "tok_MemberRest_dummy_141" getMemberRest ) (quoteJavaPat "tok_MemberRest_dummy_141" getMemberRest ) quoteJavaType quoteJavaDecs
 
-getModifier ( Ctr__Java__36 _ s) = s
+getModifier ( Ctr__Java__38 _ s) = s
 
 modifier :: QuasiQuoter
-modifier = QuasiQuoter (quoteJavaExp "tok_Modifier_dummy_134" getModifier ) (quoteJavaPat "tok_Modifier_dummy_134" getModifier ) quoteJavaType quoteJavaDecs
+modifier = QuasiQuoter (quoteJavaExp "tok_Modifier_dummy_140" getModifier ) (quoteJavaPat "tok_Modifier_dummy_140" getModifier ) quoteJavaType quoteJavaDecs
 
-getModifierList ( Ctr__Java__37 _ s) = s
+getModifierList ( Ctr__Java__39 _ s) = s
 
 modifierList :: QuasiQuoter
-modifierList = QuasiQuoter (quoteJavaExp "tok_ModifierList_dummy_133" getModifierList ) (quoteJavaPat "tok_ModifierList_dummy_133" getModifierList ) quoteJavaType quoteJavaDecs
+modifierList = QuasiQuoter (quoteJavaExp "tok_ModifierList_dummy_139" getModifierList ) (quoteJavaPat "tok_ModifierList_dummy_139" getModifierList ) quoteJavaType quoteJavaDecs
 
-getMoreTypeSpecifier ( Ctr__Java__38 _ s) = s
+getMoreTypeSpecifier ( Ctr__Java__40 _ s) = s
 
 moreTypeSpecifier :: QuasiQuoter
-moreTypeSpecifier = QuasiQuoter (quoteJavaExp "tok_MoreTypeSpecifier_dummy_132" getMoreTypeSpecifier ) (quoteJavaPat "tok_MoreTypeSpecifier_dummy_132" getMoreTypeSpecifier ) quoteJavaType quoteJavaDecs
+moreTypeSpecifier = QuasiQuoter (quoteJavaExp "tok_MoreTypeSpecifier_dummy_138" getMoreTypeSpecifier ) (quoteJavaPat "tok_MoreTypeSpecifier_dummy_138" getMoreTypeSpecifier ) quoteJavaType quoteJavaDecs
 
-getMoreVariableDeclarators ( Ctr__Java__39 _ s) = s
+getMoreVariableDeclarators ( Ctr__Java__41 _ s) = s
 
 moreVariableDeclarators :: QuasiQuoter
-moreVariableDeclarators = QuasiQuoter (quoteJavaExp "tok_MoreVariableDeclarators_dummy_131" getMoreVariableDeclarators ) (quoteJavaPat "tok_MoreVariableDeclarators_dummy_131" getMoreVariableDeclarators ) quoteJavaType quoteJavaDecs
+moreVariableDeclarators = QuasiQuoter (quoteJavaExp "tok_MoreVariableDeclarators_dummy_137" getMoreVariableDeclarators ) (quoteJavaPat "tok_MoreVariableDeclarators_dummy_137" getMoreVariableDeclarators ) quoteJavaType quoteJavaDecs
 
-getMultiplicativeOp ( Ctr__Java__40 _ s) = s
+getMultiplicativeOp ( Ctr__Java__42 _ s) = s
 
 multiplicativeOp :: QuasiQuoter
-multiplicativeOp = QuasiQuoter (quoteJavaExp "tok_MultiplicativeOp_dummy_130" getMultiplicativeOp ) (quoteJavaPat "tok_MultiplicativeOp_dummy_130" getMultiplicativeOp ) quoteJavaType quoteJavaDecs
+multiplicativeOp = QuasiQuoter (quoteJavaExp "tok_MultiplicativeOp_dummy_136" getMultiplicativeOp ) (quoteJavaPat "tok_MultiplicativeOp_dummy_136" getMultiplicativeOp ) quoteJavaType quoteJavaDecs
 
-getNestedTypeDeclaration ( Ctr__Java__41 _ s) = s
+getNestedTypeDeclaration ( Ctr__Java__43 _ s) = s
 
 nestedTypeDeclaration :: QuasiQuoter
-nestedTypeDeclaration = QuasiQuoter (quoteJavaExp "tok_NestedTypeDeclaration_dummy_129" getNestedTypeDeclaration ) (quoteJavaPat "tok_NestedTypeDeclaration_dummy_129" getNestedTypeDeclaration ) quoteJavaType quoteJavaDecs
+nestedTypeDeclaration = QuasiQuoter (quoteJavaExp "tok_NestedTypeDeclaration_dummy_135" getNestedTypeDeclaration ) (quoteJavaPat "tok_NestedTypeDeclaration_dummy_135" getNestedTypeDeclaration ) quoteJavaType quoteJavaDecs
 
-getOptDocComment ( Ctr__Java__42 _ s) = s
+getNonEmptyDims ( Ctr__Java__44 _ s) = s
+
+nonEmptyDims :: QuasiQuoter
+nonEmptyDims = QuasiQuoter (quoteJavaExp "tok_NonEmptyDims_dummy_134" getNonEmptyDims ) (quoteJavaPat "tok_NonEmptyDims_dummy_134" getNonEmptyDims ) quoteJavaType quoteJavaDecs
+
+getNonEmptyTypeArguments ( Ctr__Java__45 _ s) = s
+
+nonEmptyTypeArguments :: QuasiQuoter
+nonEmptyTypeArguments = QuasiQuoter (quoteJavaExp "tok_NonEmptyTypeArguments_dummy_133" getNonEmptyTypeArguments ) (quoteJavaPat "tok_NonEmptyTypeArguments_dummy_133" getNonEmptyTypeArguments ) quoteJavaType quoteJavaDecs
+
+getOptDocComment ( Ctr__Java__46 _ s) = s
 
 optDocComment :: QuasiQuoter
-optDocComment = QuasiQuoter (quoteJavaExp "tok_OptDocComment_dummy_128" getOptDocComment ) (quoteJavaPat "tok_OptDocComment_dummy_128" getOptDocComment ) quoteJavaType quoteJavaDecs
+optDocComment = QuasiQuoter (quoteJavaExp "tok_OptDocComment_dummy_132" getOptDocComment ) (quoteJavaPat "tok_OptDocComment_dummy_132" getOptDocComment ) quoteJavaType quoteJavaDecs
 
-getOptElsePart ( Ctr__Java__43 _ s) = s
+getOptElsePart ( Ctr__Java__47 _ s) = s
 
 optElsePart :: QuasiQuoter
-optElsePart = QuasiQuoter (quoteJavaExp "tok_OptElsePart_dummy_127" getOptElsePart ) (quoteJavaPat "tok_OptElsePart_dummy_127" getOptElsePart ) quoteJavaType quoteJavaDecs
+optElsePart = QuasiQuoter (quoteJavaExp "tok_OptElsePart_dummy_131" getOptElsePart ) (quoteJavaPat "tok_OptElsePart_dummy_131" getOptElsePart ) quoteJavaType quoteJavaDecs
 
-getOptExpression ( Ctr__Java__44 _ s) = s
+getOptExpression ( Ctr__Java__48 _ s) = s
 
 optExpression :: QuasiQuoter
-optExpression = QuasiQuoter (quoteJavaExp "tok_OptExpression_dummy_126" getOptExpression ) (quoteJavaPat "tok_OptExpression_dummy_126" getOptExpression ) quoteJavaType quoteJavaDecs
+optExpression = QuasiQuoter (quoteJavaExp "tok_OptExpression_dummy_130" getOptExpression ) (quoteJavaPat "tok_OptExpression_dummy_130" getOptExpression ) quoteJavaType quoteJavaDecs
 
-getOptFinally ( Ctr__Java__45 _ s) = s
+getOptFinally ( Ctr__Java__49 _ s) = s
 
 optFinally :: QuasiQuoter
-optFinally = QuasiQuoter (quoteJavaExp "tok_OptFinally_dummy_125" getOptFinally ) (quoteJavaPat "tok_OptFinally_dummy_125" getOptFinally ) quoteJavaType quoteJavaDecs
+optFinally = QuasiQuoter (quoteJavaExp "tok_OptFinally_dummy_129" getOptFinally ) (quoteJavaPat "tok_OptFinally_dummy_129" getOptFinally ) quoteJavaType quoteJavaDecs
 
-getOptId ( Ctr__Java__46 _ s) = s
+getOptId ( Ctr__Java__50 _ s) = s
 
 optId :: QuasiQuoter
-optId = QuasiQuoter (quoteJavaExp "tok_OptId_dummy_124" getOptId ) (quoteJavaPat "tok_OptId_dummy_124" getOptId ) quoteJavaType quoteJavaDecs
+optId = QuasiQuoter (quoteJavaExp "tok_OptId_dummy_128" getOptId ) (quoteJavaPat "tok_OptId_dummy_128" getOptId ) quoteJavaType quoteJavaDecs
 
-getOptVariableInitializer ( Ctr__Java__47 _ s) = s
+getOptVariableInitializer ( Ctr__Java__51 _ s) = s
 
 optVariableInitializer :: QuasiQuoter
-optVariableInitializer = QuasiQuoter (quoteJavaExp "tok_OptVariableInitializer_dummy_123" getOptVariableInitializer ) (quoteJavaPat "tok_OptVariableInitializer_dummy_123" getOptVariableInitializer ) quoteJavaType quoteJavaDecs
+optVariableInitializer = QuasiQuoter (quoteJavaExp "tok_OptVariableInitializer_dummy_127" getOptVariableInitializer ) (quoteJavaPat "tok_OptVariableInitializer_dummy_127" getOptVariableInitializer ) quoteJavaType quoteJavaDecs
 
-getPackage ( Ctr__Java__48 _ s) = s
+getPackage ( Ctr__Java__52 _ s) = s
 
 package :: QuasiQuoter
-package = QuasiQuoter (quoteJavaExp "tok_Package_dummy_122" getPackage ) (quoteJavaPat "tok_Package_dummy_122" getPackage ) quoteJavaType quoteJavaDecs
+package = QuasiQuoter (quoteJavaExp "tok_Package_dummy_126" getPackage ) (quoteJavaPat "tok_Package_dummy_126" getPackage ) quoteJavaType quoteJavaDecs
 
-getParameter ( Ctr__Java__49 _ s) = s
+getParameter ( Ctr__Java__53 _ s) = s
 
 parameter :: QuasiQuoter
-parameter = QuasiQuoter (quoteJavaExp "tok_Parameter_dummy_121" getParameter ) (quoteJavaPat "tok_Parameter_dummy_121" getParameter ) quoteJavaType quoteJavaDecs
+parameter = QuasiQuoter (quoteJavaExp "tok_Parameter_dummy_125" getParameter ) (quoteJavaPat "tok_Parameter_dummy_125" getParameter ) quoteJavaType quoteJavaDecs
 
-getParameterList ( Ctr__Java__50 _ s) = s
+getParameterList ( Ctr__Java__54 _ s) = s
 
 parameterList :: QuasiQuoter
-parameterList = QuasiQuoter (quoteJavaExp "tok_ParameterList_dummy_120" getParameterList ) (quoteJavaPat "tok_ParameterList_dummy_120" getParameterList ) quoteJavaType quoteJavaDecs
+parameterList = QuasiQuoter (quoteJavaExp "tok_ParameterList_dummy_124" getParameterList ) (quoteJavaPat "tok_ParameterList_dummy_124" getParameterList ) quoteJavaType quoteJavaDecs
 
-getPostfixOp ( Ctr__Java__51 _ s) = s
+getPostfixOp ( Ctr__Java__55 _ s) = s
 
 postfixOp :: QuasiQuoter
-postfixOp = QuasiQuoter (quoteJavaExp "tok_PostfixOp_dummy_119" getPostfixOp ) (quoteJavaPat "tok_PostfixOp_dummy_119" getPostfixOp ) quoteJavaType quoteJavaDecs
+postfixOp = QuasiQuoter (quoteJavaExp "tok_PostfixOp_dummy_123" getPostfixOp ) (quoteJavaPat "tok_PostfixOp_dummy_123" getPostfixOp ) quoteJavaType quoteJavaDecs
 
-getPrefixOp ( Ctr__Java__52 _ s) = s
+getPrefixOp ( Ctr__Java__56 _ s) = s
 
 prefixOp :: QuasiQuoter
-prefixOp = QuasiQuoter (quoteJavaExp "tok_PrefixOp_dummy_118" getPrefixOp ) (quoteJavaPat "tok_PrefixOp_dummy_118" getPrefixOp ) quoteJavaType quoteJavaDecs
+prefixOp = QuasiQuoter (quoteJavaExp "tok_PrefixOp_dummy_122" getPrefixOp ) (quoteJavaPat "tok_PrefixOp_dummy_122" getPrefixOp ) quoteJavaType quoteJavaDecs
 
-getPrimitiveTypeKeyword ( Ctr__Java__53 _ s) = s
+getPrimitiveTypeKeyword ( Ctr__Java__57 _ s) = s
 
 primitiveTypeKeyword :: QuasiQuoter
-primitiveTypeKeyword = QuasiQuoter (quoteJavaExp "tok_PrimitiveTypeKeyword_dummy_117" getPrimitiveTypeKeyword ) (quoteJavaPat "tok_PrimitiveTypeKeyword_dummy_117" getPrimitiveTypeKeyword ) quoteJavaType quoteJavaDecs
+primitiveTypeKeyword = QuasiQuoter (quoteJavaExp "tok_PrimitiveTypeKeyword_dummy_121" getPrimitiveTypeKeyword ) (quoteJavaPat "tok_PrimitiveTypeKeyword_dummy_121" getPrimitiveTypeKeyword ) quoteJavaType quoteJavaDecs
 
-getRelationalOp ( Ctr__Java__54 _ s) = s
+getRelationalOp ( Ctr__Java__58 _ s) = s
 
 relationalOp :: QuasiQuoter
-relationalOp = QuasiQuoter (quoteJavaExp "tok_RelationalOp_dummy_116" getRelationalOp ) (quoteJavaPat "tok_RelationalOp_dummy_116" getRelationalOp ) quoteJavaType quoteJavaDecs
+relationalOp = QuasiQuoter (quoteJavaExp "tok_RelationalOp_dummy_120" getRelationalOp ) (quoteJavaPat "tok_RelationalOp_dummy_120" getRelationalOp ) quoteJavaType quoteJavaDecs
 
-getShiftOp ( Ctr__Java__55 _ s) = s
+getShiftOp ( Ctr__Java__59 _ s) = s
 
 shiftOp :: QuasiQuoter
-shiftOp = QuasiQuoter (quoteJavaExp "tok_ShiftOp_dummy_115" getShiftOp ) (quoteJavaPat "tok_ShiftOp_dummy_115" getShiftOp ) quoteJavaType quoteJavaDecs
+shiftOp = QuasiQuoter (quoteJavaExp "tok_ShiftOp_dummy_119" getShiftOp ) (quoteJavaPat "tok_ShiftOp_dummy_119" getShiftOp ) quoteJavaType quoteJavaDecs
 
-getSquareBracketsList ( Ctr__Java__56 _ s) = s
-
-squareBracketsList :: QuasiQuoter
-squareBracketsList = QuasiQuoter (quoteJavaExp "tok_SquareBracketsList_dummy_114" getSquareBracketsList ) (quoteJavaPat "tok_SquareBracketsList_dummy_114" getSquareBracketsList ) quoteJavaType quoteJavaDecs
-
-getStatement ( Ctr__Java__57 _ s) = s
+getStatement ( Ctr__Java__60 _ s) = s
 
 statement :: QuasiQuoter
-statement = QuasiQuoter (quoteJavaExp "tok_Statement_dummy_113" getStatement ) (quoteJavaPat "tok_Statement_dummy_113" getStatement ) quoteJavaType quoteJavaDecs
+statement = QuasiQuoter (quoteJavaExp "tok_Statement_dummy_118" getStatement ) (quoteJavaPat "tok_Statement_dummy_118" getStatement ) quoteJavaType quoteJavaDecs
 
-getStatementBlock ( Ctr__Java__58 _ s) = s
+getStatementBlock ( Ctr__Java__61 _ s) = s
 
 statementBlock :: QuasiQuoter
-statementBlock = QuasiQuoter (quoteJavaExp "tok_StatementBlock_dummy_112" getStatementBlock ) (quoteJavaPat "tok_StatementBlock_dummy_112" getStatementBlock ) quoteJavaType quoteJavaDecs
+statementBlock = QuasiQuoter (quoteJavaExp "tok_StatementBlock_dummy_117" getStatementBlock ) (quoteJavaPat "tok_StatementBlock_dummy_117" getStatementBlock ) quoteJavaType quoteJavaDecs
 
-getStatementList ( Ctr__Java__59 _ s) = s
+getStatementList ( Ctr__Java__62 _ s) = s
 
 statementList :: QuasiQuoter
-statementList = QuasiQuoter (quoteJavaExp "tok_StatementList_dummy_111" getStatementList ) (quoteJavaPat "tok_StatementList_dummy_111" getStatementList ) quoteJavaType quoteJavaDecs
+statementList = QuasiQuoter (quoteJavaExp "tok_StatementList_dummy_116" getStatementList ) (quoteJavaPat "tok_StatementList_dummy_116" getStatementList ) quoteJavaType quoteJavaDecs
 
-getStatementWithoutIf ( Ctr__Java__60 _ s) = s
+getStatementWithoutIf ( Ctr__Java__63 _ s) = s
 
 statementWithoutIf :: QuasiQuoter
-statementWithoutIf = QuasiQuoter (quoteJavaExp "tok_StatementWithoutIf_dummy_110" getStatementWithoutIf ) (quoteJavaPat "tok_StatementWithoutIf_dummy_110" getStatementWithoutIf ) quoteJavaType quoteJavaDecs
+statementWithoutIf = QuasiQuoter (quoteJavaExp "tok_StatementWithoutIf_dummy_115" getStatementWithoutIf ) (quoteJavaPat "tok_StatementWithoutIf_dummy_115" getStatementWithoutIf ) quoteJavaType quoteJavaDecs
 
-getStaticInitializer ( Ctr__Java__61 _ s) = s
+getStaticInitializer ( Ctr__Java__64 _ s) = s
 
 staticInitializer :: QuasiQuoter
-staticInitializer = QuasiQuoter (quoteJavaExp "tok_StaticInitializer_dummy_109" getStaticInitializer ) (quoteJavaPat "tok_StaticInitializer_dummy_109" getStaticInitializer ) quoteJavaType quoteJavaDecs
+staticInitializer = QuasiQuoter (quoteJavaExp "tok_StaticInitializer_dummy_114" getStaticInitializer ) (quoteJavaPat "tok_StaticInitializer_dummy_114" getStaticInitializer ) quoteJavaType quoteJavaDecs
 
-getSwitchCaseList ( Ctr__Java__62 _ s) = s
+getSwitchCaseList ( Ctr__Java__65 _ s) = s
 
 switchCaseList :: QuasiQuoter
-switchCaseList = QuasiQuoter (quoteJavaExp "tok_SwitchCaseList_dummy_108" getSwitchCaseList ) (quoteJavaPat "tok_SwitchCaseList_dummy_108" getSwitchCaseList ) quoteJavaType quoteJavaDecs
+switchCaseList = QuasiQuoter (quoteJavaExp "tok_SwitchCaseList_dummy_113" getSwitchCaseList ) (quoteJavaPat "tok_SwitchCaseList_dummy_113" getSwitchCaseList ) quoteJavaType quoteJavaDecs
 
-getSwitchStatement ( Ctr__Java__63 _ s) = s
+getSwitchStatement ( Ctr__Java__66 _ s) = s
 
 switchStatement :: QuasiQuoter
-switchStatement = QuasiQuoter (quoteJavaExp "tok_SwitchStatement_dummy_107" getSwitchStatement ) (quoteJavaPat "tok_SwitchStatement_dummy_107" getSwitchStatement ) quoteJavaType quoteJavaDecs
+switchStatement = QuasiQuoter (quoteJavaExp "tok_SwitchStatement_dummy_112" getSwitchStatement ) (quoteJavaPat "tok_SwitchStatement_dummy_112" getSwitchStatement ) quoteJavaType quoteJavaDecs
 
-getTryStatement ( Ctr__Java__64 _ s) = s
+getTryStatement ( Ctr__Java__67 _ s) = s
 
 tryStatement :: QuasiQuoter
-tryStatement = QuasiQuoter (quoteJavaExp "tok_TryStatement_dummy_106" getTryStatement ) (quoteJavaPat "tok_TryStatement_dummy_106" getTryStatement ) quoteJavaType quoteJavaDecs
+tryStatement = QuasiQuoter (quoteJavaExp "tok_TryStatement_dummy_111" getTryStatement ) (quoteJavaPat "tok_TryStatement_dummy_111" getTryStatement ) quoteJavaType quoteJavaDecs
 
-getType ( Ctr__Java__65 _ s) = s
+getType ( Ctr__Java__68 _ s) = s
 
 __type :: QuasiQuoter
-__type = QuasiQuoter (quoteJavaExp "tok_Type_dummy_105" getType ) (quoteJavaPat "tok_Type_dummy_105" getType ) quoteJavaType quoteJavaDecs
+__type = QuasiQuoter (quoteJavaExp "tok_Type_dummy_110" getType ) (quoteJavaPat "tok_Type_dummy_110" getType ) quoteJavaType quoteJavaDecs
 
-getTypeArgument ( Ctr__Java__66 _ s) = s
+getTypeArgument ( Ctr__Java__69 _ s) = s
 
 typeArgument :: QuasiQuoter
-typeArgument = QuasiQuoter (quoteJavaExp "tok_TypeArgument_dummy_104" getTypeArgument ) (quoteJavaPat "tok_TypeArgument_dummy_104" getTypeArgument ) quoteJavaType quoteJavaDecs
+typeArgument = QuasiQuoter (quoteJavaExp "tok_TypeArgument_dummy_109" getTypeArgument ) (quoteJavaPat "tok_TypeArgument_dummy_109" getTypeArgument ) quoteJavaType quoteJavaDecs
 
-getTypeArguments ( Ctr__Java__67 _ s) = s
+getTypeArguments ( Ctr__Java__70 _ s) = s
 
 typeArguments :: QuasiQuoter
-typeArguments = QuasiQuoter (quoteJavaExp "tok_TypeArguments_dummy_103" getTypeArguments ) (quoteJavaPat "tok_TypeArguments_dummy_103" getTypeArguments ) quoteJavaType quoteJavaDecs
+typeArguments = QuasiQuoter (quoteJavaExp "tok_TypeArguments_dummy_108" getTypeArguments ) (quoteJavaPat "tok_TypeArguments_dummy_108" getTypeArguments ) quoteJavaType quoteJavaDecs
 
-getTypeDeclaration ( Ctr__Java__68 _ s) = s
+getTypeDeclaration ( Ctr__Java__71 _ s) = s
 
 typeDeclaration :: QuasiQuoter
-typeDeclaration = QuasiQuoter (quoteJavaExp "tok_TypeDeclaration_dummy_102" getTypeDeclaration ) (quoteJavaPat "tok_TypeDeclaration_dummy_102" getTypeDeclaration ) quoteJavaType quoteJavaDecs
+typeDeclaration = QuasiQuoter (quoteJavaExp "tok_TypeDeclaration_dummy_107" getTypeDeclaration ) (quoteJavaPat "tok_TypeDeclaration_dummy_107" getTypeDeclaration ) quoteJavaType quoteJavaDecs
 
-getTypeParameter ( Ctr__Java__69 _ s) = s
+getTypeParameter ( Ctr__Java__72 _ s) = s
 
 typeParameter :: QuasiQuoter
-typeParameter = QuasiQuoter (quoteJavaExp "tok_TypeParameter_dummy_101" getTypeParameter ) (quoteJavaPat "tok_TypeParameter_dummy_101" getTypeParameter ) quoteJavaType quoteJavaDecs
+typeParameter = QuasiQuoter (quoteJavaExp "tok_TypeParameter_dummy_106" getTypeParameter ) (quoteJavaPat "tok_TypeParameter_dummy_106" getTypeParameter ) quoteJavaType quoteJavaDecs
 
-getTypeParameters ( Ctr__Java__70 _ s) = s
+getTypeParameters ( Ctr__Java__73 _ s) = s
 
 typeParameters :: QuasiQuoter
-typeParameters = QuasiQuoter (quoteJavaExp "tok_TypeParameters_dummy_100" getTypeParameters ) (quoteJavaPat "tok_TypeParameters_dummy_100" getTypeParameters ) quoteJavaType quoteJavaDecs
+typeParameters = QuasiQuoter (quoteJavaExp "tok_TypeParameters_dummy_105" getTypeParameters ) (quoteJavaPat "tok_TypeParameters_dummy_105" getTypeParameters ) quoteJavaType quoteJavaDecs
 
-getTypeSpecifier ( Ctr__Java__71 _ s) = s
+getTypeSpecifier ( Ctr__Java__74 _ s) = s
 
 typeSpecifier :: QuasiQuoter
-typeSpecifier = QuasiQuoter (quoteJavaExp "tok_TypeSpecifier_dummy_99" getTypeSpecifier ) (quoteJavaPat "tok_TypeSpecifier_dummy_99" getTypeSpecifier ) quoteJavaType quoteJavaDecs
+typeSpecifier = QuasiQuoter (quoteJavaExp "tok_TypeSpecifier_dummy_104" getTypeSpecifier ) (quoteJavaPat "tok_TypeSpecifier_dummy_104" getTypeSpecifier ) quoteJavaType quoteJavaDecs
 
-getVariableDeclaration ( Ctr__Java__72 _ s) = s
+getVariableDeclaration ( Ctr__Java__75 _ s) = s
 
 variableDeclaration :: QuasiQuoter
-variableDeclaration = QuasiQuoter (quoteJavaExp "tok_VariableDeclaration_dummy_98" getVariableDeclaration ) (quoteJavaPat "tok_VariableDeclaration_dummy_98" getVariableDeclaration ) quoteJavaType quoteJavaDecs
+variableDeclaration = QuasiQuoter (quoteJavaExp "tok_VariableDeclaration_dummy_103" getVariableDeclaration ) (quoteJavaPat "tok_VariableDeclaration_dummy_103" getVariableDeclaration ) quoteJavaType quoteJavaDecs
 
-getVariableDeclarator ( Ctr__Java__73 _ s) = s
+getVariableDeclarator ( Ctr__Java__76 _ s) = s
 
 variableDeclarator :: QuasiQuoter
-variableDeclarator = QuasiQuoter (quoteJavaExp "tok_VariableDeclarator_dummy_97" getVariableDeclarator ) (quoteJavaPat "tok_VariableDeclarator_dummy_97" getVariableDeclarator ) quoteJavaType quoteJavaDecs
+variableDeclarator = QuasiQuoter (quoteJavaExp "tok_VariableDeclarator_dummy_102" getVariableDeclarator ) (quoteJavaPat "tok_VariableDeclarator_dummy_102" getVariableDeclarator ) quoteJavaType quoteJavaDecs
 
-getVariableDeclaratorList ( Ctr__Java__74 _ s) = s
+getVariableDeclaratorList ( Ctr__Java__77 _ s) = s
 
 variableDeclaratorList :: QuasiQuoter
-variableDeclaratorList = QuasiQuoter (quoteJavaExp "tok_VariableDeclaratorList_dummy_96" getVariableDeclaratorList ) (quoteJavaPat "tok_VariableDeclaratorList_dummy_96" getVariableDeclaratorList ) quoteJavaType quoteJavaDecs
+variableDeclaratorList = QuasiQuoter (quoteJavaExp "tok_VariableDeclaratorList_dummy_101" getVariableDeclaratorList ) (quoteJavaPat "tok_VariableDeclaratorList_dummy_101" getVariableDeclaratorList ) quoteJavaType quoteJavaDecs
 
-getVariableInitializer ( Ctr__Java__75 _ s) = s
+getVariableInitializer ( Ctr__Java__78 _ s) = s
 
 variableInitializer :: QuasiQuoter
-variableInitializer = QuasiQuoter (quoteJavaExp "tok_VariableInitializer_dummy_95" getVariableInitializer ) (quoteJavaPat "tok_VariableInitializer_dummy_95" getVariableInitializer ) quoteJavaType quoteJavaDecs
+variableInitializer = QuasiQuoter (quoteJavaExp "tok_VariableInitializer_dummy_100" getVariableInitializer ) (quoteJavaPat "tok_VariableInitializer_dummy_100" getVariableInitializer ) quoteJavaType quoteJavaDecs
 
-getVariableInitializerList ( Ctr__Java__76 _ s) = s
+getVariableInitializerList ( Ctr__Java__79 _ s) = s
 
 variableInitializerList :: QuasiQuoter
-variableInitializerList = QuasiQuoter (quoteJavaExp "tok_VariableInitializerList_dummy_94" getVariableInitializerList ) (quoteJavaPat "tok_VariableInitializerList_dummy_94" getVariableInitializerList ) quoteJavaType quoteJavaDecs
+variableInitializerList = QuasiQuoter (quoteJavaExp "tok_VariableInitializerList_dummy_99" getVariableInitializerList ) (quoteJavaPat "tok_VariableInitializerList_dummy_99" getVariableInitializerList ) quoteJavaType quoteJavaDecs
 
-getWhileStatement ( Ctr__Java__77 _ s) = s
+getWhileStatement ( Ctr__Java__80 _ s) = s
 
 whileStatement :: QuasiQuoter
-whileStatement = QuasiQuoter (quoteJavaExp "tok_WhileStatement_dummy_93" getWhileStatement ) (quoteJavaPat "tok_WhileStatement_dummy_93" getWhileStatement ) quoteJavaType quoteJavaDecs
+whileStatement = QuasiQuoter (quoteJavaExp "tok_WhileStatement_dummy_98" getWhileStatement ) (quoteJavaPat "tok_WhileStatement_dummy_98" getWhileStatement ) quoteJavaType quoteJavaDecs
 
-getWildcardType ( Ctr__Java__78 _ s) = s
+getWildcardType ( Ctr__Java__81 _ s) = s
 
 wildcardType :: QuasiQuoter
-wildcardType = QuasiQuoter (quoteJavaExp "tok_WildcardType_dummy_92" getWildcardType ) (quoteJavaPat "tok_WildcardType_dummy_92" getWildcardType ) quoteJavaType quoteJavaDecs
+wildcardType = QuasiQuoter (quoteJavaExp "tok_WildcardType_dummy_97" getWildcardType ) (quoteJavaPat "tok_WildcardType_dummy_97" getWildcardType ) quoteJavaType quoteJavaDecs
 


### PR DESCRIPTION
After a CompoundName in a position where both a type and an expression
may start (statement start; after '(' that may open a cast), the parser
had to commit too early: the reduce/reduce resolution picked the type
interpretation on '[' and ')', rejecting valid Java like 'a[0] = 1;'
and 'x = (a);'. Two coordinated restructures fix this; happy now
reports 0 reduce/reduce conflicts (down from 2) and 32 shift/reduce
(up from 29 - all 8 java-specific ones are intended shift-preferences,
itemized in java.pg).

(1) Split bracket lists. Types and declarators take only empty bracket
pairs: Dims = ('[' ']')* replaces SquareBracketsList in Type,
Parameter, VariableDeclarator, MemberDeclaration, MemberRest and
MoreTypeSpecifier; only array creation keeps sizing expressions
('new' TypeSpecifier (DimExprs (NonEmptyDims)? | '(' Arglist ')')).
Type is spelled out by alternatives anchored on the unreduced
CompoundName (NonEmptyTypeArguments / NonEmptyDims / bare name), and
PrimaryNoPostfix gains a name-anchored array access
(CompoundName '[' Expression ']'), so both interpretations shift '['
and the next token (']' vs expression start) decides - RTK's '*' lists
are left-recursive with an empty base, so a nullable Dims directly
after CompoundName would have forced the early epsilon-reduce back in.

(2) JLS cast trick. CastExpression = '(' Type ')' UnaryExpression is
replaced with explicit alternatives: primitive casts, generic casts
('<' commits), array-of-reference casts (NonEmptyDims), and
'(' Expression ')' UnaryExpressionNotPlusMinus for plain reference
casts, where cast-vs-paren is decided conflict-free one token after
')' (operand start means cast; '(a) + b' stays an addition because
'+'/'-' are excluded from UnaryExpressionNotPlusMinus).

Now parsing: a[0] = 1; x = (a); x = (Foo) y; x = (List<String>) y;
((Map) c).get(k); new int[3][]; arr[i][j] = v; int a[]; -- and
JLS-invalid 'int[3] x;' is now rejected. Known residual limitation
(standard LALR Java trade-off, documented in java.pg): '(a < b)' as a
parenthesized primary mis-commits to a generic cast on '<'; conditions
('if (a < b)') and call arguments are unaffected.

The commons-lang corpus is unchanged (14/16 main/tests files passing
with identical success sets): every remaining failure hits a still
unsupported feature (e.g. 'final' parameters, nested generics) before
any of these constructs, so the parser blacklists stay as they are.
All test suites pass: unit, golden (snapshots refreshed), all-java,
lex-java, java-qq, parse/lex-commons-lang-all, bootstrap.

https://claude.ai/code/session_011Qf1dLYuMTBFmA8ChZko8U