### PR TITLE
Implement --debug-rule RULENAME: single-rule pipeline trace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   moved from the identifier to the leading dot (a rule's position is where
   the rule starts), aligning it with first-symbol capture; no corpus
   grammar uses that form
+- `--debug-rule RULENAME` is back, this time with a real implementation
+  (it was removed together with the other never-implemented placeholder
+  flags): it traces one rule through the pipeline, printing only that
+  rule's representation after each stage — its mentions in the token
+  stream (with positions), the matching `IRule`s after parsing and after
+  string normalization (making literal-to-`!tok_*` rewrites visible), and
+  the matching rule groups/lexical rules after clause normalization and
+  constructor filling — instead of full-grammar dumps. `--expand-rule`
+  shows a rule's final expanded form; this flag shows its evolution. When
+  the rule is missing at a stage the trace says so and lists up to five
+  case-insensitive near matches (normalization renames things — `Rule_N`,
+  `ListElem_*`, `tok_*`); a rule found at no stage at all fails the run
+  with exit code 1, so typos don't go unnoticed in scripts. Composes with
+  `--debug-stage` (stop early) and works under `--use-generated`, where
+  the token stage is internal to the generated front end and the trace
+  starts after parsing
 - Self-hosting milestone (Prototype 2 closed): `rtk --use-generated` parses
   grammar files with the lexer/parser RTK generated from
   `test-grammars/grammar.pg`. The generated modules are compiled into rtk

--- a/DEBUG_OPTIONS.md
+++ b/DEBUG_OPTIONS.md
@@ -164,6 +164,113 @@ rtk test-grammars/java.rtk test-out --list-rules
 
 ## Selective Debug Options
 
+### `--debug-rule=RULENAME`
+Trace a single rule through the transformation pipeline. After each stage
+(tokens, parse, string normalization, clause normalization, constructor
+fill) only that rule's representation is printed instead of a full-grammar
+dump. Where `--expand-rule` shows a rule's *final* expanded form, this flag
+shows its *evolution* — e.g. string normalization rewriting literals into
+`!tok_*` references, or clause normalization adding generated rules to the
+rule's group.
+
+If the rule is missing at some stage, the trace says so and lists up to
+five case-insensitive near matches present at that stage (normalization
+renames things — `Rule_N`, `ListElem_*`, `tok_*`). A rule that matches at
+no stage at all fails the run with exit code 1, so typos are caught in
+scripts. Composes with `--debug-stage` (stop early) and with
+`--use-generated` (the token stage is internal to the generated front end,
+so it is reduced to a note and the trace starts after parsing).
+
+**Example:**
+```bash
+rtk test-grammars/grammar.pg test-out --debug-rule=Clause
+```
+
+**Output (abridged):**
+```
+======================================================================
+  RULE TRACE: 'Clause' - Tokens
+======================================================================
+Mentioned 11 time(s) in the token stream:
+  line 28, column 24: Id "Clause"
+  line 40, column 1: Id "Clause"
+  ...
+
+======================================================================
+  RULE TRACE: 'Clause' - After Parse
+======================================================================
+-- Rule 'Clause' (line 40, column 1)
+IRule
+  { getIDataTypeName = Nothing
+  , getIRuleName = "Clause"
+  , getIClause =
+      IAlt
+        [ ISeq
+            [ IId { getIdStr = "Clause" }
+            , IStrLit "|"
+            , IId { getIdStr = "Clause2" }
+            ]
+        , ISeq [ ILifted IId { getIdStr = "Clause2" } ]
+        ]
+  , ...
+  }
+-- Rule 'Clause2' (line 43, column 1)  [matches via its 'Clause' data type]
+...
+
+======================================================================
+  RULE TRACE: 'Clause' - After String Normalization
+======================================================================
+-- Rule 'Clause' (line 40, column 1)
+IRule
+  { ...
+  , getIClause =
+      IAlt
+        [ ISeq
+            [ IId { getIdStr = "Clause" }
+            , IIgnore IId { getIdStr = "tok__pipe__11" }   -- was IStrLit "|"
+            , IId { getIdStr = "Clause2" }
+            ]
+        , ... ]
+  }
+...
+
+======================================================================
+  RULE TRACE: 'Clause' - After Clause Normalization
+======================================================================
+  Clause (5 rules)
+    - Clause5: 6 alternatives
+    - Clause4: 4 alternatives
+    - Clause3: 3 alternatives
+    - Clause2: 2 alternatives
+    - Clause: 2 alternatives
+SyntaxRuleGroup
+  { getSDataTypeName = "Clause"
+  , getSRules =
+      [ SyntaxRule
+          { getSRuleName = "Clause5"
+          , getSClause =
+              STAltOfSeq
+                { getAltOfSeq =
+                    [ STSeq "Anti_Clause" [ SSId "qq_Clause" ]
+                    , ... ] } }
+      , ... ] }
+
+======================================================================
+  RULE TRACE: 'Clause' - After Constructor Fill
+======================================================================
+  ...same group, with the empty constructor names filled in:
+                    [ STSeq "Anti_Clause" [ SSId "qq_Clause" ]
+                    , STSeq
+                        "Ctr__Clause__0"
+                        [ SSIgnore "tok__lparen__7"
+                        , SSLifted "Clause"
+                        , SSIgnore "tok__rparen__8"
+                        ]
+                    , ... ]
+```
+
+**Use case:** Deep-dive debugging of problematic rules.
+
 ### `--debug-stage=STAGE`
 Stop after a specific stage and dump state.
 
@@ -302,7 +409,7 @@ rtk grammar.rtk out --stats --list-rules --show-rule-graph --unused-rules --chec
 
 ### Deep Debugging a Specific Rule
 ```bash
-rtk grammar.rtk out --expand-rule=myRule
+rtk grammar.rtk out --debug-rule=myRule --expand-rule=myRule
 ```
 
 ## Tips
@@ -316,10 +423,11 @@ rtk grammar.rtk out --expand-rule=myRule
 ## Implementation Status
 
 All options documented above are fully implemented. Earlier placeholder
-options that were advertised but never implemented (`--debug-rule`,
-`--compare-stages`, `--memory-stats`, `--debug-output-dir`, `--debug-log`,
-`--interactive`, and the `json`/`tree` debug formats) have been removed
-from the CLI; they can be reintroduced together with real implementations.
+options that were advertised but never implemented (`--compare-stages`,
+`--memory-stats`, `--debug-output-dir`, `--debug-log`, `--interactive`,
+and the `json`/`tree` debug formats) have been removed from the CLI; they
+can be reintroduced together with real implementations, as `--debug-rule`
+has been.
 
 ## See Also
 

--- a/Debug.hs
+++ b/Debug.hs
@@ -10,6 +10,12 @@ module Debug
     , printNormalGrammar
     , printComparison
 
+    -- * Single-rule pipeline trace
+    , traceRuleTokens
+    , traceRuleTokensUnavailable
+    , traceRuleInitial
+    , traceRuleNormal
+
     -- * Statistics and analysis
     , showGrammarStats
     , analyzeGrammarConflicts
@@ -37,10 +43,13 @@ module Debug
 import qualified Lexer as L
 import Parser
 import DebugOptions
+import Diagnostics (showSourcePos)
 import Text.Show.Pretty (ppShow)
+import Control.Monad (when)
+import Data.Char (toLower)
 import Data.Data (Data, gmapQ)
 import Data.Time.Clock (getCurrentTime, diffUTCTime, UTCTime)
-import Data.List (intercalate, nub, (\\))
+import Data.List (intercalate, isInfixOf, nub, (\\))
 import qualified Data.Map as M
 import qualified Data.Set as S
 import Data.Maybe (fromMaybe, mapMaybe)
@@ -153,6 +162,131 @@ printComparison opts title1 val1 title2 val2 = do
     if val1 == val2
         then withColor (debugColor opts) Green "No differences found.\n"
         else withColor (debugColor opts) Yellow "Differences detected.\n"
+
+-------------------------------------------------------------------------------
+-- Single-rule pipeline trace (--debug-rule)
+-------------------------------------------------------------------------------
+
+-- | Header shared by all stages of a rule trace
+traceSection :: DebugOptions -> String -> String -> IO ()
+traceSection opts ruleName stage =
+    debugSection opts $ "RULE TRACE: '" ++ ruleName ++ "' - " ++ stage
+
+-- | Token-stage view of a rule trace: every place the rule name is mentioned
+-- in the source, as Id tokens with their positions. Returns whether the rule
+-- was found at this stage.
+traceRuleTokens :: DebugOptions -> String -> [L.PosToken] -> IO Bool
+traceRuleTokens opts ruleName tokens = do
+    traceSection opts ruleName "Tokens"
+    let mentions = [pos | L.PosToken pos (L.Id name) <- tokens, name == ruleName]
+    if null mentions
+        then do
+            reportNotFoundAtStage opts ruleName [n | L.PosToken _ (L.Id n) <- tokens]
+            return False
+        else do
+            putStrLn $ "Mentioned " ++ show (length mentions) ++ " time(s) in the token stream:"
+            mapM_ (putStrLn . showMention) mentions
+            putStrLn ""
+            return True
+  where
+    showMention (L.AlexPn _ line col) =
+        "  line " ++ show line ++ ", column " ++ show col ++ ": Id " ++ show ruleName
+
+-- | Under --use-generated the front end has no separate token stream to
+-- inspect, so the token stage of a rule trace is just a note.
+traceRuleTokensUnavailable :: DebugOptions -> String -> IO ()
+traceRuleTokensUnavailable opts ruleName = do
+    traceSection opts ruleName "Tokens"
+    putStrLn "Token stage is internal to the generated front end; trace continues after parsing."
+    putStrLn ""
+
+-- | InitialGrammar-stage view of a rule trace (after parse, after
+-- string-norm): the IRules whose rule name or data type name matches, each
+-- headed by its source position.
+traceRuleInitial :: DebugOptions -> String -> String -> InitialGrammar -> IO Bool
+traceRuleInitial opts ruleName stage grammar = do
+    traceSection opts ruleName stage
+    let rules = getIRules grammar
+        matches = filter matchesRule rules
+        matchesRule r = getIRuleName r == ruleName
+                     || getIDataTypeName r == Just ruleName
+    if null matches
+        then do
+            reportNotFoundAtStage opts ruleName
+                (map getIRuleName rules ++ mapMaybe getIDataTypeName rules)
+            return False
+        else do
+            mapM_ printMatch matches
+            return True
+  where
+    printMatch rule = do
+        debugSubSection opts $
+            "Rule '" ++ getIRuleName rule ++ "' ("
+            ++ maybe "no position" showSourcePos (getIRulePos rule) ++ ")"
+        case debugFormat opts of
+            FormatPretty -> putStrLn $ ppShow rule
+            FormatCompact -> putStrLn $ show rule
+        putStrLn ""
+
+-- | NormalGrammar-stage view of a rule trace (after clause-norm, after
+-- constructor-fill): the syntax rule groups that define the rule (by data
+-- type name or by a contained rule name) plus any matching lexical rule,
+-- shown compactly, with the full structure in pretty format.
+traceRuleNormal :: DebugOptions -> String -> String -> NormalGrammar -> IO Bool
+traceRuleNormal opts ruleName stage grammar = do
+    traceSection opts ruleName stage
+    let groups = getSyntaxRuleGroups grammar
+        lRules = getLexicalRules grammar
+        proxyRules = getProxyRules (getGrammarInfo grammar)
+        matchingGroups = filter groupMatches groups
+        groupMatches g = getSDataTypeName g == ruleName
+                      || any ((== ruleName) . getSRuleName) (getSRules g)
+        matchingLexical = filter ((== ruleName) . getLRuleName) lRules
+    if null matchingGroups && null matchingLexical
+        then do
+            reportNotFoundAtStage opts ruleName $
+                map getSDataTypeName groups
+                ++ concatMap (map getSRuleName . getSRules) groups
+                ++ map getLRuleName lRules
+            return False
+        else do
+            mapM_ (printGroup proxyRules) matchingGroups
+            mapM_ printLexical matchingLexical
+            return True
+  where
+    printGroup proxyRules grp = do
+        showRuleGroup opts proxyRules grp
+        printDetail grp
+    printLexical rule = do
+        showLexicalRule opts rule
+        printDetail rule
+    printDetail :: Show a => a -> IO ()
+    printDetail x = do
+        when (debugFormat opts == FormatPretty) $
+            putStrLn $ ppShow x
+        putStrLn ""
+
+-- | Report a rule missing at one stage, with near matches: normalization
+-- renames things (Rule_N, ListElem_*, tok_*), so suggestions keep the trace
+-- usable across stages.
+reportNotFoundAtStage :: DebugOptions -> String -> [String] -> IO ()
+reportNotFoundAtStage opts ruleName names = do
+    withColor (debugColor opts) Yellow $
+        "Rule '" ++ ruleName ++ "' is not present at this stage.\n"
+    let suggestions = take 5 (nearMatches ruleName names)
+    when (not (null suggestions)) $ do
+        putStrLn "Near matches:"
+        mapM_ (putStrLn . ("  - " ++)) suggestions
+    putStrLn ""
+
+-- | Case-insensitive near matches: equal up to case, or one name contained
+-- in the other (catches tok_foo, Foo_1, ListElem_Foo style renames)
+nearMatches :: String -> [String] -> [String]
+nearMatches query names = filter close (nub names)
+  where
+    q = lower query
+    close name = let n = lower name in q `isInfixOf` n || n `isInfixOf` q
+    lower = map toLower
 
 -------------------------------------------------------------------------------
 -- Statistics and analysis

--- a/DebugOptions.hs
+++ b/DebugOptions.hs
@@ -51,6 +51,7 @@ data DebugOptions = DebugOptions
     , listRules :: Bool
 
     -- Selective debug
+    , debugRule :: Maybe String
     , debugStage :: Maybe DebugStage
 
     -- Validation
@@ -86,6 +87,7 @@ defaultDebugOptions file dir = DebugOptions
     , analyzeConflicts = False
     , showRuleGraph = False
     , listRules = False
+    , debugRule = Nothing
     , debugStage = Nothing
     , validateGrammar = False
     , showUnusedRules = False
@@ -175,6 +177,10 @@ debugOptionsParser = DebugOptions
        <> help "List all rule names by category" )
 
     -- Selective debug
+    <*> optional (strOption
+        ( long "debug-rule"
+       <> metavar "RULENAME"
+       <> help "Debug a specific rule through all stages" ))
     <*> optional (option (maybeReader parseStage)
         ( long "debug-stage"
        <> metavar "STAGE"

--- a/app/main.hs
+++ b/app/main.hs
@@ -12,7 +12,8 @@ import DebugOptions
 import qualified Debug as D
 import Control.Monad (when)
 import Data.Data (Data)
-import Data.Maybe (catMaybes)
+import Data.IORef (newIORef, readIORef, writeIORef)
+import Data.Maybe (catMaybes, isJust)
 import Control.Exception (evaluate)
 import System.IO (hPutStrLn, stderr)
 import System.Exit (exitSuccess, exitWith, ExitCode (ExitFailure))
@@ -24,6 +25,16 @@ main = do
 
     -- Load grammar file
     content <- readFile (grammarFile opts)
+
+    -- --debug-rule: trace one rule through the pipeline, printing only its
+    -- representation after each stage. Remember whether it was seen at any
+    -- stage so an unknown name can fail the run at the end (catches typos).
+    ruleFound <- newIORef False
+    let traceRule trace = case debugRule opts of
+            Just name -> do
+                found <- trace name
+                when found $ writeIORef ruleFound True
+            Nothing -> return ()
 
     -- Stages 1-2: front end (lexing and parsing). --use-generated swaps the
     -- hand-written lexer/parser for the ones RTK generated from
@@ -38,6 +49,9 @@ main = do
                 (eGrammar, maybeT) <- runStage opts "Front End (generated)" $
                     parseWithGenerated content
                 g <- orDie opts eGrammar
+                traceRule $ \name -> do
+                    D.traceRuleTokensUnavailable opts name
+                    return False
                 when (debugStage opts == Just StageLex)
                     exitAfterDebug
                 return (g, [maybeT])
@@ -53,6 +67,8 @@ main = do
                 when (debugTokens opts) $
                     D.printTokens opts tokens
 
+                traceRule $ \name -> D.traceRuleTokens opts name tokens
+
                 when (debugStage opts == Just StageLex)
                     exitAfterDebug
 
@@ -64,6 +80,8 @@ main = do
     when (debugParse opts) $
         D.printInitialGrammar opts grammar
 
+    traceRule $ \name -> D.traceRuleInitial opts name "After Parse" grammar
+
     when (debugStage opts == Just StageParse)
         exitAfterDebug
 
@@ -72,6 +90,8 @@ main = do
 
     when (debugStringNorm opts) $
         D.printComparison opts "Before String Normalization" grammar "After String Normalization" grammar0
+
+    traceRule $ \name -> D.traceRuleInitial opts name "After String Normalization" grammar0
 
     when (debugStage opts == Just StageStringNorm)
         exitAfterDebug
@@ -83,6 +103,8 @@ main = do
     when (debugClauseNorm opts) $
         D.printNormalGrammar opts "CLAUSE NORMALIZATION OUTPUT" grammar1
 
+    traceRule $ \name -> D.traceRuleNormal opts name "After Clause Normalization" grammar1
+
     when (debugStage opts == Just StageClauseNorm)
         exitAfterDebug
 
@@ -91,6 +113,19 @@ main = do
 
     when (debugConstructors opts) $
         D.printNormalGrammar opts "FINAL GRAMMAR (with Constructor Names)" grammar2
+
+    traceRule $ \name -> D.traceRuleNormal opts name "After Constructor Fill" grammar2
+
+    -- Constructor fill is the last traced stage: a rule that matched nowhere
+    -- can only be a typo, so fail the run
+    case debugRule opts of
+        Just name -> do
+            found <- readIORef ruleFound
+            when (not found) $ do
+                hPutStrLn stderr $
+                    "rtk: rule '" ++ name ++ "' was not found at any pipeline stage"
+                exitWith (ExitFailure 1)
+        Nothing -> return ()
 
     when (debugStage opts == Just StageFillNames)
         exitAfterDebug
@@ -172,7 +207,8 @@ main = do
     when (not $ any id [debugTokens opts, debugParse opts, debugStringNorm opts,
                         debugClauseNorm opts, debugConstructors opts,
                         debugParserSpec opts, debugLexerSpec opts, debugQQSpec opts,
-                        showStats opts, validateGrammar opts]) $ do
+                        showStats opts, validateGrammar opts,
+                        isJust (debugRule opts)]) $ do
         putStrLn $ "Successfully generated files for " ++ grammar_name
 
 -- | Either surface a pipeline diagnostic on stderr and exit 1, or return the

--- a/test-debug-options.sh
+++ b/test-debug-options.sh
@@ -44,6 +44,60 @@ test_option() {
     fi
 }
 
+# Function to test an option that must fail (non-zero exit) with a pattern
+test_option_fails() {
+    local test_name="$1"
+    local option="$2"
+    local expected_pattern="$3"
+
+    echo -n "Testing $test_name... "
+
+    # Run rtk with the option and capture output (expecting failure)
+    if output=$($RTK_EXEC "$GRAMMAR" "$OUT_DIR" $option 2>&1); then
+        echo -e "${RED}FAIL${NC} - Expected non-zero exit code"
+        ((failed++))
+        return 1
+    fi
+
+    if echo "$output" | grep -q "$expected_pattern"; then
+        echo -e "${GREEN}PASS${NC}"
+        ((passed++))
+        return 0
+    else
+        echo -e "${RED}FAIL${NC} - Expected pattern '$expected_pattern' not found in output"
+        ((failed++))
+        return 1
+    fi
+}
+
+# Function to test an option whose output must contain several patterns
+test_option_multi() {
+    local test_name="$1"
+    local option="$2"
+    shift 2
+
+    echo -n "Testing $test_name... "
+
+    if ! output=$($RTK_EXEC "$GRAMMAR" "$OUT_DIR" $option 2>&1); then
+        echo -e "${RED}FAIL${NC} - Command failed with exit code $?"
+        ((failed++))
+        return 1
+    fi
+
+    local pattern
+    for pattern in "$@"; do
+        if ! echo "$output" | grep -qF "$pattern"; then
+            echo -e "${RED}FAIL${NC} - Expected pattern '$pattern' not found in output"
+            ((failed++))
+            return 1
+        fi
+    done
+
+    echo -e "${GREEN}PASS${NC}"
+    ((passed++))
+    return 0
+}
+
 # Function to test option with file output
 test_option_file() {
     local test_name="$1"
@@ -116,6 +170,24 @@ echo "=== Selective Debug ==="
 # --debug-stage stops the pipeline early and must exit successfully
 test_option "--debug-stage=lex" "--debug-stage=lex" "Stopped after requested debug stage"
 test_option "--debug-stage=parse" "--debug-stage=parse" "Stopped after requested debug stage"
+# --debug-rule traces one rule through the pipeline: one block per stage
+test_option_multi "--debug-rule=Clause" "--debug-rule=Clause" \
+    "RULE TRACE: 'Clause' - Tokens" \
+    "RULE TRACE: 'Clause' - After Parse" \
+    "RULE TRACE: 'Clause' - After String Normalization" \
+    "RULE TRACE: 'Clause' - After Clause Normalization" \
+    "RULE TRACE: 'Clause' - After Constructor Fill"
+# an unknown rule must fail the run and suggest near matches
+test_option_fails "--debug-rule=clause (unknown, suggests)" "--debug-rule=clause" "Near matches"
+test_option_fails "--debug-rule=NoSuchRule (unknown)" "--debug-rule=NoSuchRule" "not found at any pipeline stage"
+# --debug-rule composes with --debug-stage: stop early, exit 0
+test_option_multi "--debug-rule=Clause --debug-stage=parse" "--debug-rule=Clause --debug-stage=parse" \
+    "RULE TRACE: 'Clause' - After Parse" \
+    "Stopped after requested debug stage"
+# under --use-generated the token stage is only a note, the rest works
+test_option_multi "--use-generated --debug-rule=Clause" "--use-generated --debug-rule=Clause" \
+    "internal to the generated front end" \
+    "RULE TRACE: 'Clause' - After Constructor Fill"
 echo ""
 
 echo "=== Output Format ==="


### PR DESCRIPTION
Bring back --debug-rule (removed as a never-implemented no-op in the CLI
cleanup) with a real implementation: trace ONE rule through the pipeline,
printing only that rule's representation after each stage instead of
full-grammar dumps. Where --expand-rule shows a rule's final expanded
form, this flag shows its evolution:

- Tokens: every Id mention of the rule in the source, with line/column
  (under --use-generated, a note that the token stage is internal to the
  generated front end)
- After parse / after string normalization: the matching IRules (by rule
  name or data type name) headed by their source position, making the
  literal-to-!tok_* rewrites visible side by side
- After clause normalization / constructor fill: the matching syntax rule
  groups and lexical rules, compact summary plus full structure

When the rule is missing at a stage the trace says so and lists up to
five case-insensitive near matches (normalization renames things --
Rule_N, ListElem_*, tok_*). A rule found at no stage at all fails the
run with exit 1, so typos don't go unnoticed in scripts. Composes with
--debug-stage (stop early); generation still runs, but the success
message is suppressed like for the other inspection flags.

The per-stage trace functions in Debug.hs are kept composable for the
upcoming --compare-stages work. CLI layer only: no generator changes,
no golden changes. test-debug-options.sh covers the full trace, both
unknown-rule failure modes, --debug-stage composition and
--use-generated.

https://claude.ai/code/session_019HNSbRsP81dA8urSueHcN5