### PR TITLE
Capture source positions in generated ASTs, position-transparently

### DIFF
--- a/BOOTSTRAP.md
+++ b/BOOTSTRAP.md
@@ -37,43 +37,44 @@ regenerates that parser byte-for-byte.
 
 - `cabal test golden` runs **every** grammar in `test-grammars/` through both
   front ends; both must reproduce the snapshots in `test/golden/`
-  byte-for-byte (except the three grammars pinned for divergences 5 and 6
+  byte-for-byte (except the three grammars pinned for divergences 4 and 5
   below, which are checked hand-written-only plus a still-diverges guard).
 - `cabal test unit` parses every grammar with both front ends and asserts
-  the `InitialGrammar`s are equal after stripping source positions (same
-  three pinned exceptions, with the same guard).
+  the `InitialGrammar`s are equal, source positions included (same three
+  pinned exceptions, with the same guard).
 
 ### Known divergences (accepted and documented)
 
 These do not affect generated artifacts for any grammar in the corpus — the
 equivalence harness proves it — but they are real behavioral deltas:
 
-1. **Error reporting.** The generated front end reports `Either String` with
-   the line/column rendered into the message text; the hand-written front end
-   reports structured `Either Diagnostic` (so `--use-generated` errors lack
-   the `FILE:LINE:COL:` prefix). Converges further in task 7b.
-2. **No `getIRulePos` capture.** Rule positions are `Nothing` under
-   `--use-generated` until task 7b. Positions never reach the generated
-   artifacts, so output is unaffected.
-3. **Nested comments.** The generated lexer cannot lex nested
+1. **Lexer/parser error reporting.** The generated lexer and parser report
+   `Either String` with the line/column rendered into the message text; the
+   hand-written front end reports structured `Either Diagnostic` (so a
+   `--use-generated` *parse* error lacks the `FILE:LINE:COL:` prefix).
+   Everything after parsing is converged: generated ASTs carry the position
+   of every constructor's first token, the adapter maps rule positions into
+   `getIRulePos`, and diagnostics from the shared pipeline (normalization,
+   generation) are identical under both front ends.
+2. **Nested comments.** The generated lexer cannot lex nested
    `/* /* */ */` comments (hand-written lexer can; GitHub issue #25). No
    corpus grammar nests comments.
-4. **Adjacent `"""…"""` blocks.** The hand-written path concatenates adjacent
+3. **Adjacent `"""…"""` blocks.** The hand-written path concatenates adjacent
    triple-quoted blocks (`catBigstrs`); the generated grammar accepts a
    single block after `imports`. Only `grammar.pg` uses `imports`, with one
    block, so this is theoretical today.
-5. **Empty alternatives.** The hand-written parser accepts `Gd = | ExpI ;`
+4. **Empty alternatives.** The hand-written parser accepts `Gd = | ExpI ;`
    (an empty first alternative, used by `test-grammars/haskell.pg`);
    grammar.pg's own clause syntax cannot derive an empty alternative, so the
    generated front end rejects the file. One of the two definitions of the
    grammar language has to win here — follow-up work.
-6. **Redundant parentheses are grouping to the hand-written parser.**
+5. **Redundant parentheses are grouping to the hand-written parser.**
    `(ImportStatement)*` (java.pg) and `(A B) C` (t1.pg) parse to nested
    `IAlt [ISeq …]` groups that normalize into extra proxy sub-rules;
    grammar.pg's `Clause5 = '(' ,Clause ')'` lifts the group, so the parens
    are absent from the generated AST and the artifacts genuinely differ.
 
-Because of 5 and 6, three grammars (`haskell`, `java`, `t1`) are pinned in
+Because of 4 and 5, three grammars (`haskell`, `java`, `t1`) are pinned in
 `test/TestSupport.hs` (`frontEndDivergentGrammars`): the golden suite checks
 them with the hand-written front end only, and both suites fail as soon as a
 pinned grammar stops diverging so the pin gets dropped. Every other grammar
@@ -151,14 +152,17 @@ This focuses the comparison on actual semantic differences rather than formattin
 
 1. ✅ **Verify grammar completeness**: `test-grammars/grammar.pg` parses the
    corpus, surfacing exactly two constructs the hand-written parser supports
-   beyond the spec (divergences 5 and 6 above)
+   beyond the spec (divergences 4 and 5 above)
 2. ✅ **Test equivalence**: both front ends reproduce identical artifacts for
    every corpus grammar except the three pinned divergent ones
 3. ✅ **Dual-mode entry point**: `--use-generated` switches `main.hs` to the
    generated front end
 4. ✅ **Bootstrap cycle**: `rtk --use-generated grammar.pg` regenerates its own
    parser byte-for-byte (the fixed point)
-5. **Structured positions in the generated path** (task 7b)
+5. ✅ **Structured positions in the generated path**: every generated AST
+   constructor carries the position of its first token (equality-transparent
+   `RtkPos`), the adapter maps rule positions into `getIRulePos`, and the
+   AST equality suite compares positions too
 6. **Retire hand-written files**: make generated mode the default, keep
    `Lexer.x`/`Parser.y` as reference
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Source positions in generated ASTs: every constructor that generated
+  parsers build (except the quasi-quotation-only `Anti_*` splice
+  constructors) now stores the position of its alternative's first symbol
+  in a leading `RtkPos` field. `RtkPos` is transparent for equality and
+  ordering (`==` always holds, `compare` is always `EQ`), so ASTs that
+  differ only in source positions compare equal — in particular a
+  quasi-quote parsed at compile time still matches the same construct
+  parsed at run time, and quasi-quote *patterns* wildcard every position
+  field while *expressions* may embed them. Payload-carrying `%token`
+  bindings now bind the whole positioned token, with generated `tkVal_*`
+  extractors recovering the payload in semantic actions; a generated
+  `RtkPosOf` class projects the position of any symbol (tokens,
+  nonterminals, lists, optionals). Generated code stays dependency-free.
+  The self-hosted front end now maps the rule constructors' positions into
+  `getIRulePos` (previously `Nothing` under `--use-generated`), so
+  pipeline diagnostics carry real `FILE:LINE:COL:` positions with both
+  front ends, and the dual-front-end AST equality suite compares positions
+  too. The hand-written parser's position for the `'.' id ':' …` rule form
+  moved from the identifier to the leading dot (a rule's position is where
+  the rule starts), aligning it with first-symbol capture; no corpus
+  grammar uses that form
 - Self-hosting milestone (Prototype 2 closed): `rtk --use-generated` parses
   grammar files with the lexer/parser RTK generated from
   `test-grammars/grammar.pg`. The generated modules are compiled into rtk

--- a/GenAST.hs
+++ b/GenAST.hs
@@ -1,4 +1,4 @@
-module GenAST (genAST)
+module GenAST (genAST, isAntiConstructor)
     where
 
 import Parser
@@ -8,6 +8,15 @@ import Grammar
 import qualified Data.Map as Map
 import qualified Data.List as List
 import Data.Maybe (mapMaybe)
+
+-- Anti_* constructors are compile-time artifacts: they exist only so a
+-- $Type:var quasi-quote splice has a constructor to reduce to, and they are
+-- replaced by the spliced variable during Template Haskell expansion. They
+-- never describe a source construct, so they are exempt from position
+-- capture (no leading RtkPos field). The Anti_ naming convention is owned by
+-- Normalize.addAntiRuleCached, which builds every such constructor name.
+isAntiConstructor :: ConstructorName -> Bool
+isAntiConstructor = List.isPrefixOf "Anti_"
 
 normalRulesNamed :: [SyntaxRuleGroup] -> [(ID, SyntaxTopClause)]
 normalRulesNamed groups = map (\g -> (getSDataTypeName g, combineClauses $ map getSClause $ getSRules g))
@@ -63,12 +72,32 @@ genData rmap name sequences = do
     ctors <- mapM (genConstructor rmap name) sequences'
     return $ text "data" <+> text name <+> text "=" <+> (joinAlts ctors
                                                          $$ text "deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)")
+             $$ genPosInstance name sequences'
     where sequences' = filter needGenereateAlt sequences
+
+-- Every non-anti constructor stores its source position in its first field,
+-- so projecting a node's position is one pattern match per constructor.
+-- List and Maybe rules are type synonyms and are covered by the generic
+-- [a]/Maybe instances emitted with the RtkPos definitions in GenY.
+genPosInstance :: String -> [STSeq] -> Doc
+genPosInstance name sequences =
+    text "instance RtkPosOf" <+> text name <+> text "where"
+    $$ nest 4 (vcat (map arm sequences))
+    where arm (STSeq constructor clauses) =
+            let wildcards = hsep (replicate (fieldCount clauses) (text "_")) in
+              if isAntiConstructor constructor
+                then text "rtkPosOf" <+> parens (text constructor <+> wildcards) <+> text "= rtkNoPos"
+                else text "rtkPosOf" <+> parens (text constructor <+> text "p" <+> wildcards) <+> text "= p"
+          fieldCount = length . filter isField
+          isField SSId{} = True
+          isField _      = False
 
 genConstructor :: RulesMap -> String -> STSeq -> Either Diagnostic Doc
 genConstructor rmap refType (STSeq constructor clauses) = do
     items <- mapM (genSimpleItem rmap refType) clauses
-    return $ text constructor <+> hsep items
+    let fields | isAntiConstructor constructor = items
+               | otherwise                     = text "RtkPos" : items
+    return $ text constructor <+> hsep fields
 
 genItem :: RulesMap -> String -> SyntaxTopClause -> Either Diagnostic Doc
 genItem rmap refType (STMany _ cl _) = brackets <$> genSimpleItem rmap refType cl

--- a/GenQ.hs
+++ b/GenQ.hs
@@ -74,6 +74,14 @@ replaceAllPatterns str = init <$> replaceAllPatterns1 (str ++ " ")
 
 ?qqShortCutsMapDef
 
+-- A quasi-quote pattern must match an AST parsed from anywhere in a source
+-- file, while the pattern itself was parsed from the quote body - so every
+-- RtkPos position field becomes a wildcard in generated patterns.
+-- (Expressions need no special case: the compile-time position they embed
+-- is equality-transparent.)
+rtkPosWildPat :: RtkPos -> Maybe (TH.Q TH.Pat)
+rtkPosWildPat _ = Just TH.wildP
+
 ?(qqFunProtoGen expType)
 ?(qqFunImplGen expType)
 ?(qqFunProtoGen pat)
@@ -93,7 +101,11 @@ replaceAllPatterns str = init <$> replaceAllPatterns1 (str ++ " ")
           typeNames = map arQQName antiRules
           antiNameGen typ n = "anti" ++ n ++ typ
           antiTermGen typ = map (antiNameGen typ) typeNames
-          antiExprsGen typ = foldr (\antiTerm res -> [str|?res `Generics.extQ` ?antiTerm|]) "const Nothing" $ antiTermGen typ
+          -- Patterns additionally wildcard every RtkPos field (see
+          -- rtkPosWildPat in the generated module)
+          extBase "Pat" = "const Nothing `Generics.extQ` rtkPosWildPat"
+          extBase _     = "const Nothing"
+          antiExprsGen typ = foldr (\antiTerm res -> [str|?res `Generics.extQ` ?antiTerm|]) (extBase typ) $ antiTermGen typ
           antiFunsGen typ = map (\(AntiRule tdName qqName consName isList) ->
                                         let antiName = antiNameGen typ qqName
                                             varConstructor = case typ of
@@ -165,7 +177,7 @@ replaceAllPatterns str = init <$> replaceAllPatterns1 (str ++ " ")
                                                getFun = "get" ++ typeName
                                                dataConstructor = constructorFor typeName
                                            in
-                                             [str|?getFun ( ?dataConstructor s) = s
+                                             [str|?getFun ( ?dataConstructor _ s) = s
 
 ?sortFunName :: QuasiQuoter
 ?sortFunName = QuasiQuoter (?(qqFunName expType) ?dummy ?getFun ) (?(qqFunName pat) ?dummy ?getFun ) ?(qqFunName "Type") ?(qqFunName "Decs")

--- a/GenX.hs
+++ b/GenX.hs
@@ -67,9 +67,18 @@ genX (NormalGrammar { getNGrammarName = name, getLexicalRules = tokens, getNImpo
     where macroIds = getMacroIds tokens
           symMacroIds = getSymMacroIds tokens
           adt = genTokenADT $ removeSymmacros tokens
-          header = vcat [text "{", ((text "module" <+> text name) <> text "Lexer(scanTokens, alexScanTokens, Token(..), PosToken(..), AlexPosn(..))"), text "where", text imports, text " }",
+          header = vcat [text "{",
+                         text "{-# LANGUAGE StandaloneDeriving, DeriveDataTypeable #-}",
+                         ((text "module" <+> text name) <> text "Lexer(scanTokens, alexScanTokens, Token(..), PosToken(..), AlexPosn(..))"), text "where",
+                         text "import Data.Data (Data)",
+                         text imports, text " }",
                          text "%wrapper \"monad\""]
           funs_text = [str|
+-- AlexPosn is defined by the alex wrapper, so the Data instance (required by
+-- the parser's RtkPos position type) can only be attached via standalone
+-- deriving - the same solution as the hand-written Lexer.x
+deriving instance Data AlexPosn
+
 -- A token together with the source position where it starts
 data PosToken = PosToken { ptPos :: AlexPosn, ptToken :: Token }
                 deriving (Show)

--- a/GenY.hs
+++ b/GenY.hs
@@ -1,12 +1,15 @@
+{-# LANGUAGE QuasiQuotes #-}
 module GenY (genY)
     where
 
 import Parser
 import Diagnostics (Diagnostic)
 import Text.PrettyPrint hiding ((<>))
+import qualified Data.List as List
 import qualified Data.Set as Set
 import GenAST
 import Grammar
+import StrQuote
 
 genY :: NormalGrammar -> Either Diagnostic String
 genY g@(NormalGrammar name srules lex_rules _ _ _ _) = do
@@ -31,6 +34,7 @@ genY g@(NormalGrammar name srules lex_rules _ _ _ _) = do
                   ]
     where normal_rules = normalRules srules
           listRuleSet = makeListRuleSet normal_rules
+          payloadTokens = makePayloadTokenSet lex_rules
           -- The start rule is wrapped so that the parser consumes the
           -- EndOfFile token emitted by the lexer; this way errors at end of
           -- input are reported by parseError with a real source position
@@ -38,7 +42,7 @@ genY g@(NormalGrammar name srules lex_rules _ _ _ _) = do
                            (r : _) -> [(text (name ++ "__top") <+> text ":" <+> text (getSRuleName r)
                                         <+> text "rtk__eof" <+> text "{ $1 }") <> text "\n"]
                            []      -> []
-          rulesDoc = vcat (startWrapper ++ map (genRule listRuleSet) normal_rules)
+          rulesDoc = vcat (startWrapper ++ map (genRule listRuleSet payloadTokens) normal_rules)
           lexDoc = vcat (combineAlt (text "rtk__eof") (text "L.PosToken _ L.EndOfFile")
                          : map genToken (removeSymmacros lex_rules))
           nl = text ""
@@ -56,7 +60,12 @@ genY g@(NormalGrammar name srules lex_rules _ _ _ _) = do
                                          : text "showRtkToken :: L.Token -> String"
                                          : text "showRtkToken L.EndOfFile = \"end of input\""
                                          : map genShowToken (removeSymmacros lex_rules))
-          footer ast = "{\n" ++ parseErrorDefs ++ "\n" ++ showTokenDefs ++ "\n\n" ++ ast ++ "\n}"
+          posDefs = genPosDefs lex_rules
+          tkValDefs = render $ vcat (text "-- Recover a token's payload from the whole positioned token: %token"
+                                     : text "-- bindings keep the L.PosToken so semantic actions can read its position"
+                                     : map genTkVal (removeSymmacros lex_rules))
+          footer ast = "{\n" ++ parseErrorDefs ++ "\n" ++ showTokenDefs ++ "\n\n" ++ posDefs
+                       ++ "\n" ++ tkValDefs ++ "\n\n" ++ ast ++ "\n}"
 
 type ListRuleSet = Set.Set ID
 
@@ -65,13 +74,76 @@ makeListRuleSet lst = Set.fromList $ map getSRuleName $ filter isMany lst
     where isMany (SyntaxRule { getSClause = STMany{} }) = True
           isMany _ = False
 
+-- The tokens that carry a payload (everything except keywords, which are
+-- their own value, and ignored tokens, which never reach the parser).
+-- References to them in semantic actions go through a tkVal_* extractor.
+type PayloadTokenSet = Set.Set ID
+
+makePayloadTokenSet :: [LexicalRule] -> PayloadTokenSet
+makePayloadTokenSet lst = Set.fromList [ name | LexicalRule{ getLRuleName = name, getLRuleDataType = dt } <- lst
+                                        , not (dt == "Keyword" || dt == "Ignore") ]
+
+-- The RtkPos machinery shared by all generated parsers, plus one dummy
+-- RtkPosOf instance per non-String token payload type (String is covered by
+-- the Char instance through [a]); a list or optional rule over such a token
+-- is a type synonym, and projecting its position goes through the payload.
+genPosDefs :: [LexicalRule] -> String
+genPosDefs lex_rules =
+    [str|-- Source position of a node: every constructor except the Anti_* splice
+-- artifacts stores the position of its alternative's first symbol in its
+-- first field. Positions are transparent for equality and ordering, so two
+-- ASTs that differ only in source positions (e.g. a quasi-quote parsed at
+-- compile time vs the same construct parsed at run time) compare equal.
+newtype RtkPos = RtkPos L.AlexPosn deriving (Show, Gen.Data, Gen.Typeable)
+instance Eq RtkPos where _ == _ = True
+instance Ord RtkPos where compare _ _ = EQ
+
+-- The position used where no source token exists: empty productions, empty
+-- lists, absent optionals and Anti_* quasi-quote splices
+rtkNoPos :: RtkPos
+rtkNoPos = RtkPos (L.AlexPn 0 0 0)
+
+class RtkPosOf a where
+    rtkPosOf :: a -> RtkPos
+instance RtkPosOf L.PosToken where
+    rtkPosOf (L.PosToken p _) = RtkPos p
+instance RtkPosOf a => RtkPosOf [a] where
+    rtkPosOf (x : _) = rtkPosOf x
+    rtkPosOf []      = rtkNoPos
+instance RtkPosOf a => RtkPosOf (Maybe a) where
+    rtkPosOf (Just x) = rtkPosOf x
+    rtkPosOf Nothing  = rtkNoPos
+-- A Char carries no position; this also covers String token payloads
+instance RtkPosOf Char where
+    rtkPosOf _ = rtkNoPos
+|] ++ payloadInstances
+    where payloadInstances =
+              concat [ "instance RtkPosOf " ++ dt ++ " where rtkPosOf _ = rtkNoPos\n"
+                     | dt <- List.nub [ dt | LexicalRule{ getLRuleDataType = dt } <- lex_rules ]
+                     , dt `notElem` ["Keyword", "Ignore", "String", "Char"] ]
+
 genToken :: LexicalRule -> Doc
 genToken LexicalRule{ getLRuleName = name, getLRuleDataType = dtn } =
     case dtn of
         "Keyword" -> combineAlt (text name) (text "L.PosToken _ L." <> text (tokenName name))
         "Ignore"  -> empty
-        _         -> combineAlt (text name) (text "L.PosToken _ (L." <> text (tokenName name) <> text " $$)")
+        -- payload tokens bind the whole positioned token (not a $$
+        -- projection), so semantic actions can take their position; the
+        -- payload is recovered with the tkVal_* extractor at the use site
+        _         -> combineAlt (text name) (text "L.PosToken _ (L." <> text (tokenName name) <> text " _)")
 genToken (MacroRule _ _) = empty
+
+genTkVal :: LexicalRule -> Doc
+genTkVal LexicalRule{ getLRuleName = name, getLRuleDataType = dtn } =
+    case dtn of
+        "Keyword" -> empty
+        "Ignore"  -> empty
+        _         -> vcat [ text ("tkVal_" ++ name ++ " :: L.PosToken -> " ++ dtn)
+                          , text ("tkVal_" ++ name ++ " (L.PosToken _ (L." ++ tokenName name ++ " v)) = v")
+                          , text ("tkVal_" ++ name ++ " t = error (\"rtk internal error: token "
+                                  ++ name ++ " expected, got \" ++ showRtkToken (L.ptToken t))")
+                          ]
+genTkVal (MacroRule _ _) = empty
 
 genShowToken :: LexicalRule -> Doc
 genShowToken LexicalRule{ getLRuleName = name, getLRuleDataType = dtn, getLClause = cl } =
@@ -83,47 +155,49 @@ genShowToken LexicalRule{ getLRuleName = name, getLRuleDataType = dtn, getLClaus
           keywordText _           = name
 genShowToken (MacroRule _ _) = empty
 
-genRule :: ListRuleSet -> SyntaxRule -> Doc
+genRule :: ListRuleSet -> PayloadTokenSet -> SyntaxRule -> Doc
 -- <Rule>* with separator can only be expressed using two rules in LR grammar
--- Will do it here 
-genRule listRuleSet SyntaxRule{ getSClause = (STMany STStar cl (Just cl1)), getSRuleName = name } = 
+-- Will do it here
+genRule lrs toks SyntaxRule{ getSClause = (STMany STStar cl (Just cl1)), getSRuleName = name } =
     let lstName = name ++ "__plus_list_"
     in
       vcat [
-            ((text lstName) <+> (text ":") <+> (genTopClause listRuleSet lstName 
+            ((text lstName) <+> (text ":") <+> (genTopClause lrs toks lstName
                                                (STMany STPlus cl (Just cl1)))) <> text "\n",
             ((text name) <+> (text ":") <+> (genOptPlusClause lstName)) <> text "\n"
            ]
-          
 
-genRule listRuleSet SyntaxRule{ getSClause = cl, getSRuleName = name } = 
-    ((text name) <+> (text ":") <+> (genTopClause listRuleSet name cl)) <> text "\n"
 
-genTopClause :: ListRuleSet -> String -> SyntaxTopClause -> Doc
+genRule lrs toks SyntaxRule{ getSClause = cl, getSRuleName = name } =
+    ((text name) <+> (text ":") <+> (genTopClause lrs toks name cl)) <> text "\n"
+
+genTopClause :: ListRuleSet -> PayloadTokenSet -> String -> SyntaxTopClause -> Doc
 
 -- Ignore is not expected in the cl
-genTopClause _ rn (STMany op cl Nothing) = joinAlts [base, step]
+genTopClause _ toks rn (STMany op cl Nothing) = joinAlts [base, step]
     where (baseAlt,alt) = case op of
-                            STStar -> ("[]", emptyAlt)
-                            STPlus -> ("[$1]", clDoc)
-          base = combineAlt alt (text baseAlt)
-          step = combineAlt (text rn <+> clDoc) (text "$2 : $1")
+                            STStar -> (text "[]", emptyAlt)
+                            STPlus -> (brackets (clRef 1), clDoc)
+          base = combineAlt alt baseAlt
+          step = combineAlt (text rn <+> clDoc) (clRef 2 <+> text ": $1")
           clDoc = genSimpleClause cl
+          clRef = tokenAwareRef toks cl
 
-genTopClause _ rn (STMany STPlus cl (Just cl1)) = joinAlts [base, step]
-    where base = combineAlt clDoc (text "[$1]")
-          step = combineAlt (text rn <+> genSimpleClause cl1 <+> clDoc) (text "$3 : $1")
+genTopClause _ toks rn (STMany STPlus cl (Just cl1)) = joinAlts [base, step]
+    where base = combineAlt clDoc (brackets (clRef 1))
+          step = combineAlt (text rn <+> genSimpleClause cl1 <+> clDoc) (clRef 3 <+> text ": $1")
           clDoc = genSimpleClause cl
+          clRef = tokenAwareRef toks cl
 
-genTopClause _ _ (STMany STStar _ (Just _)) = error "STMany with STStar and separator not supported in this position"
+genTopClause _ _ _ (STMany STStar _ (Just _)) = error "STMany with STStar and separator not supported in this position"
 
-genTopClause lrs _ (STOpt cl) = joinAlts [present, not_present]
+genTopClause lrs toks _ (STOpt cl) = joinAlts [present, not_present]
     where present = combineAlt (genSimpleClause cl)
                                (text "Just" <+> constructor_call)
-          constructor_call = hsep $ enumClauses lrs [cl]
+          constructor_call = hsep $ enumClauses lrs toks [cl]
           not_present = combineAlt emptyAlt (text "Nothing")
 
-genTopClause lrs _ (STAltOfSeq clauses) = joinAlts $ map (genClauseSeq lrs) clauses
+genTopClause lrs toks _ (STAltOfSeq clauses) = joinAlts $ map (genClauseSeq lrs toks) clauses
 
 genOptPlusClause :: String -> Doc
 genOptPlusClause lstName = joinAlts [present, not_present]
@@ -131,13 +205,27 @@ genOptPlusClause lstName = joinAlts [present, not_present]
                                (text "$1")
           not_present = combineAlt emptyAlt (text "[]")
 
-genClauseSeq :: ListRuleSet -> STSeq -> Doc
-genClauseSeq lrs (STSeq _ clauses) | isClauseSeqLifted clauses = combineAlt rule production
+genClauseSeq :: ListRuleSet -> PayloadTokenSet -> STSeq -> Doc
+genClauseSeq lrs toks (STSeq _ clauses) | isClauseSeqLifted clauses = combineAlt rule production
     where rule = hsep (map genSimpleClause clauses)
-          production = hsep $ (enumClauses lrs clauses)
-genClauseSeq lrs (STSeq constructor clauses)  = combineAlt rule production
+          production = hsep $ (enumClauses lrs toks clauses)
+genClauseSeq lrs toks (STSeq constructor clauses)  = combineAlt rule production
     where rule = hsep (map genSimpleClause clauses)
-          production = hsep $ (text constructor) : (enumClauses lrs clauses)
+          production = hsep $ (text constructor) : posArgs ++ (enumClauses lrs toks clauses)
+          -- Anti_* constructors are quasi-quote splice artifacts and carry
+          -- no position field (see GenAST.isAntiConstructor)
+          posArgs | isAntiConstructor constructor = []
+                  | otherwise                     = [posOfFirst lrs clauses]
+
+-- The position of an alternative's first symbol - token or nonterminal,
+-- ignored or not (every symbol stays $n-addressable in happy actions). List
+-- rules build their lists reversed, so the source-order head is at the end.
+-- An empty alternative has no symbols and gets the dummy position.
+posOfFirst :: ListRuleSet -> [SyntaxSimpleClause] -> Doc
+posOfFirst _ [] = text "rtkNoPos"
+posOfFirst lrs (cl : _)
+    | Set.member (getSID cl) lrs = text "(rtkPosOf (reverse $1))"
+    | otherwise                  = text "(rtkPosOf $1)"
 
 genSimpleClause :: SyntaxSimpleClause -> Doc
 -- TODO: check whether reverse is needed (monad again) (switch to left recursion)
@@ -146,17 +234,25 @@ genSimpleClause (SSIgnore idName) = text idName
  -- TODO: no lifted yet, need monad with rules map here
 genSimpleClause (SSLifted idName) = text idName
 
-enumClauses :: ListRuleSet -> [SyntaxSimpleClause] -> [Doc]
-enumClauses lrs cls = f cls 1 []
-    where f (ssc:rest) count acc | isNotIgnored ssc = f rest (count + 1)
-                                                        (if Set.member (getSID ssc) lrs
-                                                            then ((text "(reverse $" <> int count <> text ")") : acc)
-                                                            else ((text "$" <> int count) : acc))
+-- A reference to symbol $n of a production: payload tokens go through their
+-- tkVal_* extractor, everything else is the plain happy attribute.
+tokenAwareRef :: PayloadTokenSet -> SyntaxSimpleClause -> Int -> Doc
+tokenAwareRef toks cl n
+    | Set.member (getSID cl) toks = parens (text ("tkVal_" ++ getSID cl) <+> (text "$" <> int n))
+    | otherwise                   = text "$" <> int n
+
+enumClauses :: ListRuleSet -> PayloadTokenSet -> [SyntaxSimpleClause] -> [Doc]
+enumClauses lrs toks cls = f cls 1 []
+    where f (ssc:rest) count acc | isNotIgnored ssc = f rest (count + 1) (ref ssc count : acc)
           f (_:       rest) count acc               = f rest (count + 1) acc
           f []              _     acc               = reverse acc
-          getSID (SSId n) = n
-          getSID (SSLifted n) = n
-          getSID (SSIgnore n) = n
+          ref ssc count | Set.member (getSID ssc) lrs = text "(reverse $" <> int count <> text ")"
+                        | otherwise                   = tokenAwareRef toks ssc count
+
+getSID :: SyntaxSimpleClause -> ID
+getSID (SSId n) = n
+getSID (SSLifted n) = n
+getSID (SSIgnore n) = n
 
 emptyAlt :: Doc
 emptyAlt = text "{- empty -}"

--- a/Parser.y
+++ b/Parser.y
@@ -71,7 +71,10 @@ IdList : IdList ',' id              { idStr $3 : $1}
 Rule : id '=' ClauseAlt ';'         { IRule Nothing Nothing (idStr $1) $3 [] (Just (idPos $1)) }
      | id ':' id '=' ClauseAlt ';'  { IRule (Just (idStr $1)) Nothing (idStr $3) $5 [] (Just (idPos $1)) }
      | id '.' id ':' id '=' ClauseAlt ';'  { IRule (Just (idStr $1)) (Just (idStr $3)) (idStr $5) $7 [] (Just (idPos $1)) }
-     | '.' id ':' id '=' ClauseAlt ';'  { IRule Nothing (Just (idStr $2)) (idStr $4) $6 [] (Just (idPos $2)) }
+     -- a rule's position is where the rule starts: for the '.' form that is
+     -- the dot itself, matching the first-symbol positions captured by
+     -- generated parsers
+     | '.' id ':' id '=' ClauseAlt ';'  { IRule Nothing (Just (idStr $2)) (idStr $4) $6 [] (Just (idPos $1)) }
 
 ClauseAlt : ClauseAlt1              { IAlt (reverse $1) }
 

--- a/src/generated/ASTAdapter.hs
+++ b/src/generated/ASTAdapter.hs
@@ -21,10 +21,11 @@
 --     regex literals, so 'convertGrammar' applies the same exported function
 --     to those leaves.
 --
--- Source positions are not captured yet (task 7b): 'getIRulePos' is 'Nothing'
--- everywhere. Generated artifacts never embed source positions — positions
--- only affect error messages — so this cannot change the generated output for
--- a valid grammar.
+-- Every generated constructor (except the quasi-quotation-only @Anti_*@
+-- ones) carries the source position of its first symbol in its first field;
+-- the adapter maps the rule constructors' position into 'getIRulePos', so
+-- diagnostics under @--use-generated@ point at real source locations, the
+-- same ones the hand-written front end records.
 module ASTAdapter
     ( parseWithGenerated
     , convertGrammar
@@ -33,15 +34,15 @@ module ASTAdapter
 import qualified GrammarLexer as GL
 import qualified GrammarParser as GP
 
-import Diagnostics (Diagnostic(..))
+import Diagnostics (Diagnostic(..), SourcePos(..))
 import Parser (IClause(..), IOption(..), IRule(..), InitialGrammar(..),
                addRuleOptions)
 import TokenProcessing (unBackQuote)
 
 -- | Lex and parse a grammar source with the generated front end and adapt the
 -- result. The generated modules report @Either String@ with the position
--- rendered into the message text, so the 'Diagnostic' carries no structured
--- position (that converges in task 7b).
+-- rendered into the message text, so lexer and parser failures carry no
+-- structured position; everything after parsing works on real positions.
 parseWithGenerated :: String -> Either Diagnostic InitialGrammar
 parseWithGenerated src =
     case GL.scanTokens src >>= GP.parseGrammar of
@@ -50,7 +51,7 @@ parseWithGenerated src =
 
 -- | Convert the generated AST to the hand-written 'InitialGrammar'.
 convertGrammar :: GP.Grammar -> InitialGrammar
-convertGrammar (GP.Ctr__Grammar__11 gname imports rules) =
+convertGrammar (GP.Ctr__Grammar__11 _ gname imports rules) =
     InitialGrammar { getIGrammarName = strLit gname
                    , getImports     = importsOpt imports
                    , getIRules      = map rule rules
@@ -58,25 +59,31 @@ convertGrammar (GP.Ctr__Grammar__11 gname imports rules) =
 convertGrammar g = qqOnly "Grammar" g
 
 rule :: GP.Rule -> IRule
-rule (GP.Ctr__Rule__0 n c)     = mkRule Nothing              Nothing              n c
-rule (GP.Ctr__Rule__1 t n c)   = mkRule (Just (name t))      Nothing              n c
-rule (GP.Ctr__Rule__2 t f n c) = mkRule (Just (name t))      (Just (name f))      n c
-rule (GP.Ctr__Rule__3 f n c)   = mkRule Nothing              (Just (name f))      n c
-rule (GP.Ctr__Rule__4 opts r)  = addRuleOptions (map option opts) (rule r)
-rule r@GP.Anti_Rule{}          = qqOnly "Rule" r
+rule (GP.Ctr__Rule__0 p n c)     = mkRule p Nothing         Nothing         n c
+rule (GP.Ctr__Rule__1 p t n c)   = mkRule p (Just (name t)) Nothing         n c
+rule (GP.Ctr__Rule__2 p t f n c) = mkRule p (Just (name t)) (Just (name f)) n c
+rule (GP.Ctr__Rule__3 p f n c)   = mkRule p Nothing         (Just (name f)) n c
+rule (GP.Ctr__Rule__4 _ opts r)  = addRuleOptions (map option opts) (rule r)
+rule r@GP.Anti_Rule{}            = qqOnly "Rule" r
 
-mkRule :: Maybe String -> Maybe String -> GP.Name -> GP.Clause -> IRule
-mkRule dataType dataFunc n c = IRule dataType dataFunc (name n) (topClause c) [] Nothing
+mkRule :: GP.RtkPos -> Maybe String -> Maybe String -> GP.Name -> GP.Clause -> IRule
+mkRule p dataType dataFunc n c =
+    IRule dataType dataFunc (name n) (topClause c) [] (Just (sourcePos p))
+
+-- | The position of a rule's first token, as the hand-written parser's
+-- 'SourcePos' (the hand-written front end records the same token's position).
+sourcePos :: GP.RtkPos -> SourcePos
+sourcePos (GP.RtkPos (GL.AlexPn _ line col)) = SourcePos line col
 
 option :: GP.Option -> IOption
-option (GP.Ctr__Option__0 ids) = OShortcuts (map name ids)
-option GP.Ctr__Option__1       = OSymmacro
-option o@GP.Anti_Option{}      = qqOnly "Option" o
+option (GP.Ctr__Option__0 _ ids) = OShortcuts (map name ids)
+option (GP.Ctr__Option__1 _)     = OSymmacro
+option o@GP.Anti_Option{}        = qqOnly "Option" o
 
 importsOpt :: GP.ImportsOpt -> String
-importsOpt GP.Ctr__ImportsOpt__0                           = ""
-importsOpt (GP.Ctr__ImportsOpt__1 (GP.Ctr__Rule_0__0 big)) = stripEnds 3 big
-importsOpt i@GP.Anti_ImportsOpt{}                          = qqOnly "ImportsOpt" i
+importsOpt (GP.Ctr__ImportsOpt__0 _)                           = ""
+importsOpt (GP.Ctr__ImportsOpt__1 _ (GP.Ctr__Rule_0__0 _ big)) = stripEnds 3 big
+importsOpt i@GP.Anti_ImportsOpt{}                              = qqOnly "ImportsOpt" i
 
 -- | A clause in alternative position: a rule's right-hand side or a
 -- parenthesized group. The hand-written parser always wraps these as an
@@ -89,24 +96,24 @@ topClause c = IAlt [ ISeq (map preClause (seqElems alt)) | alt <- altElems c ]
 -- alternation (parenthesized alternations stay as elements and get wrapped
 -- by 'itemClause').
 altElems :: GP.Clause -> [GP.Clause]
-altElems (GP.Ctr__Clause__14 l r) = altElems l ++ [r]
-altElems c                        = [c]
+altElems (GP.Ctr__Clause__14 _ l r) = altElems l ++ [r]
+altElems c                          = [c]
 
 -- | Flatten the left-recursive juxtaposition spine of one alternative.
 seqElems :: GP.Clause -> [GP.Clause]
-seqElems (GP.Ctr__Clause__12 l r) = seqElems l ++ [r]
-seqElems c                        = [c]
+seqElems (GP.Ctr__Clause__12 _ l r) = seqElems l ++ [r]
+seqElems c                          = [c]
 
 preClause :: GP.Clause -> IClause
-preClause (GP.Ctr__Clause__9 c)  = ILifted (postClause c)
-preClause (GP.Ctr__Clause__10 c) = IIgnore (postClause c)
-preClause c                      = postClause c
+preClause (GP.Ctr__Clause__9 _ c)  = ILifted (postClause c)
+preClause (GP.Ctr__Clause__10 _ c) = IIgnore (postClause c)
+preClause c                        = postClause c
 
 postClause :: GP.Clause -> IClause
-postClause (GP.Ctr__Clause__5 c d) = IStar (itemClause c) (delim d)
-postClause (GP.Ctr__Clause__6 c d) = IPlus (itemClause c) (delim d)
-postClause (GP.Ctr__Clause__7 c)   = IOpt (itemClause c)
-postClause c                       = itemClause c
+postClause (GP.Ctr__Clause__5 _ c d) = IStar (itemClause c) (delim d)
+postClause (GP.Ctr__Clause__6 _ c d) = IPlus (itemClause c) (delim d)
+postClause (GP.Ctr__Clause__7 _ c)   = IOpt (itemClause c)
+postClause c                         = itemClause c
 
 -- | A clause in item position: a leaf, or — when it is still a sequence,
 -- alternation, lift, ignore or repetition — a construct that can only have
@@ -114,25 +121,25 @@ postClause c                       = itemClause c
 -- as a nested @IAlt [ISeq …]@. The generated parser drops the parentheses
 -- themselves, so redundant parens around a single leaf normalize away.
 itemClause :: GP.Clause -> IClause
-itemClause (GP.Ctr__Clause__1 n) = IId (name n)
-itemClause (GP.Ctr__Clause__2 s) = IStrLit (strLit s)
-itemClause GP.Ctr__Clause__3     = IDot
-itemClause (GP.Ctr__Clause__4 s) = IRegExpLit (unBackQuote (stripEnds 1 s))
-itemClause c@GP.Anti_Clause{}    = qqOnly "Clause" c
-itemClause c                     = topClause c
+itemClause (GP.Ctr__Clause__1 _ n) = IId (name n)
+itemClause (GP.Ctr__Clause__2 _ s) = IStrLit (strLit s)
+itemClause (GP.Ctr__Clause__3 _)   = IDot
+itemClause (GP.Ctr__Clause__4 _ s) = IRegExpLit (unBackQuote (stripEnds 1 s))
+itemClause c@GP.Anti_Clause{}      = qqOnly "Clause" c
+itemClause c                       = topClause c
 
 delim :: GP.OptDelim -> Maybe IClause
-delim GP.Ctr__OptDelim__0                            = Nothing
-delim (GP.Ctr__OptDelim__1 (GP.Ctr__Rule_4__0 c))    = Just (itemClause c)
-delim d@GP.Anti_OptDelim{}                           = qqOnly "OptDelim" d
+delim (GP.Ctr__OptDelim__0 _)                            = Nothing
+delim (GP.Ctr__OptDelim__1 _ (GP.Ctr__Rule_4__0 _ c))    = Just (itemClause c)
+delim d@GP.Anti_OptDelim{}                               = qqOnly "OptDelim" d
 
 name :: GP.Name -> String
-name (GP.Ctr__Name__0 s) = s
-name n@GP.Anti_Name{}    = qqOnly "Name" n
+name (GP.Ctr__Name__0 _ s) = s
+name n@GP.Anti_Name{}      = qqOnly "Name" n
 
 strLit :: GP.StrLit -> String
-strLit (GP.Ctr__StrLit__0 s) = unBackQuote (stripEnds 1 s)
-strLit s@GP.Anti_StrLit{}    = qqOnly "StrLit" s
+strLit (GP.Ctr__StrLit__0 _ s) = unBackQuote (stripEnds 1 s)
+strLit s@GP.Anti_StrLit{}      = qqOnly "StrLit" s
 
 -- | Drop @n@ delimiter characters from both ends of a token's text.
 stripEnds :: Int -> String -> String

--- a/src/generated/README.md
+++ b/src/generated/README.md
@@ -49,10 +49,12 @@ Two things the hand-written front end does between lexing and parsing:
    exported `unBackQuote` on the same leaves — the escape logic is not
    duplicated.
 
-Source positions are **not** captured yet (task 7b): `getIRulePos` is
-`Nothing` everywhere. Generated artifacts never embed source positions —
-positions only affect error messages — so this cannot change the generated
-output for a valid grammar.
+3. **Rule positions.** Every generated constructor (except the
+   quasi-quotation-only `Anti_*` ones) stores the position of its first
+   token in a leading `RtkPos` field; the adapter maps the rule
+   constructors' positions into `getIRulePos`, so diagnostics under
+   `--use-generated` point at the same source locations the hand-written
+   front end records.
 
 ## Equivalence guarantees
 
@@ -61,16 +63,17 @@ output for a valid grammar.
   byte-for-byte (three grammars that use hand-parser-only syntax are pinned
   in `TestSupport.frontEndDivergentGrammars` with a still-diverges guard).
 - `cabal test unit` parses every grammar with both front ends and asserts the
-  `InitialGrammar`s are equal after stripping positions (same pins).
+  `InitialGrammar`s are equal, source positions included (same pins).
 - The fixed point: `rtk --use-generated test-grammars/grammar.pg out/`
   regenerates `test/golden/grammar/` exactly — RTK parses its own grammar
   with the parser it generated from that grammar.
 
 ## Known divergences (documented, accepted)
 
-See `BOOTSTRAP.md` for the full list: `Either String` errors with positions
-in the message text (structured positions come with task 7b), no nested
-`/* /* */ */` comments (GitHub issue #25), no concatenation of adjacent
-`"""…"""` blocks, no empty alternatives (`Gd = | ExpI ;` is
-hand-parser-only syntax), and no redundant-parenthesis grouping
-(grammar.pg lifts paren groups, the hand-written parser keeps them).
+See `BOOTSTRAP.md` for the full list: lexer/parser failures are
+`Either String` with positions in the message text (everything after
+parsing carries structured positions), no nested `/* /* */ */` comments
+(GitHub issue #25), no concatenation of adjacent `"""…"""` blocks, no empty
+alternatives (`Gd = | ExpI ;` is hand-parser-only syntax), and no
+redundant-parenthesis grouping (grammar.pg lifts paren groups, the
+hand-written parser keeps them).

--- a/test-grammars/p-main.hs
+++ b/test-grammars/p-main.hs
@@ -28,5 +28,5 @@ main = do
     let _p = either errorWithoutStackTrace Prelude.id $
                scanTokens "(lambda (x) (fold x 0 (lambda (y z) (or y z))))" >>= parseP
     let [p|(lambda ($id) $e)|] = _p
-    putStrLn $ show $ subst (Ctr__Id__0 "x") e 0x1122334455667788
+    putStrLn $ show $ subst (Ctr__Id__0 rtkNoPos "x") e 0x1122334455667788
     return ()

--- a/test/GoldenTests.hs
+++ b/test/GoldenTests.hs
@@ -9,9 +9,9 @@
 -- Every grammar is run through BOTH front ends — the hand-written
 -- lexer/parser and the self-hosted one that RTK generated from grammar.pg
 -- (--use-generated) — and both must reproduce the same snapshots
--- byte-for-byte. This is the self-hosting equivalence harness: positions
--- never reach the generated artifacts, so the position-blind generated
--- front end cannot cause artifact divergence on a valid grammar. The
+-- byte-for-byte. This is the self-hosting equivalence harness: source
+-- positions only affect diagnostics, never the generated artifacts, so any
+-- artifact divergence on a valid grammar is a real front-end bug. The
 -- exceptions are the grammars pinned in
 -- TestSupport.frontEndDivergentGrammars (hand-parser-only syntax that
 -- grammar.pg cannot express); those are checked with the hand-written front

--- a/test/UnitTests.hs
+++ b/test/UnitTests.hs
@@ -10,7 +10,6 @@ module Main (main) where
 
 import Control.Exception (SomeException, evaluate, try)
 import Control.Monad (when)
-import Data.Generics (everywhere, mkT)
 import Data.List (find, group, isInfixOf, isPrefixOf, nub, sort)
 import qualified Data.Map as M
 import Data.Maybe (maybeToList)
@@ -450,13 +449,15 @@ testFillConstructorNames = TestCase $ do
 
 selfHostedFrontEndTests :: Test
 selfHostedFrontEndTests = TestList
-    [ TestLabel "errors carry the position in the message text" $ TestCase $
-        -- ';' missing after the grammar declaration. Until task 7b the
-        -- generated front end has no structured positions; the message text
-        -- itself names line and column.
+    [ TestLabel "parse errors carry the position in the message text" $ TestCase $
+        -- ';' missing after the grammar declaration. The generated lexer and
+        -- parser report Either String, so their failures render line and
+        -- column into the message text instead of a structured position
+        -- (everything after parsing carries structured positions, see the
+        -- duplicate-rule test below).
         expectDiagnostic "a missing ';'"
             (parseGrammarSourceGenerated "grammar 'Test'\nFoo = bar;\n") $ \d -> do
-            assertEqual "no structured position yet (task 7b)" Nothing (diagPos d)
+            assertEqual "no structured position for parse errors" Nothing (diagPos d)
             assertBool ("message names the position: " ++ diagMessage d) $
                 "line 2" `isInfixOf` diagMessage d
     , TestLabel "lexical errors are diagnostics, not exceptions" $ TestCase $
@@ -464,15 +465,27 @@ selfHostedFrontEndTests = TestList
             (parseGrammarSourceGenerated "grammar 'Test';\nA = % ;\n") $ \d ->
             assertBool ("message names the position: " ++ diagMessage d) $
                 "line 2" `isInfixOf` diagMessage d
+    , TestLabel "rule positions are captured: duplicate rules get a structured diagnostic" $ TestCase $
+        -- The generated AST carries the position of every rule's first
+        -- token, and the adapter maps it into getIRulePos, so a
+        -- normalization diagnostic under --use-generated points at the
+        -- offending line and column exactly like the hand-written front end.
+        expectDiagnostic "a duplicate rule"
+            (parseGrammarSourceGenerated "grammar 'Dup';\nFoo = 'a';\nFoo = 'b';\n"
+                >>= normalizeParsedGrammar) $ \d -> do
+            assertEqual "position of the second definition" (Just (SourcePos 3 1)) (diagPos d)
+            assertBool ("unexpected message: " ++ diagMessage d) $
+                "defined more than once" `isInfixOf` diagMessage d
+                && "line 2, column 1" `isInfixOf` diagMessage d
     ]
 
 -- | Both front ends must produce the same 'InitialGrammar' for every grammar
--- in the corpus, up to source positions: the generated front end does not
--- capture 'getIRulePos' yet (task 7b), so positions are stripped before
--- comparing. This catches adapter bugs with far better messages than a
--- generated-artifact diff. Grammars pinned in 'frontEndDivergentGrammars'
--- are expected to differ (or be rejected); the test fails once they agree,
--- so the pin gets dropped.
+-- in the corpus, source positions included: the generated front end captures
+-- 'getIRulePos' from the position fields of its AST, and they must agree
+-- with the positions the hand-written parser records. This catches adapter
+-- bugs with far better messages than a generated-artifact diff. Grammars
+-- pinned in 'frontEndDivergentGrammars' are expected to differ (or be
+-- rejected); the test fails once they agree, so the pin gets dropped.
 astEqualityTestFor :: FilePath -> IO Test
 astEqualityTestFor pgFile = do
     source <- readFileUtf8 pgFile
@@ -484,19 +497,14 @@ astEqualityTestFor pgFile = do
             (_, Left d, _) -> assertFailure $
                 "hand-written front end failed on " ++ pgFile ++ ": " ++ show d
             (Nothing, Right h, Right g) ->
-                assertEqual "hand-written vs generated front end (positions stripped)"
-                    (stripPositions h) (stripPositions g)
+                assertEqual "hand-written vs generated front end (positions included)" h g
             (Nothing, _, Left d) -> assertFailure $
                 "generated front end failed on " ++ pgFile ++ ": " ++ show d
             (Just _, _, Left _) -> return () -- rejected: still divergent
             (Just reason, Right h, Right g) ->
-                when (stripPositions h == stripPositions g) $ assertFailure $
+                when (h == g) $ assertFailure $
                     "the front ends now agree on this grammar (pinned because: " ++ reason
                     ++ ");\ndrop it from frontEndDivergentGrammars in test/TestSupport.hs"
-
--- | Forget every source position in the parsed grammar.
-stripPositions :: InitialGrammar -> InitialGrammar
-stripPositions = everywhere (mkT (const Nothing :: Maybe SourcePos -> Maybe SourcePos))
 
 --------------------------------------------------------------------------------
 -- Invariants checked against every grammar in test-grammars/

--- a/test/golden/debug-test/DebugTestLexer.x
+++ b/test/golden/debug-test/DebugTestLexer.x
@@ -1,6 +1,8 @@
 {
+{-# LANGUAGE StandaloneDeriving, DeriveDataTypeable #-}
 module DebugTestLexer(scanTokens, alexScanTokens, Token(..), PosToken(..), AlexPosn(..))
 where
+import Data.Data (Data)
 
  }
 %wrapper "monad"
@@ -87,6 +89,11 @@ data Token = EndOfFile |
              Tk__qq_Statement String |
              Tk__qq_Program String
              deriving (Show)
+
+-- AlexPosn is defined by the alex wrapper, so the Data instance (required by
+-- the parser's RtkPos position type) can only be attached via standalone
+-- deriving - the same solution as the hand-written Lexer.x
+deriving instance Data AlexPosn
 
 -- A token together with the source position where it starts
 data PosToken = PosToken { ptPos :: AlexPosn, ptToken :: Token }

--- a/test/golden/debug-test/DebugTestParser.y
+++ b/test/golden/debug-test/DebugTestParser.y
@@ -38,99 +38,99 @@ tok__plus__2 { L.PosToken _ L.Tk__tok__plus__2 }
 tok__star__4 { L.PosToken _ L.Tk__tok__star__4 }
 tok__rparen__7 { L.PosToken _ L.Tk__tok__rparen__7 }
 tok__lparen__6 { L.PosToken _ L.Tk__tok__lparen__6 }
-number { L.PosToken _ (L.Tk__number $$) }
-identifier { L.PosToken _ (L.Tk__identifier $$) }
-qq_UnusedRule2 { L.PosToken _ (L.Tk__qq_UnusedRule2 $$) }
-qq_UnusedRule1 { L.PosToken _ (L.Tk__qq_UnusedRule1 $$) }
-qq_Block { L.PosToken _ (L.Tk__qq_Block $$) }
-qq_WhileLoop { L.PosToken _ (L.Tk__qq_WhileLoop $$) }
-qq_IfStatement { L.PosToken _ (L.Tk__qq_IfStatement $$) }
-qq_Factor { L.PosToken _ (L.Tk__qq_Factor $$) }
-qq_Term { L.PosToken _ (L.Tk__qq_Term $$) }
-qq_Expression { L.PosToken _ (L.Tk__qq_Expression $$) }
-qq_Assignment { L.PosToken _ (L.Tk__qq_Assignment $$) }
-qq_Statement { L.PosToken _ (L.Tk__qq_Statement $$) }
-qq_Program { L.PosToken _ (L.Tk__qq_Program $$) }
+number { L.PosToken _ (L.Tk__number _) }
+identifier { L.PosToken _ (L.Tk__identifier _) }
+qq_UnusedRule2 { L.PosToken _ (L.Tk__qq_UnusedRule2 _) }
+qq_UnusedRule1 { L.PosToken _ (L.Tk__qq_UnusedRule1 _) }
+qq_Block { L.PosToken _ (L.Tk__qq_Block _) }
+qq_WhileLoop { L.PosToken _ (L.Tk__qq_WhileLoop _) }
+qq_IfStatement { L.PosToken _ (L.Tk__qq_IfStatement _) }
+qq_Factor { L.PosToken _ (L.Tk__qq_Factor _) }
+qq_Term { L.PosToken _ (L.Tk__qq_Term _) }
+qq_Expression { L.PosToken _ (L.Tk__qq_Expression _) }
+qq_Assignment { L.PosToken _ (L.Tk__qq_Assignment _) }
+qq_Statement { L.PosToken _ (L.Tk__qq_Statement _) }
+qq_Program { L.PosToken _ (L.Tk__qq_Program _) }
 
 %%
 
 DebugTest__top : Program rtk__eof { $1 }
 
-Program : tok_Program_dummy_19 Program tok_Program_dummy_19 { Ctr__Program__0 (reverse $2) } |
-          tok_Assignment_dummy_18 Assignment tok_Assignment_dummy_18 { Ctr__Program__1 $2 } |
-          tok_Block_dummy_17 Block tok_Block_dummy_17 { Ctr__Program__2 $2 } |
-          tok_Expression_dummy_16 Expression tok_Expression_dummy_16 { Ctr__Program__3 $2 } |
-          tok_Factor_dummy_15 Factor tok_Factor_dummy_15 { Ctr__Program__4 $2 } |
-          tok_IfStatement_dummy_14 IfStatement tok_IfStatement_dummy_14 { Ctr__Program__5 $2 } |
-          tok_Statement_dummy_13 Statement tok_Statement_dummy_13 { Ctr__Program__6 $2 } |
-          tok_Term_dummy_12 Term tok_Term_dummy_12 { Ctr__Program__7 $2 } |
-          tok_UnusedRule1_dummy_11 UnusedRule1 tok_UnusedRule1_dummy_11 { Ctr__Program__8 $2 } |
-          tok_UnusedRule2_dummy_10 UnusedRule2 tok_UnusedRule2_dummy_10 { Ctr__Program__9 (reverse $2) } |
-          tok_WhileLoop_dummy_9 WhileLoop tok_WhileLoop_dummy_9 { Ctr__Program__10 $2 }
+Program : tok_Program_dummy_19 Program tok_Program_dummy_19 { Ctr__Program__0 (rtkPosOf $1) (reverse $2) } |
+          tok_Assignment_dummy_18 Assignment tok_Assignment_dummy_18 { Ctr__Program__1 (rtkPosOf $1) $2 } |
+          tok_Block_dummy_17 Block tok_Block_dummy_17 { Ctr__Program__2 (rtkPosOf $1) $2 } |
+          tok_Expression_dummy_16 Expression tok_Expression_dummy_16 { Ctr__Program__3 (rtkPosOf $1) $2 } |
+          tok_Factor_dummy_15 Factor tok_Factor_dummy_15 { Ctr__Program__4 (rtkPosOf $1) $2 } |
+          tok_IfStatement_dummy_14 IfStatement tok_IfStatement_dummy_14 { Ctr__Program__5 (rtkPosOf $1) $2 } |
+          tok_Statement_dummy_13 Statement tok_Statement_dummy_13 { Ctr__Program__6 (rtkPosOf $1) $2 } |
+          tok_Term_dummy_12 Term tok_Term_dummy_12 { Ctr__Program__7 (rtkPosOf $1) $2 } |
+          tok_UnusedRule1_dummy_11 UnusedRule1 tok_UnusedRule1_dummy_11 { Ctr__Program__8 (rtkPosOf $1) $2 } |
+          tok_UnusedRule2_dummy_10 UnusedRule2 tok_UnusedRule2_dummy_10 { Ctr__Program__9 (rtkPosOf $1) (reverse $2) } |
+          tok_WhileLoop_dummy_9 WhileLoop tok_WhileLoop_dummy_9 { Ctr__Program__10 (rtkPosOf $1) $2 }
 
 Program : {- empty -} { [] } |
           Program ListElem_Program0 { $2 : $1 }
 
-Assignment : qq_Assignment { Anti_Assignment $1 } |
-             identifier tok__eql__0 Expression tok__semi__1 { Ctr__Assignment__0 $1 $3 }
+Assignment : qq_Assignment { Anti_Assignment (tkVal_qq_Assignment $1) } |
+             identifier tok__eql__0 Expression tok__semi__1 { Ctr__Assignment__0 (rtkPosOf $1) (tkVal_identifier $1) $3 }
 
-Block : qq_Block { Anti_Block $1 } |
-        tok__symbol__11 Rule_7 tok__symbol__12 { Ctr__Block__0 (reverse $2) }
+Block : qq_Block { Anti_Block (tkVal_qq_Block $1) } |
+        tok__symbol__11 Rule_7 tok__symbol__12 { Ctr__Block__0 (rtkPosOf $1) (reverse $2) }
 
-Expression : qq_Expression { Anti_Expression $1 } |
-             Term Rule_1 { Ctr__Expression__0 $1 (reverse $2) }
+Expression : qq_Expression { Anti_Expression (tkVal_qq_Expression $1) } |
+             Term Rule_1 { Ctr__Expression__0 (rtkPosOf $1) $1 (reverse $2) }
 
-Factor : qq_Factor { Anti_Factor $1 } |
-         identifier { Ctr__Factor__0 $1 } |
-         number { Ctr__Factor__1 $1 } |
-         tok__lparen__6 Expression tok__rparen__7 { Ctr__Factor__2 $2 }
+Factor : qq_Factor { Anti_Factor (tkVal_qq_Factor $1) } |
+         identifier { Ctr__Factor__0 (rtkPosOf $1) (tkVal_identifier $1) } |
+         number { Ctr__Factor__1 (rtkPosOf $1) (tkVal_number $1) } |
+         tok__lparen__6 Expression tok__rparen__7 { Ctr__Factor__2 (rtkPosOf $1) $2 }
 
-IfStatement : qq_IfStatement { Anti_IfStatement $1 } |
-              tok_if_8 tok__lparen__6 Expression tok__rparen__7 Statement { Ctr__IfStatement__0 $3 $5 } |
-              tok_if_8 tok__lparen__6 Expression tok__rparen__7 Statement tok_else_9 Statement { Ctr__IfStatement__1 $3 $5 $7 }
+IfStatement : qq_IfStatement { Anti_IfStatement (tkVal_qq_IfStatement $1) } |
+              tok_if_8 tok__lparen__6 Expression tok__rparen__7 Statement { Ctr__IfStatement__0 (rtkPosOf $1) $3 $5 } |
+              tok_if_8 tok__lparen__6 Expression tok__rparen__7 Statement tok_else_9 Statement { Ctr__IfStatement__1 (rtkPosOf $1) $3 $5 $7 }
 
 Rule_1 : {- empty -} { [] } |
          Rule_1 Rule_2 { $2 : $1 }
 
-Rule_2 : Rule_3 Term { Ctr__Rule_2__0 $1 $2 }
+Rule_2 : Rule_3 Term { Ctr__Rule_2__0 (rtkPosOf $1) $1 $2 }
 
-Rule_3 : tok__plus__2 { Ctr__Rule_3__0 } |
-         tok__minus__3 { Ctr__Rule_3__1 }
+Rule_3 : tok__plus__2 { Ctr__Rule_3__0 (rtkPosOf $1) } |
+         tok__minus__3 { Ctr__Rule_3__1 (rtkPosOf $1) }
 
 Rule_4 : {- empty -} { [] } |
          Rule_4 Rule_5 { $2 : $1 }
 
-Rule_5 : Rule_6 Factor { Ctr__Rule_5__0 $1 $2 }
+Rule_5 : Rule_6 Factor { Ctr__Rule_5__0 (rtkPosOf $1) $1 $2 }
 
-Rule_6 : tok__star__4 { Ctr__Rule_6__0 } |
-         tok__symbol__5 { Ctr__Rule_6__1 }
+Rule_6 : tok__star__4 { Ctr__Rule_6__0 (rtkPosOf $1) } |
+         tok__symbol__5 { Ctr__Rule_6__1 (rtkPosOf $1) }
 
 Rule_7 : {- empty -} { [] } |
          Rule_7 Statement { $2 : $1 }
 
-Statement : qq_Statement { Anti_Statement $1 } |
-            Assignment { Ctr__Statement__0 $1 } |
-            IfStatement { Ctr__Statement__1 $1 } |
-            WhileLoop { Ctr__Statement__2 $1 } |
-            Block { Ctr__Statement__3 $1 }
+Statement : qq_Statement { Anti_Statement (tkVal_qq_Statement $1) } |
+            Assignment { Ctr__Statement__0 (rtkPosOf $1) $1 } |
+            IfStatement { Ctr__Statement__1 (rtkPosOf $1) $1 } |
+            WhileLoop { Ctr__Statement__2 (rtkPosOf $1) $1 } |
+            Block { Ctr__Statement__3 (rtkPosOf $1) $1 }
 
-ListElem_Program0 : qq_Program { Anti_Statement $1 } |
+ListElem_Program0 : qq_Program { Anti_Statement (tkVal_qq_Program $1) } |
                     Statement { $1 }
 
-Term : qq_Term { Anti_Term $1 } |
-       Factor Rule_4 { Ctr__Term__0 $1 (reverse $2) }
+Term : qq_Term { Anti_Term (tkVal_qq_Term $1) } |
+       Factor Rule_4 { Ctr__Term__0 (rtkPosOf $1) $1 (reverse $2) }
 
-ListElem_UnusedRule28 : qq_UnusedRule2 { Anti_UnusedRule1 $1 } |
+ListElem_UnusedRule28 : qq_UnusedRule2 { Anti_UnusedRule1 (tkVal_qq_UnusedRule2 $1) } |
                         UnusedRule1 { $1 }
 
-UnusedRule1 : qq_UnusedRule1 { Anti_UnusedRule1 $1 } |
-              tok_unused_13 identifier { Ctr__UnusedRule1__1 $2 }
+UnusedRule1 : qq_UnusedRule1 { Anti_UnusedRule1 (tkVal_qq_UnusedRule1 $1) } |
+              tok_unused_13 identifier { Ctr__UnusedRule1__1 (rtkPosOf $1) (tkVal_identifier $2) }
 
 UnusedRule2 : {- empty -} { [] } |
               UnusedRule2 ListElem_UnusedRule28 { $2 : $1 }
 
-WhileLoop : qq_WhileLoop { Anti_WhileLoop $1 } |
-            tok_while_10 tok__lparen__6 Expression tok__rparen__7 Statement { Ctr__WhileLoop__0 $3 $5 }
+WhileLoop : qq_WhileLoop { Anti_WhileLoop (tkVal_qq_WhileLoop $1) } |
+            tok_while_10 tok__lparen__6 Expression tok__rparen__7 Statement { Ctr__WhileLoop__0 (rtkPosOf $1) $3 $5 }
 
 
 {
@@ -181,63 +181,188 @@ showRtkToken (L.Tk__qq_Assignment v) = "qq_Assignment " ++ show v
 showRtkToken (L.Tk__qq_Statement v) = "qq_Statement " ++ show v
 showRtkToken (L.Tk__qq_Program v) = "qq_Program " ++ show v
 
-data Program = Ctr__Program__0 Program |
-               Ctr__Program__1 Assignment |
-               Ctr__Program__2 Block |
-               Ctr__Program__3 Expression |
-               Ctr__Program__4 Factor |
-               Ctr__Program__5 IfStatement |
-               Ctr__Program__6 Statement |
-               Ctr__Program__7 Term |
-               Ctr__Program__8 UnusedRule1 |
-               Ctr__Program__9 UnusedRule2 |
-               Ctr__Program__10 WhileLoop
+-- Source position of a node: every constructor except the Anti_* splice
+-- artifacts stores the position of its alternative's first symbol in its
+-- first field. Positions are transparent for equality and ordering, so two
+-- ASTs that differ only in source positions (e.g. a quasi-quote parsed at
+-- compile time vs the same construct parsed at run time) compare equal.
+newtype RtkPos = RtkPos L.AlexPosn deriving (Show, Gen.Data, Gen.Typeable)
+instance Eq RtkPos where _ == _ = True
+instance Ord RtkPos where compare _ _ = EQ
+
+-- The position used where no source token exists: empty productions, empty
+-- lists, absent optionals and Anti_* quasi-quote splices
+rtkNoPos :: RtkPos
+rtkNoPos = RtkPos (L.AlexPn 0 0 0)
+
+class RtkPosOf a where
+    rtkPosOf :: a -> RtkPos
+instance RtkPosOf L.PosToken where
+    rtkPosOf (L.PosToken p _) = RtkPos p
+instance RtkPosOf a => RtkPosOf [a] where
+    rtkPosOf (x : _) = rtkPosOf x
+    rtkPosOf []      = rtkNoPos
+instance RtkPosOf a => RtkPosOf (Maybe a) where
+    rtkPosOf (Just x) = rtkPosOf x
+    rtkPosOf Nothing  = rtkNoPos
+-- A Char carries no position; this also covers String token payloads
+instance RtkPosOf Char where
+    rtkPosOf _ = rtkNoPos
+
+-- Recover a token's payload from the whole positioned token: %token
+-- bindings keep the L.PosToken so semantic actions can read its position
+tkVal_number :: L.PosToken -> String
+tkVal_number (L.PosToken _ (L.Tk__number v)) = v
+tkVal_number t = error ("rtk internal error: token number expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_identifier :: L.PosToken -> String
+tkVal_identifier (L.PosToken _ (L.Tk__identifier v)) = v
+tkVal_identifier t = error ("rtk internal error: token identifier expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_UnusedRule2 :: L.PosToken -> String
+tkVal_qq_UnusedRule2 (L.PosToken _ (L.Tk__qq_UnusedRule2 v)) = v
+tkVal_qq_UnusedRule2 t = error ("rtk internal error: token qq_UnusedRule2 expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_UnusedRule1 :: L.PosToken -> String
+tkVal_qq_UnusedRule1 (L.PosToken _ (L.Tk__qq_UnusedRule1 v)) = v
+tkVal_qq_UnusedRule1 t = error ("rtk internal error: token qq_UnusedRule1 expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_Block :: L.PosToken -> String
+tkVal_qq_Block (L.PosToken _ (L.Tk__qq_Block v)) = v
+tkVal_qq_Block t = error ("rtk internal error: token qq_Block expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_WhileLoop :: L.PosToken -> String
+tkVal_qq_WhileLoop (L.PosToken _ (L.Tk__qq_WhileLoop v)) = v
+tkVal_qq_WhileLoop t = error ("rtk internal error: token qq_WhileLoop expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_IfStatement :: L.PosToken -> String
+tkVal_qq_IfStatement (L.PosToken _ (L.Tk__qq_IfStatement v)) = v
+tkVal_qq_IfStatement t = error ("rtk internal error: token qq_IfStatement expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_Factor :: L.PosToken -> String
+tkVal_qq_Factor (L.PosToken _ (L.Tk__qq_Factor v)) = v
+tkVal_qq_Factor t = error ("rtk internal error: token qq_Factor expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_Term :: L.PosToken -> String
+tkVal_qq_Term (L.PosToken _ (L.Tk__qq_Term v)) = v
+tkVal_qq_Term t = error ("rtk internal error: token qq_Term expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_Expression :: L.PosToken -> String
+tkVal_qq_Expression (L.PosToken _ (L.Tk__qq_Expression v)) = v
+tkVal_qq_Expression t = error ("rtk internal error: token qq_Expression expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_Assignment :: L.PosToken -> String
+tkVal_qq_Assignment (L.PosToken _ (L.Tk__qq_Assignment v)) = v
+tkVal_qq_Assignment t = error ("rtk internal error: token qq_Assignment expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_Statement :: L.PosToken -> String
+tkVal_qq_Statement (L.PosToken _ (L.Tk__qq_Statement v)) = v
+tkVal_qq_Statement t = error ("rtk internal error: token qq_Statement expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_Program :: L.PosToken -> String
+tkVal_qq_Program (L.PosToken _ (L.Tk__qq_Program v)) = v
+tkVal_qq_Program t = error ("rtk internal error: token qq_Program expected, got " ++ showRtkToken (L.ptToken t))
+
+data Program = Ctr__Program__0 RtkPos Program |
+               Ctr__Program__1 RtkPos Assignment |
+               Ctr__Program__2 RtkPos Block |
+               Ctr__Program__3 RtkPos Expression |
+               Ctr__Program__4 RtkPos Factor |
+               Ctr__Program__5 RtkPos IfStatement |
+               Ctr__Program__6 RtkPos Statement |
+               Ctr__Program__7 RtkPos Term |
+               Ctr__Program__8 RtkPos UnusedRule1 |
+               Ctr__Program__9 RtkPos UnusedRule2 |
+               Ctr__Program__10 RtkPos WhileLoop
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Program where
+    rtkPosOf (Ctr__Program__0 p _) = p
+    rtkPosOf (Ctr__Program__1 p _) = p
+    rtkPosOf (Ctr__Program__2 p _) = p
+    rtkPosOf (Ctr__Program__3 p _) = p
+    rtkPosOf (Ctr__Program__4 p _) = p
+    rtkPosOf (Ctr__Program__5 p _) = p
+    rtkPosOf (Ctr__Program__6 p _) = p
+    rtkPosOf (Ctr__Program__7 p _) = p
+    rtkPosOf (Ctr__Program__8 p _) = p
+    rtkPosOf (Ctr__Program__9 p _) = p
+    rtkPosOf (Ctr__Program__10 p _) = p
 data Assignment = Anti_Assignment String |
-                  Ctr__Assignment__0 String Expression
+                  Ctr__Assignment__0 RtkPos String Expression
                   deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Assignment where
+    rtkPosOf (Anti_Assignment _) = rtkNoPos
+    rtkPosOf (Ctr__Assignment__0 p _ _) = p
 data Block = Anti_Block String |
-             Ctr__Block__0 Rule_7
+             Ctr__Block__0 RtkPos Rule_7
              deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Block where
+    rtkPosOf (Anti_Block _) = rtkNoPos
+    rtkPosOf (Ctr__Block__0 p _) = p
 data Expression = Anti_Expression String |
-                  Ctr__Expression__0 Term Rule_1
+                  Ctr__Expression__0 RtkPos Term Rule_1
                   deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Expression where
+    rtkPosOf (Anti_Expression _) = rtkNoPos
+    rtkPosOf (Ctr__Expression__0 p _ _) = p
 data Factor = Anti_Factor String |
-              Ctr__Factor__0 String |
-              Ctr__Factor__1 String |
-              Ctr__Factor__2 Expression
+              Ctr__Factor__0 RtkPos String |
+              Ctr__Factor__1 RtkPos String |
+              Ctr__Factor__2 RtkPos Expression
               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Factor where
+    rtkPosOf (Anti_Factor _) = rtkNoPos
+    rtkPosOf (Ctr__Factor__0 p _) = p
+    rtkPosOf (Ctr__Factor__1 p _) = p
+    rtkPosOf (Ctr__Factor__2 p _) = p
 data IfStatement = Anti_IfStatement String |
-                   Ctr__IfStatement__0 Expression Statement |
-                   Ctr__IfStatement__1 Expression Statement Statement
+                   Ctr__IfStatement__0 RtkPos Expression Statement |
+                   Ctr__IfStatement__1 RtkPos Expression Statement Statement
                    deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf IfStatement where
+    rtkPosOf (Anti_IfStatement _) = rtkNoPos
+    rtkPosOf (Ctr__IfStatement__0 p _ _) = p
+    rtkPosOf (Ctr__IfStatement__1 p _ _ _) = p
 type Rule_1 = [Rule_2]
-data Rule_2 = Ctr__Rule_2__0 Rule_3 Term
+data Rule_2 = Ctr__Rule_2__0 RtkPos Rule_3 Term
               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_3 = Ctr__Rule_3__0 |
-              Ctr__Rule_3__1
+instance RtkPosOf Rule_2 where
+    rtkPosOf (Ctr__Rule_2__0 p _ _) = p
+data Rule_3 = Ctr__Rule_3__0 RtkPos |
+              Ctr__Rule_3__1 RtkPos
               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_3 where
+    rtkPosOf (Ctr__Rule_3__0 p) = p
+    rtkPosOf (Ctr__Rule_3__1 p) = p
 type Rule_4 = [Rule_5]
-data Rule_5 = Ctr__Rule_5__0 Rule_6 Factor
+data Rule_5 = Ctr__Rule_5__0 RtkPos Rule_6 Factor
               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_6 = Ctr__Rule_6__0 |
-              Ctr__Rule_6__1
+instance RtkPosOf Rule_5 where
+    rtkPosOf (Ctr__Rule_5__0 p _ _) = p
+data Rule_6 = Ctr__Rule_6__0 RtkPos |
+              Ctr__Rule_6__1 RtkPos
               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_6 where
+    rtkPosOf (Ctr__Rule_6__0 p) = p
+    rtkPosOf (Ctr__Rule_6__1 p) = p
 type Rule_7 = [Statement]
 data Statement = Anti_Statement String |
-                 Ctr__Statement__0 Assignment |
-                 Ctr__Statement__1 IfStatement |
-                 Ctr__Statement__2 WhileLoop |
-                 Ctr__Statement__3 Block
+                 Ctr__Statement__0 RtkPos Assignment |
+                 Ctr__Statement__1 RtkPos IfStatement |
+                 Ctr__Statement__2 RtkPos WhileLoop |
+                 Ctr__Statement__3 RtkPos Block
                  deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Statement where
+    rtkPosOf (Anti_Statement _) = rtkNoPos
+    rtkPosOf (Ctr__Statement__0 p _) = p
+    rtkPosOf (Ctr__Statement__1 p _) = p
+    rtkPosOf (Ctr__Statement__2 p _) = p
+    rtkPosOf (Ctr__Statement__3 p _) = p
 data Term = Anti_Term String |
-            Ctr__Term__0 Factor Rule_4
+            Ctr__Term__0 RtkPos Factor Rule_4
             deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Term where
+    rtkPosOf (Anti_Term _) = rtkNoPos
+    rtkPosOf (Ctr__Term__0 p _ _) = p
 data UnusedRule1 = Anti_UnusedRule1 String |
-                   Ctr__UnusedRule1__1 String
+                   Ctr__UnusedRule1__1 RtkPos String
                    deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf UnusedRule1 where
+    rtkPosOf (Anti_UnusedRule1 _) = rtkNoPos
+    rtkPosOf (Ctr__UnusedRule1__1 p _) = p
 type UnusedRule2 = [UnusedRule1]
 data WhileLoop = Anti_WhileLoop String |
-                 Ctr__WhileLoop__0 Expression Statement
+                 Ctr__WhileLoop__0 RtkPos Expression Statement
                  deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf WhileLoop where
+    rtkPosOf (Anti_WhileLoop _) = rtkNoPos
+    rtkPosOf (Ctr__WhileLoop__0 p _ _) = p
 }

--- a/test/golden/debug-test/DebugTestQQ.hs
+++ b/test/golden/debug-test/DebugTestQQ.hs
@@ -51,6 +51,14 @@ replaceAllPatterns str = init <$> replaceAllPatterns1 (str ++ " ")
 
 qqShortcuts = M.fromList [ ("program","Program"),("assignment","Assignment"),("block","Block"),("expression","Expression"),("factor","Factor"),("ifStatement","IfStatement"),("statement","Statement"),("term","Term"),("unusedRule1","UnusedRule1"),("unusedRule2","UnusedRule2"),("whileLoop","WhileLoop")]
 
+-- A quasi-quote pattern must match an AST parsed from anywhere in a source
+-- file, while the pattern itself was parsed from the quote body - so every
+-- RtkPos position field becomes a wildcard in generated patterns.
+-- (Expressions need no special case: the compile-time position they embed
+-- is equality-transparent.)
+rtkPosWildPat :: RtkPos -> Maybe (TH.Q TH.Pat)
+rtkPosWildPat _ = Just TH.wildP
+
 quoteDebugTestExp :: Data.Data a => String -> (Program -> a) -> String -> TH.ExpQ
 quoteDebugTestExp dummy func s = do
   s1 <- either fail return (replaceAllPatterns s)
@@ -66,7 +74,7 @@ quoteDebugTestPat dummy func s = do
            Left err -> fail err
            Right a -> return a
   let expr = func ast
-  dataToPatQ (const Nothing `Generics.extQ` antiStatementPat `Generics.extQ` antiAssignmentPat `Generics.extQ` antiExpressionPat `Generics.extQ` antiTermPat `Generics.extQ` antiFactorPat `Generics.extQ` antiIfStatementPat `Generics.extQ` antiWhileLoopPat `Generics.extQ` antiBlockPat `Generics.extQ` antiUnusedRule1Pat) expr
+  dataToPatQ (const Nothing `Generics.extQ` rtkPosWildPat `Generics.extQ` antiStatementPat `Generics.extQ` antiAssignmentPat `Generics.extQ` antiExpressionPat `Generics.extQ` antiTermPat `Generics.extQ` antiFactorPat `Generics.extQ` antiIfStatementPat `Generics.extQ` antiWhileLoopPat `Generics.extQ` antiBlockPat `Generics.extQ` antiUnusedRule1Pat) expr
 
 antiUnusedRule1Exp :: UnusedRule1 -> Maybe (TH.Q TH.Exp )
 antiUnusedRule1Exp ( Anti_UnusedRule1 v) = Just $ TH.varE (TH.mkName v)
@@ -166,57 +174,57 @@ antiStatementPat _ = Nothing
 quoteDebugTestType s = return TH.ListT
 quoteDebugTestDecs s = return []
 
-getProgram ( Ctr__Program__0 s) = s
+getProgram ( Ctr__Program__0 _ s) = s
 
 program :: QuasiQuoter
 program = QuasiQuoter (quoteDebugTestExp "tok_Program_dummy_19" getProgram ) (quoteDebugTestPat "tok_Program_dummy_19" getProgram ) quoteDebugTestType quoteDebugTestDecs
 
-getAssignment ( Ctr__Program__1 s) = s
+getAssignment ( Ctr__Program__1 _ s) = s
 
 assignment :: QuasiQuoter
 assignment = QuasiQuoter (quoteDebugTestExp "tok_Assignment_dummy_18" getAssignment ) (quoteDebugTestPat "tok_Assignment_dummy_18" getAssignment ) quoteDebugTestType quoteDebugTestDecs
 
-getBlock ( Ctr__Program__2 s) = s
+getBlock ( Ctr__Program__2 _ s) = s
 
 block :: QuasiQuoter
 block = QuasiQuoter (quoteDebugTestExp "tok_Block_dummy_17" getBlock ) (quoteDebugTestPat "tok_Block_dummy_17" getBlock ) quoteDebugTestType quoteDebugTestDecs
 
-getExpression ( Ctr__Program__3 s) = s
+getExpression ( Ctr__Program__3 _ s) = s
 
 expression :: QuasiQuoter
 expression = QuasiQuoter (quoteDebugTestExp "tok_Expression_dummy_16" getExpression ) (quoteDebugTestPat "tok_Expression_dummy_16" getExpression ) quoteDebugTestType quoteDebugTestDecs
 
-getFactor ( Ctr__Program__4 s) = s
+getFactor ( Ctr__Program__4 _ s) = s
 
 factor :: QuasiQuoter
 factor = QuasiQuoter (quoteDebugTestExp "tok_Factor_dummy_15" getFactor ) (quoteDebugTestPat "tok_Factor_dummy_15" getFactor ) quoteDebugTestType quoteDebugTestDecs
 
-getIfStatement ( Ctr__Program__5 s) = s
+getIfStatement ( Ctr__Program__5 _ s) = s
 
 ifStatement :: QuasiQuoter
 ifStatement = QuasiQuoter (quoteDebugTestExp "tok_IfStatement_dummy_14" getIfStatement ) (quoteDebugTestPat "tok_IfStatement_dummy_14" getIfStatement ) quoteDebugTestType quoteDebugTestDecs
 
-getStatement ( Ctr__Program__6 s) = s
+getStatement ( Ctr__Program__6 _ s) = s
 
 statement :: QuasiQuoter
 statement = QuasiQuoter (quoteDebugTestExp "tok_Statement_dummy_13" getStatement ) (quoteDebugTestPat "tok_Statement_dummy_13" getStatement ) quoteDebugTestType quoteDebugTestDecs
 
-getTerm ( Ctr__Program__7 s) = s
+getTerm ( Ctr__Program__7 _ s) = s
 
 term :: QuasiQuoter
 term = QuasiQuoter (quoteDebugTestExp "tok_Term_dummy_12" getTerm ) (quoteDebugTestPat "tok_Term_dummy_12" getTerm ) quoteDebugTestType quoteDebugTestDecs
 
-getUnusedRule1 ( Ctr__Program__8 s) = s
+getUnusedRule1 ( Ctr__Program__8 _ s) = s
 
 unusedRule1 :: QuasiQuoter
 unusedRule1 = QuasiQuoter (quoteDebugTestExp "tok_UnusedRule1_dummy_11" getUnusedRule1 ) (quoteDebugTestPat "tok_UnusedRule1_dummy_11" getUnusedRule1 ) quoteDebugTestType quoteDebugTestDecs
 
-getUnusedRule2 ( Ctr__Program__9 s) = s
+getUnusedRule2 ( Ctr__Program__9 _ s) = s
 
 unusedRule2 :: QuasiQuoter
 unusedRule2 = QuasiQuoter (quoteDebugTestExp "tok_UnusedRule2_dummy_10" getUnusedRule2 ) (quoteDebugTestPat "tok_UnusedRule2_dummy_10" getUnusedRule2 ) quoteDebugTestType quoteDebugTestDecs
 
-getWhileLoop ( Ctr__Program__10 s) = s
+getWhileLoop ( Ctr__Program__10 _ s) = s
 
 whileLoop :: QuasiQuoter
 whileLoop = QuasiQuoter (quoteDebugTestExp "tok_WhileLoop_dummy_9" getWhileLoop ) (quoteDebugTestPat "tok_WhileLoop_dummy_9" getWhileLoop ) quoteDebugTestType quoteDebugTestDecs

--- a/test/golden/grammar/GrammarLexer.x
+++ b/test/golden/grammar/GrammarLexer.x
@@ -1,6 +1,8 @@
 {
+{-# LANGUAGE StandaloneDeriving, DeriveDataTypeable #-}
 module GrammarLexer(scanTokens, alexScanTokens, Token(..), PosToken(..), AlexPosn(..))
 where
+import Data.Data (Data)
 
 import Data.List
 import qualified Data.Map as M
@@ -105,6 +107,11 @@ data Token = EndOfFile |
              Tk__qq_ImportsOpt String |
              Tk__qq_Grammar String
              deriving (Show)
+
+-- AlexPosn is defined by the alex wrapper, so the Data instance (required by
+-- the parser's RtkPos position type) can only be attached via standalone
+-- deriving - the same solution as the hand-written Lexer.x
+deriving instance Data AlexPosn
 
 -- A token together with the source position where it starts
 data PosToken = PosToken { ptPos :: AlexPosn, ptToken :: Token }

--- a/test/golden/grammar/GrammarParser.y
+++ b/test/golden/grammar/GrammarParser.y
@@ -41,61 +41,61 @@ tok__star__13 { L.PosToken _ L.Tk__tok__star__13 }
 tok__rparen__8 { L.PosToken _ L.Tk__tok__rparen__8 }
 tok__lparen__7 { L.PosToken _ L.Tk__tok__lparen__7 }
 tok__exclamation__12 { L.PosToken _ L.Tk__tok__exclamation__12 }
-regexplit { L.PosToken _ (L.Tk__regexplit $$) }
-bigstr { L.PosToken _ (L.Tk__bigstr $$) }
-str { L.PosToken _ (L.Tk__str $$) }
-id { L.PosToken _ (L.Tk__id $$) }
-qq_Name { L.PosToken _ (L.Tk__qq_Name $$) }
-qq_StrLit { L.PosToken _ (L.Tk__qq_StrLit $$) }
-qq_OptDelim { L.PosToken _ (L.Tk__qq_OptDelim $$) }
-qq_Clause { L.PosToken _ (L.Tk__qq_Clause $$) }
-qq_IdList { L.PosToken _ (L.Tk__qq_IdList $$) }
-qq_Option { L.PosToken _ (L.Tk__qq_Option $$) }
-qq_OptionList { L.PosToken _ (L.Tk__qq_OptionList $$) }
-qq_Rule { L.PosToken _ (L.Tk__qq_Rule $$) }
-qq_RuleList { L.PosToken _ (L.Tk__qq_RuleList $$) }
-qq_ImportsOpt { L.PosToken _ (L.Tk__qq_ImportsOpt $$) }
-qq_Grammar { L.PosToken _ (L.Tk__qq_Grammar $$) }
+regexplit { L.PosToken _ (L.Tk__regexplit _) }
+bigstr { L.PosToken _ (L.Tk__bigstr _) }
+str { L.PosToken _ (L.Tk__str _) }
+id { L.PosToken _ (L.Tk__id _) }
+qq_Name { L.PosToken _ (L.Tk__qq_Name _) }
+qq_StrLit { L.PosToken _ (L.Tk__qq_StrLit _) }
+qq_OptDelim { L.PosToken _ (L.Tk__qq_OptDelim _) }
+qq_Clause { L.PosToken _ (L.Tk__qq_Clause _) }
+qq_IdList { L.PosToken _ (L.Tk__qq_IdList _) }
+qq_Option { L.PosToken _ (L.Tk__qq_Option _) }
+qq_OptionList { L.PosToken _ (L.Tk__qq_OptionList _) }
+qq_Rule { L.PosToken _ (L.Tk__qq_Rule _) }
+qq_RuleList { L.PosToken _ (L.Tk__qq_RuleList _) }
+qq_ImportsOpt { L.PosToken _ (L.Tk__qq_ImportsOpt _) }
+qq_Grammar { L.PosToken _ (L.Tk__qq_Grammar _) }
 
 %%
 
 Grammar__top : Grammar rtk__eof { $1 }
 
-Grammar : tok_Grammar_dummy_15 Grammar tok_Grammar_dummy_15 { Ctr__Grammar__0 $2 } |
-          tok_Clause_dummy_14 Clause tok_Clause_dummy_14 { Ctr__Grammar__1 $2 } |
-          tok_IdList_dummy_13 IdList tok_IdList_dummy_13 { Ctr__Grammar__2 (reverse $2) } |
-          tok_ImportsOpt_dummy_12 ImportsOpt tok_ImportsOpt_dummy_12 { Ctr__Grammar__3 $2 } |
-          tok_Name_dummy_11 Name tok_Name_dummy_11 { Ctr__Grammar__4 $2 } |
-          tok_OptDelim_dummy_10 OptDelim tok_OptDelim_dummy_10 { Ctr__Grammar__5 $2 } |
-          tok_Option_dummy_9 Option tok_Option_dummy_9 { Ctr__Grammar__6 $2 } |
-          tok_OptionList_dummy_8 OptionList tok_OptionList_dummy_8 { Ctr__Grammar__7 (reverse $2) } |
-          tok_Rule_dummy_7 Rule tok_Rule_dummy_7 { Ctr__Grammar__8 $2 } |
-          tok_RuleList_dummy_6 RuleList tok_RuleList_dummy_6 { Ctr__Grammar__9 (reverse $2) } |
-          tok_StrLit_dummy_5 StrLit tok_StrLit_dummy_5 { Ctr__Grammar__10 $2 }
+Grammar : tok_Grammar_dummy_15 Grammar tok_Grammar_dummy_15 { Ctr__Grammar__0 (rtkPosOf $1) $2 } |
+          tok_Clause_dummy_14 Clause tok_Clause_dummy_14 { Ctr__Grammar__1 (rtkPosOf $1) $2 } |
+          tok_IdList_dummy_13 IdList tok_IdList_dummy_13 { Ctr__Grammar__2 (rtkPosOf $1) (reverse $2) } |
+          tok_ImportsOpt_dummy_12 ImportsOpt tok_ImportsOpt_dummy_12 { Ctr__Grammar__3 (rtkPosOf $1) $2 } |
+          tok_Name_dummy_11 Name tok_Name_dummy_11 { Ctr__Grammar__4 (rtkPosOf $1) $2 } |
+          tok_OptDelim_dummy_10 OptDelim tok_OptDelim_dummy_10 { Ctr__Grammar__5 (rtkPosOf $1) $2 } |
+          tok_Option_dummy_9 Option tok_Option_dummy_9 { Ctr__Grammar__6 (rtkPosOf $1) $2 } |
+          tok_OptionList_dummy_8 OptionList tok_OptionList_dummy_8 { Ctr__Grammar__7 (rtkPosOf $1) (reverse $2) } |
+          tok_Rule_dummy_7 Rule tok_Rule_dummy_7 { Ctr__Grammar__8 (rtkPosOf $1) $2 } |
+          tok_RuleList_dummy_6 RuleList tok_RuleList_dummy_6 { Ctr__Grammar__9 (rtkPosOf $1) (reverse $2) } |
+          tok_StrLit_dummy_5 StrLit tok_StrLit_dummy_5 { Ctr__Grammar__10 (rtkPosOf $1) $2 }
 
-Grammar : qq_Grammar { Anti_Grammar $1 } |
-          tok_grammar_0 StrLit tok__semi__1 ImportsOpt RuleList { Ctr__Grammar__11 $2 $4 (reverse $5) }
+Grammar : qq_Grammar { Anti_Grammar (tkVal_qq_Grammar $1) } |
+          tok_grammar_0 StrLit tok__semi__1 ImportsOpt RuleList { Ctr__Grammar__11 (rtkPosOf $1) $2 $4 (reverse $5) }
 
-Clause5 : qq_Clause { Anti_Clause $1 } |
+Clause5 : qq_Clause { Anti_Clause (tkVal_qq_Clause $1) } |
           tok__lparen__7 Clause tok__rparen__8 { $2 } |
-          Name { Ctr__Clause__1 $1 } |
-          StrLit { Ctr__Clause__2 $1 } |
-          tok__dot__5 { Ctr__Clause__3 } |
-          regexplit { Ctr__Clause__4 $1 }
+          Name { Ctr__Clause__1 (rtkPosOf $1) $1 } |
+          StrLit { Ctr__Clause__2 (rtkPosOf $1) $1 } |
+          tok__dot__5 { Ctr__Clause__3 (rtkPosOf $1) } |
+          regexplit { Ctr__Clause__4 (rtkPosOf $1) (tkVal_regexplit $1) }
 
-Clause4 : Clause5 tok__star__13 OptDelim { Ctr__Clause__5 $1 $3 } |
-          Clause5 tok__plus__14 OptDelim { Ctr__Clause__6 $1 $3 } |
-          Clause5 tok__symbol__15 { Ctr__Clause__7 $1 } |
+Clause4 : Clause5 tok__star__13 OptDelim { Ctr__Clause__5 (rtkPosOf $1) $1 $3 } |
+          Clause5 tok__plus__14 OptDelim { Ctr__Clause__6 (rtkPosOf $1) $1 $3 } |
+          Clause5 tok__symbol__15 { Ctr__Clause__7 (rtkPosOf $1) $1 } |
           Clause5 { $1 }
 
-Clause3 : tok__coma__10 Clause4 { Ctr__Clause__9 $2 } |
-          tok__exclamation__12 Clause4 { Ctr__Clause__10 $2 } |
+Clause3 : tok__coma__10 Clause4 { Ctr__Clause__9 (rtkPosOf $1) $2 } |
+          tok__exclamation__12 Clause4 { Ctr__Clause__10 (rtkPosOf $1) $2 } |
           Clause4 { $1 }
 
-Clause2 : Clause2 Clause3 { Ctr__Clause__12 $1 $2 } |
+Clause2 : Clause2 Clause3 { Ctr__Clause__12 (rtkPosOf $1) $1 $2 } |
           Clause3 { $1 }
 
-Clause : Clause tok__pipe__11 Clause2 { Ctr__Clause__14 $1 $3 } |
+Clause : Clause tok__pipe__11 Clause2 { Ctr__Clause__14 (rtkPosOf $1) $1 $3 } |
          Clause2 { $1 }
 
 IdList__plus_list_ : ListElem_IdList3 { [$1] } |
@@ -104,51 +104,51 @@ IdList__plus_list_ : ListElem_IdList3 { [$1] } |
 IdList : IdList__plus_list_ { $1 } |
          {- empty -} { [] }
 
-ImportsOpt : qq_ImportsOpt { Anti_ImportsOpt $1 } |
-             { Ctr__ImportsOpt__0 } |
-             Rule_0 { Ctr__ImportsOpt__1 $1 }
+ImportsOpt : qq_ImportsOpt { Anti_ImportsOpt (tkVal_qq_ImportsOpt $1) } |
+             { Ctr__ImportsOpt__0 rtkNoPos } |
+             Rule_0 { Ctr__ImportsOpt__1 (rtkPosOf $1) $1 }
 
-Name : qq_Name { Anti_Name $1 } |
-       id { Ctr__Name__0 $1 }
+Name : qq_Name { Anti_Name (tkVal_qq_Name $1) } |
+       id { Ctr__Name__0 (rtkPosOf $1) (tkVal_id $1) }
 
-ListElem_IdList3 : qq_IdList { Anti_Name $1 } |
+ListElem_IdList3 : qq_IdList { Anti_Name (tkVal_qq_IdList $1) } |
                    Name { $1 }
 
-OptDelim : qq_OptDelim { Anti_OptDelim $1 } |
-           { Ctr__OptDelim__0 } |
-           Rule_4 { Ctr__OptDelim__1 $1 }
+OptDelim : qq_OptDelim { Anti_OptDelim (tkVal_qq_OptDelim $1) } |
+           { Ctr__OptDelim__0 rtkNoPos } |
+           Rule_4 { Ctr__OptDelim__1 (rtkPosOf $1) $1 }
 
-Option : qq_Option { Anti_Option $1 } |
-         tok__symbol_shortcuts_6 tok__lparen__7 IdList tok__rparen__8 { Ctr__Option__0 (reverse $3) } |
-         tok__symbol_symmacro_9 { Ctr__Option__1 }
+Option : qq_Option { Anti_Option (tkVal_qq_Option $1) } |
+         tok__symbol_shortcuts_6 tok__lparen__7 IdList tok__rparen__8 { Ctr__Option__0 (rtkPosOf $1) (reverse $3) } |
+         tok__symbol_symmacro_9 { Ctr__Option__1 (rtkPosOf $1) }
 
-ListElem_OptionList2 : qq_OptionList { Anti_Option $1 } |
+ListElem_OptionList2 : qq_OptionList { Anti_Option (tkVal_qq_OptionList $1) } |
                        Option { $1 }
 
 OptionList : ListElem_OptionList2 { [$1] } |
              OptionList ListElem_OptionList2 { $2 : $1 }
 
-Rule1 : qq_Rule { Anti_Rule $1 } |
-        Name tok__eql__3 Clause tok__semi__1 { Ctr__Rule__0 $1 $3 } |
-        Name tok__colon__4 Name tok__eql__3 Clause tok__semi__1 { Ctr__Rule__1 $1 $3 $5 } |
-        Name tok__dot__5 Name tok__colon__4 Name tok__eql__3 Clause tok__semi__1 { Ctr__Rule__2 $1 $3 $5 $7 } |
-        tok__dot__5 Name tok__colon__4 Name tok__eql__3 Clause tok__semi__1 { Ctr__Rule__3 $2 $4 $6 }
+Rule1 : qq_Rule { Anti_Rule (tkVal_qq_Rule $1) } |
+        Name tok__eql__3 Clause tok__semi__1 { Ctr__Rule__0 (rtkPosOf $1) $1 $3 } |
+        Name tok__colon__4 Name tok__eql__3 Clause tok__semi__1 { Ctr__Rule__1 (rtkPosOf $1) $1 $3 $5 } |
+        Name tok__dot__5 Name tok__colon__4 Name tok__eql__3 Clause tok__semi__1 { Ctr__Rule__2 (rtkPosOf $1) $1 $3 $5 $7 } |
+        tok__dot__5 Name tok__colon__4 Name tok__eql__3 Clause tok__semi__1 { Ctr__Rule__3 (rtkPosOf $1) $2 $4 $6 }
 
-Rule : OptionList Rule1 { Ctr__Rule__4 (reverse $1) $2 } |
+Rule : OptionList Rule1 { Ctr__Rule__4 (rtkPosOf (reverse $1)) (reverse $1) $2 } |
        Rule1 { $1 }
 
-ListElem_RuleList1 : qq_RuleList { Anti_Rule $1 } |
+ListElem_RuleList1 : qq_RuleList { Anti_Rule (tkVal_qq_RuleList $1) } |
                      Rule { $1 }
 
 RuleList : {- empty -} { [] } |
            RuleList ListElem_RuleList1 { $2 : $1 }
 
-Rule_0 : tok_imports_2 bigstr { Ctr__Rule_0__0 $2 }
+Rule_0 : tok_imports_2 bigstr { Ctr__Rule_0__0 (rtkPosOf $1) (tkVal_bigstr $2) }
 
-Rule_4 : tok__tilde__16 Clause5 { Ctr__Rule_4__0 $2 }
+Rule_4 : tok__tilde__16 Clause5 { Ctr__Rule_4__0 (rtkPosOf $1) $2 }
 
-StrLit : qq_StrLit { Anti_StrLit $1 } |
-         str { Ctr__StrLit__0 $1 }
+StrLit : qq_StrLit { Anti_StrLit (tkVal_qq_StrLit $1) } |
+         str { Ctr__StrLit__0 (rtkPosOf $1) (tkVal_str $1) }
 
 
 {
@@ -204,63 +204,195 @@ showRtkToken (L.Tk__qq_RuleList v) = "qq_RuleList " ++ show v
 showRtkToken (L.Tk__qq_ImportsOpt v) = "qq_ImportsOpt " ++ show v
 showRtkToken (L.Tk__qq_Grammar v) = "qq_Grammar " ++ show v
 
-data Grammar = Ctr__Grammar__0 Grammar |
-               Ctr__Grammar__1 Clause |
-               Ctr__Grammar__2 IdList |
-               Ctr__Grammar__3 ImportsOpt |
-               Ctr__Grammar__4 Name |
-               Ctr__Grammar__5 OptDelim |
-               Ctr__Grammar__6 Option |
-               Ctr__Grammar__7 OptionList |
-               Ctr__Grammar__8 Rule |
-               Ctr__Grammar__9 RuleList |
-               Ctr__Grammar__10 StrLit |
+-- Source position of a node: every constructor except the Anti_* splice
+-- artifacts stores the position of its alternative's first symbol in its
+-- first field. Positions are transparent for equality and ordering, so two
+-- ASTs that differ only in source positions (e.g. a quasi-quote parsed at
+-- compile time vs the same construct parsed at run time) compare equal.
+newtype RtkPos = RtkPos L.AlexPosn deriving (Show, Gen.Data, Gen.Typeable)
+instance Eq RtkPos where _ == _ = True
+instance Ord RtkPos where compare _ _ = EQ
+
+-- The position used where no source token exists: empty productions, empty
+-- lists, absent optionals and Anti_* quasi-quote splices
+rtkNoPos :: RtkPos
+rtkNoPos = RtkPos (L.AlexPn 0 0 0)
+
+class RtkPosOf a where
+    rtkPosOf :: a -> RtkPos
+instance RtkPosOf L.PosToken where
+    rtkPosOf (L.PosToken p _) = RtkPos p
+instance RtkPosOf a => RtkPosOf [a] where
+    rtkPosOf (x : _) = rtkPosOf x
+    rtkPosOf []      = rtkNoPos
+instance RtkPosOf a => RtkPosOf (Maybe a) where
+    rtkPosOf (Just x) = rtkPosOf x
+    rtkPosOf Nothing  = rtkNoPos
+-- A Char carries no position; this also covers String token payloads
+instance RtkPosOf Char where
+    rtkPosOf _ = rtkNoPos
+
+-- Recover a token's payload from the whole positioned token: %token
+-- bindings keep the L.PosToken so semantic actions can read its position
+tkVal_regexplit :: L.PosToken -> String
+tkVal_regexplit (L.PosToken _ (L.Tk__regexplit v)) = v
+tkVal_regexplit t = error ("rtk internal error: token regexplit expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_bigstr :: L.PosToken -> String
+tkVal_bigstr (L.PosToken _ (L.Tk__bigstr v)) = v
+tkVal_bigstr t = error ("rtk internal error: token bigstr expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_str :: L.PosToken -> String
+tkVal_str (L.PosToken _ (L.Tk__str v)) = v
+tkVal_str t = error ("rtk internal error: token str expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_id :: L.PosToken -> String
+tkVal_id (L.PosToken _ (L.Tk__id v)) = v
+tkVal_id t = error ("rtk internal error: token id expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_Name :: L.PosToken -> String
+tkVal_qq_Name (L.PosToken _ (L.Tk__qq_Name v)) = v
+tkVal_qq_Name t = error ("rtk internal error: token qq_Name expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_StrLit :: L.PosToken -> String
+tkVal_qq_StrLit (L.PosToken _ (L.Tk__qq_StrLit v)) = v
+tkVal_qq_StrLit t = error ("rtk internal error: token qq_StrLit expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_OptDelim :: L.PosToken -> String
+tkVal_qq_OptDelim (L.PosToken _ (L.Tk__qq_OptDelim v)) = v
+tkVal_qq_OptDelim t = error ("rtk internal error: token qq_OptDelim expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_Clause :: L.PosToken -> String
+tkVal_qq_Clause (L.PosToken _ (L.Tk__qq_Clause v)) = v
+tkVal_qq_Clause t = error ("rtk internal error: token qq_Clause expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_IdList :: L.PosToken -> String
+tkVal_qq_IdList (L.PosToken _ (L.Tk__qq_IdList v)) = v
+tkVal_qq_IdList t = error ("rtk internal error: token qq_IdList expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_Option :: L.PosToken -> String
+tkVal_qq_Option (L.PosToken _ (L.Tk__qq_Option v)) = v
+tkVal_qq_Option t = error ("rtk internal error: token qq_Option expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_OptionList :: L.PosToken -> String
+tkVal_qq_OptionList (L.PosToken _ (L.Tk__qq_OptionList v)) = v
+tkVal_qq_OptionList t = error ("rtk internal error: token qq_OptionList expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_Rule :: L.PosToken -> String
+tkVal_qq_Rule (L.PosToken _ (L.Tk__qq_Rule v)) = v
+tkVal_qq_Rule t = error ("rtk internal error: token qq_Rule expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_RuleList :: L.PosToken -> String
+tkVal_qq_RuleList (L.PosToken _ (L.Tk__qq_RuleList v)) = v
+tkVal_qq_RuleList t = error ("rtk internal error: token qq_RuleList expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_ImportsOpt :: L.PosToken -> String
+tkVal_qq_ImportsOpt (L.PosToken _ (L.Tk__qq_ImportsOpt v)) = v
+tkVal_qq_ImportsOpt t = error ("rtk internal error: token qq_ImportsOpt expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_Grammar :: L.PosToken -> String
+tkVal_qq_Grammar (L.PosToken _ (L.Tk__qq_Grammar v)) = v
+tkVal_qq_Grammar t = error ("rtk internal error: token qq_Grammar expected, got " ++ showRtkToken (L.ptToken t))
+
+data Grammar = Ctr__Grammar__0 RtkPos Grammar |
+               Ctr__Grammar__1 RtkPos Clause |
+               Ctr__Grammar__2 RtkPos IdList |
+               Ctr__Grammar__3 RtkPos ImportsOpt |
+               Ctr__Grammar__4 RtkPos Name |
+               Ctr__Grammar__5 RtkPos OptDelim |
+               Ctr__Grammar__6 RtkPos Option |
+               Ctr__Grammar__7 RtkPos OptionList |
+               Ctr__Grammar__8 RtkPos Rule |
+               Ctr__Grammar__9 RtkPos RuleList |
+               Ctr__Grammar__10 RtkPos StrLit |
                Anti_Grammar String |
-               Ctr__Grammar__11 StrLit ImportsOpt RuleList
+               Ctr__Grammar__11 RtkPos StrLit ImportsOpt RuleList
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Grammar where
+    rtkPosOf (Ctr__Grammar__0 p _) = p
+    rtkPosOf (Ctr__Grammar__1 p _) = p
+    rtkPosOf (Ctr__Grammar__2 p _) = p
+    rtkPosOf (Ctr__Grammar__3 p _) = p
+    rtkPosOf (Ctr__Grammar__4 p _) = p
+    rtkPosOf (Ctr__Grammar__5 p _) = p
+    rtkPosOf (Ctr__Grammar__6 p _) = p
+    rtkPosOf (Ctr__Grammar__7 p _) = p
+    rtkPosOf (Ctr__Grammar__8 p _) = p
+    rtkPosOf (Ctr__Grammar__9 p _) = p
+    rtkPosOf (Ctr__Grammar__10 p _) = p
+    rtkPosOf (Anti_Grammar _) = rtkNoPos
+    rtkPosOf (Ctr__Grammar__11 p _ _ _) = p
 data Clause = Anti_Clause String |
-              Ctr__Clause__1 Name |
-              Ctr__Clause__2 StrLit |
-              Ctr__Clause__3 |
-              Ctr__Clause__4 String |
-              Ctr__Clause__5 Clause OptDelim |
-              Ctr__Clause__6 Clause OptDelim |
-              Ctr__Clause__7 Clause |
-              Ctr__Clause__9 Clause |
-              Ctr__Clause__10 Clause |
-              Ctr__Clause__12 Clause Clause |
-              Ctr__Clause__14 Clause Clause
+              Ctr__Clause__1 RtkPos Name |
+              Ctr__Clause__2 RtkPos StrLit |
+              Ctr__Clause__3 RtkPos |
+              Ctr__Clause__4 RtkPos String |
+              Ctr__Clause__5 RtkPos Clause OptDelim |
+              Ctr__Clause__6 RtkPos Clause OptDelim |
+              Ctr__Clause__7 RtkPos Clause |
+              Ctr__Clause__9 RtkPos Clause |
+              Ctr__Clause__10 RtkPos Clause |
+              Ctr__Clause__12 RtkPos Clause Clause |
+              Ctr__Clause__14 RtkPos Clause Clause
               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Clause where
+    rtkPosOf (Anti_Clause _) = rtkNoPos
+    rtkPosOf (Ctr__Clause__1 p _) = p
+    rtkPosOf (Ctr__Clause__2 p _) = p
+    rtkPosOf (Ctr__Clause__3 p) = p
+    rtkPosOf (Ctr__Clause__4 p _) = p
+    rtkPosOf (Ctr__Clause__5 p _ _) = p
+    rtkPosOf (Ctr__Clause__6 p _ _) = p
+    rtkPosOf (Ctr__Clause__7 p _) = p
+    rtkPosOf (Ctr__Clause__9 p _) = p
+    rtkPosOf (Ctr__Clause__10 p _) = p
+    rtkPosOf (Ctr__Clause__12 p _ _) = p
+    rtkPosOf (Ctr__Clause__14 p _ _) = p
 type IdList = [Name]
 data ImportsOpt = Anti_ImportsOpt String |
-                  Ctr__ImportsOpt__0 |
-                  Ctr__ImportsOpt__1 Rule_0
+                  Ctr__ImportsOpt__0 RtkPos |
+                  Ctr__ImportsOpt__1 RtkPos Rule_0
                   deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf ImportsOpt where
+    rtkPosOf (Anti_ImportsOpt _) = rtkNoPos
+    rtkPosOf (Ctr__ImportsOpt__0 p) = p
+    rtkPosOf (Ctr__ImportsOpt__1 p _) = p
 data Name = Anti_Name String |
-            Ctr__Name__0 String
+            Ctr__Name__0 RtkPos String
             deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Name where
+    rtkPosOf (Anti_Name _) = rtkNoPos
+    rtkPosOf (Ctr__Name__0 p _) = p
 data OptDelim = Anti_OptDelim String |
-                Ctr__OptDelim__0 |
-                Ctr__OptDelim__1 Rule_4
+                Ctr__OptDelim__0 RtkPos |
+                Ctr__OptDelim__1 RtkPos Rule_4
                 deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf OptDelim where
+    rtkPosOf (Anti_OptDelim _) = rtkNoPos
+    rtkPosOf (Ctr__OptDelim__0 p) = p
+    rtkPosOf (Ctr__OptDelim__1 p _) = p
 data Option = Anti_Option String |
-              Ctr__Option__0 IdList |
-              Ctr__Option__1
+              Ctr__Option__0 RtkPos IdList |
+              Ctr__Option__1 RtkPos
               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Option where
+    rtkPosOf (Anti_Option _) = rtkNoPos
+    rtkPosOf (Ctr__Option__0 p _) = p
+    rtkPosOf (Ctr__Option__1 p) = p
 type OptionList = [Option]
 data Rule = Anti_Rule String |
-            Ctr__Rule__0 Name Clause |
-            Ctr__Rule__1 Name Name Clause |
-            Ctr__Rule__2 Name Name Name Clause |
-            Ctr__Rule__3 Name Name Clause |
-            Ctr__Rule__4 OptionList Rule
+            Ctr__Rule__0 RtkPos Name Clause |
+            Ctr__Rule__1 RtkPos Name Name Clause |
+            Ctr__Rule__2 RtkPos Name Name Name Clause |
+            Ctr__Rule__3 RtkPos Name Name Clause |
+            Ctr__Rule__4 RtkPos OptionList Rule
             deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule where
+    rtkPosOf (Anti_Rule _) = rtkNoPos
+    rtkPosOf (Ctr__Rule__0 p _ _) = p
+    rtkPosOf (Ctr__Rule__1 p _ _ _) = p
+    rtkPosOf (Ctr__Rule__2 p _ _ _ _) = p
+    rtkPosOf (Ctr__Rule__3 p _ _ _) = p
+    rtkPosOf (Ctr__Rule__4 p _ _) = p
 type RuleList = [Rule]
-data Rule_0 = Ctr__Rule_0__0 String
+data Rule_0 = Ctr__Rule_0__0 RtkPos String
               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_4 = Ctr__Rule_4__0 Clause
+instance RtkPosOf Rule_0 where
+    rtkPosOf (Ctr__Rule_0__0 p _) = p
+data Rule_4 = Ctr__Rule_4__0 RtkPos Clause
               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_4 where
+    rtkPosOf (Ctr__Rule_4__0 p _) = p
 data StrLit = Anti_StrLit String |
-              Ctr__StrLit__0 String
+              Ctr__StrLit__0 RtkPos String
               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf StrLit where
+    rtkPosOf (Anti_StrLit _) = rtkNoPos
+    rtkPosOf (Ctr__StrLit__0 p _) = p
 }

--- a/test/golden/grammar/GrammarQQ.hs
+++ b/test/golden/grammar/GrammarQQ.hs
@@ -51,6 +51,14 @@ replaceAllPatterns str = init <$> replaceAllPatterns1 (str ++ " ")
 
 qqShortcuts = M.fromList [ ("grammar","Grammar"),("clause","Clause"),("idList","IdList"),("importsOpt","ImportsOpt"),("name","Name"),("optDelim","OptDelim"),("option","Option"),("optionList","OptionList"),("rule","Rule"),("ruleList","RuleList"),("strLit","StrLit"),("cl","Clause"),("r","Rule")]
 
+-- A quasi-quote pattern must match an AST parsed from anywhere in a source
+-- file, while the pattern itself was parsed from the quote body - so every
+-- RtkPos position field becomes a wildcard in generated patterns.
+-- (Expressions need no special case: the compile-time position they embed
+-- is equality-transparent.)
+rtkPosWildPat :: RtkPos -> Maybe (TH.Q TH.Pat)
+rtkPosWildPat _ = Just TH.wildP
+
 quoteGrammarExp :: Data.Data a => String -> (Grammar -> a) -> String -> TH.ExpQ
 quoteGrammarExp dummy func s = do
   s1 <- either fail return (replaceAllPatterns s)
@@ -66,7 +74,7 @@ quoteGrammarPat dummy func s = do
            Left err -> fail err
            Right a -> return a
   let expr = func ast
-  dataToPatQ (const Nothing `Generics.extQ` antiGrammarPat `Generics.extQ` antiImportsOptPat `Generics.extQ` antiRulePat `Generics.extQ` antiOptionPat `Generics.extQ` antiNamePat `Generics.extQ` antiClausePat `Generics.extQ` antiOptDelimPat `Generics.extQ` antiStrLitPat) expr
+  dataToPatQ (const Nothing `Generics.extQ` rtkPosWildPat `Generics.extQ` antiGrammarPat `Generics.extQ` antiImportsOptPat `Generics.extQ` antiRulePat `Generics.extQ` antiOptionPat `Generics.extQ` antiNamePat `Generics.extQ` antiClausePat `Generics.extQ` antiOptDelimPat `Generics.extQ` antiStrLitPat) expr
 
 antiStrLitExp :: StrLit -> Maybe (TH.Q TH.Exp )
 antiStrLitExp ( Anti_StrLit v) = Just $ TH.varE (TH.mkName v)
@@ -162,57 +170,57 @@ antiGrammarPat _ = Nothing
 quoteGrammarType s = return TH.ListT
 quoteGrammarDecs s = return []
 
-getGrammar ( Ctr__Grammar__0 s) = s
+getGrammar ( Ctr__Grammar__0 _ s) = s
 
 grammar :: QuasiQuoter
 grammar = QuasiQuoter (quoteGrammarExp "tok_Grammar_dummy_15" getGrammar ) (quoteGrammarPat "tok_Grammar_dummy_15" getGrammar ) quoteGrammarType quoteGrammarDecs
 
-getClause ( Ctr__Grammar__1 s) = s
+getClause ( Ctr__Grammar__1 _ s) = s
 
 clause :: QuasiQuoter
 clause = QuasiQuoter (quoteGrammarExp "tok_Clause_dummy_14" getClause ) (quoteGrammarPat "tok_Clause_dummy_14" getClause ) quoteGrammarType quoteGrammarDecs
 
-getIdList ( Ctr__Grammar__2 s) = s
+getIdList ( Ctr__Grammar__2 _ s) = s
 
 idList :: QuasiQuoter
 idList = QuasiQuoter (quoteGrammarExp "tok_IdList_dummy_13" getIdList ) (quoteGrammarPat "tok_IdList_dummy_13" getIdList ) quoteGrammarType quoteGrammarDecs
 
-getImportsOpt ( Ctr__Grammar__3 s) = s
+getImportsOpt ( Ctr__Grammar__3 _ s) = s
 
 importsOpt :: QuasiQuoter
 importsOpt = QuasiQuoter (quoteGrammarExp "tok_ImportsOpt_dummy_12" getImportsOpt ) (quoteGrammarPat "tok_ImportsOpt_dummy_12" getImportsOpt ) quoteGrammarType quoteGrammarDecs
 
-getName ( Ctr__Grammar__4 s) = s
+getName ( Ctr__Grammar__4 _ s) = s
 
 name :: QuasiQuoter
 name = QuasiQuoter (quoteGrammarExp "tok_Name_dummy_11" getName ) (quoteGrammarPat "tok_Name_dummy_11" getName ) quoteGrammarType quoteGrammarDecs
 
-getOptDelim ( Ctr__Grammar__5 s) = s
+getOptDelim ( Ctr__Grammar__5 _ s) = s
 
 optDelim :: QuasiQuoter
 optDelim = QuasiQuoter (quoteGrammarExp "tok_OptDelim_dummy_10" getOptDelim ) (quoteGrammarPat "tok_OptDelim_dummy_10" getOptDelim ) quoteGrammarType quoteGrammarDecs
 
-getOption ( Ctr__Grammar__6 s) = s
+getOption ( Ctr__Grammar__6 _ s) = s
 
 option :: QuasiQuoter
 option = QuasiQuoter (quoteGrammarExp "tok_Option_dummy_9" getOption ) (quoteGrammarPat "tok_Option_dummy_9" getOption ) quoteGrammarType quoteGrammarDecs
 
-getOptionList ( Ctr__Grammar__7 s) = s
+getOptionList ( Ctr__Grammar__7 _ s) = s
 
 optionList :: QuasiQuoter
 optionList = QuasiQuoter (quoteGrammarExp "tok_OptionList_dummy_8" getOptionList ) (quoteGrammarPat "tok_OptionList_dummy_8" getOptionList ) quoteGrammarType quoteGrammarDecs
 
-getRule ( Ctr__Grammar__8 s) = s
+getRule ( Ctr__Grammar__8 _ s) = s
 
 rule :: QuasiQuoter
 rule = QuasiQuoter (quoteGrammarExp "tok_Rule_dummy_7" getRule ) (quoteGrammarPat "tok_Rule_dummy_7" getRule ) quoteGrammarType quoteGrammarDecs
 
-getRuleList ( Ctr__Grammar__9 s) = s
+getRuleList ( Ctr__Grammar__9 _ s) = s
 
 ruleList :: QuasiQuoter
 ruleList = QuasiQuoter (quoteGrammarExp "tok_RuleList_dummy_6" getRuleList ) (quoteGrammarPat "tok_RuleList_dummy_6" getRuleList ) quoteGrammarType quoteGrammarDecs
 
-getStrLit ( Ctr__Grammar__10 s) = s
+getStrLit ( Ctr__Grammar__10 _ s) = s
 
 strLit :: QuasiQuoter
 strLit = QuasiQuoter (quoteGrammarExp "tok_StrLit_dummy_5" getStrLit ) (quoteGrammarPat "tok_StrLit_dummy_5" getStrLit ) quoteGrammarType quoteGrammarDecs

--- a/test/golden/haskell/HaskellLexer.x
+++ b/test/golden/haskell/HaskellLexer.x
@@ -1,6 +1,8 @@
 {
+{-# LANGUAGE StandaloneDeriving, DeriveDataTypeable #-}
 module HaskellLexer(scanTokens, alexScanTokens, Token(..), PosToken(..), AlexPosn(..))
 where
+import Data.Data (Data)
 
  }
 %wrapper "monad"
@@ -363,6 +365,11 @@ data Token = EndOfFile |
              Tk__qq_Module String |
              Tk__qq_Haskell String
              deriving (Show)
+
+-- AlexPosn is defined by the alex wrapper, so the Data instance (required by
+-- the parser's RtkPos position type) can only be attached via standalone
+-- deriving - the same solution as the hand-written Lexer.x
+deriving instance Data AlexPosn
 
 -- A token together with the source position where it starts
 data PosToken = PosToken { ptPos :: AlexPosn, ptToken :: Token }

--- a/test/golden/haskell/HaskellParser.y
+++ b/test/golden/haskell/HaskellParser.y
@@ -109,369 +109,369 @@ tok__coma__3 { L.PosToken _ L.Tk__tok__coma__3 }
 tok__rparen__4 { L.PosToken _ L.Tk__tok__rparen__4 }
 tok__lparen__2 { L.PosToken _ L.Tk__tok__lparen__2 }
 tok__exclamation__22 { L.PosToken _ L.Tk__tok__exclamation__22 }
-th { L.PosToken _ (L.Tk__th $$) }
-ncomment { L.PosToken _ (L.Tk__ncomment $$) }
-whitespace { L.PosToken _ (L.Tk__whitespace $$) }
-integer { L.PosToken _ (L.Tk__integer $$) }
-hexadecimal { L.PosToken _ (L.Tk__hexadecimal $$) }
-octal { L.PosToken _ (L.Tk__octal $$) }
-decimal { L.PosToken _ (L.Tk__decimal $$) }
-qq_QOp { L.PosToken _ (L.Tk__qq_QOp $$) }
-qq_Op { L.PosToken _ (L.Tk__qq_Op $$) }
-qq_TyCls { L.PosToken _ (L.Tk__qq_TyCls $$) }
-qq_ModId { L.PosToken _ (L.Tk__qq_ModId $$) }
-qq_TyCon { L.PosToken _ (L.Tk__qq_TyCon $$) }
-qq_TyVar { L.PosToken _ (L.Tk__qq_TyVar $$) }
-varid { L.PosToken _ (L.Tk__varid $$) }
-conid { L.PosToken _ (L.Tk__conid $$) }
-qq_TyVars { L.PosToken _ (L.Tk__qq_TyVars $$) }
-qq_SimpleType { L.PosToken _ (L.Tk__qq_SimpleType $$) }
-qq_TypeList { L.PosToken _ (L.Tk__qq_TypeList $$) }
-qq_GTyCon { L.PosToken _ (L.Tk__qq_GTyCon $$) }
-qq_AType { L.PosToken _ (L.Tk__qq_AType $$) }
-qq_ATypeList { L.PosToken _ (L.Tk__qq_ATypeList $$) }
-qq_BType { L.PosToken _ (L.Tk__qq_BType $$) }
-qq_Type { L.PosToken _ (L.Tk__qq_Type $$) }
-qq_Class { L.PosToken _ (L.Tk__qq_Class $$) }
-qq_ClassList { L.PosToken _ (L.Tk__qq_ClassList $$) }
-qq_Context { L.PosToken _ (L.Tk__qq_Context $$) }
-qq_DClass { L.PosToken _ (L.Tk__qq_DClass $$) }
-qq_DClassList { L.PosToken _ (L.Tk__qq_DClassList $$) }
-qq_Deriving { L.PosToken _ (L.Tk__qq_Deriving $$) }
-qq_OptDeriving { L.PosToken _ (L.Tk__qq_OptDeriving $$) }
-qq_Vars { L.PosToken _ (L.Tk__qq_Vars $$) }
-qq_FieldDecl { L.PosToken _ (L.Tk__qq_FieldDecl $$) }
-qq_FieldDeclList { L.PosToken _ (L.Tk__qq_FieldDeclList $$) }
-qq_Constr { L.PosToken _ (L.Tk__qq_Constr $$) }
-qq_Constrs { L.PosToken _ (L.Tk__qq_Constrs $$) }
-qq_GdRhs { L.PosToken _ (L.Tk__qq_GdRhs $$) }
-qq_ExpI { L.PosToken _ (L.Tk__qq_ExpI $$) }
-qq_Exp { L.PosToken _ (L.Tk__qq_Exp $$) }
-qq_OptExpTypeSignature { L.PosToken _ (L.Tk__qq_OptExpTypeSignature $$) }
-qq_Gd { L.PosToken _ (L.Tk__qq_Gd $$) }
-qq_OptGdRhs { L.PosToken _ (L.Tk__qq_OptGdRhs $$) }
-qq_Rhs { L.PosToken _ (L.Tk__qq_Rhs $$) }
-qq_Decls { L.PosToken _ (L.Tk__qq_Decls $$) }
-qq_DeclList { L.PosToken _ (L.Tk__qq_DeclList $$) }
-qq_OptWhere { L.PosToken _ (L.Tk__qq_OptWhere $$) }
-qq_Pat { L.PosToken _ (L.Tk__qq_Pat $$) }
-qq_FunLhs { L.PosToken _ (L.Tk__qq_FunLhs $$) }
-qq_Fixity { L.PosToken _ (L.Tk__qq_Fixity $$) }
-qq_Ops { L.PosToken _ (L.Tk__qq_Ops $$) }
-qq_OptInteger { L.PosToken _ (L.Tk__qq_OptInteger $$) }
-qq_GenDecl { L.PosToken _ (L.Tk__qq_GenDecl $$) }
-qq_OptContext { L.PosToken _ (L.Tk__qq_OptContext $$) }
-qq_Decl { L.PosToken _ (L.Tk__qq_Decl $$) }
-qq_TopDecl { L.PosToken _ (L.Tk__qq_TopDecl $$) }
-qq_TopDecls { L.PosToken _ (L.Tk__qq_TopDecls $$) }
-qq_ImpDecl { L.PosToken _ (L.Tk__qq_ImpDecl $$) }
-qq_OptImpSpec { L.PosToken _ (L.Tk__qq_OptImpSpec $$) }
-qq_OptQualifiedAs { L.PosToken _ (L.Tk__qq_OptQualifiedAs $$) }
-qq_OptQualified { L.PosToken _ (L.Tk__qq_OptQualified $$) }
-qq_Import { L.PosToken _ (L.Tk__qq_Import $$) }
-qq_QVarList { L.PosToken _ (L.Tk__qq_QVarList $$) }
-qq_CNameList { L.PosToken _ (L.Tk__qq_CNameList $$) }
-qq_CName { L.PosToken _ (L.Tk__qq_CName $$) }
-qq_QTyCon { L.PosToken _ (L.Tk__qq_QTyCon $$) }
-qq_QTyCls { L.PosToken _ (L.Tk__qq_QTyCls $$) }
-qq_QVar { L.PosToken _ (L.Tk__qq_QVar $$) }
-qq_QVarId { L.PosToken _ (L.Tk__qq_QVarId $$) }
-qq_ModIdList { L.PosToken _ (L.Tk__qq_ModIdList $$) }
-qq_Con { L.PosToken _ (L.Tk__qq_Con $$) }
-qq_Var { L.PosToken _ (L.Tk__qq_Var $$) }
-qq_ImportList { L.PosToken _ (L.Tk__qq_ImportList $$) }
-qq_ImpDeclList { L.PosToken _ (L.Tk__qq_ImpDeclList $$) }
-qq_Body { L.PosToken _ (L.Tk__qq_Body $$) }
-qq_Export { L.PosToken _ (L.Tk__qq_Export $$) }
-qq_ExportsList { L.PosToken _ (L.Tk__qq_ExportsList $$) }
-qq_ExportsOpt { L.PosToken _ (L.Tk__qq_ExportsOpt $$) }
-qq_Module { L.PosToken _ (L.Tk__qq_Module $$) }
-qq_Haskell { L.PosToken _ (L.Tk__qq_Haskell $$) }
+th { L.PosToken _ (L.Tk__th _) }
+ncomment { L.PosToken _ (L.Tk__ncomment _) }
+whitespace { L.PosToken _ (L.Tk__whitespace _) }
+integer { L.PosToken _ (L.Tk__integer _) }
+hexadecimal { L.PosToken _ (L.Tk__hexadecimal _) }
+octal { L.PosToken _ (L.Tk__octal _) }
+decimal { L.PosToken _ (L.Tk__decimal _) }
+qq_QOp { L.PosToken _ (L.Tk__qq_QOp _) }
+qq_Op { L.PosToken _ (L.Tk__qq_Op _) }
+qq_TyCls { L.PosToken _ (L.Tk__qq_TyCls _) }
+qq_ModId { L.PosToken _ (L.Tk__qq_ModId _) }
+qq_TyCon { L.PosToken _ (L.Tk__qq_TyCon _) }
+qq_TyVar { L.PosToken _ (L.Tk__qq_TyVar _) }
+varid { L.PosToken _ (L.Tk__varid _) }
+conid { L.PosToken _ (L.Tk__conid _) }
+qq_TyVars { L.PosToken _ (L.Tk__qq_TyVars _) }
+qq_SimpleType { L.PosToken _ (L.Tk__qq_SimpleType _) }
+qq_TypeList { L.PosToken _ (L.Tk__qq_TypeList _) }
+qq_GTyCon { L.PosToken _ (L.Tk__qq_GTyCon _) }
+qq_AType { L.PosToken _ (L.Tk__qq_AType _) }
+qq_ATypeList { L.PosToken _ (L.Tk__qq_ATypeList _) }
+qq_BType { L.PosToken _ (L.Tk__qq_BType _) }
+qq_Type { L.PosToken _ (L.Tk__qq_Type _) }
+qq_Class { L.PosToken _ (L.Tk__qq_Class _) }
+qq_ClassList { L.PosToken _ (L.Tk__qq_ClassList _) }
+qq_Context { L.PosToken _ (L.Tk__qq_Context _) }
+qq_DClass { L.PosToken _ (L.Tk__qq_DClass _) }
+qq_DClassList { L.PosToken _ (L.Tk__qq_DClassList _) }
+qq_Deriving { L.PosToken _ (L.Tk__qq_Deriving _) }
+qq_OptDeriving { L.PosToken _ (L.Tk__qq_OptDeriving _) }
+qq_Vars { L.PosToken _ (L.Tk__qq_Vars _) }
+qq_FieldDecl { L.PosToken _ (L.Tk__qq_FieldDecl _) }
+qq_FieldDeclList { L.PosToken _ (L.Tk__qq_FieldDeclList _) }
+qq_Constr { L.PosToken _ (L.Tk__qq_Constr _) }
+qq_Constrs { L.PosToken _ (L.Tk__qq_Constrs _) }
+qq_GdRhs { L.PosToken _ (L.Tk__qq_GdRhs _) }
+qq_ExpI { L.PosToken _ (L.Tk__qq_ExpI _) }
+qq_Exp { L.PosToken _ (L.Tk__qq_Exp _) }
+qq_OptExpTypeSignature { L.PosToken _ (L.Tk__qq_OptExpTypeSignature _) }
+qq_Gd { L.PosToken _ (L.Tk__qq_Gd _) }
+qq_OptGdRhs { L.PosToken _ (L.Tk__qq_OptGdRhs _) }
+qq_Rhs { L.PosToken _ (L.Tk__qq_Rhs _) }
+qq_Decls { L.PosToken _ (L.Tk__qq_Decls _) }
+qq_DeclList { L.PosToken _ (L.Tk__qq_DeclList _) }
+qq_OptWhere { L.PosToken _ (L.Tk__qq_OptWhere _) }
+qq_Pat { L.PosToken _ (L.Tk__qq_Pat _) }
+qq_FunLhs { L.PosToken _ (L.Tk__qq_FunLhs _) }
+qq_Fixity { L.PosToken _ (L.Tk__qq_Fixity _) }
+qq_Ops { L.PosToken _ (L.Tk__qq_Ops _) }
+qq_OptInteger { L.PosToken _ (L.Tk__qq_OptInteger _) }
+qq_GenDecl { L.PosToken _ (L.Tk__qq_GenDecl _) }
+qq_OptContext { L.PosToken _ (L.Tk__qq_OptContext _) }
+qq_Decl { L.PosToken _ (L.Tk__qq_Decl _) }
+qq_TopDecl { L.PosToken _ (L.Tk__qq_TopDecl _) }
+qq_TopDecls { L.PosToken _ (L.Tk__qq_TopDecls _) }
+qq_ImpDecl { L.PosToken _ (L.Tk__qq_ImpDecl _) }
+qq_OptImpSpec { L.PosToken _ (L.Tk__qq_OptImpSpec _) }
+qq_OptQualifiedAs { L.PosToken _ (L.Tk__qq_OptQualifiedAs _) }
+qq_OptQualified { L.PosToken _ (L.Tk__qq_OptQualified _) }
+qq_Import { L.PosToken _ (L.Tk__qq_Import _) }
+qq_QVarList { L.PosToken _ (L.Tk__qq_QVarList _) }
+qq_CNameList { L.PosToken _ (L.Tk__qq_CNameList _) }
+qq_CName { L.PosToken _ (L.Tk__qq_CName _) }
+qq_QTyCon { L.PosToken _ (L.Tk__qq_QTyCon _) }
+qq_QTyCls { L.PosToken _ (L.Tk__qq_QTyCls _) }
+qq_QVar { L.PosToken _ (L.Tk__qq_QVar _) }
+qq_QVarId { L.PosToken _ (L.Tk__qq_QVarId _) }
+qq_ModIdList { L.PosToken _ (L.Tk__qq_ModIdList _) }
+qq_Con { L.PosToken _ (L.Tk__qq_Con _) }
+qq_Var { L.PosToken _ (L.Tk__qq_Var _) }
+qq_ImportList { L.PosToken _ (L.Tk__qq_ImportList _) }
+qq_ImpDeclList { L.PosToken _ (L.Tk__qq_ImpDeclList _) }
+qq_Body { L.PosToken _ (L.Tk__qq_Body _) }
+qq_Export { L.PosToken _ (L.Tk__qq_Export _) }
+qq_ExportsList { L.PosToken _ (L.Tk__qq_ExportsList _) }
+qq_ExportsOpt { L.PosToken _ (L.Tk__qq_ExportsOpt _) }
+qq_Module { L.PosToken _ (L.Tk__qq_Module _) }
+qq_Haskell { L.PosToken _ (L.Tk__qq_Haskell _) }
 
 %%
 
 Haskell__top : Haskell rtk__eof { $1 }
 
-Haskell : tok_Haskell_dummy_122 Haskell tok_Haskell_dummy_122 { Ctr__Haskell__0 $2 } |
-          tok_AType_dummy_121 AType tok_AType_dummy_121 { Ctr__Haskell__1 $2 } |
-          tok_ATypeList_dummy_120 ATypeList tok_ATypeList_dummy_120 { Ctr__Haskell__2 (reverse $2) } |
-          tok_BType_dummy_119 BType tok_BType_dummy_119 { Ctr__Haskell__3 $2 } |
-          tok_Body_dummy_118 Body tok_Body_dummy_118 { Ctr__Haskell__4 $2 } |
-          tok_CName_dummy_117 CName tok_CName_dummy_117 { Ctr__Haskell__5 $2 } |
-          tok_CNameList_dummy_116 CNameList tok_CNameList_dummy_116 { Ctr__Haskell__6 $2 } |
-          tok_Class_dummy_115 Class tok_Class_dummy_115 { Ctr__Haskell__7 $2 } |
-          tok_ClassList_dummy_114 ClassList tok_ClassList_dummy_114 { Ctr__Haskell__8 $2 } |
-          tok_Con_dummy_113 Con tok_Con_dummy_113 { Ctr__Haskell__9 $2 } |
-          tok_Constr_dummy_112 Constr tok_Constr_dummy_112 { Ctr__Haskell__10 $2 } |
-          tok_Constrs_dummy_111 Constrs tok_Constrs_dummy_111 { Ctr__Haskell__11 $2 } |
-          tok_Context_dummy_110 Context tok_Context_dummy_110 { Ctr__Haskell__12 $2 } |
-          tok_DClass_dummy_109 DClass tok_DClass_dummy_109 { Ctr__Haskell__13 $2 } |
-          tok_DClassList_dummy_108 DClassList tok_DClassList_dummy_108 { Ctr__Haskell__14 $2 } |
-          tok_Decl_dummy_107 Decl tok_Decl_dummy_107 { Ctr__Haskell__15 $2 } |
-          tok_DeclList_dummy_106 DeclList tok_DeclList_dummy_106 { Ctr__Haskell__16 $2 } |
-          tok_Decls_dummy_105 Decls tok_Decls_dummy_105 { Ctr__Haskell__17 $2 } |
-          tok_Deriving_dummy_104 Deriving tok_Deriving_dummy_104 { Ctr__Haskell__18 $2 } |
-          tok_Exp_dummy_103 Exp tok_Exp_dummy_103 { Ctr__Haskell__19 $2 } |
-          tok_ExpI_dummy_102 ExpI tok_ExpI_dummy_102 { Ctr__Haskell__20 $2 } |
-          tok_Export_dummy_101 Export tok_Export_dummy_101 { Ctr__Haskell__21 $2 } |
-          tok_ExportsList_dummy_100 ExportsList tok_ExportsList_dummy_100 { Ctr__Haskell__22 $2 } |
-          tok_ExportsOpt_dummy_99 ExportsOpt tok_ExportsOpt_dummy_99 { Ctr__Haskell__23 $2 } |
-          tok_FieldDecl_dummy_98 FieldDecl tok_FieldDecl_dummy_98 { Ctr__Haskell__24 $2 } |
-          tok_FieldDeclList_dummy_97 FieldDeclList tok_FieldDeclList_dummy_97 { Ctr__Haskell__25 $2 } |
-          tok_Fixity_dummy_96 Fixity tok_Fixity_dummy_96 { Ctr__Haskell__26 $2 } |
-          tok_FunLhs_dummy_95 FunLhs tok_FunLhs_dummy_95 { Ctr__Haskell__27 $2 } |
-          tok_GTyCon_dummy_94 GTyCon tok_GTyCon_dummy_94 { Ctr__Haskell__28 $2 } |
-          tok_Gd_dummy_93 Gd tok_Gd_dummy_93 { Ctr__Haskell__29 $2 } |
-          tok_GdRhs_dummy_92 GdRhs tok_GdRhs_dummy_92 { Ctr__Haskell__30 $2 } |
-          tok_GenDecl_dummy_91 GenDecl tok_GenDecl_dummy_91 { Ctr__Haskell__31 $2 } |
-          tok_ImpDecl_dummy_90 ImpDecl tok_ImpDecl_dummy_90 { Ctr__Haskell__32 $2 } |
-          tok_ImpDeclList_dummy_89 ImpDeclList tok_ImpDeclList_dummy_89 { Ctr__Haskell__33 $2 } |
-          tok_Import_dummy_88 Import tok_Import_dummy_88 { Ctr__Haskell__34 $2 } |
-          tok_ImportList_dummy_87 ImportList tok_ImportList_dummy_87 { Ctr__Haskell__35 $2 } |
-          tok_ModId_dummy_86 ModId tok_ModId_dummy_86 { Ctr__Haskell__36 $2 } |
-          tok_ModIdList_dummy_85 ModIdList tok_ModIdList_dummy_85 { Ctr__Haskell__37 (reverse $2) } |
-          tok_Module_dummy_84 Module tok_Module_dummy_84 { Ctr__Haskell__38 $2 } |
-          tok_Op_dummy_83 Op tok_Op_dummy_83 { Ctr__Haskell__39 $2 } |
-          tok_Ops_dummy_82 Ops tok_Ops_dummy_82 { Ctr__Haskell__40 $2 } |
-          tok_OptContext_dummy_81 OptContext tok_OptContext_dummy_81 { Ctr__Haskell__41 $2 } |
-          tok_OptDeriving_dummy_80 OptDeriving tok_OptDeriving_dummy_80 { Ctr__Haskell__42 $2 } |
-          tok_OptExpTypeSignature_dummy_79 OptExpTypeSignature tok_OptExpTypeSignature_dummy_79 { Ctr__Haskell__43 $2 } |
-          tok_OptGdRhs_dummy_78 OptGdRhs tok_OptGdRhs_dummy_78 { Ctr__Haskell__44 $2 } |
-          tok_OptImpSpec_dummy_77 OptImpSpec tok_OptImpSpec_dummy_77 { Ctr__Haskell__45 $2 } |
-          tok_OptInteger_dummy_76 OptInteger tok_OptInteger_dummy_76 { Ctr__Haskell__46 $2 } |
-          tok_OptQualified_dummy_75 OptQualified tok_OptQualified_dummy_75 { Ctr__Haskell__47 $2 } |
-          tok_OptQualifiedAs_dummy_74 OptQualifiedAs tok_OptQualifiedAs_dummy_74 { Ctr__Haskell__48 $2 } |
-          tok_OptWhere_dummy_73 OptWhere tok_OptWhere_dummy_73 { Ctr__Haskell__49 $2 } |
-          tok_Pat_dummy_72 Pat tok_Pat_dummy_72 { Ctr__Haskell__50 $2 } |
-          tok_QOp_dummy_71 QOp tok_QOp_dummy_71 { Ctr__Haskell__51 $2 } |
-          tok_QTyCls_dummy_70 QTyCls tok_QTyCls_dummy_70 { Ctr__Haskell__52 $2 } |
-          tok_QTyCon_dummy_69 QTyCon tok_QTyCon_dummy_69 { Ctr__Haskell__53 $2 } |
-          tok_QVar_dummy_68 QVar tok_QVar_dummy_68 { Ctr__Haskell__54 $2 } |
-          tok_QVarId_dummy_67 QVarId tok_QVarId_dummy_67 { Ctr__Haskell__55 $2 } |
-          tok_QVarList_dummy_66 QVarList tok_QVarList_dummy_66 { Ctr__Haskell__56 $2 } |
-          tok_Rhs_dummy_65 Rhs tok_Rhs_dummy_65 { Ctr__Haskell__57 $2 } |
-          tok_SimpleType_dummy_64 SimpleType tok_SimpleType_dummy_64 { Ctr__Haskell__58 $2 } |
-          tok_TopDecl_dummy_63 TopDecl tok_TopDecl_dummy_63 { Ctr__Haskell__59 $2 } |
-          tok_TopDecls_dummy_62 TopDecls tok_TopDecls_dummy_62 { Ctr__Haskell__60 $2 } |
-          tok_TyCls_dummy_61 TyCls tok_TyCls_dummy_61 { Ctr__Haskell__61 $2 } |
-          tok_TyCon_dummy_60 TyCon tok_TyCon_dummy_60 { Ctr__Haskell__62 $2 } |
-          tok_TyVar_dummy_59 TyVar tok_TyVar_dummy_59 { Ctr__Haskell__63 $2 } |
-          tok_TyVars_dummy_58 TyVars tok_TyVars_dummy_58 { Ctr__Haskell__64 (reverse $2) } |
-          tok_Type_dummy_57 Type tok_Type_dummy_57 { Ctr__Haskell__65 $2 } |
-          tok_TypeList_dummy_56 TypeList tok_TypeList_dummy_56 { Ctr__Haskell__66 $2 } |
-          tok_Var_dummy_55 Var tok_Var_dummy_55 { Ctr__Haskell__67 $2 } |
-          tok_Vars_dummy_54 Vars tok_Vars_dummy_54 { Ctr__Haskell__68 $2 }
+Haskell : tok_Haskell_dummy_122 Haskell tok_Haskell_dummy_122 { Ctr__Haskell__0 (rtkPosOf $1) $2 } |
+          tok_AType_dummy_121 AType tok_AType_dummy_121 { Ctr__Haskell__1 (rtkPosOf $1) $2 } |
+          tok_ATypeList_dummy_120 ATypeList tok_ATypeList_dummy_120 { Ctr__Haskell__2 (rtkPosOf $1) (reverse $2) } |
+          tok_BType_dummy_119 BType tok_BType_dummy_119 { Ctr__Haskell__3 (rtkPosOf $1) $2 } |
+          tok_Body_dummy_118 Body tok_Body_dummy_118 { Ctr__Haskell__4 (rtkPosOf $1) $2 } |
+          tok_CName_dummy_117 CName tok_CName_dummy_117 { Ctr__Haskell__5 (rtkPosOf $1) $2 } |
+          tok_CNameList_dummy_116 CNameList tok_CNameList_dummy_116 { Ctr__Haskell__6 (rtkPosOf $1) $2 } |
+          tok_Class_dummy_115 Class tok_Class_dummy_115 { Ctr__Haskell__7 (rtkPosOf $1) $2 } |
+          tok_ClassList_dummy_114 ClassList tok_ClassList_dummy_114 { Ctr__Haskell__8 (rtkPosOf $1) $2 } |
+          tok_Con_dummy_113 Con tok_Con_dummy_113 { Ctr__Haskell__9 (rtkPosOf $1) $2 } |
+          tok_Constr_dummy_112 Constr tok_Constr_dummy_112 { Ctr__Haskell__10 (rtkPosOf $1) $2 } |
+          tok_Constrs_dummy_111 Constrs tok_Constrs_dummy_111 { Ctr__Haskell__11 (rtkPosOf $1) $2 } |
+          tok_Context_dummy_110 Context tok_Context_dummy_110 { Ctr__Haskell__12 (rtkPosOf $1) $2 } |
+          tok_DClass_dummy_109 DClass tok_DClass_dummy_109 { Ctr__Haskell__13 (rtkPosOf $1) $2 } |
+          tok_DClassList_dummy_108 DClassList tok_DClassList_dummy_108 { Ctr__Haskell__14 (rtkPosOf $1) $2 } |
+          tok_Decl_dummy_107 Decl tok_Decl_dummy_107 { Ctr__Haskell__15 (rtkPosOf $1) $2 } |
+          tok_DeclList_dummy_106 DeclList tok_DeclList_dummy_106 { Ctr__Haskell__16 (rtkPosOf $1) $2 } |
+          tok_Decls_dummy_105 Decls tok_Decls_dummy_105 { Ctr__Haskell__17 (rtkPosOf $1) $2 } |
+          tok_Deriving_dummy_104 Deriving tok_Deriving_dummy_104 { Ctr__Haskell__18 (rtkPosOf $1) $2 } |
+          tok_Exp_dummy_103 Exp tok_Exp_dummy_103 { Ctr__Haskell__19 (rtkPosOf $1) $2 } |
+          tok_ExpI_dummy_102 ExpI tok_ExpI_dummy_102 { Ctr__Haskell__20 (rtkPosOf $1) $2 } |
+          tok_Export_dummy_101 Export tok_Export_dummy_101 { Ctr__Haskell__21 (rtkPosOf $1) $2 } |
+          tok_ExportsList_dummy_100 ExportsList tok_ExportsList_dummy_100 { Ctr__Haskell__22 (rtkPosOf $1) $2 } |
+          tok_ExportsOpt_dummy_99 ExportsOpt tok_ExportsOpt_dummy_99 { Ctr__Haskell__23 (rtkPosOf $1) $2 } |
+          tok_FieldDecl_dummy_98 FieldDecl tok_FieldDecl_dummy_98 { Ctr__Haskell__24 (rtkPosOf $1) $2 } |
+          tok_FieldDeclList_dummy_97 FieldDeclList tok_FieldDeclList_dummy_97 { Ctr__Haskell__25 (rtkPosOf $1) $2 } |
+          tok_Fixity_dummy_96 Fixity tok_Fixity_dummy_96 { Ctr__Haskell__26 (rtkPosOf $1) $2 } |
+          tok_FunLhs_dummy_95 FunLhs tok_FunLhs_dummy_95 { Ctr__Haskell__27 (rtkPosOf $1) $2 } |
+          tok_GTyCon_dummy_94 GTyCon tok_GTyCon_dummy_94 { Ctr__Haskell__28 (rtkPosOf $1) $2 } |
+          tok_Gd_dummy_93 Gd tok_Gd_dummy_93 { Ctr__Haskell__29 (rtkPosOf $1) $2 } |
+          tok_GdRhs_dummy_92 GdRhs tok_GdRhs_dummy_92 { Ctr__Haskell__30 (rtkPosOf $1) $2 } |
+          tok_GenDecl_dummy_91 GenDecl tok_GenDecl_dummy_91 { Ctr__Haskell__31 (rtkPosOf $1) $2 } |
+          tok_ImpDecl_dummy_90 ImpDecl tok_ImpDecl_dummy_90 { Ctr__Haskell__32 (rtkPosOf $1) $2 } |
+          tok_ImpDeclList_dummy_89 ImpDeclList tok_ImpDeclList_dummy_89 { Ctr__Haskell__33 (rtkPosOf $1) $2 } |
+          tok_Import_dummy_88 Import tok_Import_dummy_88 { Ctr__Haskell__34 (rtkPosOf $1) $2 } |
+          tok_ImportList_dummy_87 ImportList tok_ImportList_dummy_87 { Ctr__Haskell__35 (rtkPosOf $1) $2 } |
+          tok_ModId_dummy_86 ModId tok_ModId_dummy_86 { Ctr__Haskell__36 (rtkPosOf $1) $2 } |
+          tok_ModIdList_dummy_85 ModIdList tok_ModIdList_dummy_85 { Ctr__Haskell__37 (rtkPosOf $1) (reverse $2) } |
+          tok_Module_dummy_84 Module tok_Module_dummy_84 { Ctr__Haskell__38 (rtkPosOf $1) $2 } |
+          tok_Op_dummy_83 Op tok_Op_dummy_83 { Ctr__Haskell__39 (rtkPosOf $1) $2 } |
+          tok_Ops_dummy_82 Ops tok_Ops_dummy_82 { Ctr__Haskell__40 (rtkPosOf $1) $2 } |
+          tok_OptContext_dummy_81 OptContext tok_OptContext_dummy_81 { Ctr__Haskell__41 (rtkPosOf $1) $2 } |
+          tok_OptDeriving_dummy_80 OptDeriving tok_OptDeriving_dummy_80 { Ctr__Haskell__42 (rtkPosOf $1) $2 } |
+          tok_OptExpTypeSignature_dummy_79 OptExpTypeSignature tok_OptExpTypeSignature_dummy_79 { Ctr__Haskell__43 (rtkPosOf $1) $2 } |
+          tok_OptGdRhs_dummy_78 OptGdRhs tok_OptGdRhs_dummy_78 { Ctr__Haskell__44 (rtkPosOf $1) $2 } |
+          tok_OptImpSpec_dummy_77 OptImpSpec tok_OptImpSpec_dummy_77 { Ctr__Haskell__45 (rtkPosOf $1) $2 } |
+          tok_OptInteger_dummy_76 OptInteger tok_OptInteger_dummy_76 { Ctr__Haskell__46 (rtkPosOf $1) $2 } |
+          tok_OptQualified_dummy_75 OptQualified tok_OptQualified_dummy_75 { Ctr__Haskell__47 (rtkPosOf $1) $2 } |
+          tok_OptQualifiedAs_dummy_74 OptQualifiedAs tok_OptQualifiedAs_dummy_74 { Ctr__Haskell__48 (rtkPosOf $1) $2 } |
+          tok_OptWhere_dummy_73 OptWhere tok_OptWhere_dummy_73 { Ctr__Haskell__49 (rtkPosOf $1) $2 } |
+          tok_Pat_dummy_72 Pat tok_Pat_dummy_72 { Ctr__Haskell__50 (rtkPosOf $1) $2 } |
+          tok_QOp_dummy_71 QOp tok_QOp_dummy_71 { Ctr__Haskell__51 (rtkPosOf $1) $2 } |
+          tok_QTyCls_dummy_70 QTyCls tok_QTyCls_dummy_70 { Ctr__Haskell__52 (rtkPosOf $1) $2 } |
+          tok_QTyCon_dummy_69 QTyCon tok_QTyCon_dummy_69 { Ctr__Haskell__53 (rtkPosOf $1) $2 } |
+          tok_QVar_dummy_68 QVar tok_QVar_dummy_68 { Ctr__Haskell__54 (rtkPosOf $1) $2 } |
+          tok_QVarId_dummy_67 QVarId tok_QVarId_dummy_67 { Ctr__Haskell__55 (rtkPosOf $1) $2 } |
+          tok_QVarList_dummy_66 QVarList tok_QVarList_dummy_66 { Ctr__Haskell__56 (rtkPosOf $1) $2 } |
+          tok_Rhs_dummy_65 Rhs tok_Rhs_dummy_65 { Ctr__Haskell__57 (rtkPosOf $1) $2 } |
+          tok_SimpleType_dummy_64 SimpleType tok_SimpleType_dummy_64 { Ctr__Haskell__58 (rtkPosOf $1) $2 } |
+          tok_TopDecl_dummy_63 TopDecl tok_TopDecl_dummy_63 { Ctr__Haskell__59 (rtkPosOf $1) $2 } |
+          tok_TopDecls_dummy_62 TopDecls tok_TopDecls_dummy_62 { Ctr__Haskell__60 (rtkPosOf $1) $2 } |
+          tok_TyCls_dummy_61 TyCls tok_TyCls_dummy_61 { Ctr__Haskell__61 (rtkPosOf $1) $2 } |
+          tok_TyCon_dummy_60 TyCon tok_TyCon_dummy_60 { Ctr__Haskell__62 (rtkPosOf $1) $2 } |
+          tok_TyVar_dummy_59 TyVar tok_TyVar_dummy_59 { Ctr__Haskell__63 (rtkPosOf $1) $2 } |
+          tok_TyVars_dummy_58 TyVars tok_TyVars_dummy_58 { Ctr__Haskell__64 (rtkPosOf $1) (reverse $2) } |
+          tok_Type_dummy_57 Type tok_Type_dummy_57 { Ctr__Haskell__65 (rtkPosOf $1) $2 } |
+          tok_TypeList_dummy_56 TypeList tok_TypeList_dummy_56 { Ctr__Haskell__66 (rtkPosOf $1) $2 } |
+          tok_Var_dummy_55 Var tok_Var_dummy_55 { Ctr__Haskell__67 (rtkPosOf $1) $2 } |
+          tok_Vars_dummy_54 Vars tok_Vars_dummy_54 { Ctr__Haskell__68 (rtkPosOf $1) $2 }
 
-Haskell : qq_Haskell { Anti_Haskell $1 } |
-          Module { Ctr__Haskell__69 $1 }
+Haskell : qq_Haskell { Anti_Haskell (tkVal_qq_Haskell $1) } |
+          Module { Ctr__Haskell__69 (rtkPosOf $1) $1 }
 
-AType : qq_AType { Anti_AType $1 } |
-        TyVar { Ctr__AType__0 $1 } |
-        GTyCon { Ctr__AType__1 $1 } |
-        tok__lparen__2 Rule_49 tok__rparen__4 { Ctr__AType__2 $2 } |
-        tok__sq_bkt_l__25 Rule_50 tok__sq_bkt_r__26 { Ctr__AType__3 $2 }
+AType : qq_AType { Anti_AType (tkVal_qq_AType $1) } |
+        TyVar { Ctr__AType__0 (rtkPosOf $1) $1 } |
+        GTyCon { Ctr__AType__1 (rtkPosOf $1) $1 } |
+        tok__lparen__2 Rule_49 tok__rparen__4 { Ctr__AType__2 (rtkPosOf $1) $2 } |
+        tok__sq_bkt_l__25 Rule_50 tok__sq_bkt_r__26 { Ctr__AType__3 (rtkPosOf $1) $2 }
 
-ListElem_ATypeList48 : qq_ATypeList { Anti_AType $1 } |
+ListElem_ATypeList48 : qq_ATypeList { Anti_AType (tkVal_qq_ATypeList $1) } |
                        AType { $1 }
 
 ATypeList : {- empty -} { [] } |
             ATypeList ListElem_ATypeList48 { $2 : $1 }
 
-BType : qq_BType { Anti_BType $1 } |
-        Rule_46 AType { Ctr__BType__0 $1 $2 }
+BType : qq_BType { Anti_BType (tkVal_qq_BType $1) } |
+        Rule_46 AType { Ctr__BType__0 (rtkPosOf $1) $1 $2 }
 
-Body : qq_Body { Anti_Body $1 } |
-       tok__symbol__6 Rule_8 tok__symbol__8 { Ctr__Body__0 $2 }
+Body : qq_Body { Anti_Body (tkVal_qq_Body $1) } |
+       tok__symbol__6 Rule_8 tok__symbol__8 { Ctr__Body__0 (rtkPosOf $1) $2 }
 
-CName : qq_CName { Anti_CName $1 } |
-        Var { Ctr__CName__0 $1 } |
-        Con { Ctr__CName__1 $1 }
+CName : qq_CName { Anti_CName (tkVal_qq_CName $1) } |
+        Var { Ctr__CName__0 (rtkPosOf $1) $1 } |
+        Con { Ctr__CName__1 (rtkPosOf $1) $1 }
 
-CNameList : qq_CNameList { Anti_CNameList $1 } |
-            Rule_15 tok__coma__3 { Ctr__CNameList__0 (reverse $1) }
+CNameList : qq_CNameList { Anti_CNameList (tkVal_qq_CNameList $1) } |
+            Rule_15 tok__coma__3 { Ctr__CNameList__0 (rtkPosOf (reverse $1)) (reverse $1) }
 
-Class : qq_Class { Anti_Class $1 } |
-        QTyCls TyVar { Ctr__Class__0 $1 $2 } |
-        QTyCls tok__lparen__2 TyVar ATypeList tok__rparen__4 { Ctr__Class__1 $1 $3 (reverse $4) }
+Class : qq_Class { Anti_Class (tkVal_qq_Class $1) } |
+        QTyCls TyVar { Ctr__Class__0 (rtkPosOf $1) $1 $2 } |
+        QTyCls tok__lparen__2 TyVar ATypeList tok__rparen__4 { Ctr__Class__1 (rtkPosOf $1) $1 $3 (reverse $4) }
 
-ClassList : qq_ClassList { Anti_ClassList $1 } |
-            Rule_43 tok__coma__3 { Ctr__ClassList__0 (reverse $1) }
+ClassList : qq_ClassList { Anti_ClassList (tkVal_qq_ClassList $1) } |
+            Rule_43 tok__coma__3 { Ctr__ClassList__0 (rtkPosOf (reverse $1)) (reverse $1) }
 
-Con : qq_Con { Anti_Con $1 } |
-      conid { Ctr__Con__0 $1 }
+Con : qq_Con { Anti_Con (tkVal_qq_Con $1) } |
+      conid { Ctr__Con__0 (rtkPosOf $1) (tkVal_conid $1) }
 
-Constr : qq_Constr { Anti_Constr $1 } |
-         Con tok__symbol__6 FieldDeclList tok__symbol__8 { Ctr__Constr__0 $1 $3 }
+Constr : qq_Constr { Anti_Constr (tkVal_qq_Constr $1) } |
+         Con tok__symbol__6 FieldDeclList tok__symbol__8 { Ctr__Constr__0 (rtkPosOf $1) $1 $3 }
 
-Constrs : qq_Constrs { Anti_Constrs $1 } |
-          Rule_36 tok__pipe__21 { Ctr__Constrs__0 (reverse $1) }
+Constrs : qq_Constrs { Anti_Constrs (tkVal_qq_Constrs $1) } |
+          Rule_36 tok__pipe__21 { Ctr__Constrs__0 (rtkPosOf (reverse $1)) (reverse $1) }
 
-Context : qq_Context { Anti_Context $1 } |
-          Class { Ctr__Context__0 $1 } |
-          tok__lparen__2 ClassList tok__rparen__4 { Ctr__Context__1 $2 }
+Context : qq_Context { Anti_Context (tkVal_qq_Context $1) } |
+          Class { Ctr__Context__0 (rtkPosOf $1) $1 } |
+          tok__lparen__2 ClassList tok__rparen__4 { Ctr__Context__1 (rtkPosOf $1) $2 }
 
-DClass : qq_DClass { Anti_DClass $1 } |
-         QTyCls { Ctr__DClass__0 $1 }
+DClass : qq_DClass { Anti_DClass (tkVal_qq_DClass $1) } |
+         QTyCls { Ctr__DClass__0 (rtkPosOf $1) $1 }
 
-DClassList : qq_DClassList { Anti_DClassList $1 } |
-             Rule_42 tok__coma__3 { Ctr__DClassList__0 (reverse $1) }
+DClassList : qq_DClassList { Anti_DClassList (tkVal_qq_DClassList $1) } |
+             Rule_42 tok__coma__3 { Ctr__DClassList__0 (rtkPosOf (reverse $1)) (reverse $1) }
 
-Decl : qq_Decl { Anti_Decl $1 } |
-       GenDecl { Ctr__Decl__0 $1 } |
-       Rule_25 Rhs { Ctr__Decl__1 $1 $2 }
+Decl : qq_Decl { Anti_Decl (tkVal_qq_Decl $1) } |
+       GenDecl { Ctr__Decl__0 (rtkPosOf $1) $1 } |
+       Rule_25 Rhs { Ctr__Decl__1 (rtkPosOf $1) $1 $2 }
 
-DeclList : qq_DeclList { Anti_DeclList $1 } |
-           Rule_31 tok__semi__7 { Ctr__DeclList__0 (reverse $1) }
+DeclList : qq_DeclList { Anti_DeclList (tkVal_qq_DeclList $1) } |
+           Rule_31 tok__semi__7 { Ctr__DeclList__0 (rtkPosOf (reverse $1)) (reverse $1) }
 
-Decls : qq_Decls { Anti_Decls $1 } |
-        tok__symbol__6 DeclList tok__symbol__8 { Ctr__Decls__0 $2 }
+Decls : qq_Decls { Anti_Decls (tkVal_qq_Decls $1) } |
+        tok__symbol__6 DeclList tok__symbol__8 { Ctr__Decls__0 (rtkPosOf $1) $2 }
 
-Deriving : qq_Deriving { Anti_Deriving $1 } |
-           tok_deriving_23 Rule_41 { Ctr__Deriving__0 $2 }
+Deriving : qq_Deriving { Anti_Deriving (tkVal_qq_Deriving $1) } |
+           tok_deriving_23 Rule_41 { Ctr__Deriving__0 (rtkPosOf $1) $2 }
 
-Exp : qq_Exp { Anti_Exp $1 } |
-      ExpI OptExpTypeSignature { Ctr__Exp__0 $1 $2 }
+Exp : qq_Exp { Anti_Exp (tkVal_qq_Exp $1) } |
+      ExpI OptExpTypeSignature { Ctr__Exp__0 (rtkPosOf $1) $1 $2 }
 
-ExpI : qq_ExpI { Anti_ExpI $1 } |
-       ExpI Rule_34 { Ctr__ExpI__0 $1 (reverse $2) }
+ExpI : qq_ExpI { Anti_ExpI (tkVal_qq_ExpI $1) } |
+       ExpI Rule_34 { Ctr__ExpI__0 (rtkPosOf $1) $1 (reverse $2) }
 
-Export : qq_Export { Anti_Export $1 } |
-         tok_module_0 ModId { Ctr__Export__0 $2 } |
-         QVar { Ctr__Export__1 $1 } |
-         QTyCon Rule_4 { Ctr__Export__2 $1 $2 } |
-         QTyCls Rule_6 { Ctr__Export__3 $1 $2 }
+Export : qq_Export { Anti_Export (tkVal_qq_Export $1) } |
+         tok_module_0 ModId { Ctr__Export__0 (rtkPosOf $1) $2 } |
+         QVar { Ctr__Export__1 (rtkPosOf $1) $1 } |
+         QTyCon Rule_4 { Ctr__Export__2 (rtkPosOf $1) $1 $2 } |
+         QTyCls Rule_6 { Ctr__Export__3 (rtkPosOf $1) $1 $2 }
 
-ExportsList : qq_ExportsList { Anti_ExportsList $1 } |
-              Rule_3 tok__coma__3 { Ctr__ExportsList__0 (reverse $1) }
+ExportsList : qq_ExportsList { Anti_ExportsList (tkVal_qq_ExportsList $1) } |
+              Rule_3 tok__coma__3 { Ctr__ExportsList__0 (rtkPosOf (reverse $1)) (reverse $1) }
 
-ExportsOpt : qq_ExportsOpt { Anti_ExportsOpt $1 } |
-             { Ctr__ExportsOpt__0 } |
-             Rule_0 { Ctr__ExportsOpt__1 $1 }
+ExportsOpt : qq_ExportsOpt { Anti_ExportsOpt (tkVal_qq_ExportsOpt $1) } |
+             { Ctr__ExportsOpt__0 rtkNoPos } |
+             Rule_0 { Ctr__ExportsOpt__1 (rtkPosOf $1) $1 }
 
-FieldDecl : qq_FieldDecl { Anti_FieldDecl $1 } |
-            Vars tok__colon__colon__17 Rule_38 { Ctr__FieldDecl__0 $1 $3 }
+FieldDecl : qq_FieldDecl { Anti_FieldDecl (tkVal_qq_FieldDecl $1) } |
+            Vars tok__colon__colon__17 Rule_38 { Ctr__FieldDecl__0 (rtkPosOf $1) $1 $3 }
 
-FieldDeclList : qq_FieldDeclList { Anti_FieldDeclList $1 } |
-                Rule_37 tok__coma__3 { Ctr__FieldDeclList__0 (reverse $1) }
+FieldDeclList : qq_FieldDeclList { Anti_FieldDeclList (tkVal_qq_FieldDeclList $1) } |
+                Rule_37 tok__coma__3 { Ctr__FieldDeclList__0 (rtkPosOf (reverse $1)) (reverse $1) }
 
-Fixity : qq_Fixity { Anti_Fixity $1 } |
-         tok_infixl_18 { Ctr__Fixity__0 } |
-         tok_infixr_19 { Ctr__Fixity__1 } |
-         tok_infix_20 { Ctr__Fixity__2 }
+Fixity : qq_Fixity { Anti_Fixity (tkVal_qq_Fixity $1) } |
+         tok_infixl_18 { Ctr__Fixity__0 (rtkPosOf $1) } |
+         tok_infixr_19 { Ctr__Fixity__1 (rtkPosOf $1) } |
+         tok_infix_20 { Ctr__Fixity__2 (rtkPosOf $1) }
 
-FunLhs : qq_FunLhs { Anti_FunLhs $1 } |
-         Var { Ctr__FunLhs__0 $1 }
+FunLhs : qq_FunLhs { Anti_FunLhs (tkVal_qq_FunLhs $1) } |
+         Var { Ctr__FunLhs__0 (rtkPosOf $1) $1 }
 
-GTyCon : qq_GTyCon { Anti_GTyCon $1 } |
-         QTyCon { Ctr__GTyCon__0 $1 } |
-         tok__lparen__2 tok__minus__symbol__24 tok__rparen__4 { Ctr__GTyCon__1 }
+GTyCon : qq_GTyCon { Anti_GTyCon (tkVal_qq_GTyCon $1) } |
+         QTyCon { Ctr__GTyCon__0 (rtkPosOf $1) $1 } |
+         tok__lparen__2 tok__minus__symbol__24 tok__rparen__4 { Ctr__GTyCon__1 (rtkPosOf $1) }
 
-Gd : qq_Gd { Anti_Gd $1 } |
-     { Ctr__Gd__0 } |
-     ExpI { Ctr__Gd__1 $1 }
+Gd : qq_Gd { Anti_Gd (tkVal_qq_Gd $1) } |
+     { Ctr__Gd__0 rtkNoPos } |
+     ExpI { Ctr__Gd__1 (rtkPosOf $1) $1 }
 
-GdRhs : qq_GdRhs { Anti_GdRhs $1 } |
-        Gd tok__eql__14 Exp OptGdRhs { Ctr__GdRhs__0 $1 $3 $4 }
+GdRhs : qq_GdRhs { Anti_GdRhs (tkVal_qq_GdRhs $1) } |
+        Gd tok__eql__14 Exp OptGdRhs { Ctr__GdRhs__0 (rtkPosOf $1) $1 $3 $4 }
 
-GenDecl : qq_GenDecl { Anti_GenDecl $1 } |
-          Vars tok__colon__colon__17 OptContext Type { Ctr__GenDecl__0 $1 $3 $4 } |
-          Fixity OptInteger Ops { Ctr__GenDecl__1 $1 $2 $3 }
+GenDecl : qq_GenDecl { Anti_GenDecl (tkVal_qq_GenDecl $1) } |
+          Vars tok__colon__colon__17 OptContext Type { Ctr__GenDecl__0 (rtkPosOf $1) $1 $3 $4 } |
+          Fixity OptInteger Ops { Ctr__GenDecl__1 (rtkPosOf $1) $1 $2 $3 }
 
-ImpDecl : qq_ImpDecl { Anti_ImpDecl $1 } |
-          tok_import_12 OptQualified ModId OptQualifiedAs Rule_23 { Ctr__ImpDecl__0 $2 $3 $4 $5 }
+ImpDecl : qq_ImpDecl { Anti_ImpDecl (tkVal_qq_ImpDecl $1) } |
+          tok_import_12 OptQualified ModId OptQualifiedAs Rule_23 { Ctr__ImpDecl__0 (rtkPosOf $1) $2 $3 $4 $5 }
 
-ImpDeclList : qq_ImpDeclList { Anti_ImpDeclList $1 } |
-              Rule_11 tok__semi__7 { Ctr__ImpDeclList__0 (reverse $1) }
+ImpDeclList : qq_ImpDeclList { Anti_ImpDeclList (tkVal_qq_ImpDeclList $1) } |
+              Rule_11 tok__semi__7 { Ctr__ImpDeclList__0 (rtkPosOf (reverse $1)) (reverse $1) }
 
-Import : qq_Import { Anti_Import $1 } |
-         Var { Ctr__Import__0 $1 } |
-         TyCon Rule_17 { Ctr__Import__1 $1 $2 }
+Import : qq_Import { Anti_Import (tkVal_qq_Import $1) } |
+         Var { Ctr__Import__0 (rtkPosOf $1) $1 } |
+         TyCon Rule_17 { Ctr__Import__1 (rtkPosOf $1) $1 $2 }
 
-ImportList : qq_ImportList { Anti_ImportList $1 } |
-             Rule_12 tok__coma__3 { Ctr__ImportList__0 (reverse $1) }
+ImportList : qq_ImportList { Anti_ImportList (tkVal_qq_ImportList $1) } |
+             Rule_12 tok__coma__3 { Ctr__ImportList__0 (rtkPosOf (reverse $1)) (reverse $1) }
 
-ModId : qq_ModId { Anti_ModId $1 } |
-        conid { Ctr__ModId__0 $1 }
+ModId : qq_ModId { Anti_ModId (tkVal_qq_ModId $1) } |
+        conid { Ctr__ModId__0 (rtkPosOf $1) (tkVal_conid $1) }
 
 ModIdList : {- empty -} { [] } |
             ModIdList ListElem_ModIdList14 { $2 : $1 }
 
-Module : qq_Module { Anti_Module $1 } |
-         tok_module_0 ModId ExportsOpt tok_where_1 Body { Ctr__Module__0 $2 $3 $5 } |
-         Body { Ctr__Module__1 $1 }
+Module : qq_Module { Anti_Module (tkVal_qq_Module $1) } |
+         tok_module_0 ModId ExportsOpt tok_where_1 Body { Ctr__Module__0 (rtkPosOf $1) $2 $3 $5 } |
+         Body { Ctr__Module__1 (rtkPosOf $1) $1 }
 
-Op : qq_Op { Anti_Op $1 } |
-     varid { Ctr__Op__0 $1 } |
-     conid { Ctr__Op__1 $1 }
+Op : qq_Op { Anti_Op (tkVal_qq_Op $1) } |
+     varid { Ctr__Op__0 (rtkPosOf $1) (tkVal_varid $1) } |
+     conid { Ctr__Op__1 (rtkPosOf $1) (tkVal_conid $1) }
 
-Ops : qq_Ops { Anti_Ops $1 } |
-      Rule_28 tok__coma__3 { Ctr__Ops__0 (reverse $1) }
+Ops : qq_Ops { Anti_Ops (tkVal_qq_Ops $1) } |
+      Rule_28 tok__coma__3 { Ctr__Ops__0 (rtkPosOf (reverse $1)) (reverse $1) }
 
-OptContext : qq_OptContext { Anti_OptContext $1 } |
-             { Ctr__OptContext__0 } |
-             Rule_26 { Ctr__OptContext__1 $1 }
+OptContext : qq_OptContext { Anti_OptContext (tkVal_qq_OptContext $1) } |
+             { Ctr__OptContext__0 rtkNoPos } |
+             Rule_26 { Ctr__OptContext__1 (rtkPosOf $1) $1 }
 
-OptDeriving : qq_OptDeriving { Anti_OptDeriving $1 } |
-              { Ctr__OptDeriving__0 } |
-              Rule_40 { Ctr__OptDeriving__1 $1 }
+OptDeriving : qq_OptDeriving { Anti_OptDeriving (tkVal_qq_OptDeriving $1) } |
+              { Ctr__OptDeriving__0 rtkNoPos } |
+              Rule_40 { Ctr__OptDeriving__1 (rtkPosOf $1) $1 }
 
-OptExpTypeSignature : qq_OptExpTypeSignature { Anti_OptExpTypeSignature $1 } |
-                      { Ctr__OptExpTypeSignature__0 } |
-                      Rule_33 { Ctr__OptExpTypeSignature__1 $1 }
+OptExpTypeSignature : qq_OptExpTypeSignature { Anti_OptExpTypeSignature (tkVal_qq_OptExpTypeSignature $1) } |
+                      { Ctr__OptExpTypeSignature__0 rtkNoPos } |
+                      Rule_33 { Ctr__OptExpTypeSignature__1 (rtkPosOf $1) $1 }
 
-OptGdRhs : qq_OptGdRhs { Anti_OptGdRhs $1 } |
-           { Ctr__OptGdRhs__0 } |
-           Rule_32 { Ctr__OptGdRhs__1 $1 }
+OptGdRhs : qq_OptGdRhs { Anti_OptGdRhs (tkVal_qq_OptGdRhs $1) } |
+           { Ctr__OptGdRhs__0 rtkNoPos } |
+           Rule_32 { Ctr__OptGdRhs__1 (rtkPosOf $1) $1 }
 
-OptImpSpec : qq_OptImpSpec { Anti_OptImpSpec $1 } |
-             tok__lparen__2 ImportList Rule_21 tok__rparen__4 { Ctr__OptImpSpec__0 $2 $3 }
+OptImpSpec : qq_OptImpSpec { Anti_OptImpSpec (tkVal_qq_OptImpSpec $1) } |
+             tok__lparen__2 ImportList Rule_21 tok__rparen__4 { Ctr__OptImpSpec__0 (rtkPosOf $1) $2 $3 }
 
-OptInteger : qq_OptInteger { Anti_OptInteger $1 } |
-             { Ctr__OptInteger__0 } |
-             Rule_27 { Ctr__OptInteger__1 $1 }
+OptInteger : qq_OptInteger { Anti_OptInteger (tkVal_qq_OptInteger $1) } |
+             { Ctr__OptInteger__0 rtkNoPos } |
+             Rule_27 { Ctr__OptInteger__1 (rtkPosOf $1) $1 }
 
-OptQualified : qq_OptQualified { Anti_OptQualified $1 } |
-               { Ctr__OptQualified__0 } |
-               Rule_19 { Ctr__OptQualified__1 $1 }
+OptQualified : qq_OptQualified { Anti_OptQualified (tkVal_qq_OptQualified $1) } |
+               { Ctr__OptQualified__0 rtkNoPos } |
+               Rule_19 { Ctr__OptQualified__1 (rtkPosOf $1) $1 }
 
-OptQualifiedAs : qq_OptQualifiedAs { Anti_OptQualifiedAs $1 } |
-                 { Ctr__OptQualifiedAs__0 } |
-                 Rule_20 { Ctr__OptQualifiedAs__1 $1 }
+OptQualifiedAs : qq_OptQualifiedAs { Anti_OptQualifiedAs (tkVal_qq_OptQualifiedAs $1) } |
+                 { Ctr__OptQualifiedAs__0 rtkNoPos } |
+                 Rule_20 { Ctr__OptQualifiedAs__1 (rtkPosOf $1) $1 }
 
-OptWhere : qq_OptWhere { Anti_OptWhere $1 } |
-           tok_where_1 Decls { Ctr__OptWhere__0 $2 }
+OptWhere : qq_OptWhere { Anti_OptWhere (tkVal_qq_OptWhere $1) } |
+           tok_where_1 Decls { Ctr__OptWhere__0 (rtkPosOf $1) $2 }
 
-Pat : qq_Pat { Anti_Pat $1 } |
-      Con Rule_29 { Ctr__Pat__0 $1 (reverse $2) }
+Pat : qq_Pat { Anti_Pat (tkVal_qq_Pat $1) } |
+      Con Rule_29 { Ctr__Pat__0 (rtkPosOf $1) $1 (reverse $2) }
 
-QOp : qq_QOp { Anti_QOp $1 } |
-      ModIdList Op { Ctr__QOp__0 (reverse $1) $2 }
+QOp : qq_QOp { Anti_QOp (tkVal_qq_QOp $1) } |
+      ModIdList Op { Ctr__QOp__0 (rtkPosOf (reverse $1)) (reverse $1) $2 }
 
-QTyCls : qq_QTyCls { Anti_QTyCls $1 } |
-         ModIdList TyCls { Ctr__QTyCls__0 (reverse $1) $2 }
+QTyCls : qq_QTyCls { Anti_QTyCls (tkVal_qq_QTyCls $1) } |
+         ModIdList TyCls { Ctr__QTyCls__0 (rtkPosOf (reverse $1)) (reverse $1) $2 }
 
-QTyCon : qq_QTyCon { Anti_QTyCon $1 } |
-         ModIdList TyCon { Ctr__QTyCon__0 (reverse $1) $2 }
+QTyCon : qq_QTyCon { Anti_QTyCon (tkVal_qq_QTyCon $1) } |
+         ModIdList TyCon { Ctr__QTyCon__0 (rtkPosOf (reverse $1)) (reverse $1) $2 }
 
-QVar : qq_QVar { Anti_QVar $1 } |
-       QVarId { Ctr__QVar__0 $1 }
+QVar : qq_QVar { Anti_QVar (tkVal_qq_QVar $1) } |
+       QVarId { Ctr__QVar__0 (rtkPosOf $1) $1 }
 
-QVarId : qq_QVarId { Anti_QVarId $1 } |
-         ModIdList varid { Ctr__QVarId__0 (reverse $1) $2 }
+QVarId : qq_QVarId { Anti_QVarId (tkVal_qq_QVarId $1) } |
+         ModIdList varid { Ctr__QVarId__0 (rtkPosOf (reverse $1)) (reverse $1) (tkVal_varid $2) }
 
-QVarList : qq_QVarList { Anti_QVarList $1 } |
-           Rule_16 tok__coma__3 { Ctr__QVarList__0 (reverse $1) }
+QVarList : qq_QVarList { Anti_QVarList (tkVal_qq_QVarList $1) } |
+           Rule_16 tok__coma__3 { Ctr__QVarList__0 (rtkPosOf (reverse $1)) (reverse $1) }
 
-Rhs : qq_Rhs { Anti_Rhs $1 } |
-      tok__eql__14 Exp OptWhere { Ctr__Rhs__0 $2 $3 } |
-      GdRhs OptWhere { Ctr__Rhs__1 $1 $2 }
+Rhs : qq_Rhs { Anti_Rhs (tkVal_qq_Rhs $1) } |
+      tok__eql__14 Exp OptWhere { Ctr__Rhs__0 (rtkPosOf $1) $2 $3 } |
+      GdRhs OptWhere { Ctr__Rhs__1 (rtkPosOf $1) $1 $2 }
 
-Rule_0 : tok__lparen__2 ExportsList Rule_1 tok__rparen__4 { Ctr__Rule_0__0 $2 $3 }
+Rule_0 : tok__lparen__2 ExportsList Rule_1 tok__rparen__4 { Ctr__Rule_0__0 (rtkPosOf $1) $2 $3 }
 
-Rule_1 : { Ctr__Rule_1__0 } |
-         Rule_2 { Ctr__Rule_1__1 $1 }
+Rule_1 : { Ctr__Rule_1__0 rtkNoPos } |
+         Rule_2 { Ctr__Rule_1__1 (rtkPosOf $1) $1 }
 
-Rule_10 : tok__semi__7 TopDecls { Ctr__Rule_10__0 $2 }
+Rule_10 : tok__semi__7 TopDecls { Ctr__Rule_10__0 (rtkPosOf $1) $2 }
 
 Rule_11 : ImpDecl { [$1] } |
           Rule_11 ImpDecl { $2 : $1 }
@@ -479,10 +479,10 @@ Rule_11 : ImpDecl { [$1] } |
 Rule_12 : {- empty -} { [] } |
           Rule_12 Import { $2 : $1 }
 
-ListElem_ModIdList14 : qq_ModIdList { Anti_Rule_13 $1 } |
+ListElem_ModIdList14 : qq_ModIdList { Anti_Rule_13 (tkVal_qq_ModIdList $1) } |
                        Rule_13 { $1 }
 
-Rule_13 : ModId tok__dot__9 { Ctr__Rule_13__1 $1 }
+Rule_13 : ModId tok__dot__9 { Ctr__Rule_13__1 (rtkPosOf $1) $1 }
 
 Rule_15 : {- empty -} { [] } |
           Rule_15 CName { $2 : $1 }
@@ -490,35 +490,35 @@ Rule_15 : {- empty -} { [] } |
 Rule_16 : {- empty -} { [] } |
           Rule_16 QVar { $2 : $1 }
 
-Rule_17 : { Ctr__Rule_17__0 } |
-          Rule_18 { Ctr__Rule_17__1 $1 }
+Rule_17 : { Ctr__Rule_17__0 rtkNoPos } |
+          Rule_18 { Ctr__Rule_17__1 (rtkPosOf $1) $1 }
 
-Rule_18 : tok__lparen__2 tok__dot__dot__5 tok__rparen__4 { Ctr__Rule_18__0 } |
-          tok__lparen__2 CNameList tok__rparen__4 { Ctr__Rule_18__1 $2 }
+Rule_18 : tok__lparen__2 tok__dot__dot__5 tok__rparen__4 { Ctr__Rule_18__0 (rtkPosOf $1) } |
+          tok__lparen__2 CNameList tok__rparen__4 { Ctr__Rule_18__1 (rtkPosOf $1) $2 }
 
-Rule_19 : tok_qualified_10 { Ctr__Rule_19__0 }
+Rule_19 : tok_qualified_10 { Ctr__Rule_19__0 (rtkPosOf $1) }
 
-Rule_2 : tok__coma__3 { Ctr__Rule_2__0 }
+Rule_2 : tok__coma__3 { Ctr__Rule_2__0 (rtkPosOf $1) }
 
-Rule_20 : tok_as_11 ModId { Ctr__Rule_20__0 $2 }
+Rule_20 : tok_as_11 ModId { Ctr__Rule_20__0 (rtkPosOf $1) $2 }
 
-Rule_21 : { Ctr__Rule_21__0 } |
-          Rule_22 { Ctr__Rule_21__1 $1 }
+Rule_21 : { Ctr__Rule_21__0 rtkNoPos } |
+          Rule_22 { Ctr__Rule_21__1 (rtkPosOf $1) $1 }
 
-Rule_22 : tok__coma__3 { Ctr__Rule_22__0 }
+Rule_22 : tok__coma__3 { Ctr__Rule_22__0 (rtkPosOf $1) }
 
-Rule_23 : { Ctr__Rule_23__0 } |
-          OptImpSpec { Ctr__Rule_23__1 $1 }
+Rule_23 : { Ctr__Rule_23__0 rtkNoPos } |
+          OptImpSpec { Ctr__Rule_23__1 (rtkPosOf $1) $1 }
 
 Rule_24 : {- empty -} { [] } |
           Rule_24 TopDecl { $2 : $1 }
 
-Rule_25 : FunLhs { Ctr__Rule_25__0 $1 } |
-          Pat { Ctr__Rule_25__1 $1 }
+Rule_25 : FunLhs { Ctr__Rule_25__0 (rtkPosOf $1) $1 } |
+          Pat { Ctr__Rule_25__1 (rtkPosOf $1) $1 }
 
-Rule_26 : Context tok__eql__symbol__16 { Ctr__Rule_26__0 $1 }
+Rule_26 : Context tok__eql__symbol__16 { Ctr__Rule_26__0 (rtkPosOf $1) $1 }
 
-Rule_27 : integer { Ctr__Rule_27__0 $1 }
+Rule_27 : integer { Ctr__Rule_27__0 (rtkPosOf $1) (tkVal_integer $1) }
 
 Rule_28 : {- empty -} { [] } |
           Rule_28 Op { $2 : $1 }
@@ -529,19 +529,19 @@ Rule_29 : {- empty -} { [] } |
 Rule_3 : {- empty -} { [] } |
          Rule_3 Export { $2 : $1 }
 
-Rule_30 : Var { Ctr__Rule_30__0 $1 }
+Rule_30 : Var { Ctr__Rule_30__0 (rtkPosOf $1) $1 }
 
 Rule_31 : {- empty -} { [] } |
           Rule_31 Decl { $2 : $1 }
 
-Rule_32 : GdRhs { Ctr__Rule_32__0 $1 }
+Rule_32 : GdRhs { Ctr__Rule_32__0 (rtkPosOf $1) $1 }
 
-Rule_33 : tok__colon__colon__17 OptContext Type { Ctr__Rule_33__0 $2 $3 }
+Rule_33 : tok__colon__colon__17 OptContext Type { Ctr__Rule_33__0 (rtkPosOf $1) $2 $3 }
 
 Rule_34 : {- empty -} { [] } |
           Rule_34 Rule_35 { $2 : $1 }
 
-Rule_35 : QOp ExpI { Ctr__Rule_35__0 $1 $2 }
+Rule_35 : QOp ExpI { Ctr__Rule_35__0 (rtkPosOf $1) $1 $2 }
 
 Rule_36 : {- empty -} { [] } |
           Rule_36 Constr { $2 : $1 }
@@ -549,19 +549,19 @@ Rule_36 : {- empty -} { [] } |
 Rule_37 : {- empty -} { [] } |
           Rule_37 FieldDecl { $2 : $1 }
 
-Rule_38 : Type { Ctr__Rule_38__0 $1 } |
-          tok__exclamation__22 AType { Ctr__Rule_38__1 $2 }
+Rule_38 : Type { Ctr__Rule_38__0 (rtkPosOf $1) $1 } |
+          tok__exclamation__22 AType { Ctr__Rule_38__1 (rtkPosOf $1) $2 }
 
 Rule_39 : {- empty -} { [] } |
           Rule_39 Var { $2 : $1 }
 
-Rule_4 : { Ctr__Rule_4__0 } |
-         Rule_5 { Ctr__Rule_4__1 $1 }
+Rule_4 : { Ctr__Rule_4__0 rtkNoPos } |
+         Rule_5 { Ctr__Rule_4__1 (rtkPosOf $1) $1 }
 
-Rule_40 : Deriving { Ctr__Rule_40__0 $1 }
+Rule_40 : Deriving { Ctr__Rule_40__0 (rtkPosOf $1) $1 }
 
-Rule_41 : DClass { Ctr__Rule_41__0 $1 } |
-          tok__lparen__2 DClassList tok__rparen__4 { Ctr__Rule_41__1 $2 }
+Rule_41 : DClass { Ctr__Rule_41__0 (rtkPosOf $1) $1 } |
+          tok__lparen__2 DClassList tok__rparen__4 { Ctr__Rule_41__1 (rtkPosOf $1) $2 }
 
 Rule_42 : {- empty -} { [] } |
           Rule_42 DClass { $2 : $1 }
@@ -569,78 +569,78 @@ Rule_42 : {- empty -} { [] } |
 Rule_43 : {- empty -} { [] } |
           Rule_43 Class { $2 : $1 }
 
-Rule_44 : { Ctr__Rule_44__0 } |
-          Rule_45 { Ctr__Rule_44__1 $1 }
+Rule_44 : { Ctr__Rule_44__0 rtkNoPos } |
+          Rule_45 { Ctr__Rule_44__1 (rtkPosOf $1) $1 }
 
-Rule_45 : tok__minus__symbol__24 Type { Ctr__Rule_45__0 $2 }
+Rule_45 : tok__minus__symbol__24 Type { Ctr__Rule_45__0 (rtkPosOf $1) $2 }
 
-Rule_46 : { Ctr__Rule_46__0 } |
-          Rule_47 { Ctr__Rule_46__1 $1 }
+Rule_46 : { Ctr__Rule_46__0 rtkNoPos } |
+          Rule_47 { Ctr__Rule_46__1 (rtkPosOf $1) $1 }
 
-Rule_47 : BType { Ctr__Rule_47__0 $1 }
+Rule_47 : BType { Ctr__Rule_47__0 (rtkPosOf $1) $1 }
 
-Rule_49 : TypeList { Ctr__Rule_49__0 $1 }
+Rule_49 : TypeList { Ctr__Rule_49__0 (rtkPosOf $1) $1 }
 
-Rule_5 : tok__lparen__2 tok__dot__dot__5 tok__rparen__4 { Ctr__Rule_5__0 } |
-         tok__lparen__2 CNameList tok__rparen__4 { Ctr__Rule_5__1 $2 }
+Rule_5 : tok__lparen__2 tok__dot__dot__5 tok__rparen__4 { Ctr__Rule_5__0 (rtkPosOf $1) } |
+         tok__lparen__2 CNameList tok__rparen__4 { Ctr__Rule_5__1 (rtkPosOf $1) $2 }
 
-Rule_50 : { Ctr__Rule_50__0 } |
-          Rule_51 { Ctr__Rule_50__1 $1 }
+Rule_50 : { Ctr__Rule_50__0 rtkNoPos } |
+          Rule_51 { Ctr__Rule_50__1 (rtkPosOf $1) $1 }
 
-Rule_51 : Type { Ctr__Rule_51__0 $1 }
+Rule_51 : Type { Ctr__Rule_51__0 (rtkPosOf $1) $1 }
 
 Rule_52 : {- empty -} { [] } |
           Rule_52 Type { $2 : $1 }
 
-Rule_6 : { Ctr__Rule_6__0 } |
-         Rule_7 { Ctr__Rule_6__1 $1 }
+Rule_6 : { Ctr__Rule_6__0 rtkNoPos } |
+         Rule_7 { Ctr__Rule_6__1 (rtkPosOf $1) $1 }
 
-Rule_7 : tok__lparen__2 tok__dot__dot__5 tok__rparen__4 { Ctr__Rule_7__0 } |
-         tok__lparen__2 QVarList tok__rparen__4 { Ctr__Rule_7__1 $2 }
+Rule_7 : tok__lparen__2 tok__dot__dot__5 tok__rparen__4 { Ctr__Rule_7__0 (rtkPosOf $1) } |
+         tok__lparen__2 QVarList tok__rparen__4 { Ctr__Rule_7__1 (rtkPosOf $1) $2 }
 
-Rule_8 : ImpDeclList Rule_9 { Ctr__Rule_8__0 $1 $2 } |
-         ImpDeclList { Ctr__Rule_8__1 $1 }
+Rule_8 : ImpDeclList Rule_9 { Ctr__Rule_8__0 (rtkPosOf $1) $1 $2 } |
+         ImpDeclList { Ctr__Rule_8__1 (rtkPosOf $1) $1 }
 
-Rule_9 : { Ctr__Rule_9__0 } |
-         Rule_10 { Ctr__Rule_9__1 $1 }
+Rule_9 : { Ctr__Rule_9__0 rtkNoPos } |
+         Rule_10 { Ctr__Rule_9__1 (rtkPosOf $1) $1 }
 
-SimpleType : qq_SimpleType { Anti_SimpleType $1 } |
-             TyCon TyVars { Ctr__SimpleType__0 $1 (reverse $2) }
+SimpleType : qq_SimpleType { Anti_SimpleType (tkVal_qq_SimpleType $1) } |
+             TyCon TyVars { Ctr__SimpleType__0 (rtkPosOf $1) $1 (reverse $2) }
 
-TopDecl : qq_TopDecl { Anti_TopDecl $1 } |
-          tok_type_13 SimpleType tok__eql__14 Type { Ctr__TopDecl__0 $2 $4 } |
-          tok_data_15 OptContext SimpleType tok__eql__14 Constrs OptDeriving { Ctr__TopDecl__1 $2 $3 $5 $6 } |
-          Decl { Ctr__TopDecl__2 $1 }
+TopDecl : qq_TopDecl { Anti_TopDecl (tkVal_qq_TopDecl $1) } |
+          tok_type_13 SimpleType tok__eql__14 Type { Ctr__TopDecl__0 (rtkPosOf $1) $2 $4 } |
+          tok_data_15 OptContext SimpleType tok__eql__14 Constrs OptDeriving { Ctr__TopDecl__1 (rtkPosOf $1) $2 $3 $5 $6 } |
+          Decl { Ctr__TopDecl__2 (rtkPosOf $1) $1 }
 
-TopDecls : qq_TopDecls { Anti_TopDecls $1 } |
-           Rule_24 tok__semi__7 { Ctr__TopDecls__0 (reverse $1) }
+TopDecls : qq_TopDecls { Anti_TopDecls (tkVal_qq_TopDecls $1) } |
+           Rule_24 tok__semi__7 { Ctr__TopDecls__0 (rtkPosOf (reverse $1)) (reverse $1) }
 
-TyCls : qq_TyCls { Anti_TyCls $1 } |
-        conid { Ctr__TyCls__0 $1 }
+TyCls : qq_TyCls { Anti_TyCls (tkVal_qq_TyCls $1) } |
+        conid { Ctr__TyCls__0 (rtkPosOf $1) (tkVal_conid $1) }
 
-TyCon : qq_TyCon { Anti_TyCon $1 } |
-        conid { Ctr__TyCon__0 $1 }
+TyCon : qq_TyCon { Anti_TyCon (tkVal_qq_TyCon $1) } |
+        conid { Ctr__TyCon__0 (rtkPosOf $1) (tkVal_conid $1) }
 
-TyVar : qq_TyVar { Anti_TyVar $1 } |
-        varid { Ctr__TyVar__0 $1 }
+TyVar : qq_TyVar { Anti_TyVar (tkVal_qq_TyVar $1) } |
+        varid { Ctr__TyVar__0 (rtkPosOf $1) (tkVal_varid $1) }
 
-ListElem_TyVars53 : qq_TyVars { Anti_TyVar $1 } |
+ListElem_TyVars53 : qq_TyVars { Anti_TyVar (tkVal_qq_TyVars $1) } |
                     TyVar { $1 }
 
 TyVars : {- empty -} { [] } |
          TyVars ListElem_TyVars53 { $2 : $1 }
 
-Type : qq_Type { Anti_Type $1 } |
-       BType Rule_44 { Ctr__Type__0 $1 $2 }
+Type : qq_Type { Anti_Type (tkVal_qq_Type $1) } |
+       BType Rule_44 { Ctr__Type__0 (rtkPosOf $1) $1 $2 }
 
-TypeList : qq_TypeList { Anti_TypeList $1 } |
-           Rule_52 tok__coma__3 { Ctr__TypeList__0 (reverse $1) }
+TypeList : qq_TypeList { Anti_TypeList (tkVal_qq_TypeList $1) } |
+           Rule_52 tok__coma__3 { Ctr__TypeList__0 (rtkPosOf (reverse $1)) (reverse $1) }
 
-Var : qq_Var { Anti_Var $1 } |
-      varid { Ctr__Var__0 $1 }
+Var : qq_Var { Anti_Var (tkVal_qq_Var $1) } |
+      varid { Ctr__Var__0 (rtkPosOf $1) (tkVal_varid $1) }
 
-Vars : qq_Vars { Anti_Vars $1 } |
-       Rule_39 tok__coma__3 { Ctr__Vars__0 (reverse $1) }
+Vars : qq_Vars { Anti_Vars (tkVal_qq_Vars $1) } |
+       Rule_39 tok__coma__3 { Ctr__Vars__0 (rtkPosOf (reverse $1)) (reverse $1) }
 
 
 {
@@ -827,407 +827,1056 @@ showRtkToken (L.Tk__qq_ExportsOpt v) = "qq_ExportsOpt " ++ show v
 showRtkToken (L.Tk__qq_Module v) = "qq_Module " ++ show v
 showRtkToken (L.Tk__qq_Haskell v) = "qq_Haskell " ++ show v
 
-data Haskell = Ctr__Haskell__0 Haskell |
-               Ctr__Haskell__1 AType |
-               Ctr__Haskell__2 ATypeList |
-               Ctr__Haskell__3 BType |
-               Ctr__Haskell__4 Body |
-               Ctr__Haskell__5 CName |
-               Ctr__Haskell__6 CNameList |
-               Ctr__Haskell__7 Class |
-               Ctr__Haskell__8 ClassList |
-               Ctr__Haskell__9 Con |
-               Ctr__Haskell__10 Constr |
-               Ctr__Haskell__11 Constrs |
-               Ctr__Haskell__12 Context |
-               Ctr__Haskell__13 DClass |
-               Ctr__Haskell__14 DClassList |
-               Ctr__Haskell__15 Decl |
-               Ctr__Haskell__16 DeclList |
-               Ctr__Haskell__17 Decls |
-               Ctr__Haskell__18 Deriving |
-               Ctr__Haskell__19 Exp |
-               Ctr__Haskell__20 ExpI |
-               Ctr__Haskell__21 Export |
-               Ctr__Haskell__22 ExportsList |
-               Ctr__Haskell__23 ExportsOpt |
-               Ctr__Haskell__24 FieldDecl |
-               Ctr__Haskell__25 FieldDeclList |
-               Ctr__Haskell__26 Fixity |
-               Ctr__Haskell__27 FunLhs |
-               Ctr__Haskell__28 GTyCon |
-               Ctr__Haskell__29 Gd |
-               Ctr__Haskell__30 GdRhs |
-               Ctr__Haskell__31 GenDecl |
-               Ctr__Haskell__32 ImpDecl |
-               Ctr__Haskell__33 ImpDeclList |
-               Ctr__Haskell__34 Import |
-               Ctr__Haskell__35 ImportList |
-               Ctr__Haskell__36 ModId |
-               Ctr__Haskell__37 ModIdList |
-               Ctr__Haskell__38 Module |
-               Ctr__Haskell__39 Op |
-               Ctr__Haskell__40 Ops |
-               Ctr__Haskell__41 OptContext |
-               Ctr__Haskell__42 OptDeriving |
-               Ctr__Haskell__43 OptExpTypeSignature |
-               Ctr__Haskell__44 OptGdRhs |
-               Ctr__Haskell__45 OptImpSpec |
-               Ctr__Haskell__46 OptInteger |
-               Ctr__Haskell__47 OptQualified |
-               Ctr__Haskell__48 OptQualifiedAs |
-               Ctr__Haskell__49 OptWhere |
-               Ctr__Haskell__50 Pat |
-               Ctr__Haskell__51 QOp |
-               Ctr__Haskell__52 QTyCls |
-               Ctr__Haskell__53 QTyCon |
-               Ctr__Haskell__54 QVar |
-               Ctr__Haskell__55 QVarId |
-               Ctr__Haskell__56 QVarList |
-               Ctr__Haskell__57 Rhs |
-               Ctr__Haskell__58 SimpleType |
-               Ctr__Haskell__59 TopDecl |
-               Ctr__Haskell__60 TopDecls |
-               Ctr__Haskell__61 TyCls |
-               Ctr__Haskell__62 TyCon |
-               Ctr__Haskell__63 TyVar |
-               Ctr__Haskell__64 TyVars |
-               Ctr__Haskell__65 Type |
-               Ctr__Haskell__66 TypeList |
-               Ctr__Haskell__67 Var |
-               Ctr__Haskell__68 Vars |
+-- Source position of a node: every constructor except the Anti_* splice
+-- artifacts stores the position of its alternative's first symbol in its
+-- first field. Positions are transparent for equality and ordering, so two
+-- ASTs that differ only in source positions (e.g. a quasi-quote parsed at
+-- compile time vs the same construct parsed at run time) compare equal.
+newtype RtkPos = RtkPos L.AlexPosn deriving (Show, Gen.Data, Gen.Typeable)
+instance Eq RtkPos where _ == _ = True
+instance Ord RtkPos where compare _ _ = EQ
+
+-- The position used where no source token exists: empty productions, empty
+-- lists, absent optionals and Anti_* quasi-quote splices
+rtkNoPos :: RtkPos
+rtkNoPos = RtkPos (L.AlexPn 0 0 0)
+
+class RtkPosOf a where
+    rtkPosOf :: a -> RtkPos
+instance RtkPosOf L.PosToken where
+    rtkPosOf (L.PosToken p _) = RtkPos p
+instance RtkPosOf a => RtkPosOf [a] where
+    rtkPosOf (x : _) = rtkPosOf x
+    rtkPosOf []      = rtkNoPos
+instance RtkPosOf a => RtkPosOf (Maybe a) where
+    rtkPosOf (Just x) = rtkPosOf x
+    rtkPosOf Nothing  = rtkNoPos
+-- A Char carries no position; this also covers String token payloads
+instance RtkPosOf Char where
+    rtkPosOf _ = rtkNoPos
+
+-- Recover a token's payload from the whole positioned token: %token
+-- bindings keep the L.PosToken so semantic actions can read its position
+tkVal_th :: L.PosToken -> String
+tkVal_th (L.PosToken _ (L.Tk__th v)) = v
+tkVal_th t = error ("rtk internal error: token th expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_ncomment :: L.PosToken -> String
+tkVal_ncomment (L.PosToken _ (L.Tk__ncomment v)) = v
+tkVal_ncomment t = error ("rtk internal error: token ncomment expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_whitespace :: L.PosToken -> String
+tkVal_whitespace (L.PosToken _ (L.Tk__whitespace v)) = v
+tkVal_whitespace t = error ("rtk internal error: token whitespace expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_integer :: L.PosToken -> String
+tkVal_integer (L.PosToken _ (L.Tk__integer v)) = v
+tkVal_integer t = error ("rtk internal error: token integer expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_hexadecimal :: L.PosToken -> String
+tkVal_hexadecimal (L.PosToken _ (L.Tk__hexadecimal v)) = v
+tkVal_hexadecimal t = error ("rtk internal error: token hexadecimal expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_octal :: L.PosToken -> String
+tkVal_octal (L.PosToken _ (L.Tk__octal v)) = v
+tkVal_octal t = error ("rtk internal error: token octal expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_decimal :: L.PosToken -> String
+tkVal_decimal (L.PosToken _ (L.Tk__decimal v)) = v
+tkVal_decimal t = error ("rtk internal error: token decimal expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_QOp :: L.PosToken -> String
+tkVal_qq_QOp (L.PosToken _ (L.Tk__qq_QOp v)) = v
+tkVal_qq_QOp t = error ("rtk internal error: token qq_QOp expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_Op :: L.PosToken -> String
+tkVal_qq_Op (L.PosToken _ (L.Tk__qq_Op v)) = v
+tkVal_qq_Op t = error ("rtk internal error: token qq_Op expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_TyCls :: L.PosToken -> String
+tkVal_qq_TyCls (L.PosToken _ (L.Tk__qq_TyCls v)) = v
+tkVal_qq_TyCls t = error ("rtk internal error: token qq_TyCls expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_ModId :: L.PosToken -> String
+tkVal_qq_ModId (L.PosToken _ (L.Tk__qq_ModId v)) = v
+tkVal_qq_ModId t = error ("rtk internal error: token qq_ModId expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_TyCon :: L.PosToken -> String
+tkVal_qq_TyCon (L.PosToken _ (L.Tk__qq_TyCon v)) = v
+tkVal_qq_TyCon t = error ("rtk internal error: token qq_TyCon expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_TyVar :: L.PosToken -> String
+tkVal_qq_TyVar (L.PosToken _ (L.Tk__qq_TyVar v)) = v
+tkVal_qq_TyVar t = error ("rtk internal error: token qq_TyVar expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_varid :: L.PosToken -> String
+tkVal_varid (L.PosToken _ (L.Tk__varid v)) = v
+tkVal_varid t = error ("rtk internal error: token varid expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_conid :: L.PosToken -> String
+tkVal_conid (L.PosToken _ (L.Tk__conid v)) = v
+tkVal_conid t = error ("rtk internal error: token conid expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_TyVars :: L.PosToken -> String
+tkVal_qq_TyVars (L.PosToken _ (L.Tk__qq_TyVars v)) = v
+tkVal_qq_TyVars t = error ("rtk internal error: token qq_TyVars expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_SimpleType :: L.PosToken -> String
+tkVal_qq_SimpleType (L.PosToken _ (L.Tk__qq_SimpleType v)) = v
+tkVal_qq_SimpleType t = error ("rtk internal error: token qq_SimpleType expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_TypeList :: L.PosToken -> String
+tkVal_qq_TypeList (L.PosToken _ (L.Tk__qq_TypeList v)) = v
+tkVal_qq_TypeList t = error ("rtk internal error: token qq_TypeList expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_GTyCon :: L.PosToken -> String
+tkVal_qq_GTyCon (L.PosToken _ (L.Tk__qq_GTyCon v)) = v
+tkVal_qq_GTyCon t = error ("rtk internal error: token qq_GTyCon expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_AType :: L.PosToken -> String
+tkVal_qq_AType (L.PosToken _ (L.Tk__qq_AType v)) = v
+tkVal_qq_AType t = error ("rtk internal error: token qq_AType expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_ATypeList :: L.PosToken -> String
+tkVal_qq_ATypeList (L.PosToken _ (L.Tk__qq_ATypeList v)) = v
+tkVal_qq_ATypeList t = error ("rtk internal error: token qq_ATypeList expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_BType :: L.PosToken -> String
+tkVal_qq_BType (L.PosToken _ (L.Tk__qq_BType v)) = v
+tkVal_qq_BType t = error ("rtk internal error: token qq_BType expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_Type :: L.PosToken -> String
+tkVal_qq_Type (L.PosToken _ (L.Tk__qq_Type v)) = v
+tkVal_qq_Type t = error ("rtk internal error: token qq_Type expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_Class :: L.PosToken -> String
+tkVal_qq_Class (L.PosToken _ (L.Tk__qq_Class v)) = v
+tkVal_qq_Class t = error ("rtk internal error: token qq_Class expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_ClassList :: L.PosToken -> String
+tkVal_qq_ClassList (L.PosToken _ (L.Tk__qq_ClassList v)) = v
+tkVal_qq_ClassList t = error ("rtk internal error: token qq_ClassList expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_Context :: L.PosToken -> String
+tkVal_qq_Context (L.PosToken _ (L.Tk__qq_Context v)) = v
+tkVal_qq_Context t = error ("rtk internal error: token qq_Context expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_DClass :: L.PosToken -> String
+tkVal_qq_DClass (L.PosToken _ (L.Tk__qq_DClass v)) = v
+tkVal_qq_DClass t = error ("rtk internal error: token qq_DClass expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_DClassList :: L.PosToken -> String
+tkVal_qq_DClassList (L.PosToken _ (L.Tk__qq_DClassList v)) = v
+tkVal_qq_DClassList t = error ("rtk internal error: token qq_DClassList expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_Deriving :: L.PosToken -> String
+tkVal_qq_Deriving (L.PosToken _ (L.Tk__qq_Deriving v)) = v
+tkVal_qq_Deriving t = error ("rtk internal error: token qq_Deriving expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_OptDeriving :: L.PosToken -> String
+tkVal_qq_OptDeriving (L.PosToken _ (L.Tk__qq_OptDeriving v)) = v
+tkVal_qq_OptDeriving t = error ("rtk internal error: token qq_OptDeriving expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_Vars :: L.PosToken -> String
+tkVal_qq_Vars (L.PosToken _ (L.Tk__qq_Vars v)) = v
+tkVal_qq_Vars t = error ("rtk internal error: token qq_Vars expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_FieldDecl :: L.PosToken -> String
+tkVal_qq_FieldDecl (L.PosToken _ (L.Tk__qq_FieldDecl v)) = v
+tkVal_qq_FieldDecl t = error ("rtk internal error: token qq_FieldDecl expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_FieldDeclList :: L.PosToken -> String
+tkVal_qq_FieldDeclList (L.PosToken _ (L.Tk__qq_FieldDeclList v)) = v
+tkVal_qq_FieldDeclList t = error ("rtk internal error: token qq_FieldDeclList expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_Constr :: L.PosToken -> String
+tkVal_qq_Constr (L.PosToken _ (L.Tk__qq_Constr v)) = v
+tkVal_qq_Constr t = error ("rtk internal error: token qq_Constr expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_Constrs :: L.PosToken -> String
+tkVal_qq_Constrs (L.PosToken _ (L.Tk__qq_Constrs v)) = v
+tkVal_qq_Constrs t = error ("rtk internal error: token qq_Constrs expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_GdRhs :: L.PosToken -> String
+tkVal_qq_GdRhs (L.PosToken _ (L.Tk__qq_GdRhs v)) = v
+tkVal_qq_GdRhs t = error ("rtk internal error: token qq_GdRhs expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_ExpI :: L.PosToken -> String
+tkVal_qq_ExpI (L.PosToken _ (L.Tk__qq_ExpI v)) = v
+tkVal_qq_ExpI t = error ("rtk internal error: token qq_ExpI expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_Exp :: L.PosToken -> String
+tkVal_qq_Exp (L.PosToken _ (L.Tk__qq_Exp v)) = v
+tkVal_qq_Exp t = error ("rtk internal error: token qq_Exp expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_OptExpTypeSignature :: L.PosToken -> String
+tkVal_qq_OptExpTypeSignature (L.PosToken _ (L.Tk__qq_OptExpTypeSignature v)) = v
+tkVal_qq_OptExpTypeSignature t = error ("rtk internal error: token qq_OptExpTypeSignature expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_Gd :: L.PosToken -> String
+tkVal_qq_Gd (L.PosToken _ (L.Tk__qq_Gd v)) = v
+tkVal_qq_Gd t = error ("rtk internal error: token qq_Gd expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_OptGdRhs :: L.PosToken -> String
+tkVal_qq_OptGdRhs (L.PosToken _ (L.Tk__qq_OptGdRhs v)) = v
+tkVal_qq_OptGdRhs t = error ("rtk internal error: token qq_OptGdRhs expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_Rhs :: L.PosToken -> String
+tkVal_qq_Rhs (L.PosToken _ (L.Tk__qq_Rhs v)) = v
+tkVal_qq_Rhs t = error ("rtk internal error: token qq_Rhs expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_Decls :: L.PosToken -> String
+tkVal_qq_Decls (L.PosToken _ (L.Tk__qq_Decls v)) = v
+tkVal_qq_Decls t = error ("rtk internal error: token qq_Decls expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_DeclList :: L.PosToken -> String
+tkVal_qq_DeclList (L.PosToken _ (L.Tk__qq_DeclList v)) = v
+tkVal_qq_DeclList t = error ("rtk internal error: token qq_DeclList expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_OptWhere :: L.PosToken -> String
+tkVal_qq_OptWhere (L.PosToken _ (L.Tk__qq_OptWhere v)) = v
+tkVal_qq_OptWhere t = error ("rtk internal error: token qq_OptWhere expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_Pat :: L.PosToken -> String
+tkVal_qq_Pat (L.PosToken _ (L.Tk__qq_Pat v)) = v
+tkVal_qq_Pat t = error ("rtk internal error: token qq_Pat expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_FunLhs :: L.PosToken -> String
+tkVal_qq_FunLhs (L.PosToken _ (L.Tk__qq_FunLhs v)) = v
+tkVal_qq_FunLhs t = error ("rtk internal error: token qq_FunLhs expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_Fixity :: L.PosToken -> String
+tkVal_qq_Fixity (L.PosToken _ (L.Tk__qq_Fixity v)) = v
+tkVal_qq_Fixity t = error ("rtk internal error: token qq_Fixity expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_Ops :: L.PosToken -> String
+tkVal_qq_Ops (L.PosToken _ (L.Tk__qq_Ops v)) = v
+tkVal_qq_Ops t = error ("rtk internal error: token qq_Ops expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_OptInteger :: L.PosToken -> String
+tkVal_qq_OptInteger (L.PosToken _ (L.Tk__qq_OptInteger v)) = v
+tkVal_qq_OptInteger t = error ("rtk internal error: token qq_OptInteger expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_GenDecl :: L.PosToken -> String
+tkVal_qq_GenDecl (L.PosToken _ (L.Tk__qq_GenDecl v)) = v
+tkVal_qq_GenDecl t = error ("rtk internal error: token qq_GenDecl expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_OptContext :: L.PosToken -> String
+tkVal_qq_OptContext (L.PosToken _ (L.Tk__qq_OptContext v)) = v
+tkVal_qq_OptContext t = error ("rtk internal error: token qq_OptContext expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_Decl :: L.PosToken -> String
+tkVal_qq_Decl (L.PosToken _ (L.Tk__qq_Decl v)) = v
+tkVal_qq_Decl t = error ("rtk internal error: token qq_Decl expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_TopDecl :: L.PosToken -> String
+tkVal_qq_TopDecl (L.PosToken _ (L.Tk__qq_TopDecl v)) = v
+tkVal_qq_TopDecl t = error ("rtk internal error: token qq_TopDecl expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_TopDecls :: L.PosToken -> String
+tkVal_qq_TopDecls (L.PosToken _ (L.Tk__qq_TopDecls v)) = v
+tkVal_qq_TopDecls t = error ("rtk internal error: token qq_TopDecls expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_ImpDecl :: L.PosToken -> String
+tkVal_qq_ImpDecl (L.PosToken _ (L.Tk__qq_ImpDecl v)) = v
+tkVal_qq_ImpDecl t = error ("rtk internal error: token qq_ImpDecl expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_OptImpSpec :: L.PosToken -> String
+tkVal_qq_OptImpSpec (L.PosToken _ (L.Tk__qq_OptImpSpec v)) = v
+tkVal_qq_OptImpSpec t = error ("rtk internal error: token qq_OptImpSpec expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_OptQualifiedAs :: L.PosToken -> String
+tkVal_qq_OptQualifiedAs (L.PosToken _ (L.Tk__qq_OptQualifiedAs v)) = v
+tkVal_qq_OptQualifiedAs t = error ("rtk internal error: token qq_OptQualifiedAs expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_OptQualified :: L.PosToken -> String
+tkVal_qq_OptQualified (L.PosToken _ (L.Tk__qq_OptQualified v)) = v
+tkVal_qq_OptQualified t = error ("rtk internal error: token qq_OptQualified expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_Import :: L.PosToken -> String
+tkVal_qq_Import (L.PosToken _ (L.Tk__qq_Import v)) = v
+tkVal_qq_Import t = error ("rtk internal error: token qq_Import expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_QVarList :: L.PosToken -> String
+tkVal_qq_QVarList (L.PosToken _ (L.Tk__qq_QVarList v)) = v
+tkVal_qq_QVarList t = error ("rtk internal error: token qq_QVarList expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_CNameList :: L.PosToken -> String
+tkVal_qq_CNameList (L.PosToken _ (L.Tk__qq_CNameList v)) = v
+tkVal_qq_CNameList t = error ("rtk internal error: token qq_CNameList expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_CName :: L.PosToken -> String
+tkVal_qq_CName (L.PosToken _ (L.Tk__qq_CName v)) = v
+tkVal_qq_CName t = error ("rtk internal error: token qq_CName expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_QTyCon :: L.PosToken -> String
+tkVal_qq_QTyCon (L.PosToken _ (L.Tk__qq_QTyCon v)) = v
+tkVal_qq_QTyCon t = error ("rtk internal error: token qq_QTyCon expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_QTyCls :: L.PosToken -> String
+tkVal_qq_QTyCls (L.PosToken _ (L.Tk__qq_QTyCls v)) = v
+tkVal_qq_QTyCls t = error ("rtk internal error: token qq_QTyCls expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_QVar :: L.PosToken -> String
+tkVal_qq_QVar (L.PosToken _ (L.Tk__qq_QVar v)) = v
+tkVal_qq_QVar t = error ("rtk internal error: token qq_QVar expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_QVarId :: L.PosToken -> String
+tkVal_qq_QVarId (L.PosToken _ (L.Tk__qq_QVarId v)) = v
+tkVal_qq_QVarId t = error ("rtk internal error: token qq_QVarId expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_ModIdList :: L.PosToken -> String
+tkVal_qq_ModIdList (L.PosToken _ (L.Tk__qq_ModIdList v)) = v
+tkVal_qq_ModIdList t = error ("rtk internal error: token qq_ModIdList expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_Con :: L.PosToken -> String
+tkVal_qq_Con (L.PosToken _ (L.Tk__qq_Con v)) = v
+tkVal_qq_Con t = error ("rtk internal error: token qq_Con expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_Var :: L.PosToken -> String
+tkVal_qq_Var (L.PosToken _ (L.Tk__qq_Var v)) = v
+tkVal_qq_Var t = error ("rtk internal error: token qq_Var expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_ImportList :: L.PosToken -> String
+tkVal_qq_ImportList (L.PosToken _ (L.Tk__qq_ImportList v)) = v
+tkVal_qq_ImportList t = error ("rtk internal error: token qq_ImportList expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_ImpDeclList :: L.PosToken -> String
+tkVal_qq_ImpDeclList (L.PosToken _ (L.Tk__qq_ImpDeclList v)) = v
+tkVal_qq_ImpDeclList t = error ("rtk internal error: token qq_ImpDeclList expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_Body :: L.PosToken -> String
+tkVal_qq_Body (L.PosToken _ (L.Tk__qq_Body v)) = v
+tkVal_qq_Body t = error ("rtk internal error: token qq_Body expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_Export :: L.PosToken -> String
+tkVal_qq_Export (L.PosToken _ (L.Tk__qq_Export v)) = v
+tkVal_qq_Export t = error ("rtk internal error: token qq_Export expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_ExportsList :: L.PosToken -> String
+tkVal_qq_ExportsList (L.PosToken _ (L.Tk__qq_ExportsList v)) = v
+tkVal_qq_ExportsList t = error ("rtk internal error: token qq_ExportsList expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_ExportsOpt :: L.PosToken -> String
+tkVal_qq_ExportsOpt (L.PosToken _ (L.Tk__qq_ExportsOpt v)) = v
+tkVal_qq_ExportsOpt t = error ("rtk internal error: token qq_ExportsOpt expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_Module :: L.PosToken -> String
+tkVal_qq_Module (L.PosToken _ (L.Tk__qq_Module v)) = v
+tkVal_qq_Module t = error ("rtk internal error: token qq_Module expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_Haskell :: L.PosToken -> String
+tkVal_qq_Haskell (L.PosToken _ (L.Tk__qq_Haskell v)) = v
+tkVal_qq_Haskell t = error ("rtk internal error: token qq_Haskell expected, got " ++ showRtkToken (L.ptToken t))
+
+data Haskell = Ctr__Haskell__0 RtkPos Haskell |
+               Ctr__Haskell__1 RtkPos AType |
+               Ctr__Haskell__2 RtkPos ATypeList |
+               Ctr__Haskell__3 RtkPos BType |
+               Ctr__Haskell__4 RtkPos Body |
+               Ctr__Haskell__5 RtkPos CName |
+               Ctr__Haskell__6 RtkPos CNameList |
+               Ctr__Haskell__7 RtkPos Class |
+               Ctr__Haskell__8 RtkPos ClassList |
+               Ctr__Haskell__9 RtkPos Con |
+               Ctr__Haskell__10 RtkPos Constr |
+               Ctr__Haskell__11 RtkPos Constrs |
+               Ctr__Haskell__12 RtkPos Context |
+               Ctr__Haskell__13 RtkPos DClass |
+               Ctr__Haskell__14 RtkPos DClassList |
+               Ctr__Haskell__15 RtkPos Decl |
+               Ctr__Haskell__16 RtkPos DeclList |
+               Ctr__Haskell__17 RtkPos Decls |
+               Ctr__Haskell__18 RtkPos Deriving |
+               Ctr__Haskell__19 RtkPos Exp |
+               Ctr__Haskell__20 RtkPos ExpI |
+               Ctr__Haskell__21 RtkPos Export |
+               Ctr__Haskell__22 RtkPos ExportsList |
+               Ctr__Haskell__23 RtkPos ExportsOpt |
+               Ctr__Haskell__24 RtkPos FieldDecl |
+               Ctr__Haskell__25 RtkPos FieldDeclList |
+               Ctr__Haskell__26 RtkPos Fixity |
+               Ctr__Haskell__27 RtkPos FunLhs |
+               Ctr__Haskell__28 RtkPos GTyCon |
+               Ctr__Haskell__29 RtkPos Gd |
+               Ctr__Haskell__30 RtkPos GdRhs |
+               Ctr__Haskell__31 RtkPos GenDecl |
+               Ctr__Haskell__32 RtkPos ImpDecl |
+               Ctr__Haskell__33 RtkPos ImpDeclList |
+               Ctr__Haskell__34 RtkPos Import |
+               Ctr__Haskell__35 RtkPos ImportList |
+               Ctr__Haskell__36 RtkPos ModId |
+               Ctr__Haskell__37 RtkPos ModIdList |
+               Ctr__Haskell__38 RtkPos Module |
+               Ctr__Haskell__39 RtkPos Op |
+               Ctr__Haskell__40 RtkPos Ops |
+               Ctr__Haskell__41 RtkPos OptContext |
+               Ctr__Haskell__42 RtkPos OptDeriving |
+               Ctr__Haskell__43 RtkPos OptExpTypeSignature |
+               Ctr__Haskell__44 RtkPos OptGdRhs |
+               Ctr__Haskell__45 RtkPos OptImpSpec |
+               Ctr__Haskell__46 RtkPos OptInteger |
+               Ctr__Haskell__47 RtkPos OptQualified |
+               Ctr__Haskell__48 RtkPos OptQualifiedAs |
+               Ctr__Haskell__49 RtkPos OptWhere |
+               Ctr__Haskell__50 RtkPos Pat |
+               Ctr__Haskell__51 RtkPos QOp |
+               Ctr__Haskell__52 RtkPos QTyCls |
+               Ctr__Haskell__53 RtkPos QTyCon |
+               Ctr__Haskell__54 RtkPos QVar |
+               Ctr__Haskell__55 RtkPos QVarId |
+               Ctr__Haskell__56 RtkPos QVarList |
+               Ctr__Haskell__57 RtkPos Rhs |
+               Ctr__Haskell__58 RtkPos SimpleType |
+               Ctr__Haskell__59 RtkPos TopDecl |
+               Ctr__Haskell__60 RtkPos TopDecls |
+               Ctr__Haskell__61 RtkPos TyCls |
+               Ctr__Haskell__62 RtkPos TyCon |
+               Ctr__Haskell__63 RtkPos TyVar |
+               Ctr__Haskell__64 RtkPos TyVars |
+               Ctr__Haskell__65 RtkPos Type |
+               Ctr__Haskell__66 RtkPos TypeList |
+               Ctr__Haskell__67 RtkPos Var |
+               Ctr__Haskell__68 RtkPos Vars |
                Anti_Haskell String |
-               Ctr__Haskell__69 Module
+               Ctr__Haskell__69 RtkPos Module
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Haskell where
+    rtkPosOf (Ctr__Haskell__0 p _) = p
+    rtkPosOf (Ctr__Haskell__1 p _) = p
+    rtkPosOf (Ctr__Haskell__2 p _) = p
+    rtkPosOf (Ctr__Haskell__3 p _) = p
+    rtkPosOf (Ctr__Haskell__4 p _) = p
+    rtkPosOf (Ctr__Haskell__5 p _) = p
+    rtkPosOf (Ctr__Haskell__6 p _) = p
+    rtkPosOf (Ctr__Haskell__7 p _) = p
+    rtkPosOf (Ctr__Haskell__8 p _) = p
+    rtkPosOf (Ctr__Haskell__9 p _) = p
+    rtkPosOf (Ctr__Haskell__10 p _) = p
+    rtkPosOf (Ctr__Haskell__11 p _) = p
+    rtkPosOf (Ctr__Haskell__12 p _) = p
+    rtkPosOf (Ctr__Haskell__13 p _) = p
+    rtkPosOf (Ctr__Haskell__14 p _) = p
+    rtkPosOf (Ctr__Haskell__15 p _) = p
+    rtkPosOf (Ctr__Haskell__16 p _) = p
+    rtkPosOf (Ctr__Haskell__17 p _) = p
+    rtkPosOf (Ctr__Haskell__18 p _) = p
+    rtkPosOf (Ctr__Haskell__19 p _) = p
+    rtkPosOf (Ctr__Haskell__20 p _) = p
+    rtkPosOf (Ctr__Haskell__21 p _) = p
+    rtkPosOf (Ctr__Haskell__22 p _) = p
+    rtkPosOf (Ctr__Haskell__23 p _) = p
+    rtkPosOf (Ctr__Haskell__24 p _) = p
+    rtkPosOf (Ctr__Haskell__25 p _) = p
+    rtkPosOf (Ctr__Haskell__26 p _) = p
+    rtkPosOf (Ctr__Haskell__27 p _) = p
+    rtkPosOf (Ctr__Haskell__28 p _) = p
+    rtkPosOf (Ctr__Haskell__29 p _) = p
+    rtkPosOf (Ctr__Haskell__30 p _) = p
+    rtkPosOf (Ctr__Haskell__31 p _) = p
+    rtkPosOf (Ctr__Haskell__32 p _) = p
+    rtkPosOf (Ctr__Haskell__33 p _) = p
+    rtkPosOf (Ctr__Haskell__34 p _) = p
+    rtkPosOf (Ctr__Haskell__35 p _) = p
+    rtkPosOf (Ctr__Haskell__36 p _) = p
+    rtkPosOf (Ctr__Haskell__37 p _) = p
+    rtkPosOf (Ctr__Haskell__38 p _) = p
+    rtkPosOf (Ctr__Haskell__39 p _) = p
+    rtkPosOf (Ctr__Haskell__40 p _) = p
+    rtkPosOf (Ctr__Haskell__41 p _) = p
+    rtkPosOf (Ctr__Haskell__42 p _) = p
+    rtkPosOf (Ctr__Haskell__43 p _) = p
+    rtkPosOf (Ctr__Haskell__44 p _) = p
+    rtkPosOf (Ctr__Haskell__45 p _) = p
+    rtkPosOf (Ctr__Haskell__46 p _) = p
+    rtkPosOf (Ctr__Haskell__47 p _) = p
+    rtkPosOf (Ctr__Haskell__48 p _) = p
+    rtkPosOf (Ctr__Haskell__49 p _) = p
+    rtkPosOf (Ctr__Haskell__50 p _) = p
+    rtkPosOf (Ctr__Haskell__51 p _) = p
+    rtkPosOf (Ctr__Haskell__52 p _) = p
+    rtkPosOf (Ctr__Haskell__53 p _) = p
+    rtkPosOf (Ctr__Haskell__54 p _) = p
+    rtkPosOf (Ctr__Haskell__55 p _) = p
+    rtkPosOf (Ctr__Haskell__56 p _) = p
+    rtkPosOf (Ctr__Haskell__57 p _) = p
+    rtkPosOf (Ctr__Haskell__58 p _) = p
+    rtkPosOf (Ctr__Haskell__59 p _) = p
+    rtkPosOf (Ctr__Haskell__60 p _) = p
+    rtkPosOf (Ctr__Haskell__61 p _) = p
+    rtkPosOf (Ctr__Haskell__62 p _) = p
+    rtkPosOf (Ctr__Haskell__63 p _) = p
+    rtkPosOf (Ctr__Haskell__64 p _) = p
+    rtkPosOf (Ctr__Haskell__65 p _) = p
+    rtkPosOf (Ctr__Haskell__66 p _) = p
+    rtkPosOf (Ctr__Haskell__67 p _) = p
+    rtkPosOf (Ctr__Haskell__68 p _) = p
+    rtkPosOf (Anti_Haskell _) = rtkNoPos
+    rtkPosOf (Ctr__Haskell__69 p _) = p
 data AType = Anti_AType String |
-             Ctr__AType__0 TyVar |
-             Ctr__AType__1 GTyCon |
-             Ctr__AType__2 Rule_49 |
-             Ctr__AType__3 Rule_50
+             Ctr__AType__0 RtkPos TyVar |
+             Ctr__AType__1 RtkPos GTyCon |
+             Ctr__AType__2 RtkPos Rule_49 |
+             Ctr__AType__3 RtkPos Rule_50
              deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf AType where
+    rtkPosOf (Anti_AType _) = rtkNoPos
+    rtkPosOf (Ctr__AType__0 p _) = p
+    rtkPosOf (Ctr__AType__1 p _) = p
+    rtkPosOf (Ctr__AType__2 p _) = p
+    rtkPosOf (Ctr__AType__3 p _) = p
 type ATypeList = [AType]
 data BType = Anti_BType String |
-             Ctr__BType__0 Rule_46 AType
+             Ctr__BType__0 RtkPos Rule_46 AType
              deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf BType where
+    rtkPosOf (Anti_BType _) = rtkNoPos
+    rtkPosOf (Ctr__BType__0 p _ _) = p
 data Body = Anti_Body String |
-            Ctr__Body__0 Rule_8
+            Ctr__Body__0 RtkPos Rule_8
             deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Body where
+    rtkPosOf (Anti_Body _) = rtkNoPos
+    rtkPosOf (Ctr__Body__0 p _) = p
 data CName = Anti_CName String |
-             Ctr__CName__0 Var |
-             Ctr__CName__1 Con
+             Ctr__CName__0 RtkPos Var |
+             Ctr__CName__1 RtkPos Con
              deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf CName where
+    rtkPosOf (Anti_CName _) = rtkNoPos
+    rtkPosOf (Ctr__CName__0 p _) = p
+    rtkPosOf (Ctr__CName__1 p _) = p
 data CNameList = Anti_CNameList String |
-                 Ctr__CNameList__0 Rule_15
+                 Ctr__CNameList__0 RtkPos Rule_15
                  deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf CNameList where
+    rtkPosOf (Anti_CNameList _) = rtkNoPos
+    rtkPosOf (Ctr__CNameList__0 p _) = p
 data Class = Anti_Class String |
-             Ctr__Class__0 QTyCls TyVar |
-             Ctr__Class__1 QTyCls TyVar ATypeList
+             Ctr__Class__0 RtkPos QTyCls TyVar |
+             Ctr__Class__1 RtkPos QTyCls TyVar ATypeList
              deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Class where
+    rtkPosOf (Anti_Class _) = rtkNoPos
+    rtkPosOf (Ctr__Class__0 p _ _) = p
+    rtkPosOf (Ctr__Class__1 p _ _ _) = p
 data ClassList = Anti_ClassList String |
-                 Ctr__ClassList__0 Rule_43
+                 Ctr__ClassList__0 RtkPos Rule_43
                  deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf ClassList where
+    rtkPosOf (Anti_ClassList _) = rtkNoPos
+    rtkPosOf (Ctr__ClassList__0 p _) = p
 data Con = Anti_Con String |
-           Ctr__Con__0 String
+           Ctr__Con__0 RtkPos String
            deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Con where
+    rtkPosOf (Anti_Con _) = rtkNoPos
+    rtkPosOf (Ctr__Con__0 p _) = p
 data Constr = Anti_Constr String |
-              Ctr__Constr__0 Con FieldDeclList
+              Ctr__Constr__0 RtkPos Con FieldDeclList
               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Constr where
+    rtkPosOf (Anti_Constr _) = rtkNoPos
+    rtkPosOf (Ctr__Constr__0 p _ _) = p
 data Constrs = Anti_Constrs String |
-               Ctr__Constrs__0 Rule_36
+               Ctr__Constrs__0 RtkPos Rule_36
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Constrs where
+    rtkPosOf (Anti_Constrs _) = rtkNoPos
+    rtkPosOf (Ctr__Constrs__0 p _) = p
 data Context = Anti_Context String |
-               Ctr__Context__0 Class |
-               Ctr__Context__1 ClassList
+               Ctr__Context__0 RtkPos Class |
+               Ctr__Context__1 RtkPos ClassList
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Context where
+    rtkPosOf (Anti_Context _) = rtkNoPos
+    rtkPosOf (Ctr__Context__0 p _) = p
+    rtkPosOf (Ctr__Context__1 p _) = p
 data DClass = Anti_DClass String |
-              Ctr__DClass__0 QTyCls
+              Ctr__DClass__0 RtkPos QTyCls
               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf DClass where
+    rtkPosOf (Anti_DClass _) = rtkNoPos
+    rtkPosOf (Ctr__DClass__0 p _) = p
 data DClassList = Anti_DClassList String |
-                  Ctr__DClassList__0 Rule_42
+                  Ctr__DClassList__0 RtkPos Rule_42
                   deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf DClassList where
+    rtkPosOf (Anti_DClassList _) = rtkNoPos
+    rtkPosOf (Ctr__DClassList__0 p _) = p
 data Decl = Anti_Decl String |
-            Ctr__Decl__0 GenDecl |
-            Ctr__Decl__1 Rule_25 Rhs
+            Ctr__Decl__0 RtkPos GenDecl |
+            Ctr__Decl__1 RtkPos Rule_25 Rhs
             deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Decl where
+    rtkPosOf (Anti_Decl _) = rtkNoPos
+    rtkPosOf (Ctr__Decl__0 p _) = p
+    rtkPosOf (Ctr__Decl__1 p _ _) = p
 data DeclList = Anti_DeclList String |
-                Ctr__DeclList__0 Rule_31
+                Ctr__DeclList__0 RtkPos Rule_31
                 deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf DeclList where
+    rtkPosOf (Anti_DeclList _) = rtkNoPos
+    rtkPosOf (Ctr__DeclList__0 p _) = p
 data Decls = Anti_Decls String |
-             Ctr__Decls__0 DeclList
+             Ctr__Decls__0 RtkPos DeclList
              deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Decls where
+    rtkPosOf (Anti_Decls _) = rtkNoPos
+    rtkPosOf (Ctr__Decls__0 p _) = p
 data Deriving = Anti_Deriving String |
-                Ctr__Deriving__0 Rule_41
+                Ctr__Deriving__0 RtkPos Rule_41
                 deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Deriving where
+    rtkPosOf (Anti_Deriving _) = rtkNoPos
+    rtkPosOf (Ctr__Deriving__0 p _) = p
 data Exp = Anti_Exp String |
-           Ctr__Exp__0 ExpI OptExpTypeSignature
+           Ctr__Exp__0 RtkPos ExpI OptExpTypeSignature
            deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Exp where
+    rtkPosOf (Anti_Exp _) = rtkNoPos
+    rtkPosOf (Ctr__Exp__0 p _ _) = p
 data ExpI = Anti_ExpI String |
-            Ctr__ExpI__0 ExpI Rule_34
+            Ctr__ExpI__0 RtkPos ExpI Rule_34
             deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf ExpI where
+    rtkPosOf (Anti_ExpI _) = rtkNoPos
+    rtkPosOf (Ctr__ExpI__0 p _ _) = p
 data Export = Anti_Export String |
-              Ctr__Export__0 ModId |
-              Ctr__Export__1 QVar |
-              Ctr__Export__2 QTyCon Rule_4 |
-              Ctr__Export__3 QTyCls Rule_6
+              Ctr__Export__0 RtkPos ModId |
+              Ctr__Export__1 RtkPos QVar |
+              Ctr__Export__2 RtkPos QTyCon Rule_4 |
+              Ctr__Export__3 RtkPos QTyCls Rule_6
               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Export where
+    rtkPosOf (Anti_Export _) = rtkNoPos
+    rtkPosOf (Ctr__Export__0 p _) = p
+    rtkPosOf (Ctr__Export__1 p _) = p
+    rtkPosOf (Ctr__Export__2 p _ _) = p
+    rtkPosOf (Ctr__Export__3 p _ _) = p
 data ExportsList = Anti_ExportsList String |
-                   Ctr__ExportsList__0 Rule_3
+                   Ctr__ExportsList__0 RtkPos Rule_3
                    deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf ExportsList where
+    rtkPosOf (Anti_ExportsList _) = rtkNoPos
+    rtkPosOf (Ctr__ExportsList__0 p _) = p
 data ExportsOpt = Anti_ExportsOpt String |
-                  Ctr__ExportsOpt__0 |
-                  Ctr__ExportsOpt__1 Rule_0
+                  Ctr__ExportsOpt__0 RtkPos |
+                  Ctr__ExportsOpt__1 RtkPos Rule_0
                   deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf ExportsOpt where
+    rtkPosOf (Anti_ExportsOpt _) = rtkNoPos
+    rtkPosOf (Ctr__ExportsOpt__0 p) = p
+    rtkPosOf (Ctr__ExportsOpt__1 p _) = p
 data FieldDecl = Anti_FieldDecl String |
-                 Ctr__FieldDecl__0 Vars Rule_38
+                 Ctr__FieldDecl__0 RtkPos Vars Rule_38
                  deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf FieldDecl where
+    rtkPosOf (Anti_FieldDecl _) = rtkNoPos
+    rtkPosOf (Ctr__FieldDecl__0 p _ _) = p
 data FieldDeclList = Anti_FieldDeclList String |
-                     Ctr__FieldDeclList__0 Rule_37
+                     Ctr__FieldDeclList__0 RtkPos Rule_37
                      deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf FieldDeclList where
+    rtkPosOf (Anti_FieldDeclList _) = rtkNoPos
+    rtkPosOf (Ctr__FieldDeclList__0 p _) = p
 data Fixity = Anti_Fixity String |
-              Ctr__Fixity__0 |
-              Ctr__Fixity__1 |
-              Ctr__Fixity__2
+              Ctr__Fixity__0 RtkPos |
+              Ctr__Fixity__1 RtkPos |
+              Ctr__Fixity__2 RtkPos
               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Fixity where
+    rtkPosOf (Anti_Fixity _) = rtkNoPos
+    rtkPosOf (Ctr__Fixity__0 p) = p
+    rtkPosOf (Ctr__Fixity__1 p) = p
+    rtkPosOf (Ctr__Fixity__2 p) = p
 data FunLhs = Anti_FunLhs String |
-              Ctr__FunLhs__0 Var
+              Ctr__FunLhs__0 RtkPos Var
               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf FunLhs where
+    rtkPosOf (Anti_FunLhs _) = rtkNoPos
+    rtkPosOf (Ctr__FunLhs__0 p _) = p
 data GTyCon = Anti_GTyCon String |
-              Ctr__GTyCon__0 QTyCon |
-              Ctr__GTyCon__1
+              Ctr__GTyCon__0 RtkPos QTyCon |
+              Ctr__GTyCon__1 RtkPos
               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf GTyCon where
+    rtkPosOf (Anti_GTyCon _) = rtkNoPos
+    rtkPosOf (Ctr__GTyCon__0 p _) = p
+    rtkPosOf (Ctr__GTyCon__1 p) = p
 data Gd = Anti_Gd String |
-          Ctr__Gd__0 |
-          Ctr__Gd__1 ExpI
+          Ctr__Gd__0 RtkPos |
+          Ctr__Gd__1 RtkPos ExpI
           deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Gd where
+    rtkPosOf (Anti_Gd _) = rtkNoPos
+    rtkPosOf (Ctr__Gd__0 p) = p
+    rtkPosOf (Ctr__Gd__1 p _) = p
 data GdRhs = Anti_GdRhs String |
-             Ctr__GdRhs__0 Gd Exp OptGdRhs
+             Ctr__GdRhs__0 RtkPos Gd Exp OptGdRhs
              deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf GdRhs where
+    rtkPosOf (Anti_GdRhs _) = rtkNoPos
+    rtkPosOf (Ctr__GdRhs__0 p _ _ _) = p
 data GenDecl = Anti_GenDecl String |
-               Ctr__GenDecl__0 Vars OptContext Type |
-               Ctr__GenDecl__1 Fixity OptInteger Ops
+               Ctr__GenDecl__0 RtkPos Vars OptContext Type |
+               Ctr__GenDecl__1 RtkPos Fixity OptInteger Ops
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf GenDecl where
+    rtkPosOf (Anti_GenDecl _) = rtkNoPos
+    rtkPosOf (Ctr__GenDecl__0 p _ _ _) = p
+    rtkPosOf (Ctr__GenDecl__1 p _ _ _) = p
 data ImpDecl = Anti_ImpDecl String |
-               Ctr__ImpDecl__0 OptQualified ModId OptQualifiedAs Rule_23
+               Ctr__ImpDecl__0 RtkPos OptQualified ModId OptQualifiedAs Rule_23
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf ImpDecl where
+    rtkPosOf (Anti_ImpDecl _) = rtkNoPos
+    rtkPosOf (Ctr__ImpDecl__0 p _ _ _ _) = p
 data ImpDeclList = Anti_ImpDeclList String |
-                   Ctr__ImpDeclList__0 Rule_11
+                   Ctr__ImpDeclList__0 RtkPos Rule_11
                    deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf ImpDeclList where
+    rtkPosOf (Anti_ImpDeclList _) = rtkNoPos
+    rtkPosOf (Ctr__ImpDeclList__0 p _) = p
 data Import = Anti_Import String |
-              Ctr__Import__0 Var |
-              Ctr__Import__1 TyCon Rule_17
+              Ctr__Import__0 RtkPos Var |
+              Ctr__Import__1 RtkPos TyCon Rule_17
               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Import where
+    rtkPosOf (Anti_Import _) = rtkNoPos
+    rtkPosOf (Ctr__Import__0 p _) = p
+    rtkPosOf (Ctr__Import__1 p _ _) = p
 data ImportList = Anti_ImportList String |
-                  Ctr__ImportList__0 Rule_12
+                  Ctr__ImportList__0 RtkPos Rule_12
                   deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf ImportList where
+    rtkPosOf (Anti_ImportList _) = rtkNoPos
+    rtkPosOf (Ctr__ImportList__0 p _) = p
 data ModId = Anti_ModId String |
-             Ctr__ModId__0 String
+             Ctr__ModId__0 RtkPos String
              deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf ModId where
+    rtkPosOf (Anti_ModId _) = rtkNoPos
+    rtkPosOf (Ctr__ModId__0 p _) = p
 type ModIdList = [Rule_13]
 data Module = Anti_Module String |
-              Ctr__Module__0 ModId ExportsOpt Body |
-              Ctr__Module__1 Body
+              Ctr__Module__0 RtkPos ModId ExportsOpt Body |
+              Ctr__Module__1 RtkPos Body
               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Module where
+    rtkPosOf (Anti_Module _) = rtkNoPos
+    rtkPosOf (Ctr__Module__0 p _ _ _) = p
+    rtkPosOf (Ctr__Module__1 p _) = p
 data Op = Anti_Op String |
-          Ctr__Op__0 String |
-          Ctr__Op__1 String
+          Ctr__Op__0 RtkPos String |
+          Ctr__Op__1 RtkPos String
           deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Op where
+    rtkPosOf (Anti_Op _) = rtkNoPos
+    rtkPosOf (Ctr__Op__0 p _) = p
+    rtkPosOf (Ctr__Op__1 p _) = p
 data Ops = Anti_Ops String |
-           Ctr__Ops__0 Rule_28
+           Ctr__Ops__0 RtkPos Rule_28
            deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Ops where
+    rtkPosOf (Anti_Ops _) = rtkNoPos
+    rtkPosOf (Ctr__Ops__0 p _) = p
 data OptContext = Anti_OptContext String |
-                  Ctr__OptContext__0 |
-                  Ctr__OptContext__1 Rule_26
+                  Ctr__OptContext__0 RtkPos |
+                  Ctr__OptContext__1 RtkPos Rule_26
                   deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf OptContext where
+    rtkPosOf (Anti_OptContext _) = rtkNoPos
+    rtkPosOf (Ctr__OptContext__0 p) = p
+    rtkPosOf (Ctr__OptContext__1 p _) = p
 data OptDeriving = Anti_OptDeriving String |
-                   Ctr__OptDeriving__0 |
-                   Ctr__OptDeriving__1 Rule_40
+                   Ctr__OptDeriving__0 RtkPos |
+                   Ctr__OptDeriving__1 RtkPos Rule_40
                    deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf OptDeriving where
+    rtkPosOf (Anti_OptDeriving _) = rtkNoPos
+    rtkPosOf (Ctr__OptDeriving__0 p) = p
+    rtkPosOf (Ctr__OptDeriving__1 p _) = p
 data OptExpTypeSignature = Anti_OptExpTypeSignature String |
-                           Ctr__OptExpTypeSignature__0 |
-                           Ctr__OptExpTypeSignature__1 Rule_33
+                           Ctr__OptExpTypeSignature__0 RtkPos |
+                           Ctr__OptExpTypeSignature__1 RtkPos Rule_33
                            deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf OptExpTypeSignature where
+    rtkPosOf (Anti_OptExpTypeSignature _) = rtkNoPos
+    rtkPosOf (Ctr__OptExpTypeSignature__0 p) = p
+    rtkPosOf (Ctr__OptExpTypeSignature__1 p _) = p
 data OptGdRhs = Anti_OptGdRhs String |
-                Ctr__OptGdRhs__0 |
-                Ctr__OptGdRhs__1 Rule_32
+                Ctr__OptGdRhs__0 RtkPos |
+                Ctr__OptGdRhs__1 RtkPos Rule_32
                 deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf OptGdRhs where
+    rtkPosOf (Anti_OptGdRhs _) = rtkNoPos
+    rtkPosOf (Ctr__OptGdRhs__0 p) = p
+    rtkPosOf (Ctr__OptGdRhs__1 p _) = p
 data OptImpSpec = Anti_OptImpSpec String |
-                  Ctr__OptImpSpec__0 ImportList Rule_21
+                  Ctr__OptImpSpec__0 RtkPos ImportList Rule_21
                   deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf OptImpSpec where
+    rtkPosOf (Anti_OptImpSpec _) = rtkNoPos
+    rtkPosOf (Ctr__OptImpSpec__0 p _ _) = p
 data OptInteger = Anti_OptInteger String |
-                  Ctr__OptInteger__0 |
-                  Ctr__OptInteger__1 Rule_27
+                  Ctr__OptInteger__0 RtkPos |
+                  Ctr__OptInteger__1 RtkPos Rule_27
                   deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf OptInteger where
+    rtkPosOf (Anti_OptInteger _) = rtkNoPos
+    rtkPosOf (Ctr__OptInteger__0 p) = p
+    rtkPosOf (Ctr__OptInteger__1 p _) = p
 data OptQualified = Anti_OptQualified String |
-                    Ctr__OptQualified__0 |
-                    Ctr__OptQualified__1 Rule_19
+                    Ctr__OptQualified__0 RtkPos |
+                    Ctr__OptQualified__1 RtkPos Rule_19
                     deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf OptQualified where
+    rtkPosOf (Anti_OptQualified _) = rtkNoPos
+    rtkPosOf (Ctr__OptQualified__0 p) = p
+    rtkPosOf (Ctr__OptQualified__1 p _) = p
 data OptQualifiedAs = Anti_OptQualifiedAs String |
-                      Ctr__OptQualifiedAs__0 |
-                      Ctr__OptQualifiedAs__1 Rule_20
+                      Ctr__OptQualifiedAs__0 RtkPos |
+                      Ctr__OptQualifiedAs__1 RtkPos Rule_20
                       deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf OptQualifiedAs where
+    rtkPosOf (Anti_OptQualifiedAs _) = rtkNoPos
+    rtkPosOf (Ctr__OptQualifiedAs__0 p) = p
+    rtkPosOf (Ctr__OptQualifiedAs__1 p _) = p
 data OptWhere = Anti_OptWhere String |
-                Ctr__OptWhere__0 Decls
+                Ctr__OptWhere__0 RtkPos Decls
                 deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf OptWhere where
+    rtkPosOf (Anti_OptWhere _) = rtkNoPos
+    rtkPosOf (Ctr__OptWhere__0 p _) = p
 data Pat = Anti_Pat String |
-           Ctr__Pat__0 Con Rule_29
+           Ctr__Pat__0 RtkPos Con Rule_29
            deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Pat where
+    rtkPosOf (Anti_Pat _) = rtkNoPos
+    rtkPosOf (Ctr__Pat__0 p _ _) = p
 data QOp = Anti_QOp String |
-           Ctr__QOp__0 ModIdList Op
+           Ctr__QOp__0 RtkPos ModIdList Op
            deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf QOp where
+    rtkPosOf (Anti_QOp _) = rtkNoPos
+    rtkPosOf (Ctr__QOp__0 p _ _) = p
 data QTyCls = Anti_QTyCls String |
-              Ctr__QTyCls__0 ModIdList TyCls
+              Ctr__QTyCls__0 RtkPos ModIdList TyCls
               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf QTyCls where
+    rtkPosOf (Anti_QTyCls _) = rtkNoPos
+    rtkPosOf (Ctr__QTyCls__0 p _ _) = p
 data QTyCon = Anti_QTyCon String |
-              Ctr__QTyCon__0 ModIdList TyCon
+              Ctr__QTyCon__0 RtkPos ModIdList TyCon
               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf QTyCon where
+    rtkPosOf (Anti_QTyCon _) = rtkNoPos
+    rtkPosOf (Ctr__QTyCon__0 p _ _) = p
 data QVar = Anti_QVar String |
-            Ctr__QVar__0 QVarId
+            Ctr__QVar__0 RtkPos QVarId
             deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf QVar where
+    rtkPosOf (Anti_QVar _) = rtkNoPos
+    rtkPosOf (Ctr__QVar__0 p _) = p
 data QVarId = Anti_QVarId String |
-              Ctr__QVarId__0 ModIdList String
+              Ctr__QVarId__0 RtkPos ModIdList String
               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf QVarId where
+    rtkPosOf (Anti_QVarId _) = rtkNoPos
+    rtkPosOf (Ctr__QVarId__0 p _ _) = p
 data QVarList = Anti_QVarList String |
-                Ctr__QVarList__0 Rule_16
+                Ctr__QVarList__0 RtkPos Rule_16
                 deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf QVarList where
+    rtkPosOf (Anti_QVarList _) = rtkNoPos
+    rtkPosOf (Ctr__QVarList__0 p _) = p
 data Rhs = Anti_Rhs String |
-           Ctr__Rhs__0 Exp OptWhere |
-           Ctr__Rhs__1 GdRhs OptWhere
+           Ctr__Rhs__0 RtkPos Exp OptWhere |
+           Ctr__Rhs__1 RtkPos GdRhs OptWhere
            deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_0 = Ctr__Rule_0__0 ExportsList Rule_1
+instance RtkPosOf Rhs where
+    rtkPosOf (Anti_Rhs _) = rtkNoPos
+    rtkPosOf (Ctr__Rhs__0 p _ _) = p
+    rtkPosOf (Ctr__Rhs__1 p _ _) = p
+data Rule_0 = Ctr__Rule_0__0 RtkPos ExportsList Rule_1
               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_1 = Ctr__Rule_1__0 |
-              Ctr__Rule_1__1 Rule_2
+instance RtkPosOf Rule_0 where
+    rtkPosOf (Ctr__Rule_0__0 p _ _) = p
+data Rule_1 = Ctr__Rule_1__0 RtkPos |
+              Ctr__Rule_1__1 RtkPos Rule_2
               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_10 = Ctr__Rule_10__0 TopDecls
+instance RtkPosOf Rule_1 where
+    rtkPosOf (Ctr__Rule_1__0 p) = p
+    rtkPosOf (Ctr__Rule_1__1 p _) = p
+data Rule_10 = Ctr__Rule_10__0 RtkPos TopDecls
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_10 where
+    rtkPosOf (Ctr__Rule_10__0 p _) = p
 type Rule_11 = [ImpDecl]
 type Rule_12 = [Import]
 data Rule_13 = Anti_Rule_13 String |
-               Ctr__Rule_13__1 ModId
+               Ctr__Rule_13__1 RtkPos ModId
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_13 where
+    rtkPosOf (Anti_Rule_13 _) = rtkNoPos
+    rtkPosOf (Ctr__Rule_13__1 p _) = p
 type Rule_15 = [CName]
 type Rule_16 = [QVar]
-data Rule_17 = Ctr__Rule_17__0 |
-               Ctr__Rule_17__1 Rule_18
+data Rule_17 = Ctr__Rule_17__0 RtkPos |
+               Ctr__Rule_17__1 RtkPos Rule_18
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_18 = Ctr__Rule_18__0 |
-               Ctr__Rule_18__1 CNameList
+instance RtkPosOf Rule_17 where
+    rtkPosOf (Ctr__Rule_17__0 p) = p
+    rtkPosOf (Ctr__Rule_17__1 p _) = p
+data Rule_18 = Ctr__Rule_18__0 RtkPos |
+               Ctr__Rule_18__1 RtkPos CNameList
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_19 = Ctr__Rule_19__0
+instance RtkPosOf Rule_18 where
+    rtkPosOf (Ctr__Rule_18__0 p) = p
+    rtkPosOf (Ctr__Rule_18__1 p _) = p
+data Rule_19 = Ctr__Rule_19__0 RtkPos
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_2 = Ctr__Rule_2__0
+instance RtkPosOf Rule_19 where
+    rtkPosOf (Ctr__Rule_19__0 p) = p
+data Rule_2 = Ctr__Rule_2__0 RtkPos
               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_20 = Ctr__Rule_20__0 ModId
+instance RtkPosOf Rule_2 where
+    rtkPosOf (Ctr__Rule_2__0 p) = p
+data Rule_20 = Ctr__Rule_20__0 RtkPos ModId
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_21 = Ctr__Rule_21__0 |
-               Ctr__Rule_21__1 Rule_22
+instance RtkPosOf Rule_20 where
+    rtkPosOf (Ctr__Rule_20__0 p _) = p
+data Rule_21 = Ctr__Rule_21__0 RtkPos |
+               Ctr__Rule_21__1 RtkPos Rule_22
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_22 = Ctr__Rule_22__0
+instance RtkPosOf Rule_21 where
+    rtkPosOf (Ctr__Rule_21__0 p) = p
+    rtkPosOf (Ctr__Rule_21__1 p _) = p
+data Rule_22 = Ctr__Rule_22__0 RtkPos
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_23 = Ctr__Rule_23__0 |
-               Ctr__Rule_23__1 OptImpSpec
+instance RtkPosOf Rule_22 where
+    rtkPosOf (Ctr__Rule_22__0 p) = p
+data Rule_23 = Ctr__Rule_23__0 RtkPos |
+               Ctr__Rule_23__1 RtkPos OptImpSpec
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_23 where
+    rtkPosOf (Ctr__Rule_23__0 p) = p
+    rtkPosOf (Ctr__Rule_23__1 p _) = p
 type Rule_24 = [TopDecl]
-data Rule_25 = Ctr__Rule_25__0 FunLhs |
-               Ctr__Rule_25__1 Pat
+data Rule_25 = Ctr__Rule_25__0 RtkPos FunLhs |
+               Ctr__Rule_25__1 RtkPos Pat
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_26 = Ctr__Rule_26__0 Context
+instance RtkPosOf Rule_25 where
+    rtkPosOf (Ctr__Rule_25__0 p _) = p
+    rtkPosOf (Ctr__Rule_25__1 p _) = p
+data Rule_26 = Ctr__Rule_26__0 RtkPos Context
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_27 = Ctr__Rule_27__0 String
+instance RtkPosOf Rule_26 where
+    rtkPosOf (Ctr__Rule_26__0 p _) = p
+data Rule_27 = Ctr__Rule_27__0 RtkPos String
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_27 where
+    rtkPosOf (Ctr__Rule_27__0 p _) = p
 type Rule_28 = [Op]
 type Rule_29 = [Rule_30]
 type Rule_3 = [Export]
-data Rule_30 = Ctr__Rule_30__0 Var
+data Rule_30 = Ctr__Rule_30__0 RtkPos Var
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_30 where
+    rtkPosOf (Ctr__Rule_30__0 p _) = p
 type Rule_31 = [Decl]
-data Rule_32 = Ctr__Rule_32__0 GdRhs
+data Rule_32 = Ctr__Rule_32__0 RtkPos GdRhs
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_33 = Ctr__Rule_33__0 OptContext Type
+instance RtkPosOf Rule_32 where
+    rtkPosOf (Ctr__Rule_32__0 p _) = p
+data Rule_33 = Ctr__Rule_33__0 RtkPos OptContext Type
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_33 where
+    rtkPosOf (Ctr__Rule_33__0 p _ _) = p
 type Rule_34 = [Rule_35]
-data Rule_35 = Ctr__Rule_35__0 QOp ExpI
+data Rule_35 = Ctr__Rule_35__0 RtkPos QOp ExpI
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_35 where
+    rtkPosOf (Ctr__Rule_35__0 p _ _) = p
 type Rule_36 = [Constr]
 type Rule_37 = [FieldDecl]
-data Rule_38 = Ctr__Rule_38__0 Type |
-               Ctr__Rule_38__1 AType
+data Rule_38 = Ctr__Rule_38__0 RtkPos Type |
+               Ctr__Rule_38__1 RtkPos AType
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_38 where
+    rtkPosOf (Ctr__Rule_38__0 p _) = p
+    rtkPosOf (Ctr__Rule_38__1 p _) = p
 type Rule_39 = [Var]
-data Rule_4 = Ctr__Rule_4__0 |
-              Ctr__Rule_4__1 Rule_5
+data Rule_4 = Ctr__Rule_4__0 RtkPos |
+              Ctr__Rule_4__1 RtkPos Rule_5
               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_40 = Ctr__Rule_40__0 Deriving
+instance RtkPosOf Rule_4 where
+    rtkPosOf (Ctr__Rule_4__0 p) = p
+    rtkPosOf (Ctr__Rule_4__1 p _) = p
+data Rule_40 = Ctr__Rule_40__0 RtkPos Deriving
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_41 = Ctr__Rule_41__0 DClass |
-               Ctr__Rule_41__1 DClassList
+instance RtkPosOf Rule_40 where
+    rtkPosOf (Ctr__Rule_40__0 p _) = p
+data Rule_41 = Ctr__Rule_41__0 RtkPos DClass |
+               Ctr__Rule_41__1 RtkPos DClassList
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_41 where
+    rtkPosOf (Ctr__Rule_41__0 p _) = p
+    rtkPosOf (Ctr__Rule_41__1 p _) = p
 type Rule_42 = [DClass]
 type Rule_43 = [Class]
-data Rule_44 = Ctr__Rule_44__0 |
-               Ctr__Rule_44__1 Rule_45
+data Rule_44 = Ctr__Rule_44__0 RtkPos |
+               Ctr__Rule_44__1 RtkPos Rule_45
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_45 = Ctr__Rule_45__0 Type
+instance RtkPosOf Rule_44 where
+    rtkPosOf (Ctr__Rule_44__0 p) = p
+    rtkPosOf (Ctr__Rule_44__1 p _) = p
+data Rule_45 = Ctr__Rule_45__0 RtkPos Type
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_46 = Ctr__Rule_46__0 |
-               Ctr__Rule_46__1 Rule_47
+instance RtkPosOf Rule_45 where
+    rtkPosOf (Ctr__Rule_45__0 p _) = p
+data Rule_46 = Ctr__Rule_46__0 RtkPos |
+               Ctr__Rule_46__1 RtkPos Rule_47
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_47 = Ctr__Rule_47__0 BType
+instance RtkPosOf Rule_46 where
+    rtkPosOf (Ctr__Rule_46__0 p) = p
+    rtkPosOf (Ctr__Rule_46__1 p _) = p
+data Rule_47 = Ctr__Rule_47__0 RtkPos BType
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_49 = Ctr__Rule_49__0 TypeList
+instance RtkPosOf Rule_47 where
+    rtkPosOf (Ctr__Rule_47__0 p _) = p
+data Rule_49 = Ctr__Rule_49__0 RtkPos TypeList
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_5 = Ctr__Rule_5__0 |
-              Ctr__Rule_5__1 CNameList
+instance RtkPosOf Rule_49 where
+    rtkPosOf (Ctr__Rule_49__0 p _) = p
+data Rule_5 = Ctr__Rule_5__0 RtkPos |
+              Ctr__Rule_5__1 RtkPos CNameList
               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_50 = Ctr__Rule_50__0 |
-               Ctr__Rule_50__1 Rule_51
+instance RtkPosOf Rule_5 where
+    rtkPosOf (Ctr__Rule_5__0 p) = p
+    rtkPosOf (Ctr__Rule_5__1 p _) = p
+data Rule_50 = Ctr__Rule_50__0 RtkPos |
+               Ctr__Rule_50__1 RtkPos Rule_51
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_51 = Ctr__Rule_51__0 Type
+instance RtkPosOf Rule_50 where
+    rtkPosOf (Ctr__Rule_50__0 p) = p
+    rtkPosOf (Ctr__Rule_50__1 p _) = p
+data Rule_51 = Ctr__Rule_51__0 RtkPos Type
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_51 where
+    rtkPosOf (Ctr__Rule_51__0 p _) = p
 type Rule_52 = [Type]
-data Rule_6 = Ctr__Rule_6__0 |
-              Ctr__Rule_6__1 Rule_7
+data Rule_6 = Ctr__Rule_6__0 RtkPos |
+              Ctr__Rule_6__1 RtkPos Rule_7
               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_7 = Ctr__Rule_7__0 |
-              Ctr__Rule_7__1 QVarList
+instance RtkPosOf Rule_6 where
+    rtkPosOf (Ctr__Rule_6__0 p) = p
+    rtkPosOf (Ctr__Rule_6__1 p _) = p
+data Rule_7 = Ctr__Rule_7__0 RtkPos |
+              Ctr__Rule_7__1 RtkPos QVarList
               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_8 = Ctr__Rule_8__0 ImpDeclList Rule_9 |
-              Ctr__Rule_8__1 ImpDeclList
+instance RtkPosOf Rule_7 where
+    rtkPosOf (Ctr__Rule_7__0 p) = p
+    rtkPosOf (Ctr__Rule_7__1 p _) = p
+data Rule_8 = Ctr__Rule_8__0 RtkPos ImpDeclList Rule_9 |
+              Ctr__Rule_8__1 RtkPos ImpDeclList
               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_9 = Ctr__Rule_9__0 |
-              Ctr__Rule_9__1 Rule_10
+instance RtkPosOf Rule_8 where
+    rtkPosOf (Ctr__Rule_8__0 p _ _) = p
+    rtkPosOf (Ctr__Rule_8__1 p _) = p
+data Rule_9 = Ctr__Rule_9__0 RtkPos |
+              Ctr__Rule_9__1 RtkPos Rule_10
               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_9 where
+    rtkPosOf (Ctr__Rule_9__0 p) = p
+    rtkPosOf (Ctr__Rule_9__1 p _) = p
 data SimpleType = Anti_SimpleType String |
-                  Ctr__SimpleType__0 TyCon TyVars
+                  Ctr__SimpleType__0 RtkPos TyCon TyVars
                   deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf SimpleType where
+    rtkPosOf (Anti_SimpleType _) = rtkNoPos
+    rtkPosOf (Ctr__SimpleType__0 p _ _) = p
 data TopDecl = Anti_TopDecl String |
-               Ctr__TopDecl__0 SimpleType Type |
-               Ctr__TopDecl__1 OptContext SimpleType Constrs OptDeriving |
-               Ctr__TopDecl__2 Decl
+               Ctr__TopDecl__0 RtkPos SimpleType Type |
+               Ctr__TopDecl__1 RtkPos OptContext SimpleType Constrs OptDeriving |
+               Ctr__TopDecl__2 RtkPos Decl
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf TopDecl where
+    rtkPosOf (Anti_TopDecl _) = rtkNoPos
+    rtkPosOf (Ctr__TopDecl__0 p _ _) = p
+    rtkPosOf (Ctr__TopDecl__1 p _ _ _ _) = p
+    rtkPosOf (Ctr__TopDecl__2 p _) = p
 data TopDecls = Anti_TopDecls String |
-                Ctr__TopDecls__0 Rule_24
+                Ctr__TopDecls__0 RtkPos Rule_24
                 deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf TopDecls where
+    rtkPosOf (Anti_TopDecls _) = rtkNoPos
+    rtkPosOf (Ctr__TopDecls__0 p _) = p
 data TyCls = Anti_TyCls String |
-             Ctr__TyCls__0 String
+             Ctr__TyCls__0 RtkPos String
              deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf TyCls where
+    rtkPosOf (Anti_TyCls _) = rtkNoPos
+    rtkPosOf (Ctr__TyCls__0 p _) = p
 data TyCon = Anti_TyCon String |
-             Ctr__TyCon__0 String
+             Ctr__TyCon__0 RtkPos String
              deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf TyCon where
+    rtkPosOf (Anti_TyCon _) = rtkNoPos
+    rtkPosOf (Ctr__TyCon__0 p _) = p
 data TyVar = Anti_TyVar String |
-             Ctr__TyVar__0 String
+             Ctr__TyVar__0 RtkPos String
              deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf TyVar where
+    rtkPosOf (Anti_TyVar _) = rtkNoPos
+    rtkPosOf (Ctr__TyVar__0 p _) = p
 type TyVars = [TyVar]
 data Type = Anti_Type String |
-            Ctr__Type__0 BType Rule_44
+            Ctr__Type__0 RtkPos BType Rule_44
             deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Type where
+    rtkPosOf (Anti_Type _) = rtkNoPos
+    rtkPosOf (Ctr__Type__0 p _ _) = p
 data TypeList = Anti_TypeList String |
-                Ctr__TypeList__0 Rule_52
+                Ctr__TypeList__0 RtkPos Rule_52
                 deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf TypeList where
+    rtkPosOf (Anti_TypeList _) = rtkNoPos
+    rtkPosOf (Ctr__TypeList__0 p _) = p
 data Var = Anti_Var String |
-           Ctr__Var__0 String
+           Ctr__Var__0 RtkPos String
            deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Var where
+    rtkPosOf (Anti_Var _) = rtkNoPos
+    rtkPosOf (Ctr__Var__0 p _) = p
 data Vars = Anti_Vars String |
-            Ctr__Vars__0 Rule_39
+            Ctr__Vars__0 RtkPos Rule_39
             deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Vars where
+    rtkPosOf (Anti_Vars _) = rtkNoPos
+    rtkPosOf (Ctr__Vars__0 p _) = p
 }

--- a/test/golden/haskell/HaskellQQ.hs
+++ b/test/golden/haskell/HaskellQQ.hs
@@ -51,6 +51,14 @@ replaceAllPatterns str = init <$> replaceAllPatterns1 (str ++ " ")
 
 qqShortcuts = M.fromList [ ("haskell","Haskell"),("aType","AType"),("aTypeList","ATypeList"),("bType","BType"),("body","Body"),("cName","CName"),("cNameList","CNameList"),("class","Class"),("classList","ClassList"),("con","Con"),("constr","Constr"),("constrs","Constrs"),("context","Context"),("dClass","DClass"),("dClassList","DClassList"),("decl","Decl"),("declList","DeclList"),("decls","Decls"),("deriving","Deriving"),("exp","Exp"),("expI","ExpI"),("export","Export"),("exportsList","ExportsList"),("exportsOpt","ExportsOpt"),("fieldDecl","FieldDecl"),("fieldDeclList","FieldDeclList"),("fixity","Fixity"),("funLhs","FunLhs"),("gTyCon","GTyCon"),("gd","Gd"),("gdRhs","GdRhs"),("genDecl","GenDecl"),("impDecl","ImpDecl"),("impDeclList","ImpDeclList"),("import","Import"),("importList","ImportList"),("modId","ModId"),("modIdList","ModIdList"),("module","Module"),("op","Op"),("ops","Ops"),("optContext","OptContext"),("optDeriving","OptDeriving"),("optExpTypeSignature","OptExpTypeSignature"),("optGdRhs","OptGdRhs"),("optImpSpec","OptImpSpec"),("optInteger","OptInteger"),("optQualified","OptQualified"),("optQualifiedAs","OptQualifiedAs"),("optWhere","OptWhere"),("pat","Pat"),("qOp","QOp"),("qTyCls","QTyCls"),("qTyCon","QTyCon"),("qVar","QVar"),("qVarId","QVarId"),("qVarList","QVarList"),("rhs","Rhs"),("simpleType","SimpleType"),("topDecl","TopDecl"),("topDecls","TopDecls"),("tyCls","TyCls"),("tyCon","TyCon"),("tyVar","TyVar"),("tyVars","TyVars"),("type","Type"),("typeList","TypeList"),("var","Var"),("vars","Vars")]
 
+-- A quasi-quote pattern must match an AST parsed from anywhere in a source
+-- file, while the pattern itself was parsed from the quote body - so every
+-- RtkPos position field becomes a wildcard in generated patterns.
+-- (Expressions need no special case: the compile-time position they embed
+-- is equality-transparent.)
+rtkPosWildPat :: RtkPos -> Maybe (TH.Q TH.Pat)
+rtkPosWildPat _ = Just TH.wildP
+
 quoteHaskellExp :: Data.Data a => String -> (Haskell -> a) -> String -> TH.ExpQ
 quoteHaskellExp dummy func s = do
   s1 <- either fail return (replaceAllPatterns s)
@@ -66,7 +74,7 @@ quoteHaskellPat dummy func s = do
            Left err -> fail err
            Right a -> return a
   let expr = func ast
-  dataToPatQ (const Nothing `Generics.extQ` antiHaskellPat `Generics.extQ` antiModulePat `Generics.extQ` antiExportsOptPat `Generics.extQ` antiExportsListPat `Generics.extQ` antiExportPat `Generics.extQ` antiBodyPat `Generics.extQ` antiImpDeclListPat `Generics.extQ` antiImportListPat `Generics.extQ` antiVarPat `Generics.extQ` antiConPat `Generics.extQ` antiRule_13Pat `Generics.extQ` antiQVarIdPat `Generics.extQ` antiQVarPat `Generics.extQ` antiQTyClsPat `Generics.extQ` antiQTyConPat `Generics.extQ` antiCNamePat `Generics.extQ` antiCNameListPat `Generics.extQ` antiQVarListPat `Generics.extQ` antiImportPat `Generics.extQ` antiOptQualifiedPat `Generics.extQ` antiOptQualifiedAsPat `Generics.extQ` antiOptImpSpecPat `Generics.extQ` antiImpDeclPat `Generics.extQ` antiTopDeclsPat `Generics.extQ` antiTopDeclPat `Generics.extQ` antiDeclPat `Generics.extQ` antiOptContextPat `Generics.extQ` antiGenDeclPat `Generics.extQ` antiOptIntegerPat `Generics.extQ` antiOpsPat `Generics.extQ` antiFixityPat `Generics.extQ` antiFunLhsPat `Generics.extQ` antiPatPat `Generics.extQ` antiOptWherePat `Generics.extQ` antiDeclListPat `Generics.extQ` antiDeclsPat `Generics.extQ` antiRhsPat `Generics.extQ` antiOptGdRhsPat `Generics.extQ` antiGdPat `Generics.extQ` antiOptExpTypeSignaturePat `Generics.extQ` antiExpPat `Generics.extQ` antiExpIPat `Generics.extQ` antiGdRhsPat `Generics.extQ` antiConstrsPat `Generics.extQ` antiConstrPat `Generics.extQ` antiFieldDeclListPat `Generics.extQ` antiFieldDeclPat `Generics.extQ` antiVarsPat `Generics.extQ` antiOptDerivingPat `Generics.extQ` antiDerivingPat `Generics.extQ` antiDClassListPat `Generics.extQ` antiDClassPat `Generics.extQ` antiContextPat `Generics.extQ` antiClassListPat `Generics.extQ` antiClassPat `Generics.extQ` antiTypePat `Generics.extQ` antiBTypePat `Generics.extQ` antiATypePat `Generics.extQ` antiGTyConPat `Generics.extQ` antiTypeListPat `Generics.extQ` antiSimpleTypePat `Generics.extQ` antiTyVarPat `Generics.extQ` antiTyConPat `Generics.extQ` antiModIdPat `Generics.extQ` antiTyClsPat `Generics.extQ` antiOpPat `Generics.extQ` antiQOpPat) expr
+  dataToPatQ (const Nothing `Generics.extQ` rtkPosWildPat `Generics.extQ` antiHaskellPat `Generics.extQ` antiModulePat `Generics.extQ` antiExportsOptPat `Generics.extQ` antiExportsListPat `Generics.extQ` antiExportPat `Generics.extQ` antiBodyPat `Generics.extQ` antiImpDeclListPat `Generics.extQ` antiImportListPat `Generics.extQ` antiVarPat `Generics.extQ` antiConPat `Generics.extQ` antiRule_13Pat `Generics.extQ` antiQVarIdPat `Generics.extQ` antiQVarPat `Generics.extQ` antiQTyClsPat `Generics.extQ` antiQTyConPat `Generics.extQ` antiCNamePat `Generics.extQ` antiCNameListPat `Generics.extQ` antiQVarListPat `Generics.extQ` antiImportPat `Generics.extQ` antiOptQualifiedPat `Generics.extQ` antiOptQualifiedAsPat `Generics.extQ` antiOptImpSpecPat `Generics.extQ` antiImpDeclPat `Generics.extQ` antiTopDeclsPat `Generics.extQ` antiTopDeclPat `Generics.extQ` antiDeclPat `Generics.extQ` antiOptContextPat `Generics.extQ` antiGenDeclPat `Generics.extQ` antiOptIntegerPat `Generics.extQ` antiOpsPat `Generics.extQ` antiFixityPat `Generics.extQ` antiFunLhsPat `Generics.extQ` antiPatPat `Generics.extQ` antiOptWherePat `Generics.extQ` antiDeclListPat `Generics.extQ` antiDeclsPat `Generics.extQ` antiRhsPat `Generics.extQ` antiOptGdRhsPat `Generics.extQ` antiGdPat `Generics.extQ` antiOptExpTypeSignaturePat `Generics.extQ` antiExpPat `Generics.extQ` antiExpIPat `Generics.extQ` antiGdRhsPat `Generics.extQ` antiConstrsPat `Generics.extQ` antiConstrPat `Generics.extQ` antiFieldDeclListPat `Generics.extQ` antiFieldDeclPat `Generics.extQ` antiVarsPat `Generics.extQ` antiOptDerivingPat `Generics.extQ` antiDerivingPat `Generics.extQ` antiDClassListPat `Generics.extQ` antiDClassPat `Generics.extQ` antiContextPat `Generics.extQ` antiClassListPat `Generics.extQ` antiClassPat `Generics.extQ` antiTypePat `Generics.extQ` antiBTypePat `Generics.extQ` antiATypePat `Generics.extQ` antiGTyConPat `Generics.extQ` antiTypeListPat `Generics.extQ` antiSimpleTypePat `Generics.extQ` antiTyVarPat `Generics.extQ` antiTyConPat `Generics.extQ` antiModIdPat `Generics.extQ` antiTyClsPat `Generics.extQ` antiOpPat `Generics.extQ` antiQOpPat) expr
 
 antiQOpExp :: QOp -> Maybe (TH.Q TH.Exp )
 antiQOpExp ( Anti_QOp v) = Just $ TH.varE (TH.mkName v)
@@ -752,347 +760,347 @@ antiHaskellPat _ = Nothing
 quoteHaskellType s = return TH.ListT
 quoteHaskellDecs s = return []
 
-getHaskell ( Ctr__Haskell__0 s) = s
+getHaskell ( Ctr__Haskell__0 _ s) = s
 
 haskell :: QuasiQuoter
 haskell = QuasiQuoter (quoteHaskellExp "tok_Haskell_dummy_122" getHaskell ) (quoteHaskellPat "tok_Haskell_dummy_122" getHaskell ) quoteHaskellType quoteHaskellDecs
 
-getAType ( Ctr__Haskell__1 s) = s
+getAType ( Ctr__Haskell__1 _ s) = s
 
 aType :: QuasiQuoter
 aType = QuasiQuoter (quoteHaskellExp "tok_AType_dummy_121" getAType ) (quoteHaskellPat "tok_AType_dummy_121" getAType ) quoteHaskellType quoteHaskellDecs
 
-getATypeList ( Ctr__Haskell__2 s) = s
+getATypeList ( Ctr__Haskell__2 _ s) = s
 
 aTypeList :: QuasiQuoter
 aTypeList = QuasiQuoter (quoteHaskellExp "tok_ATypeList_dummy_120" getATypeList ) (quoteHaskellPat "tok_ATypeList_dummy_120" getATypeList ) quoteHaskellType quoteHaskellDecs
 
-getBType ( Ctr__Haskell__3 s) = s
+getBType ( Ctr__Haskell__3 _ s) = s
 
 bType :: QuasiQuoter
 bType = QuasiQuoter (quoteHaskellExp "tok_BType_dummy_119" getBType ) (quoteHaskellPat "tok_BType_dummy_119" getBType ) quoteHaskellType quoteHaskellDecs
 
-getBody ( Ctr__Haskell__4 s) = s
+getBody ( Ctr__Haskell__4 _ s) = s
 
 body :: QuasiQuoter
 body = QuasiQuoter (quoteHaskellExp "tok_Body_dummy_118" getBody ) (quoteHaskellPat "tok_Body_dummy_118" getBody ) quoteHaskellType quoteHaskellDecs
 
-getCName ( Ctr__Haskell__5 s) = s
+getCName ( Ctr__Haskell__5 _ s) = s
 
 cName :: QuasiQuoter
 cName = QuasiQuoter (quoteHaskellExp "tok_CName_dummy_117" getCName ) (quoteHaskellPat "tok_CName_dummy_117" getCName ) quoteHaskellType quoteHaskellDecs
 
-getCNameList ( Ctr__Haskell__6 s) = s
+getCNameList ( Ctr__Haskell__6 _ s) = s
 
 cNameList :: QuasiQuoter
 cNameList = QuasiQuoter (quoteHaskellExp "tok_CNameList_dummy_116" getCNameList ) (quoteHaskellPat "tok_CNameList_dummy_116" getCNameList ) quoteHaskellType quoteHaskellDecs
 
-getClass ( Ctr__Haskell__7 s) = s
+getClass ( Ctr__Haskell__7 _ s) = s
 
 __class :: QuasiQuoter
 __class = QuasiQuoter (quoteHaskellExp "tok_Class_dummy_115" getClass ) (quoteHaskellPat "tok_Class_dummy_115" getClass ) quoteHaskellType quoteHaskellDecs
 
-getClassList ( Ctr__Haskell__8 s) = s
+getClassList ( Ctr__Haskell__8 _ s) = s
 
 classList :: QuasiQuoter
 classList = QuasiQuoter (quoteHaskellExp "tok_ClassList_dummy_114" getClassList ) (quoteHaskellPat "tok_ClassList_dummy_114" getClassList ) quoteHaskellType quoteHaskellDecs
 
-getCon ( Ctr__Haskell__9 s) = s
+getCon ( Ctr__Haskell__9 _ s) = s
 
 con :: QuasiQuoter
 con = QuasiQuoter (quoteHaskellExp "tok_Con_dummy_113" getCon ) (quoteHaskellPat "tok_Con_dummy_113" getCon ) quoteHaskellType quoteHaskellDecs
 
-getConstr ( Ctr__Haskell__10 s) = s
+getConstr ( Ctr__Haskell__10 _ s) = s
 
 constr :: QuasiQuoter
 constr = QuasiQuoter (quoteHaskellExp "tok_Constr_dummy_112" getConstr ) (quoteHaskellPat "tok_Constr_dummy_112" getConstr ) quoteHaskellType quoteHaskellDecs
 
-getConstrs ( Ctr__Haskell__11 s) = s
+getConstrs ( Ctr__Haskell__11 _ s) = s
 
 constrs :: QuasiQuoter
 constrs = QuasiQuoter (quoteHaskellExp "tok_Constrs_dummy_111" getConstrs ) (quoteHaskellPat "tok_Constrs_dummy_111" getConstrs ) quoteHaskellType quoteHaskellDecs
 
-getContext ( Ctr__Haskell__12 s) = s
+getContext ( Ctr__Haskell__12 _ s) = s
 
 context :: QuasiQuoter
 context = QuasiQuoter (quoteHaskellExp "tok_Context_dummy_110" getContext ) (quoteHaskellPat "tok_Context_dummy_110" getContext ) quoteHaskellType quoteHaskellDecs
 
-getDClass ( Ctr__Haskell__13 s) = s
+getDClass ( Ctr__Haskell__13 _ s) = s
 
 dClass :: QuasiQuoter
 dClass = QuasiQuoter (quoteHaskellExp "tok_DClass_dummy_109" getDClass ) (quoteHaskellPat "tok_DClass_dummy_109" getDClass ) quoteHaskellType quoteHaskellDecs
 
-getDClassList ( Ctr__Haskell__14 s) = s
+getDClassList ( Ctr__Haskell__14 _ s) = s
 
 dClassList :: QuasiQuoter
 dClassList = QuasiQuoter (quoteHaskellExp "tok_DClassList_dummy_108" getDClassList ) (quoteHaskellPat "tok_DClassList_dummy_108" getDClassList ) quoteHaskellType quoteHaskellDecs
 
-getDecl ( Ctr__Haskell__15 s) = s
+getDecl ( Ctr__Haskell__15 _ s) = s
 
 decl :: QuasiQuoter
 decl = QuasiQuoter (quoteHaskellExp "tok_Decl_dummy_107" getDecl ) (quoteHaskellPat "tok_Decl_dummy_107" getDecl ) quoteHaskellType quoteHaskellDecs
 
-getDeclList ( Ctr__Haskell__16 s) = s
+getDeclList ( Ctr__Haskell__16 _ s) = s
 
 declList :: QuasiQuoter
 declList = QuasiQuoter (quoteHaskellExp "tok_DeclList_dummy_106" getDeclList ) (quoteHaskellPat "tok_DeclList_dummy_106" getDeclList ) quoteHaskellType quoteHaskellDecs
 
-getDecls ( Ctr__Haskell__17 s) = s
+getDecls ( Ctr__Haskell__17 _ s) = s
 
 decls :: QuasiQuoter
 decls = QuasiQuoter (quoteHaskellExp "tok_Decls_dummy_105" getDecls ) (quoteHaskellPat "tok_Decls_dummy_105" getDecls ) quoteHaskellType quoteHaskellDecs
 
-getDeriving ( Ctr__Haskell__18 s) = s
+getDeriving ( Ctr__Haskell__18 _ s) = s
 
 __deriving :: QuasiQuoter
 __deriving = QuasiQuoter (quoteHaskellExp "tok_Deriving_dummy_104" getDeriving ) (quoteHaskellPat "tok_Deriving_dummy_104" getDeriving ) quoteHaskellType quoteHaskellDecs
 
-getExp ( Ctr__Haskell__19 s) = s
+getExp ( Ctr__Haskell__19 _ s) = s
 
 exp :: QuasiQuoter
 exp = QuasiQuoter (quoteHaskellExp "tok_Exp_dummy_103" getExp ) (quoteHaskellPat "tok_Exp_dummy_103" getExp ) quoteHaskellType quoteHaskellDecs
 
-getExpI ( Ctr__Haskell__20 s) = s
+getExpI ( Ctr__Haskell__20 _ s) = s
 
 expI :: QuasiQuoter
 expI = QuasiQuoter (quoteHaskellExp "tok_ExpI_dummy_102" getExpI ) (quoteHaskellPat "tok_ExpI_dummy_102" getExpI ) quoteHaskellType quoteHaskellDecs
 
-getExport ( Ctr__Haskell__21 s) = s
+getExport ( Ctr__Haskell__21 _ s) = s
 
 export :: QuasiQuoter
 export = QuasiQuoter (quoteHaskellExp "tok_Export_dummy_101" getExport ) (quoteHaskellPat "tok_Export_dummy_101" getExport ) quoteHaskellType quoteHaskellDecs
 
-getExportsList ( Ctr__Haskell__22 s) = s
+getExportsList ( Ctr__Haskell__22 _ s) = s
 
 exportsList :: QuasiQuoter
 exportsList = QuasiQuoter (quoteHaskellExp "tok_ExportsList_dummy_100" getExportsList ) (quoteHaskellPat "tok_ExportsList_dummy_100" getExportsList ) quoteHaskellType quoteHaskellDecs
 
-getExportsOpt ( Ctr__Haskell__23 s) = s
+getExportsOpt ( Ctr__Haskell__23 _ s) = s
 
 exportsOpt :: QuasiQuoter
 exportsOpt = QuasiQuoter (quoteHaskellExp "tok_ExportsOpt_dummy_99" getExportsOpt ) (quoteHaskellPat "tok_ExportsOpt_dummy_99" getExportsOpt ) quoteHaskellType quoteHaskellDecs
 
-getFieldDecl ( Ctr__Haskell__24 s) = s
+getFieldDecl ( Ctr__Haskell__24 _ s) = s
 
 fieldDecl :: QuasiQuoter
 fieldDecl = QuasiQuoter (quoteHaskellExp "tok_FieldDecl_dummy_98" getFieldDecl ) (quoteHaskellPat "tok_FieldDecl_dummy_98" getFieldDecl ) quoteHaskellType quoteHaskellDecs
 
-getFieldDeclList ( Ctr__Haskell__25 s) = s
+getFieldDeclList ( Ctr__Haskell__25 _ s) = s
 
 fieldDeclList :: QuasiQuoter
 fieldDeclList = QuasiQuoter (quoteHaskellExp "tok_FieldDeclList_dummy_97" getFieldDeclList ) (quoteHaskellPat "tok_FieldDeclList_dummy_97" getFieldDeclList ) quoteHaskellType quoteHaskellDecs
 
-getFixity ( Ctr__Haskell__26 s) = s
+getFixity ( Ctr__Haskell__26 _ s) = s
 
 fixity :: QuasiQuoter
 fixity = QuasiQuoter (quoteHaskellExp "tok_Fixity_dummy_96" getFixity ) (quoteHaskellPat "tok_Fixity_dummy_96" getFixity ) quoteHaskellType quoteHaskellDecs
 
-getFunLhs ( Ctr__Haskell__27 s) = s
+getFunLhs ( Ctr__Haskell__27 _ s) = s
 
 funLhs :: QuasiQuoter
 funLhs = QuasiQuoter (quoteHaskellExp "tok_FunLhs_dummy_95" getFunLhs ) (quoteHaskellPat "tok_FunLhs_dummy_95" getFunLhs ) quoteHaskellType quoteHaskellDecs
 
-getGTyCon ( Ctr__Haskell__28 s) = s
+getGTyCon ( Ctr__Haskell__28 _ s) = s
 
 gTyCon :: QuasiQuoter
 gTyCon = QuasiQuoter (quoteHaskellExp "tok_GTyCon_dummy_94" getGTyCon ) (quoteHaskellPat "tok_GTyCon_dummy_94" getGTyCon ) quoteHaskellType quoteHaskellDecs
 
-getGd ( Ctr__Haskell__29 s) = s
+getGd ( Ctr__Haskell__29 _ s) = s
 
 gd :: QuasiQuoter
 gd = QuasiQuoter (quoteHaskellExp "tok_Gd_dummy_93" getGd ) (quoteHaskellPat "tok_Gd_dummy_93" getGd ) quoteHaskellType quoteHaskellDecs
 
-getGdRhs ( Ctr__Haskell__30 s) = s
+getGdRhs ( Ctr__Haskell__30 _ s) = s
 
 gdRhs :: QuasiQuoter
 gdRhs = QuasiQuoter (quoteHaskellExp "tok_GdRhs_dummy_92" getGdRhs ) (quoteHaskellPat "tok_GdRhs_dummy_92" getGdRhs ) quoteHaskellType quoteHaskellDecs
 
-getGenDecl ( Ctr__Haskell__31 s) = s
+getGenDecl ( Ctr__Haskell__31 _ s) = s
 
 genDecl :: QuasiQuoter
 genDecl = QuasiQuoter (quoteHaskellExp "tok_GenDecl_dummy_91" getGenDecl ) (quoteHaskellPat "tok_GenDecl_dummy_91" getGenDecl ) quoteHaskellType quoteHaskellDecs
 
-getImpDecl ( Ctr__Haskell__32 s) = s
+getImpDecl ( Ctr__Haskell__32 _ s) = s
 
 impDecl :: QuasiQuoter
 impDecl = QuasiQuoter (quoteHaskellExp "tok_ImpDecl_dummy_90" getImpDecl ) (quoteHaskellPat "tok_ImpDecl_dummy_90" getImpDecl ) quoteHaskellType quoteHaskellDecs
 
-getImpDeclList ( Ctr__Haskell__33 s) = s
+getImpDeclList ( Ctr__Haskell__33 _ s) = s
 
 impDeclList :: QuasiQuoter
 impDeclList = QuasiQuoter (quoteHaskellExp "tok_ImpDeclList_dummy_89" getImpDeclList ) (quoteHaskellPat "tok_ImpDeclList_dummy_89" getImpDeclList ) quoteHaskellType quoteHaskellDecs
 
-getImport ( Ctr__Haskell__34 s) = s
+getImport ( Ctr__Haskell__34 _ s) = s
 
 __import :: QuasiQuoter
 __import = QuasiQuoter (quoteHaskellExp "tok_Import_dummy_88" getImport ) (quoteHaskellPat "tok_Import_dummy_88" getImport ) quoteHaskellType quoteHaskellDecs
 
-getImportList ( Ctr__Haskell__35 s) = s
+getImportList ( Ctr__Haskell__35 _ s) = s
 
 importList :: QuasiQuoter
 importList = QuasiQuoter (quoteHaskellExp "tok_ImportList_dummy_87" getImportList ) (quoteHaskellPat "tok_ImportList_dummy_87" getImportList ) quoteHaskellType quoteHaskellDecs
 
-getModId ( Ctr__Haskell__36 s) = s
+getModId ( Ctr__Haskell__36 _ s) = s
 
 modId :: QuasiQuoter
 modId = QuasiQuoter (quoteHaskellExp "tok_ModId_dummy_86" getModId ) (quoteHaskellPat "tok_ModId_dummy_86" getModId ) quoteHaskellType quoteHaskellDecs
 
-getModIdList ( Ctr__Haskell__37 s) = s
+getModIdList ( Ctr__Haskell__37 _ s) = s
 
 modIdList :: QuasiQuoter
 modIdList = QuasiQuoter (quoteHaskellExp "tok_ModIdList_dummy_85" getModIdList ) (quoteHaskellPat "tok_ModIdList_dummy_85" getModIdList ) quoteHaskellType quoteHaskellDecs
 
-getModule ( Ctr__Haskell__38 s) = s
+getModule ( Ctr__Haskell__38 _ s) = s
 
 __module :: QuasiQuoter
 __module = QuasiQuoter (quoteHaskellExp "tok_Module_dummy_84" getModule ) (quoteHaskellPat "tok_Module_dummy_84" getModule ) quoteHaskellType quoteHaskellDecs
 
-getOp ( Ctr__Haskell__39 s) = s
+getOp ( Ctr__Haskell__39 _ s) = s
 
 op :: QuasiQuoter
 op = QuasiQuoter (quoteHaskellExp "tok_Op_dummy_83" getOp ) (quoteHaskellPat "tok_Op_dummy_83" getOp ) quoteHaskellType quoteHaskellDecs
 
-getOps ( Ctr__Haskell__40 s) = s
+getOps ( Ctr__Haskell__40 _ s) = s
 
 ops :: QuasiQuoter
 ops = QuasiQuoter (quoteHaskellExp "tok_Ops_dummy_82" getOps ) (quoteHaskellPat "tok_Ops_dummy_82" getOps ) quoteHaskellType quoteHaskellDecs
 
-getOptContext ( Ctr__Haskell__41 s) = s
+getOptContext ( Ctr__Haskell__41 _ s) = s
 
 optContext :: QuasiQuoter
 optContext = QuasiQuoter (quoteHaskellExp "tok_OptContext_dummy_81" getOptContext ) (quoteHaskellPat "tok_OptContext_dummy_81" getOptContext ) quoteHaskellType quoteHaskellDecs
 
-getOptDeriving ( Ctr__Haskell__42 s) = s
+getOptDeriving ( Ctr__Haskell__42 _ s) = s
 
 optDeriving :: QuasiQuoter
 optDeriving = QuasiQuoter (quoteHaskellExp "tok_OptDeriving_dummy_80" getOptDeriving ) (quoteHaskellPat "tok_OptDeriving_dummy_80" getOptDeriving ) quoteHaskellType quoteHaskellDecs
 
-getOptExpTypeSignature ( Ctr__Haskell__43 s) = s
+getOptExpTypeSignature ( Ctr__Haskell__43 _ s) = s
 
 optExpTypeSignature :: QuasiQuoter
 optExpTypeSignature = QuasiQuoter (quoteHaskellExp "tok_OptExpTypeSignature_dummy_79" getOptExpTypeSignature ) (quoteHaskellPat "tok_OptExpTypeSignature_dummy_79" getOptExpTypeSignature ) quoteHaskellType quoteHaskellDecs
 
-getOptGdRhs ( Ctr__Haskell__44 s) = s
+getOptGdRhs ( Ctr__Haskell__44 _ s) = s
 
 optGdRhs :: QuasiQuoter
 optGdRhs = QuasiQuoter (quoteHaskellExp "tok_OptGdRhs_dummy_78" getOptGdRhs ) (quoteHaskellPat "tok_OptGdRhs_dummy_78" getOptGdRhs ) quoteHaskellType quoteHaskellDecs
 
-getOptImpSpec ( Ctr__Haskell__45 s) = s
+getOptImpSpec ( Ctr__Haskell__45 _ s) = s
 
 optImpSpec :: QuasiQuoter
 optImpSpec = QuasiQuoter (quoteHaskellExp "tok_OptImpSpec_dummy_77" getOptImpSpec ) (quoteHaskellPat "tok_OptImpSpec_dummy_77" getOptImpSpec ) quoteHaskellType quoteHaskellDecs
 
-getOptInteger ( Ctr__Haskell__46 s) = s
+getOptInteger ( Ctr__Haskell__46 _ s) = s
 
 optInteger :: QuasiQuoter
 optInteger = QuasiQuoter (quoteHaskellExp "tok_OptInteger_dummy_76" getOptInteger ) (quoteHaskellPat "tok_OptInteger_dummy_76" getOptInteger ) quoteHaskellType quoteHaskellDecs
 
-getOptQualified ( Ctr__Haskell__47 s) = s
+getOptQualified ( Ctr__Haskell__47 _ s) = s
 
 optQualified :: QuasiQuoter
 optQualified = QuasiQuoter (quoteHaskellExp "tok_OptQualified_dummy_75" getOptQualified ) (quoteHaskellPat "tok_OptQualified_dummy_75" getOptQualified ) quoteHaskellType quoteHaskellDecs
 
-getOptQualifiedAs ( Ctr__Haskell__48 s) = s
+getOptQualifiedAs ( Ctr__Haskell__48 _ s) = s
 
 optQualifiedAs :: QuasiQuoter
 optQualifiedAs = QuasiQuoter (quoteHaskellExp "tok_OptQualifiedAs_dummy_74" getOptQualifiedAs ) (quoteHaskellPat "tok_OptQualifiedAs_dummy_74" getOptQualifiedAs ) quoteHaskellType quoteHaskellDecs
 
-getOptWhere ( Ctr__Haskell__49 s) = s
+getOptWhere ( Ctr__Haskell__49 _ s) = s
 
 optWhere :: QuasiQuoter
 optWhere = QuasiQuoter (quoteHaskellExp "tok_OptWhere_dummy_73" getOptWhere ) (quoteHaskellPat "tok_OptWhere_dummy_73" getOptWhere ) quoteHaskellType quoteHaskellDecs
 
-getPat ( Ctr__Haskell__50 s) = s
+getPat ( Ctr__Haskell__50 _ s) = s
 
 pat :: QuasiQuoter
 pat = QuasiQuoter (quoteHaskellExp "tok_Pat_dummy_72" getPat ) (quoteHaskellPat "tok_Pat_dummy_72" getPat ) quoteHaskellType quoteHaskellDecs
 
-getQOp ( Ctr__Haskell__51 s) = s
+getQOp ( Ctr__Haskell__51 _ s) = s
 
 qOp :: QuasiQuoter
 qOp = QuasiQuoter (quoteHaskellExp "tok_QOp_dummy_71" getQOp ) (quoteHaskellPat "tok_QOp_dummy_71" getQOp ) quoteHaskellType quoteHaskellDecs
 
-getQTyCls ( Ctr__Haskell__52 s) = s
+getQTyCls ( Ctr__Haskell__52 _ s) = s
 
 qTyCls :: QuasiQuoter
 qTyCls = QuasiQuoter (quoteHaskellExp "tok_QTyCls_dummy_70" getQTyCls ) (quoteHaskellPat "tok_QTyCls_dummy_70" getQTyCls ) quoteHaskellType quoteHaskellDecs
 
-getQTyCon ( Ctr__Haskell__53 s) = s
+getQTyCon ( Ctr__Haskell__53 _ s) = s
 
 qTyCon :: QuasiQuoter
 qTyCon = QuasiQuoter (quoteHaskellExp "tok_QTyCon_dummy_69" getQTyCon ) (quoteHaskellPat "tok_QTyCon_dummy_69" getQTyCon ) quoteHaskellType quoteHaskellDecs
 
-getQVar ( Ctr__Haskell__54 s) = s
+getQVar ( Ctr__Haskell__54 _ s) = s
 
 qVar :: QuasiQuoter
 qVar = QuasiQuoter (quoteHaskellExp "tok_QVar_dummy_68" getQVar ) (quoteHaskellPat "tok_QVar_dummy_68" getQVar ) quoteHaskellType quoteHaskellDecs
 
-getQVarId ( Ctr__Haskell__55 s) = s
+getQVarId ( Ctr__Haskell__55 _ s) = s
 
 qVarId :: QuasiQuoter
 qVarId = QuasiQuoter (quoteHaskellExp "tok_QVarId_dummy_67" getQVarId ) (quoteHaskellPat "tok_QVarId_dummy_67" getQVarId ) quoteHaskellType quoteHaskellDecs
 
-getQVarList ( Ctr__Haskell__56 s) = s
+getQVarList ( Ctr__Haskell__56 _ s) = s
 
 qVarList :: QuasiQuoter
 qVarList = QuasiQuoter (quoteHaskellExp "tok_QVarList_dummy_66" getQVarList ) (quoteHaskellPat "tok_QVarList_dummy_66" getQVarList ) quoteHaskellType quoteHaskellDecs
 
-getRhs ( Ctr__Haskell__57 s) = s
+getRhs ( Ctr__Haskell__57 _ s) = s
 
 rhs :: QuasiQuoter
 rhs = QuasiQuoter (quoteHaskellExp "tok_Rhs_dummy_65" getRhs ) (quoteHaskellPat "tok_Rhs_dummy_65" getRhs ) quoteHaskellType quoteHaskellDecs
 
-getSimpleType ( Ctr__Haskell__58 s) = s
+getSimpleType ( Ctr__Haskell__58 _ s) = s
 
 simpleType :: QuasiQuoter
 simpleType = QuasiQuoter (quoteHaskellExp "tok_SimpleType_dummy_64" getSimpleType ) (quoteHaskellPat "tok_SimpleType_dummy_64" getSimpleType ) quoteHaskellType quoteHaskellDecs
 
-getTopDecl ( Ctr__Haskell__59 s) = s
+getTopDecl ( Ctr__Haskell__59 _ s) = s
 
 topDecl :: QuasiQuoter
 topDecl = QuasiQuoter (quoteHaskellExp "tok_TopDecl_dummy_63" getTopDecl ) (quoteHaskellPat "tok_TopDecl_dummy_63" getTopDecl ) quoteHaskellType quoteHaskellDecs
 
-getTopDecls ( Ctr__Haskell__60 s) = s
+getTopDecls ( Ctr__Haskell__60 _ s) = s
 
 topDecls :: QuasiQuoter
 topDecls = QuasiQuoter (quoteHaskellExp "tok_TopDecls_dummy_62" getTopDecls ) (quoteHaskellPat "tok_TopDecls_dummy_62" getTopDecls ) quoteHaskellType quoteHaskellDecs
 
-getTyCls ( Ctr__Haskell__61 s) = s
+getTyCls ( Ctr__Haskell__61 _ s) = s
 
 tyCls :: QuasiQuoter
 tyCls = QuasiQuoter (quoteHaskellExp "tok_TyCls_dummy_61" getTyCls ) (quoteHaskellPat "tok_TyCls_dummy_61" getTyCls ) quoteHaskellType quoteHaskellDecs
 
-getTyCon ( Ctr__Haskell__62 s) = s
+getTyCon ( Ctr__Haskell__62 _ s) = s
 
 tyCon :: QuasiQuoter
 tyCon = QuasiQuoter (quoteHaskellExp "tok_TyCon_dummy_60" getTyCon ) (quoteHaskellPat "tok_TyCon_dummy_60" getTyCon ) quoteHaskellType quoteHaskellDecs
 
-getTyVar ( Ctr__Haskell__63 s) = s
+getTyVar ( Ctr__Haskell__63 _ s) = s
 
 tyVar :: QuasiQuoter
 tyVar = QuasiQuoter (quoteHaskellExp "tok_TyVar_dummy_59" getTyVar ) (quoteHaskellPat "tok_TyVar_dummy_59" getTyVar ) quoteHaskellType quoteHaskellDecs
 
-getTyVars ( Ctr__Haskell__64 s) = s
+getTyVars ( Ctr__Haskell__64 _ s) = s
 
 tyVars :: QuasiQuoter
 tyVars = QuasiQuoter (quoteHaskellExp "tok_TyVars_dummy_58" getTyVars ) (quoteHaskellPat "tok_TyVars_dummy_58" getTyVars ) quoteHaskellType quoteHaskellDecs
 
-getType ( Ctr__Haskell__65 s) = s
+getType ( Ctr__Haskell__65 _ s) = s
 
 __type :: QuasiQuoter
 __type = QuasiQuoter (quoteHaskellExp "tok_Type_dummy_57" getType ) (quoteHaskellPat "tok_Type_dummy_57" getType ) quoteHaskellType quoteHaskellDecs
 
-getTypeList ( Ctr__Haskell__66 s) = s
+getTypeList ( Ctr__Haskell__66 _ s) = s
 
 typeList :: QuasiQuoter
 typeList = QuasiQuoter (quoteHaskellExp "tok_TypeList_dummy_56" getTypeList ) (quoteHaskellPat "tok_TypeList_dummy_56" getTypeList ) quoteHaskellType quoteHaskellDecs
 
-getVar ( Ctr__Haskell__67 s) = s
+getVar ( Ctr__Haskell__67 _ s) = s
 
 var :: QuasiQuoter
 var = QuasiQuoter (quoteHaskellExp "tok_Var_dummy_55" getVar ) (quoteHaskellPat "tok_Var_dummy_55" getVar ) quoteHaskellType quoteHaskellDecs
 
-getVars ( Ctr__Haskell__68 s) = s
+getVars ( Ctr__Haskell__68 _ s) = s
 
 vars :: QuasiQuoter
 vars = QuasiQuoter (quoteHaskellExp "tok_Vars_dummy_54" getVars ) (quoteHaskellPat "tok_Vars_dummy_54" getVars ) quoteHaskellType quoteHaskellDecs

--- a/test/golden/java-simple/JavaSimpleLexer.x
+++ b/test/golden/java-simple/JavaSimpleLexer.x
@@ -1,6 +1,8 @@
 {
+{-# LANGUAGE StandaloneDeriving, DeriveDataTypeable #-}
 module JavaSimpleLexer(scanTokens, alexScanTokens, Token(..), PosToken(..), AlexPosn(..))
 where
+import Data.Data (Data)
 
  }
 %wrapper "monad"
@@ -64,6 +66,11 @@ data Token = EndOfFile |
              Tk__qq_CompilationUnit String |
              Tk__qq_JavaSimple String
              deriving (Show)
+
+-- AlexPosn is defined by the alex wrapper, so the Data instance (required by
+-- the parser's RtkPos position type) can only be attached via standalone
+-- deriving - the same solution as the hand-written Lexer.x
+deriving instance Data AlexPosn
 
 -- A token together with the source position where it starts
 data PosToken = PosToken { ptPos :: AlexPosn, ptToken :: Token }

--- a/test/golden/java-simple/JavaSimpleParser.y
+++ b/test/golden/java-simple/JavaSimpleParser.y
@@ -30,67 +30,67 @@ tok_class_3 { L.PosToken _ L.Tk__tok_class_3 }
 tok_String_7 { L.PosToken _ L.Tk__tok_String_7 }
 tok__semi__1 { L.PosToken _ L.Tk__tok__semi__1 }
 tok__dot__8 { L.PosToken _ L.Tk__tok__dot__8 }
-id { L.PosToken _ (L.Tk__id $$) }
-qq_CompoundName { L.PosToken _ (L.Tk__qq_CompoundName $$) }
-qq_Type { L.PosToken _ (L.Tk__qq_Type $$) }
-qq_Field { L.PosToken _ (L.Tk__qq_Field $$) }
-qq_FieldList { L.PosToken _ (L.Tk__qq_FieldList $$) }
-qq_ClassDeclaration { L.PosToken _ (L.Tk__qq_ClassDeclaration $$) }
-qq_Package { L.PosToken _ (L.Tk__qq_Package $$) }
-qq_CompilationUnit { L.PosToken _ (L.Tk__qq_CompilationUnit $$) }
-qq_JavaSimple { L.PosToken _ (L.Tk__qq_JavaSimple $$) }
+id { L.PosToken _ (L.Tk__id _) }
+qq_CompoundName { L.PosToken _ (L.Tk__qq_CompoundName _) }
+qq_Type { L.PosToken _ (L.Tk__qq_Type _) }
+qq_Field { L.PosToken _ (L.Tk__qq_Field _) }
+qq_FieldList { L.PosToken _ (L.Tk__qq_FieldList _) }
+qq_ClassDeclaration { L.PosToken _ (L.Tk__qq_ClassDeclaration _) }
+qq_Package { L.PosToken _ (L.Tk__qq_Package _) }
+qq_CompilationUnit { L.PosToken _ (L.Tk__qq_CompilationUnit _) }
+qq_JavaSimple { L.PosToken _ (L.Tk__qq_JavaSimple _) }
 
 %%
 
 JavaSimple__top : JavaSimple rtk__eof { $1 }
 
-JavaSimple : tok_JavaSimple_dummy_11 JavaSimple tok_JavaSimple_dummy_11 { Ctr__JavaSimple__0 $2 } |
-             tok_ClassDeclaration_dummy_10 ClassDeclaration tok_ClassDeclaration_dummy_10 { Ctr__JavaSimple__1 $2 } |
-             tok_CompilationUnit_dummy_9 CompilationUnit tok_CompilationUnit_dummy_9 { Ctr__JavaSimple__2 $2 } |
-             tok_CompoundName_dummy_8 CompoundName tok_CompoundName_dummy_8 { Ctr__JavaSimple__3 $2 } |
-             tok_Field_dummy_7 Field tok_Field_dummy_7 { Ctr__JavaSimple__4 $2 } |
-             tok_FieldList_dummy_6 FieldList tok_FieldList_dummy_6 { Ctr__JavaSimple__5 (reverse $2) } |
-             tok_Package_dummy_5 Package tok_Package_dummy_5 { Ctr__JavaSimple__6 $2 } |
-             tok_Type_dummy_4 Type tok_Type_dummy_4 { Ctr__JavaSimple__7 $2 }
+JavaSimple : tok_JavaSimple_dummy_11 JavaSimple tok_JavaSimple_dummy_11 { Ctr__JavaSimple__0 (rtkPosOf $1) $2 } |
+             tok_ClassDeclaration_dummy_10 ClassDeclaration tok_ClassDeclaration_dummy_10 { Ctr__JavaSimple__1 (rtkPosOf $1) $2 } |
+             tok_CompilationUnit_dummy_9 CompilationUnit tok_CompilationUnit_dummy_9 { Ctr__JavaSimple__2 (rtkPosOf $1) $2 } |
+             tok_CompoundName_dummy_8 CompoundName tok_CompoundName_dummy_8 { Ctr__JavaSimple__3 (rtkPosOf $1) $2 } |
+             tok_Field_dummy_7 Field tok_Field_dummy_7 { Ctr__JavaSimple__4 (rtkPosOf $1) $2 } |
+             tok_FieldList_dummy_6 FieldList tok_FieldList_dummy_6 { Ctr__JavaSimple__5 (rtkPosOf $1) (reverse $2) } |
+             tok_Package_dummy_5 Package tok_Package_dummy_5 { Ctr__JavaSimple__6 (rtkPosOf $1) $2 } |
+             tok_Type_dummy_4 Type tok_Type_dummy_4 { Ctr__JavaSimple__7 (rtkPosOf $1) $2 }
 
-JavaSimple : qq_JavaSimple { Anti_JavaSimple $1 } |
-             CompilationUnit { Ctr__JavaSimple__8 $1 }
+JavaSimple : qq_JavaSimple { Anti_JavaSimple (tkVal_qq_JavaSimple $1) } |
+             CompilationUnit { Ctr__JavaSimple__8 (rtkPosOf $1) $1 }
 
-ClassDeclaration : qq_ClassDeclaration { Anti_ClassDeclaration $1 } |
-                   Rule_2 tok_class_3 id tok__symbol__4 FieldList tok__symbol__5 { Ctr__ClassDeclaration__0 $1 $3 (reverse $5) }
+ClassDeclaration : qq_ClassDeclaration { Anti_ClassDeclaration (tkVal_qq_ClassDeclaration $1) } |
+                   Rule_2 tok_class_3 id tok__symbol__4 FieldList tok__symbol__5 { Ctr__ClassDeclaration__0 (rtkPosOf $1) $1 (tkVal_id $3) (reverse $5) }
 
-CompilationUnit : qq_CompilationUnit { Anti_CompilationUnit $1 } |
-                  Rule_0 Rule_1 { Ctr__CompilationUnit__0 $1 $2 }
+CompilationUnit : qq_CompilationUnit { Anti_CompilationUnit (tkVal_qq_CompilationUnit $1) } |
+                  Rule_0 Rule_1 { Ctr__CompilationUnit__0 (rtkPosOf $1) $1 $2 }
 
-CompoundName : qq_CompoundName { Anti_CompoundName $1 } |
-               id { Ctr__CompoundName__0 $1 } |
-               CompoundName tok__dot__8 id { Ctr__CompoundName__1 $1 $3 }
+CompoundName : qq_CompoundName { Anti_CompoundName (tkVal_qq_CompoundName $1) } |
+               id { Ctr__CompoundName__0 (rtkPosOf $1) (tkVal_id $1) } |
+               CompoundName tok__dot__8 id { Ctr__CompoundName__1 (rtkPosOf $1) $1 (tkVal_id $3) }
 
-Field : qq_Field { Anti_Field $1 } |
-        Type id tok__semi__1 { Ctr__Field__0 $1 $2 }
+Field : qq_Field { Anti_Field (tkVal_qq_Field $1) } |
+        Type id tok__semi__1 { Ctr__Field__0 (rtkPosOf $1) $1 (tkVal_id $2) }
 
-ListElem_FieldList3 : qq_FieldList { Anti_Field $1 } |
+ListElem_FieldList3 : qq_FieldList { Anti_Field (tkVal_qq_FieldList $1) } |
                       Field { $1 }
 
 FieldList : {- empty -} { [] } |
             FieldList ListElem_FieldList3 { $2 : $1 }
 
-Package : qq_Package { Anti_Package $1 } |
-          tok_package_0 CompoundName tok__semi__1 { Ctr__Package__0 $2 }
+Package : qq_Package { Anti_Package (tkVal_qq_Package $1) } |
+          tok_package_0 CompoundName tok__semi__1 { Ctr__Package__0 (rtkPosOf $1) $2 }
 
-Rule_0 : { Ctr__Rule_0__0 } |
-         Package { Ctr__Rule_0__1 $1 }
+Rule_0 : { Ctr__Rule_0__0 rtkNoPos } |
+         Package { Ctr__Rule_0__1 (rtkPosOf $1) $1 }
 
-Rule_1 : { Ctr__Rule_1__0 } |
-         ClassDeclaration { Ctr__Rule_1__1 $1 }
+Rule_1 : { Ctr__Rule_1__0 rtkNoPos } |
+         ClassDeclaration { Ctr__Rule_1__1 (rtkPosOf $1) $1 }
 
-Rule_2 : { Ctr__Rule_2__0 } |
-         tok_public_2 { Ctr__Rule_2__1 }
+Rule_2 : { Ctr__Rule_2__0 rtkNoPos } |
+         tok_public_2 { Ctr__Rule_2__1 (rtkPosOf $1) }
 
-Type : qq_Type { Anti_Type $1 } |
-       tok_int_6 { Ctr__Type__0 } |
-       tok_String_7 { Ctr__Type__1 } |
-       id { Ctr__Type__2 $1 }
+Type : qq_Type { Anti_Type (tkVal_qq_Type $1) } |
+       tok_int_6 { Ctr__Type__0 (rtkPosOf $1) } |
+       tok_String_7 { Ctr__Type__1 (rtkPosOf $1) } |
+       id { Ctr__Type__2 (rtkPosOf $1) (tkVal_id $1) }
 
 
 {
@@ -129,46 +129,145 @@ showRtkToken (L.Tk__qq_Package v) = "qq_Package " ++ show v
 showRtkToken (L.Tk__qq_CompilationUnit v) = "qq_CompilationUnit " ++ show v
 showRtkToken (L.Tk__qq_JavaSimple v) = "qq_JavaSimple " ++ show v
 
-data JavaSimple = Ctr__JavaSimple__0 JavaSimple |
-                  Ctr__JavaSimple__1 ClassDeclaration |
-                  Ctr__JavaSimple__2 CompilationUnit |
-                  Ctr__JavaSimple__3 CompoundName |
-                  Ctr__JavaSimple__4 Field |
-                  Ctr__JavaSimple__5 FieldList |
-                  Ctr__JavaSimple__6 Package |
-                  Ctr__JavaSimple__7 Type |
+-- Source position of a node: every constructor except the Anti_* splice
+-- artifacts stores the position of its alternative's first symbol in its
+-- first field. Positions are transparent for equality and ordering, so two
+-- ASTs that differ only in source positions (e.g. a quasi-quote parsed at
+-- compile time vs the same construct parsed at run time) compare equal.
+newtype RtkPos = RtkPos L.AlexPosn deriving (Show, Gen.Data, Gen.Typeable)
+instance Eq RtkPos where _ == _ = True
+instance Ord RtkPos where compare _ _ = EQ
+
+-- The position used where no source token exists: empty productions, empty
+-- lists, absent optionals and Anti_* quasi-quote splices
+rtkNoPos :: RtkPos
+rtkNoPos = RtkPos (L.AlexPn 0 0 0)
+
+class RtkPosOf a where
+    rtkPosOf :: a -> RtkPos
+instance RtkPosOf L.PosToken where
+    rtkPosOf (L.PosToken p _) = RtkPos p
+instance RtkPosOf a => RtkPosOf [a] where
+    rtkPosOf (x : _) = rtkPosOf x
+    rtkPosOf []      = rtkNoPos
+instance RtkPosOf a => RtkPosOf (Maybe a) where
+    rtkPosOf (Just x) = rtkPosOf x
+    rtkPosOf Nothing  = rtkNoPos
+-- A Char carries no position; this also covers String token payloads
+instance RtkPosOf Char where
+    rtkPosOf _ = rtkNoPos
+
+-- Recover a token's payload from the whole positioned token: %token
+-- bindings keep the L.PosToken so semantic actions can read its position
+tkVal_id :: L.PosToken -> String
+tkVal_id (L.PosToken _ (L.Tk__id v)) = v
+tkVal_id t = error ("rtk internal error: token id expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_CompoundName :: L.PosToken -> String
+tkVal_qq_CompoundName (L.PosToken _ (L.Tk__qq_CompoundName v)) = v
+tkVal_qq_CompoundName t = error ("rtk internal error: token qq_CompoundName expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_Type :: L.PosToken -> String
+tkVal_qq_Type (L.PosToken _ (L.Tk__qq_Type v)) = v
+tkVal_qq_Type t = error ("rtk internal error: token qq_Type expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_Field :: L.PosToken -> String
+tkVal_qq_Field (L.PosToken _ (L.Tk__qq_Field v)) = v
+tkVal_qq_Field t = error ("rtk internal error: token qq_Field expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_FieldList :: L.PosToken -> String
+tkVal_qq_FieldList (L.PosToken _ (L.Tk__qq_FieldList v)) = v
+tkVal_qq_FieldList t = error ("rtk internal error: token qq_FieldList expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_ClassDeclaration :: L.PosToken -> String
+tkVal_qq_ClassDeclaration (L.PosToken _ (L.Tk__qq_ClassDeclaration v)) = v
+tkVal_qq_ClassDeclaration t = error ("rtk internal error: token qq_ClassDeclaration expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_Package :: L.PosToken -> String
+tkVal_qq_Package (L.PosToken _ (L.Tk__qq_Package v)) = v
+tkVal_qq_Package t = error ("rtk internal error: token qq_Package expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_CompilationUnit :: L.PosToken -> String
+tkVal_qq_CompilationUnit (L.PosToken _ (L.Tk__qq_CompilationUnit v)) = v
+tkVal_qq_CompilationUnit t = error ("rtk internal error: token qq_CompilationUnit expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_JavaSimple :: L.PosToken -> String
+tkVal_qq_JavaSimple (L.PosToken _ (L.Tk__qq_JavaSimple v)) = v
+tkVal_qq_JavaSimple t = error ("rtk internal error: token qq_JavaSimple expected, got " ++ showRtkToken (L.ptToken t))
+
+data JavaSimple = Ctr__JavaSimple__0 RtkPos JavaSimple |
+                  Ctr__JavaSimple__1 RtkPos ClassDeclaration |
+                  Ctr__JavaSimple__2 RtkPos CompilationUnit |
+                  Ctr__JavaSimple__3 RtkPos CompoundName |
+                  Ctr__JavaSimple__4 RtkPos Field |
+                  Ctr__JavaSimple__5 RtkPos FieldList |
+                  Ctr__JavaSimple__6 RtkPos Package |
+                  Ctr__JavaSimple__7 RtkPos Type |
                   Anti_JavaSimple String |
-                  Ctr__JavaSimple__8 CompilationUnit
+                  Ctr__JavaSimple__8 RtkPos CompilationUnit
                   deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf JavaSimple where
+    rtkPosOf (Ctr__JavaSimple__0 p _) = p
+    rtkPosOf (Ctr__JavaSimple__1 p _) = p
+    rtkPosOf (Ctr__JavaSimple__2 p _) = p
+    rtkPosOf (Ctr__JavaSimple__3 p _) = p
+    rtkPosOf (Ctr__JavaSimple__4 p _) = p
+    rtkPosOf (Ctr__JavaSimple__5 p _) = p
+    rtkPosOf (Ctr__JavaSimple__6 p _) = p
+    rtkPosOf (Ctr__JavaSimple__7 p _) = p
+    rtkPosOf (Anti_JavaSimple _) = rtkNoPos
+    rtkPosOf (Ctr__JavaSimple__8 p _) = p
 data ClassDeclaration = Anti_ClassDeclaration String |
-                        Ctr__ClassDeclaration__0 Rule_2 String FieldList
+                        Ctr__ClassDeclaration__0 RtkPos Rule_2 String FieldList
                         deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf ClassDeclaration where
+    rtkPosOf (Anti_ClassDeclaration _) = rtkNoPos
+    rtkPosOf (Ctr__ClassDeclaration__0 p _ _ _) = p
 data CompilationUnit = Anti_CompilationUnit String |
-                       Ctr__CompilationUnit__0 Rule_0 Rule_1
+                       Ctr__CompilationUnit__0 RtkPos Rule_0 Rule_1
                        deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf CompilationUnit where
+    rtkPosOf (Anti_CompilationUnit _) = rtkNoPos
+    rtkPosOf (Ctr__CompilationUnit__0 p _ _) = p
 data CompoundName = Anti_CompoundName String |
-                    Ctr__CompoundName__0 String |
-                    Ctr__CompoundName__1 CompoundName String
+                    Ctr__CompoundName__0 RtkPos String |
+                    Ctr__CompoundName__1 RtkPos CompoundName String
                     deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf CompoundName where
+    rtkPosOf (Anti_CompoundName _) = rtkNoPos
+    rtkPosOf (Ctr__CompoundName__0 p _) = p
+    rtkPosOf (Ctr__CompoundName__1 p _ _) = p
 data Field = Anti_Field String |
-             Ctr__Field__0 Type String
+             Ctr__Field__0 RtkPos Type String
              deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Field where
+    rtkPosOf (Anti_Field _) = rtkNoPos
+    rtkPosOf (Ctr__Field__0 p _ _) = p
 type FieldList = [Field]
 data Package = Anti_Package String |
-               Ctr__Package__0 CompoundName
+               Ctr__Package__0 RtkPos CompoundName
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_0 = Ctr__Rule_0__0 |
-              Ctr__Rule_0__1 Package
+instance RtkPosOf Package where
+    rtkPosOf (Anti_Package _) = rtkNoPos
+    rtkPosOf (Ctr__Package__0 p _) = p
+data Rule_0 = Ctr__Rule_0__0 RtkPos |
+              Ctr__Rule_0__1 RtkPos Package
               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_1 = Ctr__Rule_1__0 |
-              Ctr__Rule_1__1 ClassDeclaration
+instance RtkPosOf Rule_0 where
+    rtkPosOf (Ctr__Rule_0__0 p) = p
+    rtkPosOf (Ctr__Rule_0__1 p _) = p
+data Rule_1 = Ctr__Rule_1__0 RtkPos |
+              Ctr__Rule_1__1 RtkPos ClassDeclaration
               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_2 = Ctr__Rule_2__0 |
-              Ctr__Rule_2__1
+instance RtkPosOf Rule_1 where
+    rtkPosOf (Ctr__Rule_1__0 p) = p
+    rtkPosOf (Ctr__Rule_1__1 p _) = p
+data Rule_2 = Ctr__Rule_2__0 RtkPos |
+              Ctr__Rule_2__1 RtkPos
               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_2 where
+    rtkPosOf (Ctr__Rule_2__0 p) = p
+    rtkPosOf (Ctr__Rule_2__1 p) = p
 data Type = Anti_Type String |
-            Ctr__Type__0 |
-            Ctr__Type__1 |
-            Ctr__Type__2 String
+            Ctr__Type__0 RtkPos |
+            Ctr__Type__1 RtkPos |
+            Ctr__Type__2 RtkPos String
             deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Type where
+    rtkPosOf (Anti_Type _) = rtkNoPos
+    rtkPosOf (Ctr__Type__0 p) = p
+    rtkPosOf (Ctr__Type__1 p) = p
+    rtkPosOf (Ctr__Type__2 p _) = p
 }

--- a/test/golden/java-simple/JavaSimpleQQ.hs
+++ b/test/golden/java-simple/JavaSimpleQQ.hs
@@ -51,6 +51,14 @@ replaceAllPatterns str = init <$> replaceAllPatterns1 (str ++ " ")
 
 qqShortcuts = M.fromList [ ("javaSimple","JavaSimple"),("classDeclaration","ClassDeclaration"),("compilationUnit","CompilationUnit"),("compoundName","CompoundName"),("field","Field"),("fieldList","FieldList"),("package","Package"),("type","Type")]
 
+-- A quasi-quote pattern must match an AST parsed from anywhere in a source
+-- file, while the pattern itself was parsed from the quote body - so every
+-- RtkPos position field becomes a wildcard in generated patterns.
+-- (Expressions need no special case: the compile-time position they embed
+-- is equality-transparent.)
+rtkPosWildPat :: RtkPos -> Maybe (TH.Q TH.Pat)
+rtkPosWildPat _ = Just TH.wildP
+
 quoteJavaSimpleExp :: Data.Data a => String -> (JavaSimple -> a) -> String -> TH.ExpQ
 quoteJavaSimpleExp dummy func s = do
   s1 <- either fail return (replaceAllPatterns s)
@@ -66,7 +74,7 @@ quoteJavaSimplePat dummy func s = do
            Left err -> fail err
            Right a -> return a
   let expr = func ast
-  dataToPatQ (const Nothing `Generics.extQ` antiJavaSimplePat `Generics.extQ` antiCompilationUnitPat `Generics.extQ` antiPackagePat `Generics.extQ` antiClassDeclarationPat `Generics.extQ` antiFieldPat `Generics.extQ` antiTypePat `Generics.extQ` antiCompoundNamePat) expr
+  dataToPatQ (const Nothing `Generics.extQ` rtkPosWildPat `Generics.extQ` antiJavaSimplePat `Generics.extQ` antiCompilationUnitPat `Generics.extQ` antiPackagePat `Generics.extQ` antiClassDeclarationPat `Generics.extQ` antiFieldPat `Generics.extQ` antiTypePat `Generics.extQ` antiCompoundNamePat) expr
 
 antiCompoundNameExp :: CompoundName -> Maybe (TH.Q TH.Exp )
 antiCompoundNameExp ( Anti_CompoundName v) = Just $ TH.varE (TH.mkName v)
@@ -146,42 +154,42 @@ antiJavaSimplePat _ = Nothing
 quoteJavaSimpleType s = return TH.ListT
 quoteJavaSimpleDecs s = return []
 
-getJavaSimple ( Ctr__JavaSimple__0 s) = s
+getJavaSimple ( Ctr__JavaSimple__0 _ s) = s
 
 javaSimple :: QuasiQuoter
 javaSimple = QuasiQuoter (quoteJavaSimpleExp "tok_JavaSimple_dummy_11" getJavaSimple ) (quoteJavaSimplePat "tok_JavaSimple_dummy_11" getJavaSimple ) quoteJavaSimpleType quoteJavaSimpleDecs
 
-getClassDeclaration ( Ctr__JavaSimple__1 s) = s
+getClassDeclaration ( Ctr__JavaSimple__1 _ s) = s
 
 classDeclaration :: QuasiQuoter
 classDeclaration = QuasiQuoter (quoteJavaSimpleExp "tok_ClassDeclaration_dummy_10" getClassDeclaration ) (quoteJavaSimplePat "tok_ClassDeclaration_dummy_10" getClassDeclaration ) quoteJavaSimpleType quoteJavaSimpleDecs
 
-getCompilationUnit ( Ctr__JavaSimple__2 s) = s
+getCompilationUnit ( Ctr__JavaSimple__2 _ s) = s
 
 compilationUnit :: QuasiQuoter
 compilationUnit = QuasiQuoter (quoteJavaSimpleExp "tok_CompilationUnit_dummy_9" getCompilationUnit ) (quoteJavaSimplePat "tok_CompilationUnit_dummy_9" getCompilationUnit ) quoteJavaSimpleType quoteJavaSimpleDecs
 
-getCompoundName ( Ctr__JavaSimple__3 s) = s
+getCompoundName ( Ctr__JavaSimple__3 _ s) = s
 
 compoundName :: QuasiQuoter
 compoundName = QuasiQuoter (quoteJavaSimpleExp "tok_CompoundName_dummy_8" getCompoundName ) (quoteJavaSimplePat "tok_CompoundName_dummy_8" getCompoundName ) quoteJavaSimpleType quoteJavaSimpleDecs
 
-getField ( Ctr__JavaSimple__4 s) = s
+getField ( Ctr__JavaSimple__4 _ s) = s
 
 field :: QuasiQuoter
 field = QuasiQuoter (quoteJavaSimpleExp "tok_Field_dummy_7" getField ) (quoteJavaSimplePat "tok_Field_dummy_7" getField ) quoteJavaSimpleType quoteJavaSimpleDecs
 
-getFieldList ( Ctr__JavaSimple__5 s) = s
+getFieldList ( Ctr__JavaSimple__5 _ s) = s
 
 fieldList :: QuasiQuoter
 fieldList = QuasiQuoter (quoteJavaSimpleExp "tok_FieldList_dummy_6" getFieldList ) (quoteJavaSimplePat "tok_FieldList_dummy_6" getFieldList ) quoteJavaSimpleType quoteJavaSimpleDecs
 
-getPackage ( Ctr__JavaSimple__6 s) = s
+getPackage ( Ctr__JavaSimple__6 _ s) = s
 
 package :: QuasiQuoter
 package = QuasiQuoter (quoteJavaSimpleExp "tok_Package_dummy_5" getPackage ) (quoteJavaSimplePat "tok_Package_dummy_5" getPackage ) quoteJavaSimpleType quoteJavaSimpleDecs
 
-getType ( Ctr__JavaSimple__7 s) = s
+getType ( Ctr__JavaSimple__7 _ s) = s
 
 __type :: QuasiQuoter
 __type = QuasiQuoter (quoteJavaSimpleExp "tok_Type_dummy_4" getType ) (quoteJavaSimplePat "tok_Type_dummy_4" getType ) quoteJavaSimpleType quoteJavaSimpleDecs

--- a/test/golden/java/JavaLexer.x
+++ b/test/golden/java/JavaLexer.x
@@ -1,6 +1,8 @@
 {
+{-# LANGUAGE StandaloneDeriving, DeriveDataTypeable #-}
 module JavaLexer(scanTokens, alexScanTokens, Token(..), PosToken(..), AlexPosn(..))
 where
+import Data.Data (Data)
 
  }
 %wrapper "monad"
@@ -538,6 +540,11 @@ data Token = EndOfFile |
              Tk__qq_OptDocComment String |
              Tk__qq_Java String
              deriving (Show)
+
+-- AlexPosn is defined by the alex wrapper, so the Data instance (required by
+-- the parser's RtkPos position type) can only be attached via standalone
+-- deriving - the same solution as the hand-written Lexer.x
+deriving instance Data AlexPosn
 
 -- A token together with the source position where it starts
 data PosToken = PosToken { ptPos :: AlexPosn, ptToken :: Token }

--- a/test/golden/java/JavaParser.y
+++ b/test/golden/java/JavaParser.y
@@ -187,807 +187,807 @@ tok__symbol__eql__52 { L.PosToken _ L.Tk__tok__symbol__eql__52 }
 tok__symbol__75 { L.PosToken _ L.Tk__tok__symbol__75 }
 tok__exclamation__eql__63 { L.PosToken _ L.Tk__tok__exclamation__eql__63 }
 tok__exclamation__79 { L.PosToken _ L.Tk__tok__exclamation__79 }
-doccomment { L.PosToken _ (L.Tk__doccomment $$) }
-id { L.PosToken _ (L.Tk__id $$) }
-string { L.PosToken _ (L.Tk__string $$) }
-char { L.PosToken _ (L.Tk__char $$) }
-floatTypeSuffix { L.PosToken _ (L.Tk__floatTypeSuffix $$) }
-exponentPart { L.PosToken _ (L.Tk__exponentPart $$) }
-floatLiteral { L.PosToken _ (L.Tk__floatLiteral $$) }
-integerLiteral { L.PosToken _ (L.Tk__integerLiteral $$) }
-qq_CompoundName { L.PosToken _ (L.Tk__qq_CompoundName $$) }
-qq_Modifier { L.PosToken _ (L.Tk__qq_Modifier $$) }
-qq_TypeSpecifier { L.PosToken _ (L.Tk__qq_TypeSpecifier $$) }
-qq_Type { L.PosToken _ (L.Tk__qq_Type $$) }
-qq_TypeParameter { L.PosToken _ (L.Tk__qq_TypeParameter $$) }
-qq_TypeParameters { L.PosToken _ (L.Tk__qq_TypeParameters $$) }
-qq_WildcardType { L.PosToken _ (L.Tk__qq_WildcardType $$) }
-qq_TypeArgument { L.PosToken _ (L.Tk__qq_TypeArgument $$) }
-qq_TypeArguments { L.PosToken _ (L.Tk__qq_TypeArguments $$) }
-qq_Arglist { L.PosToken _ (L.Tk__qq_Arglist $$) }
-qq_Literal { L.PosToken _ (L.Tk__qq_Literal $$) }
-qq_CreationExpression { L.PosToken _ (L.Tk__qq_CreationExpression $$) }
-qq_PostfixOp { L.PosToken _ (L.Tk__qq_PostfixOp $$) }
-qq_PrefixOp { L.PosToken _ (L.Tk__qq_PrefixOp $$) }
-qq_MultiplicativeOp { L.PosToken _ (L.Tk__qq_MultiplicativeOp $$) }
-qq_AdditiveOp { L.PosToken _ (L.Tk__qq_AdditiveOp $$) }
-qq_ShiftOp { L.PosToken _ (L.Tk__qq_ShiftOp $$) }
-qq_RelationalOp { L.PosToken _ (L.Tk__qq_RelationalOp $$) }
-qq_EqualityOp { L.PosToken _ (L.Tk__qq_EqualityOp $$) }
-qq_AssignmentOp { L.PosToken _ (L.Tk__qq_AssignmentOp $$) }
-qq_Expression { L.PosToken _ (L.Tk__qq_Expression $$) }
-qq_SwitchStatement { L.PosToken _ (L.Tk__qq_SwitchStatement $$) }
-qq_SwitchCaseList { L.PosToken _ (L.Tk__qq_SwitchCaseList $$) }
-qq_TryStatement { L.PosToken _ (L.Tk__qq_TryStatement $$) }
-qq_OptFinally { L.PosToken _ (L.Tk__qq_OptFinally $$) }
-qq_CatchList { L.PosToken _ (L.Tk__qq_CatchList $$) }
-qq_ForStatement { L.PosToken _ (L.Tk__qq_ForStatement $$) }
-qq_WhileStatement { L.PosToken _ (L.Tk__qq_WhileStatement $$) }
-qq_DoStatement { L.PosToken _ (L.Tk__qq_DoStatement $$) }
-qq_IfStatement { L.PosToken _ (L.Tk__qq_IfStatement $$) }
-qq_OptElsePart { L.PosToken _ (L.Tk__qq_OptElsePart $$) }
-qq_StatementWithoutIf { L.PosToken _ (L.Tk__qq_StatementWithoutIf $$) }
-qq_Statement { L.PosToken _ (L.Tk__qq_Statement $$) }
-qq_OptId { L.PosToken _ (L.Tk__qq_OptId $$) }
-qq_OptExpression { L.PosToken _ (L.Tk__qq_OptExpression $$) }
-qq_StatementList { L.PosToken _ (L.Tk__qq_StatementList $$) }
-qq_Parameter { L.PosToken _ (L.Tk__qq_Parameter $$) }
-qq_ParameterList { L.PosToken _ (L.Tk__qq_ParameterList $$) }
-qq_StaticInitializer { L.PosToken _ (L.Tk__qq_StaticInitializer $$) }
-qq_VariableInitializer { L.PosToken _ (L.Tk__qq_VariableInitializer $$) }
-qq_VariableInitializerList { L.PosToken _ (L.Tk__qq_VariableInitializerList $$) }
-qq_VariableDeclarator { L.PosToken _ (L.Tk__qq_VariableDeclarator $$) }
-qq_OptVariableInitializer { L.PosToken _ (L.Tk__qq_OptVariableInitializer $$) }
-qq_VariableDeclaration { L.PosToken _ (L.Tk__qq_VariableDeclaration $$) }
-qq_VariableDeclaratorList { L.PosToken _ (L.Tk__qq_VariableDeclaratorList $$) }
-qq_StatementBlock { L.PosToken _ (L.Tk__qq_StatementBlock $$) }
-qq_MoreVariableDeclarators { L.PosToken _ (L.Tk__qq_MoreVariableDeclarators $$) }
-qq_MemberRest { L.PosToken _ (L.Tk__qq_MemberRest $$) }
-qq_MoreTypeSpecifier { L.PosToken _ (L.Tk__qq_MoreTypeSpecifier $$) }
-qq_MemberAfterFirstId { L.PosToken _ (L.Tk__qq_MemberAfterFirstId $$) }
-qq_PrimitiveTypeKeyword { L.PosToken _ (L.Tk__qq_PrimitiveTypeKeyword $$) }
-qq_MemberDeclaration { L.PosToken _ (L.Tk__qq_MemberDeclaration $$) }
-qq_SquareBracketsList { L.PosToken _ (L.Tk__qq_SquareBracketsList $$) }
-qq_FieldDeclaration { L.PosToken _ (L.Tk__qq_FieldDeclaration $$) }
-qq_NestedTypeDeclaration { L.PosToken _ (L.Tk__qq_NestedTypeDeclaration $$) }
-qq_EnumDeclaration { L.PosToken _ (L.Tk__qq_EnumDeclaration $$) }
-qq_EnumConstantList { L.PosToken _ (L.Tk__qq_EnumConstantList $$) }
-qq_EnumConstant { L.PosToken _ (L.Tk__qq_EnumConstant $$) }
-qq_AnnotationTypeElement { L.PosToken _ (L.Tk__qq_AnnotationTypeElement $$) }
-qq_AnnotationTypeElementList { L.PosToken _ (L.Tk__qq_AnnotationTypeElementList $$) }
-qq_AnnotationDeclaration { L.PosToken _ (L.Tk__qq_AnnotationDeclaration $$) }
-qq_InterfaceDeclaration { L.PosToken _ (L.Tk__qq_InterfaceDeclaration $$) }
-qq_ClassDeclaration { L.PosToken _ (L.Tk__qq_ClassDeclaration $$) }
-qq_FieldDeclarationList { L.PosToken _ (L.Tk__qq_FieldDeclarationList $$) }
-qq_ImplementsList { L.PosToken _ (L.Tk__qq_ImplementsList $$) }
-qq_ExtendsList { L.PosToken _ (L.Tk__qq_ExtendsList $$) }
-qq_ModifierList { L.PosToken _ (L.Tk__qq_ModifierList $$) }
-qq_AnnotationList { L.PosToken _ (L.Tk__qq_AnnotationList $$) }
-qq_AnnotationElement { L.PosToken _ (L.Tk__qq_AnnotationElement $$) }
-qq_AnnotationArguments { L.PosToken _ (L.Tk__qq_AnnotationArguments $$) }
-qq_Annotation { L.PosToken _ (L.Tk__qq_Annotation $$) }
-qq_DocComment { L.PosToken _ (L.Tk__qq_DocComment $$) }
-qq_ImportStatement { L.PosToken _ (L.Tk__qq_ImportStatement $$) }
-qq_Package { L.PosToken _ (L.Tk__qq_Package $$) }
-qq_CompilationUnit { L.PosToken _ (L.Tk__qq_CompilationUnit $$) }
-qq_ImportList { L.PosToken _ (L.Tk__qq_ImportList $$) }
-qq_TypeDeclaration { L.PosToken _ (L.Tk__qq_TypeDeclaration $$) }
-qq_OptDocComment { L.PosToken _ (L.Tk__qq_OptDocComment $$) }
-qq_Java { L.PosToken _ (L.Tk__qq_Java $$) }
+doccomment { L.PosToken _ (L.Tk__doccomment _) }
+id { L.PosToken _ (L.Tk__id _) }
+string { L.PosToken _ (L.Tk__string _) }
+char { L.PosToken _ (L.Tk__char _) }
+floatTypeSuffix { L.PosToken _ (L.Tk__floatTypeSuffix _) }
+exponentPart { L.PosToken _ (L.Tk__exponentPart _) }
+floatLiteral { L.PosToken _ (L.Tk__floatLiteral _) }
+integerLiteral { L.PosToken _ (L.Tk__integerLiteral _) }
+qq_CompoundName { L.PosToken _ (L.Tk__qq_CompoundName _) }
+qq_Modifier { L.PosToken _ (L.Tk__qq_Modifier _) }
+qq_TypeSpecifier { L.PosToken _ (L.Tk__qq_TypeSpecifier _) }
+qq_Type { L.PosToken _ (L.Tk__qq_Type _) }
+qq_TypeParameter { L.PosToken _ (L.Tk__qq_TypeParameter _) }
+qq_TypeParameters { L.PosToken _ (L.Tk__qq_TypeParameters _) }
+qq_WildcardType { L.PosToken _ (L.Tk__qq_WildcardType _) }
+qq_TypeArgument { L.PosToken _ (L.Tk__qq_TypeArgument _) }
+qq_TypeArguments { L.PosToken _ (L.Tk__qq_TypeArguments _) }
+qq_Arglist { L.PosToken _ (L.Tk__qq_Arglist _) }
+qq_Literal { L.PosToken _ (L.Tk__qq_Literal _) }
+qq_CreationExpression { L.PosToken _ (L.Tk__qq_CreationExpression _) }
+qq_PostfixOp { L.PosToken _ (L.Tk__qq_PostfixOp _) }
+qq_PrefixOp { L.PosToken _ (L.Tk__qq_PrefixOp _) }
+qq_MultiplicativeOp { L.PosToken _ (L.Tk__qq_MultiplicativeOp _) }
+qq_AdditiveOp { L.PosToken _ (L.Tk__qq_AdditiveOp _) }
+qq_ShiftOp { L.PosToken _ (L.Tk__qq_ShiftOp _) }
+qq_RelationalOp { L.PosToken _ (L.Tk__qq_RelationalOp _) }
+qq_EqualityOp { L.PosToken _ (L.Tk__qq_EqualityOp _) }
+qq_AssignmentOp { L.PosToken _ (L.Tk__qq_AssignmentOp _) }
+qq_Expression { L.PosToken _ (L.Tk__qq_Expression _) }
+qq_SwitchStatement { L.PosToken _ (L.Tk__qq_SwitchStatement _) }
+qq_SwitchCaseList { L.PosToken _ (L.Tk__qq_SwitchCaseList _) }
+qq_TryStatement { L.PosToken _ (L.Tk__qq_TryStatement _) }
+qq_OptFinally { L.PosToken _ (L.Tk__qq_OptFinally _) }
+qq_CatchList { L.PosToken _ (L.Tk__qq_CatchList _) }
+qq_ForStatement { L.PosToken _ (L.Tk__qq_ForStatement _) }
+qq_WhileStatement { L.PosToken _ (L.Tk__qq_WhileStatement _) }
+qq_DoStatement { L.PosToken _ (L.Tk__qq_DoStatement _) }
+qq_IfStatement { L.PosToken _ (L.Tk__qq_IfStatement _) }
+qq_OptElsePart { L.PosToken _ (L.Tk__qq_OptElsePart _) }
+qq_StatementWithoutIf { L.PosToken _ (L.Tk__qq_StatementWithoutIf _) }
+qq_Statement { L.PosToken _ (L.Tk__qq_Statement _) }
+qq_OptId { L.PosToken _ (L.Tk__qq_OptId _) }
+qq_OptExpression { L.PosToken _ (L.Tk__qq_OptExpression _) }
+qq_StatementList { L.PosToken _ (L.Tk__qq_StatementList _) }
+qq_Parameter { L.PosToken _ (L.Tk__qq_Parameter _) }
+qq_ParameterList { L.PosToken _ (L.Tk__qq_ParameterList _) }
+qq_StaticInitializer { L.PosToken _ (L.Tk__qq_StaticInitializer _) }
+qq_VariableInitializer { L.PosToken _ (L.Tk__qq_VariableInitializer _) }
+qq_VariableInitializerList { L.PosToken _ (L.Tk__qq_VariableInitializerList _) }
+qq_VariableDeclarator { L.PosToken _ (L.Tk__qq_VariableDeclarator _) }
+qq_OptVariableInitializer { L.PosToken _ (L.Tk__qq_OptVariableInitializer _) }
+qq_VariableDeclaration { L.PosToken _ (L.Tk__qq_VariableDeclaration _) }
+qq_VariableDeclaratorList { L.PosToken _ (L.Tk__qq_VariableDeclaratorList _) }
+qq_StatementBlock { L.PosToken _ (L.Tk__qq_StatementBlock _) }
+qq_MoreVariableDeclarators { L.PosToken _ (L.Tk__qq_MoreVariableDeclarators _) }
+qq_MemberRest { L.PosToken _ (L.Tk__qq_MemberRest _) }
+qq_MoreTypeSpecifier { L.PosToken _ (L.Tk__qq_MoreTypeSpecifier _) }
+qq_MemberAfterFirstId { L.PosToken _ (L.Tk__qq_MemberAfterFirstId _) }
+qq_PrimitiveTypeKeyword { L.PosToken _ (L.Tk__qq_PrimitiveTypeKeyword _) }
+qq_MemberDeclaration { L.PosToken _ (L.Tk__qq_MemberDeclaration _) }
+qq_SquareBracketsList { L.PosToken _ (L.Tk__qq_SquareBracketsList _) }
+qq_FieldDeclaration { L.PosToken _ (L.Tk__qq_FieldDeclaration _) }
+qq_NestedTypeDeclaration { L.PosToken _ (L.Tk__qq_NestedTypeDeclaration _) }
+qq_EnumDeclaration { L.PosToken _ (L.Tk__qq_EnumDeclaration _) }
+qq_EnumConstantList { L.PosToken _ (L.Tk__qq_EnumConstantList _) }
+qq_EnumConstant { L.PosToken _ (L.Tk__qq_EnumConstant _) }
+qq_AnnotationTypeElement { L.PosToken _ (L.Tk__qq_AnnotationTypeElement _) }
+qq_AnnotationTypeElementList { L.PosToken _ (L.Tk__qq_AnnotationTypeElementList _) }
+qq_AnnotationDeclaration { L.PosToken _ (L.Tk__qq_AnnotationDeclaration _) }
+qq_InterfaceDeclaration { L.PosToken _ (L.Tk__qq_InterfaceDeclaration _) }
+qq_ClassDeclaration { L.PosToken _ (L.Tk__qq_ClassDeclaration _) }
+qq_FieldDeclarationList { L.PosToken _ (L.Tk__qq_FieldDeclarationList _) }
+qq_ImplementsList { L.PosToken _ (L.Tk__qq_ImplementsList _) }
+qq_ExtendsList { L.PosToken _ (L.Tk__qq_ExtendsList _) }
+qq_ModifierList { L.PosToken _ (L.Tk__qq_ModifierList _) }
+qq_AnnotationList { L.PosToken _ (L.Tk__qq_AnnotationList _) }
+qq_AnnotationElement { L.PosToken _ (L.Tk__qq_AnnotationElement _) }
+qq_AnnotationArguments { L.PosToken _ (L.Tk__qq_AnnotationArguments _) }
+qq_Annotation { L.PosToken _ (L.Tk__qq_Annotation _) }
+qq_DocComment { L.PosToken _ (L.Tk__qq_DocComment _) }
+qq_ImportStatement { L.PosToken _ (L.Tk__qq_ImportStatement _) }
+qq_Package { L.PosToken _ (L.Tk__qq_Package _) }
+qq_CompilationUnit { L.PosToken _ (L.Tk__qq_CompilationUnit _) }
+qq_ImportList { L.PosToken _ (L.Tk__qq_ImportList _) }
+qq_TypeDeclaration { L.PosToken _ (L.Tk__qq_TypeDeclaration _) }
+qq_OptDocComment { L.PosToken _ (L.Tk__qq_OptDocComment _) }
+qq_Java { L.PosToken _ (L.Tk__qq_Java _) }
 
 %%
 
 Java__top : Java rtk__eof { $1 }
 
-Java : tok_Java_dummy_170 Java tok_Java_dummy_170 { Ctr__Java__0 $2 } |
-       tok_AdditiveOp_dummy_169 AdditiveOp tok_AdditiveOp_dummy_169 { Ctr__Java__1 $2 } |
-       tok_Annotation_dummy_168 Annotation tok_Annotation_dummy_168 { Ctr__Java__2 $2 } |
-       tok_AnnotationArguments_dummy_167 AnnotationArguments tok_AnnotationArguments_dummy_167 { Ctr__Java__3 $2 } |
-       tok_AnnotationDeclaration_dummy_166 AnnotationDeclaration tok_AnnotationDeclaration_dummy_166 { Ctr__Java__4 $2 } |
-       tok_AnnotationElement_dummy_165 AnnotationElement tok_AnnotationElement_dummy_165 { Ctr__Java__5 $2 } |
-       tok_AnnotationList_dummy_164 AnnotationList tok_AnnotationList_dummy_164 { Ctr__Java__6 (reverse $2) } |
-       tok_AnnotationTypeElement_dummy_163 AnnotationTypeElement tok_AnnotationTypeElement_dummy_163 { Ctr__Java__7 $2 } |
-       tok_AnnotationTypeElementList_dummy_162 AnnotationTypeElementList tok_AnnotationTypeElementList_dummy_162 { Ctr__Java__8 (reverse $2) } |
-       tok_Arglist_dummy_161 Arglist tok_Arglist_dummy_161 { Ctr__Java__9 $2 } |
-       tok_AssignmentOp_dummy_160 AssignmentOp tok_AssignmentOp_dummy_160 { Ctr__Java__10 $2 } |
-       tok_CatchList_dummy_159 CatchList tok_CatchList_dummy_159 { Ctr__Java__11 (reverse $2) } |
-       tok_ClassDeclaration_dummy_158 ClassDeclaration tok_ClassDeclaration_dummy_158 { Ctr__Java__12 $2 } |
-       tok_CompilationUnit_dummy_157 CompilationUnit tok_CompilationUnit_dummy_157 { Ctr__Java__13 $2 } |
-       tok_CompoundName_dummy_156 CompoundName tok_CompoundName_dummy_156 { Ctr__Java__14 $2 } |
-       tok_CreationExpression_dummy_155 CreationExpression tok_CreationExpression_dummy_155 { Ctr__Java__15 $2 } |
-       tok_DoStatement_dummy_154 DoStatement tok_DoStatement_dummy_154 { Ctr__Java__16 $2 } |
-       tok_DocComment_dummy_153 DocComment tok_DocComment_dummy_153 { Ctr__Java__17 $2 } |
-       tok_EnumConstant_dummy_152 EnumConstant tok_EnumConstant_dummy_152 { Ctr__Java__18 $2 } |
-       tok_EnumConstantList_dummy_151 EnumConstantList tok_EnumConstantList_dummy_151 { Ctr__Java__19 $2 } |
-       tok_EnumDeclaration_dummy_150 EnumDeclaration tok_EnumDeclaration_dummy_150 { Ctr__Java__20 $2 } |
-       tok_EqualityOp_dummy_149 EqualityOp tok_EqualityOp_dummy_149 { Ctr__Java__21 $2 } |
-       tok_Expression_dummy_148 Expression tok_Expression_dummy_148 { Ctr__Java__22 $2 } |
-       tok_ExtendsList_dummy_147 ExtendsList tok_ExtendsList_dummy_147 { Ctr__Java__23 $2 } |
-       tok_FieldDeclaration_dummy_146 FieldDeclaration tok_FieldDeclaration_dummy_146 { Ctr__Java__24 $2 } |
-       tok_FieldDeclarationList_dummy_145 FieldDeclarationList tok_FieldDeclarationList_dummy_145 { Ctr__Java__25 (reverse $2) } |
-       tok_ForStatement_dummy_144 ForStatement tok_ForStatement_dummy_144 { Ctr__Java__26 $2 } |
-       tok_IfStatement_dummy_143 IfStatement tok_IfStatement_dummy_143 { Ctr__Java__27 $2 } |
-       tok_ImplementsList_dummy_142 ImplementsList tok_ImplementsList_dummy_142 { Ctr__Java__28 $2 } |
-       tok_ImportList_dummy_141 ImportList tok_ImportList_dummy_141 { Ctr__Java__29 (reverse $2) } |
-       tok_ImportStatement_dummy_140 ImportStatement tok_ImportStatement_dummy_140 { Ctr__Java__30 $2 } |
-       tok_InterfaceDeclaration_dummy_139 InterfaceDeclaration tok_InterfaceDeclaration_dummy_139 { Ctr__Java__31 $2 } |
-       tok_Literal_dummy_138 Literal tok_Literal_dummy_138 { Ctr__Java__32 $2 } |
-       tok_MemberAfterFirstId_dummy_137 MemberAfterFirstId tok_MemberAfterFirstId_dummy_137 { Ctr__Java__33 $2 } |
-       tok_MemberDeclaration_dummy_136 MemberDeclaration tok_MemberDeclaration_dummy_136 { Ctr__Java__34 $2 } |
-       tok_MemberRest_dummy_135 MemberRest tok_MemberRest_dummy_135 { Ctr__Java__35 $2 } |
-       tok_Modifier_dummy_134 Modifier tok_Modifier_dummy_134 { Ctr__Java__36 $2 } |
-       tok_ModifierList_dummy_133 ModifierList tok_ModifierList_dummy_133 { Ctr__Java__37 (reverse $2) } |
-       tok_MoreTypeSpecifier_dummy_132 MoreTypeSpecifier tok_MoreTypeSpecifier_dummy_132 { Ctr__Java__38 $2 } |
-       tok_MoreVariableDeclarators_dummy_131 MoreVariableDeclarators tok_MoreVariableDeclarators_dummy_131 { Ctr__Java__39 (reverse $2) } |
-       tok_MultiplicativeOp_dummy_130 MultiplicativeOp tok_MultiplicativeOp_dummy_130 { Ctr__Java__40 $2 } |
-       tok_NestedTypeDeclaration_dummy_129 NestedTypeDeclaration tok_NestedTypeDeclaration_dummy_129 { Ctr__Java__41 $2 } |
-       tok_OptDocComment_dummy_128 OptDocComment tok_OptDocComment_dummy_128 { Ctr__Java__42 $2 } |
-       tok_OptElsePart_dummy_127 OptElsePart tok_OptElsePart_dummy_127 { Ctr__Java__43 $2 } |
-       tok_OptExpression_dummy_126 OptExpression tok_OptExpression_dummy_126 { Ctr__Java__44 $2 } |
-       tok_OptFinally_dummy_125 OptFinally tok_OptFinally_dummy_125 { Ctr__Java__45 $2 } |
-       tok_OptId_dummy_124 OptId tok_OptId_dummy_124 { Ctr__Java__46 $2 } |
-       tok_OptVariableInitializer_dummy_123 OptVariableInitializer tok_OptVariableInitializer_dummy_123 { Ctr__Java__47 $2 } |
-       tok_Package_dummy_122 Package tok_Package_dummy_122 { Ctr__Java__48 $2 } |
-       tok_Parameter_dummy_121 Parameter tok_Parameter_dummy_121 { Ctr__Java__49 $2 } |
-       tok_ParameterList_dummy_120 ParameterList tok_ParameterList_dummy_120 { Ctr__Java__50 $2 } |
-       tok_PostfixOp_dummy_119 PostfixOp tok_PostfixOp_dummy_119 { Ctr__Java__51 $2 } |
-       tok_PrefixOp_dummy_118 PrefixOp tok_PrefixOp_dummy_118 { Ctr__Java__52 $2 } |
-       tok_PrimitiveTypeKeyword_dummy_117 PrimitiveTypeKeyword tok_PrimitiveTypeKeyword_dummy_117 { Ctr__Java__53 $2 } |
-       tok_RelationalOp_dummy_116 RelationalOp tok_RelationalOp_dummy_116 { Ctr__Java__54 $2 } |
-       tok_ShiftOp_dummy_115 ShiftOp tok_ShiftOp_dummy_115 { Ctr__Java__55 $2 } |
-       tok_SquareBracketsList_dummy_114 SquareBracketsList tok_SquareBracketsList_dummy_114 { Ctr__Java__56 (reverse $2) } |
-       tok_Statement_dummy_113 Statement tok_Statement_dummy_113 { Ctr__Java__57 $2 } |
-       tok_StatementBlock_dummy_112 StatementBlock tok_StatementBlock_dummy_112 { Ctr__Java__58 $2 } |
-       tok_StatementList_dummy_111 StatementList tok_StatementList_dummy_111 { Ctr__Java__59 (reverse $2) } |
-       tok_StatementWithoutIf_dummy_110 StatementWithoutIf tok_StatementWithoutIf_dummy_110 { Ctr__Java__60 $2 } |
-       tok_StaticInitializer_dummy_109 StaticInitializer tok_StaticInitializer_dummy_109 { Ctr__Java__61 $2 } |
-       tok_SwitchCaseList_dummy_108 SwitchCaseList tok_SwitchCaseList_dummy_108 { Ctr__Java__62 (reverse $2) } |
-       tok_SwitchStatement_dummy_107 SwitchStatement tok_SwitchStatement_dummy_107 { Ctr__Java__63 $2 } |
-       tok_TryStatement_dummy_106 TryStatement tok_TryStatement_dummy_106 { Ctr__Java__64 $2 } |
-       tok_Type_dummy_105 Type tok_Type_dummy_105 { Ctr__Java__65 $2 } |
-       tok_TypeArgument_dummy_104 TypeArgument tok_TypeArgument_dummy_104 { Ctr__Java__66 $2 } |
-       tok_TypeArguments_dummy_103 TypeArguments tok_TypeArguments_dummy_103 { Ctr__Java__67 $2 } |
-       tok_TypeDeclaration_dummy_102 TypeDeclaration tok_TypeDeclaration_dummy_102 { Ctr__Java__68 $2 } |
-       tok_TypeParameter_dummy_101 TypeParameter tok_TypeParameter_dummy_101 { Ctr__Java__69 $2 } |
-       tok_TypeParameters_dummy_100 TypeParameters tok_TypeParameters_dummy_100 { Ctr__Java__70 $2 } |
-       tok_TypeSpecifier_dummy_99 TypeSpecifier tok_TypeSpecifier_dummy_99 { Ctr__Java__71 $2 } |
-       tok_VariableDeclaration_dummy_98 VariableDeclaration tok_VariableDeclaration_dummy_98 { Ctr__Java__72 $2 } |
-       tok_VariableDeclarator_dummy_97 VariableDeclarator tok_VariableDeclarator_dummy_97 { Ctr__Java__73 $2 } |
-       tok_VariableDeclaratorList_dummy_96 VariableDeclaratorList tok_VariableDeclaratorList_dummy_96 { Ctr__Java__74 $2 } |
-       tok_VariableInitializer_dummy_95 VariableInitializer tok_VariableInitializer_dummy_95 { Ctr__Java__75 $2 } |
-       tok_VariableInitializerList_dummy_94 VariableInitializerList tok_VariableInitializerList_dummy_94 { Ctr__Java__76 $2 } |
-       tok_WhileStatement_dummy_93 WhileStatement tok_WhileStatement_dummy_93 { Ctr__Java__77 $2 } |
-       tok_WildcardType_dummy_92 WildcardType tok_WildcardType_dummy_92 { Ctr__Java__78 $2 }
+Java : tok_Java_dummy_170 Java tok_Java_dummy_170 { Ctr__Java__0 (rtkPosOf $1) $2 } |
+       tok_AdditiveOp_dummy_169 AdditiveOp tok_AdditiveOp_dummy_169 { Ctr__Java__1 (rtkPosOf $1) $2 } |
+       tok_Annotation_dummy_168 Annotation tok_Annotation_dummy_168 { Ctr__Java__2 (rtkPosOf $1) $2 } |
+       tok_AnnotationArguments_dummy_167 AnnotationArguments tok_AnnotationArguments_dummy_167 { Ctr__Java__3 (rtkPosOf $1) $2 } |
+       tok_AnnotationDeclaration_dummy_166 AnnotationDeclaration tok_AnnotationDeclaration_dummy_166 { Ctr__Java__4 (rtkPosOf $1) $2 } |
+       tok_AnnotationElement_dummy_165 AnnotationElement tok_AnnotationElement_dummy_165 { Ctr__Java__5 (rtkPosOf $1) $2 } |
+       tok_AnnotationList_dummy_164 AnnotationList tok_AnnotationList_dummy_164 { Ctr__Java__6 (rtkPosOf $1) (reverse $2) } |
+       tok_AnnotationTypeElement_dummy_163 AnnotationTypeElement tok_AnnotationTypeElement_dummy_163 { Ctr__Java__7 (rtkPosOf $1) $2 } |
+       tok_AnnotationTypeElementList_dummy_162 AnnotationTypeElementList tok_AnnotationTypeElementList_dummy_162 { Ctr__Java__8 (rtkPosOf $1) (reverse $2) } |
+       tok_Arglist_dummy_161 Arglist tok_Arglist_dummy_161 { Ctr__Java__9 (rtkPosOf $1) $2 } |
+       tok_AssignmentOp_dummy_160 AssignmentOp tok_AssignmentOp_dummy_160 { Ctr__Java__10 (rtkPosOf $1) $2 } |
+       tok_CatchList_dummy_159 CatchList tok_CatchList_dummy_159 { Ctr__Java__11 (rtkPosOf $1) (reverse $2) } |
+       tok_ClassDeclaration_dummy_158 ClassDeclaration tok_ClassDeclaration_dummy_158 { Ctr__Java__12 (rtkPosOf $1) $2 } |
+       tok_CompilationUnit_dummy_157 CompilationUnit tok_CompilationUnit_dummy_157 { Ctr__Java__13 (rtkPosOf $1) $2 } |
+       tok_CompoundName_dummy_156 CompoundName tok_CompoundName_dummy_156 { Ctr__Java__14 (rtkPosOf $1) $2 } |
+       tok_CreationExpression_dummy_155 CreationExpression tok_CreationExpression_dummy_155 { Ctr__Java__15 (rtkPosOf $1) $2 } |
+       tok_DoStatement_dummy_154 DoStatement tok_DoStatement_dummy_154 { Ctr__Java__16 (rtkPosOf $1) $2 } |
+       tok_DocComment_dummy_153 DocComment tok_DocComment_dummy_153 { Ctr__Java__17 (rtkPosOf $1) $2 } |
+       tok_EnumConstant_dummy_152 EnumConstant tok_EnumConstant_dummy_152 { Ctr__Java__18 (rtkPosOf $1) $2 } |
+       tok_EnumConstantList_dummy_151 EnumConstantList tok_EnumConstantList_dummy_151 { Ctr__Java__19 (rtkPosOf $1) $2 } |
+       tok_EnumDeclaration_dummy_150 EnumDeclaration tok_EnumDeclaration_dummy_150 { Ctr__Java__20 (rtkPosOf $1) $2 } |
+       tok_EqualityOp_dummy_149 EqualityOp tok_EqualityOp_dummy_149 { Ctr__Java__21 (rtkPosOf $1) $2 } |
+       tok_Expression_dummy_148 Expression tok_Expression_dummy_148 { Ctr__Java__22 (rtkPosOf $1) $2 } |
+       tok_ExtendsList_dummy_147 ExtendsList tok_ExtendsList_dummy_147 { Ctr__Java__23 (rtkPosOf $1) $2 } |
+       tok_FieldDeclaration_dummy_146 FieldDeclaration tok_FieldDeclaration_dummy_146 { Ctr__Java__24 (rtkPosOf $1) $2 } |
+       tok_FieldDeclarationList_dummy_145 FieldDeclarationList tok_FieldDeclarationList_dummy_145 { Ctr__Java__25 (rtkPosOf $1) (reverse $2) } |
+       tok_ForStatement_dummy_144 ForStatement tok_ForStatement_dummy_144 { Ctr__Java__26 (rtkPosOf $1) $2 } |
+       tok_IfStatement_dummy_143 IfStatement tok_IfStatement_dummy_143 { Ctr__Java__27 (rtkPosOf $1) $2 } |
+       tok_ImplementsList_dummy_142 ImplementsList tok_ImplementsList_dummy_142 { Ctr__Java__28 (rtkPosOf $1) $2 } |
+       tok_ImportList_dummy_141 ImportList tok_ImportList_dummy_141 { Ctr__Java__29 (rtkPosOf $1) (reverse $2) } |
+       tok_ImportStatement_dummy_140 ImportStatement tok_ImportStatement_dummy_140 { Ctr__Java__30 (rtkPosOf $1) $2 } |
+       tok_InterfaceDeclaration_dummy_139 InterfaceDeclaration tok_InterfaceDeclaration_dummy_139 { Ctr__Java__31 (rtkPosOf $1) $2 } |
+       tok_Literal_dummy_138 Literal tok_Literal_dummy_138 { Ctr__Java__32 (rtkPosOf $1) $2 } |
+       tok_MemberAfterFirstId_dummy_137 MemberAfterFirstId tok_MemberAfterFirstId_dummy_137 { Ctr__Java__33 (rtkPosOf $1) $2 } |
+       tok_MemberDeclaration_dummy_136 MemberDeclaration tok_MemberDeclaration_dummy_136 { Ctr__Java__34 (rtkPosOf $1) $2 } |
+       tok_MemberRest_dummy_135 MemberRest tok_MemberRest_dummy_135 { Ctr__Java__35 (rtkPosOf $1) $2 } |
+       tok_Modifier_dummy_134 Modifier tok_Modifier_dummy_134 { Ctr__Java__36 (rtkPosOf $1) $2 } |
+       tok_ModifierList_dummy_133 ModifierList tok_ModifierList_dummy_133 { Ctr__Java__37 (rtkPosOf $1) (reverse $2) } |
+       tok_MoreTypeSpecifier_dummy_132 MoreTypeSpecifier tok_MoreTypeSpecifier_dummy_132 { Ctr__Java__38 (rtkPosOf $1) $2 } |
+       tok_MoreVariableDeclarators_dummy_131 MoreVariableDeclarators tok_MoreVariableDeclarators_dummy_131 { Ctr__Java__39 (rtkPosOf $1) (reverse $2) } |
+       tok_MultiplicativeOp_dummy_130 MultiplicativeOp tok_MultiplicativeOp_dummy_130 { Ctr__Java__40 (rtkPosOf $1) $2 } |
+       tok_NestedTypeDeclaration_dummy_129 NestedTypeDeclaration tok_NestedTypeDeclaration_dummy_129 { Ctr__Java__41 (rtkPosOf $1) $2 } |
+       tok_OptDocComment_dummy_128 OptDocComment tok_OptDocComment_dummy_128 { Ctr__Java__42 (rtkPosOf $1) $2 } |
+       tok_OptElsePart_dummy_127 OptElsePart tok_OptElsePart_dummy_127 { Ctr__Java__43 (rtkPosOf $1) $2 } |
+       tok_OptExpression_dummy_126 OptExpression tok_OptExpression_dummy_126 { Ctr__Java__44 (rtkPosOf $1) $2 } |
+       tok_OptFinally_dummy_125 OptFinally tok_OptFinally_dummy_125 { Ctr__Java__45 (rtkPosOf $1) $2 } |
+       tok_OptId_dummy_124 OptId tok_OptId_dummy_124 { Ctr__Java__46 (rtkPosOf $1) $2 } |
+       tok_OptVariableInitializer_dummy_123 OptVariableInitializer tok_OptVariableInitializer_dummy_123 { Ctr__Java__47 (rtkPosOf $1) $2 } |
+       tok_Package_dummy_122 Package tok_Package_dummy_122 { Ctr__Java__48 (rtkPosOf $1) $2 } |
+       tok_Parameter_dummy_121 Parameter tok_Parameter_dummy_121 { Ctr__Java__49 (rtkPosOf $1) $2 } |
+       tok_ParameterList_dummy_120 ParameterList tok_ParameterList_dummy_120 { Ctr__Java__50 (rtkPosOf $1) $2 } |
+       tok_PostfixOp_dummy_119 PostfixOp tok_PostfixOp_dummy_119 { Ctr__Java__51 (rtkPosOf $1) $2 } |
+       tok_PrefixOp_dummy_118 PrefixOp tok_PrefixOp_dummy_118 { Ctr__Java__52 (rtkPosOf $1) $2 } |
+       tok_PrimitiveTypeKeyword_dummy_117 PrimitiveTypeKeyword tok_PrimitiveTypeKeyword_dummy_117 { Ctr__Java__53 (rtkPosOf $1) $2 } |
+       tok_RelationalOp_dummy_116 RelationalOp tok_RelationalOp_dummy_116 { Ctr__Java__54 (rtkPosOf $1) $2 } |
+       tok_ShiftOp_dummy_115 ShiftOp tok_ShiftOp_dummy_115 { Ctr__Java__55 (rtkPosOf $1) $2 } |
+       tok_SquareBracketsList_dummy_114 SquareBracketsList tok_SquareBracketsList_dummy_114 { Ctr__Java__56 (rtkPosOf $1) (reverse $2) } |
+       tok_Statement_dummy_113 Statement tok_Statement_dummy_113 { Ctr__Java__57 (rtkPosOf $1) $2 } |
+       tok_StatementBlock_dummy_112 StatementBlock tok_StatementBlock_dummy_112 { Ctr__Java__58 (rtkPosOf $1) $2 } |
+       tok_StatementList_dummy_111 StatementList tok_StatementList_dummy_111 { Ctr__Java__59 (rtkPosOf $1) (reverse $2) } |
+       tok_StatementWithoutIf_dummy_110 StatementWithoutIf tok_StatementWithoutIf_dummy_110 { Ctr__Java__60 (rtkPosOf $1) $2 } |
+       tok_StaticInitializer_dummy_109 StaticInitializer tok_StaticInitializer_dummy_109 { Ctr__Java__61 (rtkPosOf $1) $2 } |
+       tok_SwitchCaseList_dummy_108 SwitchCaseList tok_SwitchCaseList_dummy_108 { Ctr__Java__62 (rtkPosOf $1) (reverse $2) } |
+       tok_SwitchStatement_dummy_107 SwitchStatement tok_SwitchStatement_dummy_107 { Ctr__Java__63 (rtkPosOf $1) $2 } |
+       tok_TryStatement_dummy_106 TryStatement tok_TryStatement_dummy_106 { Ctr__Java__64 (rtkPosOf $1) $2 } |
+       tok_Type_dummy_105 Type tok_Type_dummy_105 { Ctr__Java__65 (rtkPosOf $1) $2 } |
+       tok_TypeArgument_dummy_104 TypeArgument tok_TypeArgument_dummy_104 { Ctr__Java__66 (rtkPosOf $1) $2 } |
+       tok_TypeArguments_dummy_103 TypeArguments tok_TypeArguments_dummy_103 { Ctr__Java__67 (rtkPosOf $1) $2 } |
+       tok_TypeDeclaration_dummy_102 TypeDeclaration tok_TypeDeclaration_dummy_102 { Ctr__Java__68 (rtkPosOf $1) $2 } |
+       tok_TypeParameter_dummy_101 TypeParameter tok_TypeParameter_dummy_101 { Ctr__Java__69 (rtkPosOf $1) $2 } |
+       tok_TypeParameters_dummy_100 TypeParameters tok_TypeParameters_dummy_100 { Ctr__Java__70 (rtkPosOf $1) $2 } |
+       tok_TypeSpecifier_dummy_99 TypeSpecifier tok_TypeSpecifier_dummy_99 { Ctr__Java__71 (rtkPosOf $1) $2 } |
+       tok_VariableDeclaration_dummy_98 VariableDeclaration tok_VariableDeclaration_dummy_98 { Ctr__Java__72 (rtkPosOf $1) $2 } |
+       tok_VariableDeclarator_dummy_97 VariableDeclarator tok_VariableDeclarator_dummy_97 { Ctr__Java__73 (rtkPosOf $1) $2 } |
+       tok_VariableDeclaratorList_dummy_96 VariableDeclaratorList tok_VariableDeclaratorList_dummy_96 { Ctr__Java__74 (rtkPosOf $1) $2 } |
+       tok_VariableInitializer_dummy_95 VariableInitializer tok_VariableInitializer_dummy_95 { Ctr__Java__75 (rtkPosOf $1) $2 } |
+       tok_VariableInitializerList_dummy_94 VariableInitializerList tok_VariableInitializerList_dummy_94 { Ctr__Java__76 (rtkPosOf $1) $2 } |
+       tok_WhileStatement_dummy_93 WhileStatement tok_WhileStatement_dummy_93 { Ctr__Java__77 (rtkPosOf $1) $2 } |
+       tok_WildcardType_dummy_92 WildcardType tok_WildcardType_dummy_92 { Ctr__Java__78 (rtkPosOf $1) $2 }
 
-Java : qq_Java { Anti_Java $1 } |
-       CompilationUnit { Ctr__Java__79 $1 }
+Java : qq_Java { Anti_Java (tkVal_qq_Java $1) } |
+       CompilationUnit { Ctr__Java__79 (rtkPosOf $1) $1 }
 
-AdditiveOp : qq_AdditiveOp { Anti_AdditiveOp $1 } |
-             tok__plus__72 { Ctr__AdditiveOp__0 } |
-             tok__minus__73 { Ctr__AdditiveOp__1 }
+AdditiveOp : qq_AdditiveOp { Anti_AdditiveOp (tkVal_qq_AdditiveOp $1) } |
+             tok__plus__72 { Ctr__AdditiveOp__0 (rtkPosOf $1) } |
+             tok__minus__73 { Ctr__AdditiveOp__1 (rtkPosOf $1) }
 
-ListElem_AnnotationList15 : qq_AnnotationList { Anti_Annotation $1 } |
+ListElem_AnnotationList15 : qq_AnnotationList { Anti_Annotation (tkVal_qq_AnnotationList $1) } |
                             Annotation { $1 }
 
-Annotation : qq_Annotation { Anti_Annotation $1 } |
-             tok__symbol__5 CompoundName Rule_10 { Ctr__Annotation__1 $2 $3 }
+Annotation : qq_Annotation { Anti_Annotation (tkVal_qq_Annotation $1) } |
+             tok__symbol__5 CompoundName Rule_10 { Ctr__Annotation__1 (rtkPosOf $1) $2 $3 }
 
-AnnotationArguments : qq_AnnotationArguments { Anti_AnnotationArguments $1 } |
-                      AnnotationElement Rule_13 { Ctr__AnnotationArguments__0 $1 (reverse $2) }
+AnnotationArguments : qq_AnnotationArguments { Anti_AnnotationArguments (tkVal_qq_AnnotationArguments $1) } |
+                      AnnotationElement Rule_13 { Ctr__AnnotationArguments__0 (rtkPosOf $1) $1 (reverse $2) }
 
-AnnotationDeclaration : qq_AnnotationDeclaration { Anti_AnnotationDeclaration $1 } |
-                        ModifierList tok__symbol__5 tok_interface_15 id tok__symbol__13 AnnotationTypeElementList tok__symbol__14 { Ctr__AnnotationDeclaration__0 (reverse $1) $4 (reverse $6) }
+AnnotationDeclaration : qq_AnnotationDeclaration { Anti_AnnotationDeclaration (tkVal_qq_AnnotationDeclaration $1) } |
+                        ModifierList tok__symbol__5 tok_interface_15 id tok__symbol__13 AnnotationTypeElementList tok__symbol__14 { Ctr__AnnotationDeclaration__0 (rtkPosOf (reverse $1)) (reverse $1) (tkVal_id $4) (reverse $6) }
 
-AnnotationElement : qq_AnnotationElement { Anti_AnnotationElement $1 } |
-                    id tok__eql__9 ConditionalExpression { Ctr__AnnotationElement__0 $1 $3 } |
-                    ConditionalExpression { Ctr__AnnotationElement__1 $1 }
+AnnotationElement : qq_AnnotationElement { Anti_AnnotationElement (tkVal_qq_AnnotationElement $1) } |
+                    id tok__eql__9 ConditionalExpression { Ctr__AnnotationElement__0 (rtkPosOf $1) (tkVal_id $1) $3 } |
+                    ConditionalExpression { Ctr__AnnotationElement__1 (rtkPosOf $1) $1 }
 
 AnnotationList : {- empty -} { [] } |
                  AnnotationList ListElem_AnnotationList15 { $2 : $1 }
 
-AnnotationTypeElement : qq_AnnotationTypeElement { Anti_AnnotationTypeElement $1 } |
-                        FieldDeclaration { Ctr__AnnotationTypeElement__0 $1 }
+AnnotationTypeElement : qq_AnnotationTypeElement { Anti_AnnotationTypeElement (tkVal_qq_AnnotationTypeElement $1) } |
+                        FieldDeclaration { Ctr__AnnotationTypeElement__0 (rtkPosOf $1) $1 }
 
-ListElem_AnnotationTypeElementList25 : qq_AnnotationTypeElementList { Anti_AnnotationTypeElement $1 } |
+ListElem_AnnotationTypeElementList25 : qq_AnnotationTypeElementList { Anti_AnnotationTypeElement (tkVal_qq_AnnotationTypeElementList $1) } |
                                        AnnotationTypeElement { $1 }
 
 AnnotationTypeElementList : {- empty -} { [] } |
                             AnnotationTypeElementList ListElem_AnnotationTypeElementList25 { $2 : $1 }
 
-Arglist : qq_Arglist { Anti_Arglist $1 } |
-          { Ctr__Arglist__0 } |
-          Rule_77 { Ctr__Arglist__1 $1 }
+Arglist : qq_Arglist { Anti_Arglist (tkVal_qq_Arglist $1) } |
+          { Ctr__Arglist__0 rtkNoPos } |
+          Rule_77 { Ctr__Arglist__1 (rtkPosOf $1) $1 }
 
-AssignmentOp : qq_AssignmentOp { Anti_AssignmentOp $1 } |
-               tok__eql__9 { Ctr__AssignmentOp__0 } |
-               tok__plus__eql__45 { Ctr__AssignmentOp__1 } |
-               tok__minus__eql__46 { Ctr__AssignmentOp__2 } |
-               tok__star__eql__47 { Ctr__AssignmentOp__3 } |
-               tok__symbol__eql__48 { Ctr__AssignmentOp__4 } |
-               tok__pipe__eql__49 { Ctr__AssignmentOp__5 } |
-               tok__symbol__eql__50 { Ctr__AssignmentOp__6 } |
-               tok__symbol__eql__51 { Ctr__AssignmentOp__7 } |
-               tok__symbol__eql__52 { Ctr__AssignmentOp__8 } |
-               tok__symbol__symbol__eql__53 { Ctr__AssignmentOp__9 } |
-               tok__symbol__symbol__eql__54 { Ctr__AssignmentOp__10 } |
-               tok__symbol__symbol__symbol__eql__55 { Ctr__AssignmentOp__11 }
+AssignmentOp : qq_AssignmentOp { Anti_AssignmentOp (tkVal_qq_AssignmentOp $1) } |
+               tok__eql__9 { Ctr__AssignmentOp__0 (rtkPosOf $1) } |
+               tok__plus__eql__45 { Ctr__AssignmentOp__1 (rtkPosOf $1) } |
+               tok__minus__eql__46 { Ctr__AssignmentOp__2 (rtkPosOf $1) } |
+               tok__star__eql__47 { Ctr__AssignmentOp__3 (rtkPosOf $1) } |
+               tok__symbol__eql__48 { Ctr__AssignmentOp__4 (rtkPosOf $1) } |
+               tok__pipe__eql__49 { Ctr__AssignmentOp__5 (rtkPosOf $1) } |
+               tok__symbol__eql__50 { Ctr__AssignmentOp__6 (rtkPosOf $1) } |
+               tok__symbol__eql__51 { Ctr__AssignmentOp__7 (rtkPosOf $1) } |
+               tok__symbol__eql__52 { Ctr__AssignmentOp__8 (rtkPosOf $1) } |
+               tok__symbol__symbol__eql__53 { Ctr__AssignmentOp__9 (rtkPosOf $1) } |
+               tok__symbol__symbol__eql__54 { Ctr__AssignmentOp__10 (rtkPosOf $1) } |
+               tok__symbol__symbol__symbol__eql__55 { Ctr__AssignmentOp__11 (rtkPosOf $1) }
 
 CatchList : {- empty -} { [] } |
             CatchList ListElem_CatchList64 { $2 : $1 }
 
-ClassDeclaration : qq_ClassDeclaration { Anti_ClassDeclaration $1 } |
-                   ModifierList tok_class_12 id TypeParameters Rule_22 Rule_23 tok__symbol__13 FieldDeclarationList tok__symbol__14 { Ctr__ClassDeclaration__0 (reverse $1) $3 $4 $5 $6 (reverse $8) }
+ClassDeclaration : qq_ClassDeclaration { Anti_ClassDeclaration (tkVal_qq_ClassDeclaration $1) } |
+                   ModifierList tok_class_12 id TypeParameters Rule_22 Rule_23 tok__symbol__13 FieldDeclarationList tok__symbol__14 { Ctr__ClassDeclaration__0 (rtkPosOf (reverse $1)) (reverse $1) (tkVal_id $3) $4 $5 $6 (reverse $8) }
 
-CompilationUnit : qq_CompilationUnit { Anti_CompilationUnit $1 } |
-                  Rule_4 ImportList Rule_6 { Ctr__CompilationUnit__0 $1 (reverse $2) $3 }
+CompilationUnit : qq_CompilationUnit { Anti_CompilationUnit (tkVal_qq_CompilationUnit $1) } |
+                  Rule_4 ImportList Rule_6 { Ctr__CompilationUnit__0 (rtkPosOf $1) $1 (reverse $2) $3 }
 
-CompoundName : qq_CompoundName { Anti_CompoundName $1 } |
-               id Rule_90 { Ctr__CompoundName__0 $1 (reverse $2) }
+CompoundName : qq_CompoundName { Anti_CompoundName (tkVal_qq_CompoundName $1) } |
+               id Rule_90 { Ctr__CompoundName__0 (rtkPosOf $1) (tkVal_id $1) (reverse $2) }
 
-CreationExpression : qq_CreationExpression { Anti_CreationExpression $1 } |
-                     tok_new_82 Type Rule_76 { Ctr__CreationExpression__0 $2 $3 }
+CreationExpression : qq_CreationExpression { Anti_CreationExpression (tkVal_qq_CreationExpression $1) } |
+                     tok_new_82 Type Rule_76 { Ctr__CreationExpression__0 (rtkPosOf $1) $2 $3 }
 
-DoStatement : qq_DoStatement { Anti_DoStatement $1 } |
-              tok_do_37 Statement tok_while_38 tok__lparen__6 Expression tok__rparen__7 tok__semi__1 { Ctr__DoStatement__0 $2 $5 }
+DoStatement : qq_DoStatement { Anti_DoStatement (tkVal_qq_DoStatement $1) } |
+              tok_do_37 Statement tok_while_38 tok__lparen__6 Expression tok__rparen__7 tok__semi__1 { Ctr__DoStatement__0 (rtkPosOf $1) $2 $5 }
 
-DocComment : qq_DocComment { Anti_DocComment $1 } |
-             doccomment { Ctr__DocComment__0 $1 }
+DocComment : qq_DocComment { Anti_DocComment (tkVal_qq_DocComment $1) } |
+             doccomment { Ctr__DocComment__0 (rtkPosOf $1) (tkVal_doccomment $1) }
 
-EnumConstant : qq_EnumConstant { Anti_EnumConstant $1 } |
-               AnnotationList id Rule_26 Rule_28 { Ctr__EnumConstant__0 (reverse $1) $2 $3 $4 }
+EnumConstant : qq_EnumConstant { Anti_EnumConstant (tkVal_qq_EnumConstant $1) } |
+               AnnotationList id Rule_26 Rule_28 { Ctr__EnumConstant__0 (rtkPosOf (reverse $1)) (reverse $1) (tkVal_id $2) $3 $4 }
 
-EnumConstantList : qq_EnumConstantList { Anti_EnumConstantList $1 } |
-                   EnumConstant Rule_30 Rule_32 { Ctr__EnumConstantList__0 $1 (reverse $2) $3 }
+EnumConstantList : qq_EnumConstantList { Anti_EnumConstantList (tkVal_qq_EnumConstantList $1) } |
+                   EnumConstant Rule_30 Rule_32 { Ctr__EnumConstantList__0 (rtkPosOf $1) $1 (reverse $2) $3 }
 
-EnumDeclaration : qq_EnumDeclaration { Anti_EnumDeclaration $1 } |
-                  ModifierList tok_enum_16 id Rule_34 tok__symbol__13 EnumConstantList Rule_35 tok__symbol__14 { Ctr__EnumDeclaration__0 (reverse $1) $3 $4 $6 $7 }
+EnumDeclaration : qq_EnumDeclaration { Anti_EnumDeclaration (tkVal_qq_EnumDeclaration $1) } |
+                  ModifierList tok_enum_16 id Rule_34 tok__symbol__13 EnumConstantList Rule_35 tok__symbol__14 { Ctr__EnumDeclaration__0 (rtkPosOf (reverse $1)) (reverse $1) (tkVal_id $3) $4 $6 $7 }
 
-EqualityOp : qq_EqualityOp { Anti_EqualityOp $1 } |
-             tok__eql__eql__62 { Ctr__EqualityOp__0 } |
-             tok__exclamation__eql__63 { Ctr__EqualityOp__1 }
+EqualityOp : qq_EqualityOp { Anti_EqualityOp (tkVal_qq_EqualityOp $1) } |
+             tok__eql__eql__62 { Ctr__EqualityOp__0 (rtkPosOf $1) } |
+             tok__exclamation__eql__63 { Ctr__EqualityOp__1 (rtkPosOf $1) }
 
-PrimaryNoPostfix : qq_Expression { Anti_Expression $1 } |
-                   Literal { Ctr__Expression__0 $1 } |
-                   tok_this_80 { Ctr__Expression__1 } |
-                   tok__lparen__6 Expression tok__rparen__7 { Ctr__Expression__2 $2 } |
-                   CreationExpression { Ctr__Expression__3 $1 } |
-                   CompoundName Rule_72 { Ctr__Expression__4 $1 $2 } |
-                   tok_super_81 tok__dot__3 id Rule_74 { Ctr__Expression__5 $3 $4 }
+PrimaryNoPostfix : qq_Expression { Anti_Expression (tkVal_qq_Expression $1) } |
+                   Literal { Ctr__Expression__0 (rtkPosOf $1) $1 } |
+                   tok_this_80 { Ctr__Expression__1 (rtkPosOf $1) } |
+                   tok__lparen__6 Expression tok__rparen__7 { Ctr__Expression__2 (rtkPosOf $1) $2 } |
+                   CreationExpression { Ctr__Expression__3 (rtkPosOf $1) $1 } |
+                   CompoundName Rule_72 { Ctr__Expression__4 (rtkPosOf $1) $1 $2 } |
+                   tok_super_81 tok__dot__3 id Rule_74 { Ctr__Expression__5 (rtkPosOf $1) (tkVal_id $3) $4 }
 
-PostfixExpression : PrimaryNoPostfix { Ctr__Expression__6 $1 } |
-                    PostfixExpression PostfixOp { Ctr__Expression__7 $1 $2 } |
-                    PostfixExpression tok__dot__3 id { Ctr__Expression__8 $1 $3 } |
-                    PostfixExpression tok__dot__3 id tok__lparen__6 Arglist tok__rparen__7 { Ctr__Expression__9 $1 $3 $5 } |
-                    PostfixExpression tok__sq_bkt_l__17 Expression tok__sq_bkt_r__18 { Ctr__Expression__10 $1 $3 }
+PostfixExpression : PrimaryNoPostfix { Ctr__Expression__6 (rtkPosOf $1) $1 } |
+                    PostfixExpression PostfixOp { Ctr__Expression__7 (rtkPosOf $1) $1 $2 } |
+                    PostfixExpression tok__dot__3 id { Ctr__Expression__8 (rtkPosOf $1) $1 (tkVal_id $3) } |
+                    PostfixExpression tok__dot__3 id tok__lparen__6 Arglist tok__rparen__7 { Ctr__Expression__9 (rtkPosOf $1) $1 (tkVal_id $3) $5 } |
+                    PostfixExpression tok__sq_bkt_l__17 Expression tok__sq_bkt_r__18 { Ctr__Expression__10 (rtkPosOf $1) $1 $3 }
 
-UnaryExpressionNotPlusMinus : PostfixExpression { Ctr__Expression__11 $1 } |
-                              tok__tilde__78 UnaryExpression { Ctr__Expression__12 $2 } |
-                              tok__exclamation__79 UnaryExpression { Ctr__Expression__13 $2 } |
-                              CastExpression { Ctr__Expression__14 $1 }
+UnaryExpressionNotPlusMinus : PostfixExpression { Ctr__Expression__11 (rtkPosOf $1) $1 } |
+                              tok__tilde__78 UnaryExpression { Ctr__Expression__12 (rtkPosOf $1) $2 } |
+                              tok__exclamation__79 UnaryExpression { Ctr__Expression__13 (rtkPosOf $1) $2 } |
+                              CastExpression { Ctr__Expression__14 (rtkPosOf $1) $1 }
 
-UnaryExpression : PrefixOp UnaryExpression { Ctr__Expression__15 $1 $2 } |
-                  UnaryExpressionNotPlusMinus { Ctr__Expression__16 $1 }
+UnaryExpression : PrefixOp UnaryExpression { Ctr__Expression__15 (rtkPosOf $1) $1 $2 } |
+                  UnaryExpressionNotPlusMinus { Ctr__Expression__16 (rtkPosOf $1) $1 }
 
-CastExpression : tok__lparen__6 Type tok__rparen__7 UnaryExpression { Ctr__Expression__17 $2 $4 }
+CastExpression : tok__lparen__6 Type tok__rparen__7 UnaryExpression { Ctr__Expression__17 (rtkPosOf $1) $2 $4 }
 
-MultiplicativeExpression : UnaryExpression { Ctr__Expression__18 $1 } |
-                           MultiplicativeExpression MultiplicativeOp UnaryExpression { Ctr__Expression__19 $1 $2 $3 }
+MultiplicativeExpression : UnaryExpression { Ctr__Expression__18 (rtkPosOf $1) $1 } |
+                           MultiplicativeExpression MultiplicativeOp UnaryExpression { Ctr__Expression__19 (rtkPosOf $1) $1 $2 $3 }
 
-AdditiveExpression : MultiplicativeExpression { Ctr__Expression__20 $1 } |
-                     AdditiveExpression AdditiveOp MultiplicativeExpression { Ctr__Expression__21 $1 $2 $3 }
+AdditiveExpression : MultiplicativeExpression { Ctr__Expression__20 (rtkPosOf $1) $1 } |
+                     AdditiveExpression AdditiveOp MultiplicativeExpression { Ctr__Expression__21 (rtkPosOf $1) $1 $2 $3 }
 
-ShiftExpression : AdditiveExpression { Ctr__Expression__22 $1 } |
-                  ShiftExpression ShiftOp AdditiveExpression { Ctr__Expression__23 $1 $2 $3 }
+ShiftExpression : AdditiveExpression { Ctr__Expression__22 (rtkPosOf $1) $1 } |
+                  ShiftExpression ShiftOp AdditiveExpression { Ctr__Expression__23 (rtkPosOf $1) $1 $2 $3 }
 
-RelationalExpression : ShiftExpression { Ctr__Expression__24 $1 } |
-                       RelationalExpression RelationalOp ShiftExpression { Ctr__Expression__25 $1 $2 $3 } |
-                       RelationalExpression tok_instanceof_68 Type { Ctr__Expression__26 $1 $3 }
+RelationalExpression : ShiftExpression { Ctr__Expression__24 (rtkPosOf $1) $1 } |
+                       RelationalExpression RelationalOp ShiftExpression { Ctr__Expression__25 (rtkPosOf $1) $1 $2 $3 } |
+                       RelationalExpression tok_instanceof_68 Type { Ctr__Expression__26 (rtkPosOf $1) $1 $3 }
 
-EqualityExpression : RelationalExpression { Ctr__Expression__27 $1 } |
-                     EqualityExpression EqualityOp RelationalExpression { Ctr__Expression__28 $1 $2 $3 }
+EqualityExpression : RelationalExpression { Ctr__Expression__27 (rtkPosOf $1) $1 } |
+                     EqualityExpression EqualityOp RelationalExpression { Ctr__Expression__28 (rtkPosOf $1) $1 $2 $3 }
 
-AndExpression : EqualityExpression { Ctr__Expression__29 $1 } |
-                AndExpression tok__symbol__61 EqualityExpression { Ctr__Expression__30 $1 $3 }
+AndExpression : EqualityExpression { Ctr__Expression__29 (rtkPosOf $1) $1 } |
+                AndExpression tok__symbol__61 EqualityExpression { Ctr__Expression__30 (rtkPosOf $1) $1 $3 }
 
-ExclusiveOrExpression : AndExpression { Ctr__Expression__31 $1 } |
-                        ExclusiveOrExpression tok__symbol__60 AndExpression { Ctr__Expression__32 $1 $3 }
+ExclusiveOrExpression : AndExpression { Ctr__Expression__31 (rtkPosOf $1) $1 } |
+                        ExclusiveOrExpression tok__symbol__60 AndExpression { Ctr__Expression__32 (rtkPosOf $1) $1 $3 }
 
-InclusiveOrEpression : ExclusiveOrExpression { Ctr__Expression__33 $1 } |
-                       InclusiveOrEpression tok__pipe__59 ExclusiveOrExpression { Ctr__Expression__34 $1 $3 }
+InclusiveOrEpression : ExclusiveOrExpression { Ctr__Expression__33 (rtkPosOf $1) $1 } |
+                       InclusiveOrEpression tok__pipe__59 ExclusiveOrExpression { Ctr__Expression__34 (rtkPosOf $1) $1 $3 }
 
-ConditionalAndExpression : InclusiveOrEpression { Ctr__Expression__35 $1 } |
-                           ConditionalAndExpression tok__symbol__symbol__58 InclusiveOrEpression { Ctr__Expression__36 $1 $3 }
+ConditionalAndExpression : InclusiveOrEpression { Ctr__Expression__35 (rtkPosOf $1) $1 } |
+                           ConditionalAndExpression tok__symbol__symbol__58 InclusiveOrEpression { Ctr__Expression__36 (rtkPosOf $1) $1 $3 }
 
-ConditionalOrExpression : ConditionalAndExpression { Ctr__Expression__37 $1 } |
-                          ConditionalOrExpression tok__pipe__pipe__57 ConditionalAndExpression { Ctr__Expression__38 $1 $3 }
+ConditionalOrExpression : ConditionalAndExpression { Ctr__Expression__37 (rtkPosOf $1) $1 } |
+                          ConditionalOrExpression tok__pipe__pipe__57 ConditionalAndExpression { Ctr__Expression__38 (rtkPosOf $1) $1 $3 }
 
-ConditionalExpression : ConditionalOrExpression { Ctr__Expression__39 $1 } |
-                        ConditionalOrExpression tok__symbol__56 Expression tok__colon__32 ConditionalExpression { Ctr__Expression__40 $1 $3 $5 }
+ConditionalExpression : ConditionalOrExpression { Ctr__Expression__39 (rtkPosOf $1) $1 } |
+                        ConditionalOrExpression tok__symbol__56 Expression tok__colon__32 ConditionalExpression { Ctr__Expression__40 (rtkPosOf $1) $1 $3 $5 }
 
-AssignmentExpression : ConditionalExpression Rule_70 { Ctr__Expression__41 $1 $2 }
+AssignmentExpression : ConditionalExpression Rule_70 { Ctr__Expression__41 (rtkPosOf $1) $1 $2 }
 
-Expression : AssignmentExpression { Ctr__Expression__42 $1 }
+Expression : AssignmentExpression { Ctr__Expression__42 (rtkPosOf $1) $1 }
 
-ExtendsList : qq_ExtendsList { Anti_ExtendsList $1 } |
-              tok_extends_10 CompoundName Rule_18 { Ctr__ExtendsList__0 $2 (reverse $3) }
+ExtendsList : qq_ExtendsList { Anti_ExtendsList (tkVal_qq_ExtendsList $1) } |
+              tok_extends_10 CompoundName Rule_18 { Ctr__ExtendsList__0 (rtkPosOf $1) $2 (reverse $3) }
 
-FieldDeclaration : qq_FieldDeclaration { Anti_FieldDeclaration $1 } |
-                   OptDocComment Rule_37 { Ctr__FieldDeclaration__0 $1 $2 } |
-                   tok__semi__1 { Ctr__FieldDeclaration__1 }
+FieldDeclaration : qq_FieldDeclaration { Anti_FieldDeclaration (tkVal_qq_FieldDeclaration $1) } |
+                   OptDocComment Rule_37 { Ctr__FieldDeclaration__0 (rtkPosOf $1) $1 $2 } |
+                   tok__semi__1 { Ctr__FieldDeclaration__1 (rtkPosOf $1) }
 
-ListElem_FieldDeclarationList21 : qq_FieldDeclarationList { Anti_FieldDeclaration $1 } |
+ListElem_FieldDeclarationList21 : qq_FieldDeclarationList { Anti_FieldDeclaration (tkVal_qq_FieldDeclarationList $1) } |
                                   FieldDeclaration { $1 }
 
 FieldDeclarationList : {- empty -} { [] } |
                        FieldDeclarationList ListElem_FieldDeclarationList21 { $2 : $1 }
 
-ForStatement : qq_ForStatement { Anti_ForStatement $1 } |
-               tok_for_39 tok__lparen__6 Rule_61 OptExpression tok__semi__1 OptExpression tok__rparen__7 Statement { Ctr__ForStatement__0 $3 $4 $6 $8 }
+ForStatement : qq_ForStatement { Anti_ForStatement (tkVal_qq_ForStatement $1) } |
+               tok_for_39 tok__lparen__6 Rule_61 OptExpression tok__semi__1 OptExpression tok__rparen__7 Statement { Ctr__ForStatement__0 (rtkPosOf $1) $3 $4 $6 $8 }
 
-IfStatement : qq_IfStatement { Anti_IfStatement $1 } |
-              tok_if_36 tok__lparen__6 Expression tok__rparen__7 StatementWithoutIf OptElsePart { Ctr__IfStatement__0 $3 $5 $6 }
+IfStatement : qq_IfStatement { Anti_IfStatement (tkVal_qq_IfStatement $1) } |
+              tok_if_36 tok__lparen__6 Expression tok__rparen__7 StatementWithoutIf OptElsePart { Ctr__IfStatement__0 (rtkPosOf $1) $3 $5 $6 }
 
-ImplementsList : qq_ImplementsList { Anti_ImplementsList $1 } |
-                 tok_implements_11 Rule_20 { Ctr__ImplementsList__0 (reverse $2) }
+ImplementsList : qq_ImplementsList { Anti_ImplementsList (tkVal_qq_ImplementsList $1) } |
+                 tok_implements_11 Rule_20 { Ctr__ImplementsList__0 (rtkPosOf $1) (reverse $2) }
 
 ImportList : {- empty -} { [] } |
              ImportList ListElem_ImportList3 { $2 : $1 }
 
-ImportStatement : qq_ImportStatement { Anti_ImportStatement $1 } |
-                  tok_import_2 Rule_8 tok__semi__1 { Ctr__ImportStatement__0 $2 }
+ImportStatement : qq_ImportStatement { Anti_ImportStatement (tkVal_qq_ImportStatement $1) } |
+                  tok_import_2 Rule_8 tok__semi__1 { Ctr__ImportStatement__0 (rtkPosOf $1) $2 }
 
-InterfaceDeclaration : qq_InterfaceDeclaration { Anti_InterfaceDeclaration $1 } |
-                       ModifierList tok_interface_15 id TypeParameters Rule_24 tok__symbol__13 FieldDeclarationList tok__symbol__14 { Ctr__InterfaceDeclaration__0 (reverse $1) $3 $4 $5 (reverse $7) }
+InterfaceDeclaration : qq_InterfaceDeclaration { Anti_InterfaceDeclaration (tkVal_qq_InterfaceDeclaration $1) } |
+                       ModifierList tok_interface_15 id TypeParameters Rule_24 tok__symbol__13 FieldDeclarationList tok__symbol__14 { Ctr__InterfaceDeclaration__0 (rtkPosOf (reverse $1)) (reverse $1) (tkVal_id $3) $4 $5 (reverse $7) }
 
-Literal : qq_Literal { Anti_Literal $1 } |
-          integerLiteral { Ctr__Literal__0 $1 } |
-          floatLiteral { Ctr__Literal__1 $1 } |
-          tok_true_83 { Ctr__Literal__2 } |
-          tok_false_84 { Ctr__Literal__3 } |
-          char { Ctr__Literal__4 $1 } |
-          string { Ctr__Literal__5 $1 } |
-          tok_null_85 { Ctr__Literal__6 }
+Literal : qq_Literal { Anti_Literal (tkVal_qq_Literal $1) } |
+          integerLiteral { Ctr__Literal__0 (rtkPosOf $1) (tkVal_integerLiteral $1) } |
+          floatLiteral { Ctr__Literal__1 (rtkPosOf $1) (tkVal_floatLiteral $1) } |
+          tok_true_83 { Ctr__Literal__2 (rtkPosOf $1) } |
+          tok_false_84 { Ctr__Literal__3 (rtkPosOf $1) } |
+          char { Ctr__Literal__4 (rtkPosOf $1) (tkVal_char $1) } |
+          string { Ctr__Literal__5 (rtkPosOf $1) (tkVal_string $1) } |
+          tok_null_85 { Ctr__Literal__6 (rtkPosOf $1) }
 
-MemberAfterFirstId : qq_MemberAfterFirstId { Anti_MemberAfterFirstId $1 } |
-                     tok__lparen__6 Rule_42 tok__rparen__7 StatementBlock { Ctr__MemberAfterFirstId__0 $2 $4 } |
-                     MoreTypeSpecifier id MemberRest { Ctr__MemberAfterFirstId__1 $1 $2 $3 }
+MemberAfterFirstId : qq_MemberAfterFirstId { Anti_MemberAfterFirstId (tkVal_qq_MemberAfterFirstId $1) } |
+                     tok__lparen__6 Rule_42 tok__rparen__7 StatementBlock { Ctr__MemberAfterFirstId__0 (rtkPosOf $1) $2 $4 } |
+                     MoreTypeSpecifier id MemberRest { Ctr__MemberAfterFirstId__1 (rtkPosOf $1) $1 (tkVal_id $2) $3 }
 
-MemberDeclaration : qq_MemberDeclaration { Anti_MemberDeclaration $1 } |
-                    PrimitiveTypeKeyword SquareBracketsList id MemberRest { Ctr__MemberDeclaration__0 $1 (reverse $2) $3 $4 } |
-                    TypeParameters id MoreTypeSpecifier id MemberRest { Ctr__MemberDeclaration__1 $1 $2 $3 $4 $5 } |
-                    id MemberAfterFirstId { Ctr__MemberDeclaration__2 $1 $2 }
+MemberDeclaration : qq_MemberDeclaration { Anti_MemberDeclaration (tkVal_qq_MemberDeclaration $1) } |
+                    PrimitiveTypeKeyword SquareBracketsList id MemberRest { Ctr__MemberDeclaration__0 (rtkPosOf $1) $1 (reverse $2) (tkVal_id $3) $4 } |
+                    TypeParameters id MoreTypeSpecifier id MemberRest { Ctr__MemberDeclaration__1 (rtkPosOf $1) $1 (tkVal_id $2) $3 (tkVal_id $4) $5 } |
+                    id MemberAfterFirstId { Ctr__MemberDeclaration__2 (rtkPosOf $1) (tkVal_id $1) $2 }
 
-MemberRest : qq_MemberRest { Anti_MemberRest $1 } |
-             tok__lparen__6 Rule_43 tok__rparen__7 SquareBracketsList Rule_44 { Ctr__MemberRest__0 $2 (reverse $4) $5 } |
-             SquareBracketsList OptVariableInitializer MoreVariableDeclarators tok__semi__1 { Ctr__MemberRest__1 (reverse $1) $2 (reverse $3) }
+MemberRest : qq_MemberRest { Anti_MemberRest (tkVal_qq_MemberRest $1) } |
+             tok__lparen__6 Rule_43 tok__rparen__7 SquareBracketsList Rule_44 { Ctr__MemberRest__0 (rtkPosOf $1) $2 (reverse $4) $5 } |
+             SquareBracketsList OptVariableInitializer MoreVariableDeclarators tok__semi__1 { Ctr__MemberRest__1 (rtkPosOf (reverse $1)) (reverse $1) $2 (reverse $3) }
 
-Modifier : qq_Modifier { Anti_Modifier $1 } |
-           tok_public_86 { Ctr__Modifier__0 } |
-           tok_private_87 { Ctr__Modifier__1 } |
-           tok_protected_88 { Ctr__Modifier__2 } |
-           tok_static_89 { Ctr__Modifier__3 } |
-           tok_final_90 { Ctr__Modifier__4 } |
-           tok_native_91 { Ctr__Modifier__5 } |
-           tok_synchronized_30 { Ctr__Modifier__6 } |
-           tok_abstract_92 { Ctr__Modifier__7 } |
-           tok_threadsafe_93 { Ctr__Modifier__8 } |
-           tok_transient_94 { Ctr__Modifier__9 }
+Modifier : qq_Modifier { Anti_Modifier (tkVal_qq_Modifier $1) } |
+           tok_public_86 { Ctr__Modifier__0 (rtkPosOf $1) } |
+           tok_private_87 { Ctr__Modifier__1 (rtkPosOf $1) } |
+           tok_protected_88 { Ctr__Modifier__2 (rtkPosOf $1) } |
+           tok_static_89 { Ctr__Modifier__3 (rtkPosOf $1) } |
+           tok_final_90 { Ctr__Modifier__4 (rtkPosOf $1) } |
+           tok_native_91 { Ctr__Modifier__5 (rtkPosOf $1) } |
+           tok_synchronized_30 { Ctr__Modifier__6 (rtkPosOf $1) } |
+           tok_abstract_92 { Ctr__Modifier__7 (rtkPosOf $1) } |
+           tok_threadsafe_93 { Ctr__Modifier__8 (rtkPosOf $1) } |
+           tok_transient_94 { Ctr__Modifier__9 (rtkPosOf $1) }
 
 ModifierList : {- empty -} { [] } |
                ModifierList ListElem_ModifierList17 { $2 : $1 }
 
-MoreTypeSpecifier : qq_MoreTypeSpecifier { Anti_MoreTypeSpecifier $1 } |
-                    tok__dot__3 id MoreTypeSpecifier { Ctr__MoreTypeSpecifier__0 $2 $3 } |
-                    TypeArguments SquareBracketsList { Ctr__MoreTypeSpecifier__1 $1 (reverse $2) }
+MoreTypeSpecifier : qq_MoreTypeSpecifier { Anti_MoreTypeSpecifier (tkVal_qq_MoreTypeSpecifier $1) } |
+                    tok__dot__3 id MoreTypeSpecifier { Ctr__MoreTypeSpecifier__0 (rtkPosOf $1) (tkVal_id $2) $3 } |
+                    TypeArguments SquareBracketsList { Ctr__MoreTypeSpecifier__1 (rtkPosOf $1) $1 (reverse $2) }
 
 MoreVariableDeclarators : {- empty -} { [] } |
                           MoreVariableDeclarators ListElem_MoreVariableDeclarators48 { $2 : $1 }
 
-MultiplicativeOp : qq_MultiplicativeOp { Anti_MultiplicativeOp $1 } |
-                   tok__star__4 { Ctr__MultiplicativeOp__0 } |
-                   tok__symbol__74 { Ctr__MultiplicativeOp__1 } |
-                   tok__symbol__75 { Ctr__MultiplicativeOp__2 }
+MultiplicativeOp : qq_MultiplicativeOp { Anti_MultiplicativeOp (tkVal_qq_MultiplicativeOp $1) } |
+                   tok__star__4 { Ctr__MultiplicativeOp__0 (rtkPosOf $1) } |
+                   tok__symbol__74 { Ctr__MultiplicativeOp__1 (rtkPosOf $1) } |
+                   tok__symbol__75 { Ctr__MultiplicativeOp__2 (rtkPosOf $1) }
 
-NestedTypeDeclaration : qq_NestedTypeDeclaration { Anti_NestedTypeDeclaration $1 } |
-                        ClassDeclaration { Ctr__NestedTypeDeclaration__0 $1 } |
-                        InterfaceDeclaration { Ctr__NestedTypeDeclaration__1 $1 } |
-                        EnumDeclaration { Ctr__NestedTypeDeclaration__2 $1 } |
-                        AnnotationDeclaration { Ctr__NestedTypeDeclaration__3 $1 }
+NestedTypeDeclaration : qq_NestedTypeDeclaration { Anti_NestedTypeDeclaration (tkVal_qq_NestedTypeDeclaration $1) } |
+                        ClassDeclaration { Ctr__NestedTypeDeclaration__0 (rtkPosOf $1) $1 } |
+                        InterfaceDeclaration { Ctr__NestedTypeDeclaration__1 (rtkPosOf $1) $1 } |
+                        EnumDeclaration { Ctr__NestedTypeDeclaration__2 (rtkPosOf $1) $1 } |
+                        AnnotationDeclaration { Ctr__NestedTypeDeclaration__3 (rtkPosOf $1) $1 }
 
-OptDocComment : qq_OptDocComment { Anti_OptDocComment $1 } |
-                { Ctr__OptDocComment__0 } |
-                Rule_0 { Ctr__OptDocComment__1 $1 }
+OptDocComment : qq_OptDocComment { Anti_OptDocComment (tkVal_qq_OptDocComment $1) } |
+                { Ctr__OptDocComment__0 rtkNoPos } |
+                Rule_0 { Ctr__OptDocComment__1 (rtkPosOf $1) $1 }
 
-OptElsePart : qq_OptElsePart { Anti_OptElsePart $1 } |
-              { Ctr__OptElsePart__0 } |
-              Rule_60 { Ctr__OptElsePart__1 $1 }
+OptElsePart : qq_OptElsePart { Anti_OptElsePart (tkVal_qq_OptElsePart $1) } |
+              { Ctr__OptElsePart__0 rtkNoPos } |
+              Rule_60 { Ctr__OptElsePart__1 (rtkPosOf $1) $1 }
 
-OptExpression : qq_OptExpression { Anti_OptExpression $1 } |
-                { Ctr__OptExpression__0 } |
-                Expression { Ctr__OptExpression__1 $1 }
+OptExpression : qq_OptExpression { Anti_OptExpression (tkVal_qq_OptExpression $1) } |
+                { Ctr__OptExpression__0 rtkNoPos } |
+                Expression { Ctr__OptExpression__1 (rtkPosOf $1) $1 }
 
-OptFinally : qq_OptFinally { Anti_OptFinally $1 } |
-             { Ctr__OptFinally__0 } |
-             Rule_65 { Ctr__OptFinally__1 $1 }
+OptFinally : qq_OptFinally { Anti_OptFinally (tkVal_qq_OptFinally $1) } |
+             { Ctr__OptFinally__0 rtkNoPos } |
+             Rule_65 { Ctr__OptFinally__1 (rtkPosOf $1) $1 }
 
-OptId : qq_OptId { Anti_OptId $1 } |
-        { Ctr__OptId__0 } |
-        id { Ctr__OptId__1 $1 }
+OptId : qq_OptId { Anti_OptId (tkVal_qq_OptId $1) } |
+        { Ctr__OptId__0 rtkNoPos } |
+        id { Ctr__OptId__1 (rtkPosOf $1) (tkVal_id $1) }
 
-OptVariableInitializer : qq_OptVariableInitializer { Anti_OptVariableInitializer $1 } |
-                         { Ctr__OptVariableInitializer__0 } |
-                         Rule_51 { Ctr__OptVariableInitializer__1 $1 }
+OptVariableInitializer : qq_OptVariableInitializer { Anti_OptVariableInitializer (tkVal_qq_OptVariableInitializer $1) } |
+                         { Ctr__OptVariableInitializer__0 rtkNoPos } |
+                         Rule_51 { Ctr__OptVariableInitializer__1 (rtkPosOf $1) $1 }
 
-Package : qq_Package { Anti_Package $1 } |
-          tok_package_0 CompoundName tok__semi__1 { Ctr__Package__0 $2 }
+Package : qq_Package { Anti_Package (tkVal_qq_Package $1) } |
+          tok_package_0 CompoundName tok__semi__1 { Ctr__Package__0 (rtkPosOf $1) $2 }
 
-Parameter : qq_Parameter { Anti_Parameter $1 } |
-            Type id SquareBracketsList { Ctr__Parameter__0 $1 $2 (reverse $3) }
+Parameter : qq_Parameter { Anti_Parameter (tkVal_qq_Parameter $1) } |
+            Type id SquareBracketsList { Ctr__Parameter__0 (rtkPosOf $1) $1 (tkVal_id $2) (reverse $3) }
 
-ParameterList : qq_ParameterList { Anti_ParameterList $1 } |
-                Parameter Rule_57 { Ctr__ParameterList__0 $1 (reverse $2) }
+ParameterList : qq_ParameterList { Anti_ParameterList (tkVal_qq_ParameterList $1) } |
+                Parameter Rule_57 { Ctr__ParameterList__0 (rtkPosOf $1) $1 (reverse $2) }
 
-PostfixOp : qq_PostfixOp { Anti_PostfixOp $1 } |
-            tok__plus__plus__76 { Ctr__PostfixOp__0 } |
-            tok__minus__minus__77 { Ctr__PostfixOp__1 }
+PostfixOp : qq_PostfixOp { Anti_PostfixOp (tkVal_qq_PostfixOp $1) } |
+            tok__plus__plus__76 { Ctr__PostfixOp__0 (rtkPosOf $1) } |
+            tok__minus__minus__77 { Ctr__PostfixOp__1 (rtkPosOf $1) }
 
-PrefixOp : qq_PrefixOp { Anti_PrefixOp $1 } |
-           tok__plus__plus__76 { Ctr__PrefixOp__0 } |
-           tok__minus__minus__77 { Ctr__PrefixOp__1 } |
-           tok__plus__72 { Ctr__PrefixOp__2 } |
-           tok__minus__73 { Ctr__PrefixOp__3 }
+PrefixOp : qq_PrefixOp { Anti_PrefixOp (tkVal_qq_PrefixOp $1) } |
+           tok__plus__plus__76 { Ctr__PrefixOp__0 (rtkPosOf $1) } |
+           tok__minus__minus__77 { Ctr__PrefixOp__1 (rtkPosOf $1) } |
+           tok__plus__72 { Ctr__PrefixOp__2 (rtkPosOf $1) } |
+           tok__minus__73 { Ctr__PrefixOp__3 (rtkPosOf $1) }
 
-PrimitiveTypeKeyword : qq_PrimitiveTypeKeyword { Anti_PrimitiveTypeKeyword $1 } |
-                       tok_boolean_19 { Ctr__PrimitiveTypeKeyword__0 } |
-                       tok_byte_20 { Ctr__PrimitiveTypeKeyword__1 } |
-                       tok_char_21 { Ctr__PrimitiveTypeKeyword__2 } |
-                       tok_short_22 { Ctr__PrimitiveTypeKeyword__3 } |
-                       tok_int_23 { Ctr__PrimitiveTypeKeyword__4 } |
-                       tok_float_24 { Ctr__PrimitiveTypeKeyword__5 } |
-                       tok_long_25 { Ctr__PrimitiveTypeKeyword__6 } |
-                       tok_double_26 { Ctr__PrimitiveTypeKeyword__7 } |
-                       tok_void_27 { Ctr__PrimitiveTypeKeyword__8 }
+PrimitiveTypeKeyword : qq_PrimitiveTypeKeyword { Anti_PrimitiveTypeKeyword (tkVal_qq_PrimitiveTypeKeyword $1) } |
+                       tok_boolean_19 { Ctr__PrimitiveTypeKeyword__0 (rtkPosOf $1) } |
+                       tok_byte_20 { Ctr__PrimitiveTypeKeyword__1 (rtkPosOf $1) } |
+                       tok_char_21 { Ctr__PrimitiveTypeKeyword__2 (rtkPosOf $1) } |
+                       tok_short_22 { Ctr__PrimitiveTypeKeyword__3 (rtkPosOf $1) } |
+                       tok_int_23 { Ctr__PrimitiveTypeKeyword__4 (rtkPosOf $1) } |
+                       tok_float_24 { Ctr__PrimitiveTypeKeyword__5 (rtkPosOf $1) } |
+                       tok_long_25 { Ctr__PrimitiveTypeKeyword__6 (rtkPosOf $1) } |
+                       tok_double_26 { Ctr__PrimitiveTypeKeyword__7 (rtkPosOf $1) } |
+                       tok_void_27 { Ctr__PrimitiveTypeKeyword__8 (rtkPosOf $1) }
 
-RelationalOp : qq_RelationalOp { Anti_RelationalOp $1 } |
-               tok__symbol__64 { Ctr__RelationalOp__0 } |
-               tok__symbol__65 { Ctr__RelationalOp__1 } |
-               tok__symbol__eql__66 { Ctr__RelationalOp__2 } |
-               tok__symbol__eql__67 { Ctr__RelationalOp__3 }
+RelationalOp : qq_RelationalOp { Anti_RelationalOp (tkVal_qq_RelationalOp $1) } |
+               tok__symbol__64 { Ctr__RelationalOp__0 (rtkPosOf $1) } |
+               tok__symbol__65 { Ctr__RelationalOp__1 (rtkPosOf $1) } |
+               tok__symbol__eql__66 { Ctr__RelationalOp__2 (rtkPosOf $1) } |
+               tok__symbol__eql__67 { Ctr__RelationalOp__3 (rtkPosOf $1) }
 
-Rule_0 : DocComment { Ctr__Rule_0__0 $1 }
+Rule_0 : DocComment { Ctr__Rule_0__0 (rtkPosOf $1) $1 }
 
-Rule_1 : ClassDeclaration { Ctr__Rule_1__0 $1 } |
-         InterfaceDeclaration { Ctr__Rule_1__1 $1 } |
-         EnumDeclaration { Ctr__Rule_1__2 $1 } |
-         AnnotationDeclaration { Ctr__Rule_1__3 $1 }
+Rule_1 : ClassDeclaration { Ctr__Rule_1__0 (rtkPosOf $1) $1 } |
+         InterfaceDeclaration { Ctr__Rule_1__1 (rtkPosOf $1) $1 } |
+         EnumDeclaration { Ctr__Rule_1__2 (rtkPosOf $1) $1 } |
+         AnnotationDeclaration { Ctr__Rule_1__3 (rtkPosOf $1) $1 }
 
-Rule_10 : { Ctr__Rule_10__0 } |
-          Rule_11 { Ctr__Rule_10__1 $1 }
+Rule_10 : { Ctr__Rule_10__0 rtkNoPos } |
+          Rule_11 { Ctr__Rule_10__1 (rtkPosOf $1) $1 }
 
-Rule_11 : tok__lparen__6 Rule_12 tok__rparen__7 { Ctr__Rule_11__0 $2 }
+Rule_11 : tok__lparen__6 Rule_12 tok__rparen__7 { Ctr__Rule_11__0 (rtkPosOf $1) $2 }
 
-Rule_12 : { Ctr__Rule_12__0 } |
-          AnnotationArguments { Ctr__Rule_12__1 $1 }
+Rule_12 : { Ctr__Rule_12__0 rtkNoPos } |
+          AnnotationArguments { Ctr__Rule_12__1 (rtkPosOf $1) $1 }
 
 Rule_13 : {- empty -} { [] } |
           Rule_13 Rule_14 { $2 : $1 }
 
-Rule_14 : tok__coma__8 AnnotationElement { Ctr__Rule_14__0 $2 }
+Rule_14 : tok__coma__8 AnnotationElement { Ctr__Rule_14__0 (rtkPosOf $1) $2 }
 
-ListElem_ModifierList17 : qq_ModifierList { Anti_Rule_16 $1 } |
+ListElem_ModifierList17 : qq_ModifierList { Anti_Rule_16 (tkVal_qq_ModifierList $1) } |
                           Rule_16 { $1 }
 
-Rule_16 : Modifier { Ctr__Rule_16__1 $1 } |
-          Annotation { Ctr__Rule_16__2 $1 }
+Rule_16 : Modifier { Ctr__Rule_16__1 (rtkPosOf $1) $1 } |
+          Annotation { Ctr__Rule_16__2 (rtkPosOf $1) $1 }
 
 Rule_18 : {- empty -} { [] } |
           Rule_18 Rule_19 { $2 : $1 }
 
-Rule_19 : tok__coma__8 CompoundName { Ctr__Rule_19__0 $2 }
+Rule_19 : tok__coma__8 CompoundName { Ctr__Rule_19__0 (rtkPosOf $1) $2 }
 
-ListElem_ImportList3 : qq_ImportList { Anti_Rule_2 $1 } |
+ListElem_ImportList3 : qq_ImportList { Anti_Rule_2 (tkVal_qq_ImportList $1) } |
                        Rule_2 { $1 }
 
-Rule_2 : ImportStatement { Ctr__Rule_2__1 $1 }
+Rule_2 : ImportStatement { Ctr__Rule_2__1 (rtkPosOf $1) $1 }
 
 Rule_20 : CompoundName { [$1] } |
           Rule_20 tok__coma__8 CompoundName { $3 : $1 }
 
-Rule_22 : { Ctr__Rule_22__0 } |
-          ExtendsList { Ctr__Rule_22__1 $1 }
+Rule_22 : { Ctr__Rule_22__0 rtkNoPos } |
+          ExtendsList { Ctr__Rule_22__1 (rtkPosOf $1) $1 }
 
-Rule_23 : { Ctr__Rule_23__0 } |
-          ImplementsList { Ctr__Rule_23__1 $1 }
+Rule_23 : { Ctr__Rule_23__0 rtkNoPos } |
+          ImplementsList { Ctr__Rule_23__1 (rtkPosOf $1) $1 }
 
-Rule_24 : { Ctr__Rule_24__0 } |
-          ExtendsList { Ctr__Rule_24__1 $1 }
+Rule_24 : { Ctr__Rule_24__0 rtkNoPos } |
+          ExtendsList { Ctr__Rule_24__1 (rtkPosOf $1) $1 }
 
-Rule_26 : { Ctr__Rule_26__0 } |
-          Rule_27 { Ctr__Rule_26__1 $1 }
+Rule_26 : { Ctr__Rule_26__0 rtkNoPos } |
+          Rule_27 { Ctr__Rule_26__1 (rtkPosOf $1) $1 }
 
-Rule_27 : tok__lparen__6 Arglist tok__rparen__7 { Ctr__Rule_27__0 $2 }
+Rule_27 : tok__lparen__6 Arglist tok__rparen__7 { Ctr__Rule_27__0 (rtkPosOf $1) $2 }
 
-Rule_28 : { Ctr__Rule_28__0 } |
-          Rule_29 { Ctr__Rule_28__1 $1 }
+Rule_28 : { Ctr__Rule_28__0 rtkNoPos } |
+          Rule_29 { Ctr__Rule_28__1 (rtkPosOf $1) $1 }
 
-Rule_29 : tok__symbol__13 FieldDeclarationList tok__symbol__14 { Ctr__Rule_29__0 (reverse $2) }
+Rule_29 : tok__symbol__13 FieldDeclarationList tok__symbol__14 { Ctr__Rule_29__0 (rtkPosOf $1) (reverse $2) }
 
 Rule_30 : {- empty -} { [] } |
           Rule_30 Rule_31 { $2 : $1 }
 
-Rule_31 : tok__coma__8 EnumConstant { Ctr__Rule_31__0 $2 }
+Rule_31 : tok__coma__8 EnumConstant { Ctr__Rule_31__0 (rtkPosOf $1) $2 }
 
-Rule_32 : { Ctr__Rule_32__0 } |
-          Rule_33 { Ctr__Rule_32__1 $1 }
+Rule_32 : { Ctr__Rule_32__0 rtkNoPos } |
+          Rule_33 { Ctr__Rule_32__1 (rtkPosOf $1) $1 }
 
-Rule_33 : tok__coma__8 { Ctr__Rule_33__0 }
+Rule_33 : tok__coma__8 { Ctr__Rule_33__0 (rtkPosOf $1) }
 
-Rule_34 : { Ctr__Rule_34__0 } |
-          ImplementsList { Ctr__Rule_34__1 $1 }
+Rule_34 : { Ctr__Rule_34__0 rtkNoPos } |
+          ImplementsList { Ctr__Rule_34__1 (rtkPosOf $1) $1 }
 
-Rule_35 : { Ctr__Rule_35__0 } |
-          Rule_36 { Ctr__Rule_35__1 $1 }
+Rule_35 : { Ctr__Rule_35__0 rtkNoPos } |
+          Rule_36 { Ctr__Rule_35__1 (rtkPosOf $1) $1 }
 
-Rule_36 : tok__semi__1 FieldDeclarationList { Ctr__Rule_36__0 (reverse $2) }
+Rule_36 : tok__semi__1 FieldDeclarationList { Ctr__Rule_36__0 (rtkPosOf $1) (reverse $2) }
 
-Rule_37 : ModifierList Rule_38 { Ctr__Rule_37__0 (reverse $1) $2 }
+Rule_37 : ModifierList Rule_38 { Ctr__Rule_37__0 (rtkPosOf (reverse $1)) (reverse $1) $2 }
 
-Rule_38 : Rule_39 { Ctr__Rule_38__0 $1 } |
-          StaticInitializer { Ctr__Rule_38__1 $1 }
+Rule_38 : Rule_39 { Ctr__Rule_38__0 (rtkPosOf $1) $1 } |
+          StaticInitializer { Ctr__Rule_38__1 (rtkPosOf $1) $1 }
 
-Rule_39 : MemberDeclaration { Ctr__Rule_39__0 $1 } |
-          NestedTypeDeclaration { Ctr__Rule_39__1 $1 }
+Rule_39 : MemberDeclaration { Ctr__Rule_39__0 (rtkPosOf $1) $1 } |
+          NestedTypeDeclaration { Ctr__Rule_39__1 (rtkPosOf $1) $1 }
 
-Rule_4 : { Ctr__Rule_4__0 } |
-         Rule_5 { Ctr__Rule_4__1 $1 }
+Rule_4 : { Ctr__Rule_4__0 rtkNoPos } |
+         Rule_5 { Ctr__Rule_4__1 (rtkPosOf $1) $1 }
 
-ListElem_SquareBracketsList41 : qq_SquareBracketsList { Anti_Rule_40 $1 } |
+ListElem_SquareBracketsList41 : qq_SquareBracketsList { Anti_Rule_40 (tkVal_qq_SquareBracketsList $1) } |
                                 Rule_40 { $1 }
 
-Rule_40 : tok__sq_bkt_l__17 OptExpression tok__sq_bkt_r__18 { Ctr__Rule_40__1 $2 }
+Rule_40 : tok__sq_bkt_l__17 OptExpression tok__sq_bkt_r__18 { Ctr__Rule_40__1 (rtkPosOf $1) $2 }
 
-Rule_42 : { Ctr__Rule_42__0 } |
-          ParameterList { Ctr__Rule_42__1 $1 }
+Rule_42 : { Ctr__Rule_42__0 rtkNoPos } |
+          ParameterList { Ctr__Rule_42__1 (rtkPosOf $1) $1 }
 
-Rule_43 : { Ctr__Rule_43__0 } |
-          ParameterList { Ctr__Rule_43__1 $1 }
+Rule_43 : { Ctr__Rule_43__0 rtkNoPos } |
+          ParameterList { Ctr__Rule_43__1 (rtkPosOf $1) $1 }
 
-Rule_44 : StatementBlock { Ctr__Rule_44__0 $1 } |
-          Rule_45 tok__semi__1 { Ctr__Rule_44__1 $1 }
+Rule_44 : StatementBlock { Ctr__Rule_44__0 (rtkPosOf $1) $1 } |
+          Rule_45 tok__semi__1 { Ctr__Rule_44__1 (rtkPosOf $1) $1 }
 
-Rule_45 : { Ctr__Rule_45__0 } |
-          Rule_46 { Ctr__Rule_45__1 $1 }
+Rule_45 : { Ctr__Rule_45__0 rtkNoPos } |
+          Rule_46 { Ctr__Rule_45__1 (rtkPosOf $1) $1 }
 
-Rule_46 : tok_default_28 Expression { Ctr__Rule_46__0 $2 }
+Rule_46 : tok_default_28 Expression { Ctr__Rule_46__0 (rtkPosOf $1) $2 }
 
-ListElem_MoreVariableDeclarators48 : qq_MoreVariableDeclarators { Anti_Rule_47 $1 } |
+ListElem_MoreVariableDeclarators48 : qq_MoreVariableDeclarators { Anti_Rule_47 (tkVal_qq_MoreVariableDeclarators $1) } |
                                      Rule_47 { $1 }
 
-Rule_47 : tok__coma__8 VariableDeclarator { Ctr__Rule_47__1 $2 }
+Rule_47 : tok__coma__8 VariableDeclarator { Ctr__Rule_47__1 (rtkPosOf $1) $2 }
 
 Rule_49 : {- empty -} { [] } |
           Rule_49 Rule_50 { $2 : $1 }
 
-Rule_5 : Package { Ctr__Rule_5__0 $1 }
+Rule_5 : Package { Ctr__Rule_5__0 (rtkPosOf $1) $1 }
 
-Rule_50 : tok__coma__8 VariableDeclarator { Ctr__Rule_50__0 $2 }
+Rule_50 : tok__coma__8 VariableDeclarator { Ctr__Rule_50__0 (rtkPosOf $1) $2 }
 
-Rule_51 : tok__eql__9 VariableInitializer { Ctr__Rule_51__0 $2 }
+Rule_51 : tok__eql__9 VariableInitializer { Ctr__Rule_51__0 (rtkPosOf $1) $2 }
 
-Rule_52 : VariableInitializer Rule_53 Rule_55 { Ctr__Rule_52__0 $1 (reverse $2) $3 }
+Rule_52 : VariableInitializer Rule_53 Rule_55 { Ctr__Rule_52__0 (rtkPosOf $1) $1 (reverse $2) $3 }
 
 Rule_53 : {- empty -} { [] } |
           Rule_53 Rule_54 { $2 : $1 }
 
-Rule_54 : tok__coma__8 VariableInitializer { Ctr__Rule_54__0 $2 }
+Rule_54 : tok__coma__8 VariableInitializer { Ctr__Rule_54__0 (rtkPosOf $1) $2 }
 
-Rule_55 : { Ctr__Rule_55__0 } |
-          Rule_56 { Ctr__Rule_55__1 $1 }
+Rule_55 : { Ctr__Rule_55__0 rtkNoPos } |
+          Rule_56 { Ctr__Rule_55__1 (rtkPosOf $1) $1 }
 
-Rule_56 : tok__coma__8 { Ctr__Rule_56__0 }
+Rule_56 : tok__coma__8 { Ctr__Rule_56__0 (rtkPosOf $1) }
 
 Rule_57 : {- empty -} { [] } |
           Rule_57 Rule_58 { $2 : $1 }
 
-Rule_58 : tok__coma__8 Parameter { Ctr__Rule_58__0 $2 }
+Rule_58 : tok__coma__8 Parameter { Ctr__Rule_58__0 (rtkPosOf $1) $2 }
 
-Rule_6 : { Ctr__Rule_6__0 } |
-         Rule_7 { Ctr__Rule_6__1 $1 }
+Rule_6 : { Ctr__Rule_6__0 rtkNoPos } |
+         Rule_7 { Ctr__Rule_6__1 (rtkPosOf $1) $1 }
 
-Rule_60 : tok_else_35 Statement { Ctr__Rule_60__0 $2 }
+Rule_60 : tok_else_35 Statement { Ctr__Rule_60__0 (rtkPosOf $1) $2 }
 
-Rule_61 : VariableDeclaration { Ctr__Rule_61__0 $1 } |
-          Rule_62 { Ctr__Rule_61__1 $1 } |
-          tok__semi__1 { Ctr__Rule_61__2 }
+Rule_61 : VariableDeclaration { Ctr__Rule_61__0 (rtkPosOf $1) $1 } |
+          Rule_62 { Ctr__Rule_61__1 (rtkPosOf $1) $1 } |
+          tok__semi__1 { Ctr__Rule_61__2 (rtkPosOf $1) }
 
-Rule_62 : Expression tok__semi__1 { Ctr__Rule_62__0 $1 }
+Rule_62 : Expression tok__semi__1 { Ctr__Rule_62__0 (rtkPosOf $1) $1 }
 
-ListElem_CatchList64 : qq_CatchList { Anti_Rule_63 $1 } |
+ListElem_CatchList64 : qq_CatchList { Anti_Rule_63 (tkVal_qq_CatchList $1) } |
                        Rule_63 { $1 }
 
-Rule_63 : tok_catch_40 tok__lparen__6 Parameter tok__rparen__7 Statement { Ctr__Rule_63__1 $3 $5 }
+Rule_63 : tok_catch_40 tok__lparen__6 Parameter tok__rparen__7 Statement { Ctr__Rule_63__1 (rtkPosOf $1) $3 $5 }
 
-Rule_65 : tok_finally_41 Statement { Ctr__Rule_65__0 $2 }
+Rule_65 : tok_finally_41 Statement { Ctr__Rule_65__0 (rtkPosOf $1) $2 }
 
-ListElem_SwitchCaseList69 : qq_SwitchCaseList { Anti_Rule_66 $1 } |
+ListElem_SwitchCaseList69 : qq_SwitchCaseList { Anti_Rule_66 (tkVal_qq_SwitchCaseList $1) } |
                             Rule_66 { $1 }
 
-Rule_66 : Rule_67 { Ctr__Rule_66__1 $1 } |
-          Rule_68 { Ctr__Rule_66__2 $1 } |
-          Statement { Ctr__Rule_66__3 $1 }
+Rule_66 : Rule_67 { Ctr__Rule_66__1 (rtkPosOf $1) $1 } |
+          Rule_68 { Ctr__Rule_66__2 (rtkPosOf $1) $1 } |
+          Statement { Ctr__Rule_66__3 (rtkPosOf $1) $1 }
 
-Rule_67 : tok_case_43 Expression tok__colon__32 { Ctr__Rule_67__0 $2 }
+Rule_67 : tok_case_43 Expression tok__colon__32 { Ctr__Rule_67__0 (rtkPosOf $1) $2 }
 
-Rule_68 : tok_default_28 tok__colon__32 { Ctr__Rule_68__0 }
+Rule_68 : tok_default_28 tok__colon__32 { Ctr__Rule_68__0 (rtkPosOf $1) }
 
-Rule_7 : TypeDeclaration { Ctr__Rule_7__0 $1 }
+Rule_7 : TypeDeclaration { Ctr__Rule_7__0 (rtkPosOf $1) $1 }
 
-Rule_70 : { Ctr__Rule_70__0 } |
-          Rule_71 { Ctr__Rule_70__1 $1 }
+Rule_70 : { Ctr__Rule_70__0 rtkNoPos } |
+          Rule_71 { Ctr__Rule_70__1 (rtkPosOf $1) $1 }
 
-Rule_71 : AssignmentOp AssignmentExpression { Ctr__Rule_71__0 $1 $2 }
+Rule_71 : AssignmentOp AssignmentExpression { Ctr__Rule_71__0 (rtkPosOf $1) $1 $2 }
 
-Rule_72 : { Ctr__Rule_72__0 } |
-          Rule_73 { Ctr__Rule_72__1 $1 }
+Rule_72 : { Ctr__Rule_72__0 rtkNoPos } |
+          Rule_73 { Ctr__Rule_72__1 (rtkPosOf $1) $1 }
 
-Rule_73 : tok__lparen__6 Arglist tok__rparen__7 { Ctr__Rule_73__0 $2 }
+Rule_73 : tok__lparen__6 Arglist tok__rparen__7 { Ctr__Rule_73__0 (rtkPosOf $1) $2 }
 
-Rule_74 : { Ctr__Rule_74__0 } |
-          Rule_75 { Ctr__Rule_74__1 $1 }
+Rule_74 : { Ctr__Rule_74__0 rtkNoPos } |
+          Rule_75 { Ctr__Rule_74__1 (rtkPosOf $1) $1 }
 
-Rule_75 : tok__lparen__6 Arglist tok__rparen__7 { Ctr__Rule_75__0 $2 }
+Rule_75 : tok__lparen__6 Arglist tok__rparen__7 { Ctr__Rule_75__0 (rtkPosOf $1) $2 }
 
-Rule_76 : tok__lparen__6 Arglist tok__rparen__7 { Ctr__Rule_76__0 $2 } |
-          SquareBracketsList { Ctr__Rule_76__1 (reverse $1) }
+Rule_76 : tok__lparen__6 Arglist tok__rparen__7 { Ctr__Rule_76__0 (rtkPosOf $1) $2 } |
+          SquareBracketsList { Ctr__Rule_76__1 (rtkPosOf (reverse $1)) (reverse $1) }
 
-Rule_77 : Expression Rule_78 { Ctr__Rule_77__0 $1 (reverse $2) }
+Rule_77 : Expression Rule_78 { Ctr__Rule_77__0 (rtkPosOf $1) $1 (reverse $2) }
 
 Rule_78 : {- empty -} { [] } |
           Rule_78 Rule_79 { $2 : $1 }
 
-Rule_79 : tok__coma__8 Expression { Ctr__Rule_79__0 $2 }
+Rule_79 : tok__coma__8 Expression { Ctr__Rule_79__0 (rtkPosOf $1) $2 }
 
-Rule_8 : Rule_9 { Ctr__Rule_8__0 $1 } |
-         CompoundName { Ctr__Rule_8__1 $1 }
+Rule_8 : Rule_9 { Ctr__Rule_8__0 (rtkPosOf $1) $1 } |
+         CompoundName { Ctr__Rule_8__1 (rtkPosOf $1) $1 }
 
-Rule_80 : tok__symbol__64 TypeArgument Rule_81 tok__symbol__65 { Ctr__Rule_80__0 $2 (reverse $3) }
+Rule_80 : tok__symbol__64 TypeArgument Rule_81 tok__symbol__65 { Ctr__Rule_80__0 (rtkPosOf $1) $2 (reverse $3) }
 
 Rule_81 : {- empty -} { [] } |
           Rule_81 Rule_82 { $2 : $1 }
 
-Rule_82 : tok__coma__8 TypeArgument { Ctr__Rule_82__0 $2 }
+Rule_82 : tok__coma__8 TypeArgument { Ctr__Rule_82__0 (rtkPosOf $1) $2 }
 
-Rule_83 : tok__symbol__64 TypeParameter Rule_84 tok__symbol__65 { Ctr__Rule_83__0 $2 (reverse $3) }
+Rule_83 : tok__symbol__64 TypeParameter Rule_84 tok__symbol__65 { Ctr__Rule_83__0 (rtkPosOf $1) $2 (reverse $3) }
 
 Rule_84 : {- empty -} { [] } |
           Rule_84 Rule_85 { $2 : $1 }
 
-Rule_85 : tok__coma__8 TypeParameter { Ctr__Rule_85__0 $2 }
+Rule_85 : tok__coma__8 TypeParameter { Ctr__Rule_85__0 (rtkPosOf $1) $2 }
 
-Rule_86 : { Ctr__Rule_86__0 } |
-          Rule_87 { Ctr__Rule_86__1 $1 }
+Rule_86 : { Ctr__Rule_86__0 rtkNoPos } |
+          Rule_87 { Ctr__Rule_86__1 (rtkPosOf $1) $1 }
 
-Rule_87 : tok_extends_10 Type Rule_88 { Ctr__Rule_87__0 $2 (reverse $3) }
+Rule_87 : tok_extends_10 Type Rule_88 { Ctr__Rule_87__0 (rtkPosOf $1) $2 (reverse $3) }
 
 Rule_88 : {- empty -} { [] } |
           Rule_88 Rule_89 { $2 : $1 }
 
-Rule_89 : tok__symbol__61 Type { Ctr__Rule_89__0 $2 }
+Rule_89 : tok__symbol__61 Type { Ctr__Rule_89__0 (rtkPosOf $1) $2 }
 
-Rule_9 : CompoundName tok__dot__3 tok__star__4 { Ctr__Rule_9__0 $1 }
+Rule_9 : CompoundName tok__dot__3 tok__star__4 { Ctr__Rule_9__0 (rtkPosOf $1) $1 }
 
 Rule_90 : {- empty -} { [] } |
           Rule_90 Rule_91 { $2 : $1 }
 
-Rule_91 : tok__dot__3 id { Ctr__Rule_91__0 $2 }
+Rule_91 : tok__dot__3 id { Ctr__Rule_91__0 (rtkPosOf $1) (tkVal_id $2) }
 
-ShiftOp : qq_ShiftOp { Anti_ShiftOp $1 } |
-          tok__symbol__symbol__69 { Ctr__ShiftOp__0 } |
-          tok__symbol__symbol__70 { Ctr__ShiftOp__1 } |
-          tok__symbol__symbol__symbol__71 { Ctr__ShiftOp__2 }
+ShiftOp : qq_ShiftOp { Anti_ShiftOp (tkVal_qq_ShiftOp $1) } |
+          tok__symbol__symbol__69 { Ctr__ShiftOp__0 (rtkPosOf $1) } |
+          tok__symbol__symbol__70 { Ctr__ShiftOp__1 (rtkPosOf $1) } |
+          tok__symbol__symbol__symbol__71 { Ctr__ShiftOp__2 (rtkPosOf $1) }
 
 SquareBracketsList : {- empty -} { [] } |
                      SquareBracketsList ListElem_SquareBracketsList41 { $2 : $1 }
 
-Statement : qq_Statement { Anti_Statement $1 } |
-            StatementWithoutIf { Ctr__Statement__0 $1 } |
-            IfStatement { Ctr__Statement__1 $1 }
+Statement : qq_Statement { Anti_Statement (tkVal_qq_Statement $1) } |
+            StatementWithoutIf { Ctr__Statement__0 (rtkPosOf $1) $1 } |
+            IfStatement { Ctr__Statement__1 (rtkPosOf $1) $1 }
 
-ListElem_StatementList59 : qq_StatementList { Anti_Statement $1 } |
+ListElem_StatementList59 : qq_StatementList { Anti_Statement (tkVal_qq_StatementList $1) } |
                            Statement { $1 }
 
-StatementBlock : qq_StatementBlock { Anti_StatementBlock $1 } |
-                 tok__symbol__13 StatementList tok__symbol__14 { Ctr__StatementBlock__0 (reverse $2) }
+StatementBlock : qq_StatementBlock { Anti_StatementBlock (tkVal_qq_StatementBlock $1) } |
+                 tok__symbol__13 StatementList tok__symbol__14 { Ctr__StatementBlock__0 (rtkPosOf $1) (reverse $2) }
 
 StatementList : {- empty -} { [] } |
                 StatementList ListElem_StatementList59 { $2 : $1 }
 
-StatementWithoutIf : qq_StatementWithoutIf { Anti_StatementWithoutIf $1 } |
-                     VariableDeclaration { Ctr__StatementWithoutIf__0 $1 } |
-                     tok_return_29 OptExpression tok__semi__1 { Ctr__StatementWithoutIf__1 $2 } |
-                     Expression tok__semi__1 { Ctr__StatementWithoutIf__2 $1 } |
-                     StatementBlock { Ctr__StatementWithoutIf__3 $1 } |
-                     DoStatement { Ctr__StatementWithoutIf__4 $1 } |
-                     WhileStatement { Ctr__StatementWithoutIf__5 $1 } |
-                     ForStatement { Ctr__StatementWithoutIf__6 $1 } |
-                     TryStatement { Ctr__StatementWithoutIf__7 $1 } |
-                     SwitchStatement { Ctr__StatementWithoutIf__8 $1 } |
-                     tok_synchronized_30 tok__lparen__6 Expression tok__rparen__7 Statement { Ctr__StatementWithoutIf__9 $3 $5 } |
-                     tok_throw_31 Expression tok__semi__1 { Ctr__StatementWithoutIf__10 $2 } |
-                     id tok__colon__32 Statement { Ctr__StatementWithoutIf__11 $1 $3 } |
-                     tok_break_33 OptId tok__semi__1 { Ctr__StatementWithoutIf__12 $2 } |
-                     tok_continue_34 OptId tok__semi__1 { Ctr__StatementWithoutIf__13 $2 } |
-                     tok__semi__1 { Ctr__StatementWithoutIf__14 }
+StatementWithoutIf : qq_StatementWithoutIf { Anti_StatementWithoutIf (tkVal_qq_StatementWithoutIf $1) } |
+                     VariableDeclaration { Ctr__StatementWithoutIf__0 (rtkPosOf $1) $1 } |
+                     tok_return_29 OptExpression tok__semi__1 { Ctr__StatementWithoutIf__1 (rtkPosOf $1) $2 } |
+                     Expression tok__semi__1 { Ctr__StatementWithoutIf__2 (rtkPosOf $1) $1 } |
+                     StatementBlock { Ctr__StatementWithoutIf__3 (rtkPosOf $1) $1 } |
+                     DoStatement { Ctr__StatementWithoutIf__4 (rtkPosOf $1) $1 } |
+                     WhileStatement { Ctr__StatementWithoutIf__5 (rtkPosOf $1) $1 } |
+                     ForStatement { Ctr__StatementWithoutIf__6 (rtkPosOf $1) $1 } |
+                     TryStatement { Ctr__StatementWithoutIf__7 (rtkPosOf $1) $1 } |
+                     SwitchStatement { Ctr__StatementWithoutIf__8 (rtkPosOf $1) $1 } |
+                     tok_synchronized_30 tok__lparen__6 Expression tok__rparen__7 Statement { Ctr__StatementWithoutIf__9 (rtkPosOf $1) $3 $5 } |
+                     tok_throw_31 Expression tok__semi__1 { Ctr__StatementWithoutIf__10 (rtkPosOf $1) $2 } |
+                     id tok__colon__32 Statement { Ctr__StatementWithoutIf__11 (rtkPosOf $1) (tkVal_id $1) $3 } |
+                     tok_break_33 OptId tok__semi__1 { Ctr__StatementWithoutIf__12 (rtkPosOf $1) $2 } |
+                     tok_continue_34 OptId tok__semi__1 { Ctr__StatementWithoutIf__13 (rtkPosOf $1) $2 } |
+                     tok__semi__1 { Ctr__StatementWithoutIf__14 (rtkPosOf $1) }
 
-StaticInitializer : qq_StaticInitializer { Anti_StaticInitializer $1 } |
-                    StatementBlock { Ctr__StaticInitializer__0 $1 }
+StaticInitializer : qq_StaticInitializer { Anti_StaticInitializer (tkVal_qq_StaticInitializer $1) } |
+                    StatementBlock { Ctr__StaticInitializer__0 (rtkPosOf $1) $1 }
 
 SwitchCaseList : {- empty -} { [] } |
                  SwitchCaseList ListElem_SwitchCaseList69 { $2 : $1 }
 
-SwitchStatement : qq_SwitchStatement { Anti_SwitchStatement $1 } |
-                  tok_switch_44 tok__lparen__6 Expression tok__rparen__7 tok__symbol__13 SwitchCaseList tok__symbol__14 { Ctr__SwitchStatement__0 $3 (reverse $6) }
+SwitchStatement : qq_SwitchStatement { Anti_SwitchStatement (tkVal_qq_SwitchStatement $1) } |
+                  tok_switch_44 tok__lparen__6 Expression tok__rparen__7 tok__symbol__13 SwitchCaseList tok__symbol__14 { Ctr__SwitchStatement__0 (rtkPosOf $1) $3 (reverse $6) }
 
-TryStatement : qq_TryStatement { Anti_TryStatement $1 } |
-               tok_try_42 Statement CatchList OptFinally { Ctr__TryStatement__0 $2 (reverse $3) $4 }
+TryStatement : qq_TryStatement { Anti_TryStatement (tkVal_qq_TryStatement $1) } |
+               tok_try_42 Statement CatchList OptFinally { Ctr__TryStatement__0 (rtkPosOf $1) $2 (reverse $3) $4 }
 
-Type : qq_Type { Anti_Type $1 } |
-       TypeSpecifier SquareBracketsList { Ctr__Type__0 $1 (reverse $2) }
+Type : qq_Type { Anti_Type (tkVal_qq_Type $1) } |
+       TypeSpecifier SquareBracketsList { Ctr__Type__0 (rtkPosOf $1) $1 (reverse $2) }
 
-TypeArgument : qq_TypeArgument { Anti_TypeArgument $1 } |
-               Type { Ctr__TypeArgument__0 $1 } |
-               WildcardType { Ctr__TypeArgument__1 $1 }
+TypeArgument : qq_TypeArgument { Anti_TypeArgument (tkVal_qq_TypeArgument $1) } |
+               Type { Ctr__TypeArgument__0 (rtkPosOf $1) $1 } |
+               WildcardType { Ctr__TypeArgument__1 (rtkPosOf $1) $1 }
 
-TypeArguments : qq_TypeArguments { Anti_TypeArguments $1 } |
-                { Ctr__TypeArguments__0 } |
-                Rule_80 { Ctr__TypeArguments__1 $1 }
+TypeArguments : qq_TypeArguments { Anti_TypeArguments (tkVal_qq_TypeArguments $1) } |
+                { Ctr__TypeArguments__0 rtkNoPos } |
+                Rule_80 { Ctr__TypeArguments__1 (rtkPosOf $1) $1 }
 
-TypeDeclaration : qq_TypeDeclaration { Anti_TypeDeclaration $1 } |
-                  OptDocComment Rule_1 { Ctr__TypeDeclaration__0 $1 $2 }
+TypeDeclaration : qq_TypeDeclaration { Anti_TypeDeclaration (tkVal_qq_TypeDeclaration $1) } |
+                  OptDocComment Rule_1 { Ctr__TypeDeclaration__0 (rtkPosOf $1) $1 $2 }
 
-TypeParameter : qq_TypeParameter { Anti_TypeParameter $1 } |
-                id Rule_86 { Ctr__TypeParameter__0 $1 $2 }
+TypeParameter : qq_TypeParameter { Anti_TypeParameter (tkVal_qq_TypeParameter $1) } |
+                id Rule_86 { Ctr__TypeParameter__0 (rtkPosOf $1) (tkVal_id $1) $2 }
 
-TypeParameters : qq_TypeParameters { Anti_TypeParameters $1 } |
-                 { Ctr__TypeParameters__0 } |
-                 Rule_83 { Ctr__TypeParameters__1 $1 }
+TypeParameters : qq_TypeParameters { Anti_TypeParameters (tkVal_qq_TypeParameters $1) } |
+                 { Ctr__TypeParameters__0 rtkNoPos } |
+                 Rule_83 { Ctr__TypeParameters__1 (rtkPosOf $1) $1 }
 
-TypeSpecifier : qq_TypeSpecifier { Anti_TypeSpecifier $1 } |
-                tok_boolean_19 { Ctr__TypeSpecifier__0 } |
-                tok_byte_20 { Ctr__TypeSpecifier__1 } |
-                tok_char_21 { Ctr__TypeSpecifier__2 } |
-                tok_short_22 { Ctr__TypeSpecifier__3 } |
-                tok_int_23 { Ctr__TypeSpecifier__4 } |
-                tok_float_24 { Ctr__TypeSpecifier__5 } |
-                tok_long_25 { Ctr__TypeSpecifier__6 } |
-                tok_double_26 { Ctr__TypeSpecifier__7 } |
-                tok_void_27 { Ctr__TypeSpecifier__8 } |
-                CompoundName TypeArguments { Ctr__TypeSpecifier__9 $1 $2 }
+TypeSpecifier : qq_TypeSpecifier { Anti_TypeSpecifier (tkVal_qq_TypeSpecifier $1) } |
+                tok_boolean_19 { Ctr__TypeSpecifier__0 (rtkPosOf $1) } |
+                tok_byte_20 { Ctr__TypeSpecifier__1 (rtkPosOf $1) } |
+                tok_char_21 { Ctr__TypeSpecifier__2 (rtkPosOf $1) } |
+                tok_short_22 { Ctr__TypeSpecifier__3 (rtkPosOf $1) } |
+                tok_int_23 { Ctr__TypeSpecifier__4 (rtkPosOf $1) } |
+                tok_float_24 { Ctr__TypeSpecifier__5 (rtkPosOf $1) } |
+                tok_long_25 { Ctr__TypeSpecifier__6 (rtkPosOf $1) } |
+                tok_double_26 { Ctr__TypeSpecifier__7 (rtkPosOf $1) } |
+                tok_void_27 { Ctr__TypeSpecifier__8 (rtkPosOf $1) } |
+                CompoundName TypeArguments { Ctr__TypeSpecifier__9 (rtkPosOf $1) $1 $2 }
 
-VariableDeclaration : qq_VariableDeclaration { Anti_VariableDeclaration $1 } |
-                      Type VariableDeclaratorList tok__semi__1 { Ctr__VariableDeclaration__0 $1 $2 }
+VariableDeclaration : qq_VariableDeclaration { Anti_VariableDeclaration (tkVal_qq_VariableDeclaration $1) } |
+                      Type VariableDeclaratorList tok__semi__1 { Ctr__VariableDeclaration__0 (rtkPosOf $1) $1 $2 }
 
-VariableDeclarator : qq_VariableDeclarator { Anti_VariableDeclarator $1 } |
-                     id SquareBracketsList OptVariableInitializer { Ctr__VariableDeclarator__0 $1 (reverse $2) $3 }
+VariableDeclarator : qq_VariableDeclarator { Anti_VariableDeclarator (tkVal_qq_VariableDeclarator $1) } |
+                     id SquareBracketsList OptVariableInitializer { Ctr__VariableDeclarator__0 (rtkPosOf $1) (tkVal_id $1) (reverse $2) $3 }
 
-VariableDeclaratorList : qq_VariableDeclaratorList { Anti_VariableDeclaratorList $1 } |
-                         VariableDeclarator Rule_49 { Ctr__VariableDeclaratorList__0 $1 (reverse $2) }
+VariableDeclaratorList : qq_VariableDeclaratorList { Anti_VariableDeclaratorList (tkVal_qq_VariableDeclaratorList $1) } |
+                         VariableDeclarator Rule_49 { Ctr__VariableDeclaratorList__0 (rtkPosOf $1) $1 (reverse $2) }
 
-VariableInitializer : qq_VariableInitializer { Anti_VariableInitializer $1 } |
-                      Expression { Ctr__VariableInitializer__0 $1 } |
-                      tok__symbol__13 VariableInitializerList tok__symbol__14 { Ctr__VariableInitializer__1 $2 }
+VariableInitializer : qq_VariableInitializer { Anti_VariableInitializer (tkVal_qq_VariableInitializer $1) } |
+                      Expression { Ctr__VariableInitializer__0 (rtkPosOf $1) $1 } |
+                      tok__symbol__13 VariableInitializerList tok__symbol__14 { Ctr__VariableInitializer__1 (rtkPosOf $1) $2 }
 
-VariableInitializerList : qq_VariableInitializerList { Anti_VariableInitializerList $1 } |
-                          { Ctr__VariableInitializerList__0 } |
-                          Rule_52 { Ctr__VariableInitializerList__1 $1 }
+VariableInitializerList : qq_VariableInitializerList { Anti_VariableInitializerList (tkVal_qq_VariableInitializerList $1) } |
+                          { Ctr__VariableInitializerList__0 rtkNoPos } |
+                          Rule_52 { Ctr__VariableInitializerList__1 (rtkPosOf $1) $1 }
 
-WhileStatement : qq_WhileStatement { Anti_WhileStatement $1 } |
-                 tok_while_38 tok__lparen__6 Expression tok__rparen__7 Statement { Ctr__WhileStatement__0 $3 $5 }
+WhileStatement : qq_WhileStatement { Anti_WhileStatement (tkVal_qq_WhileStatement $1) } |
+                 tok_while_38 tok__lparen__6 Expression tok__rparen__7 Statement { Ctr__WhileStatement__0 (rtkPosOf $1) $3 $5 }
 
-WildcardType : qq_WildcardType { Anti_WildcardType $1 } |
-               tok__symbol__56 { Ctr__WildcardType__0 } |
-               tok__symbol__56 tok_extends_10 Type { Ctr__WildcardType__1 $3 } |
-               tok__symbol__56 tok_super_81 Type { Ctr__WildcardType__2 $3 }
+WildcardType : qq_WildcardType { Anti_WildcardType (tkVal_qq_WildcardType $1) } |
+               tok__symbol__56 { Ctr__WildcardType__0 (rtkPosOf $1) } |
+               tok__symbol__56 tok_extends_10 Type { Ctr__WildcardType__1 (rtkPosOf $1) $3 } |
+               tok__symbol__56 tok_super_81 Type { Ctr__WildcardType__2 (rtkPosOf $1) $3 }
 
 
 {
@@ -1261,628 +1261,1522 @@ showRtkToken (L.Tk__qq_TypeDeclaration v) = "qq_TypeDeclaration " ++ show v
 showRtkToken (L.Tk__qq_OptDocComment v) = "qq_OptDocComment " ++ show v
 showRtkToken (L.Tk__qq_Java v) = "qq_Java " ++ show v
 
-data Java = Ctr__Java__0 Java |
-            Ctr__Java__1 AdditiveOp |
-            Ctr__Java__2 Annotation |
-            Ctr__Java__3 AnnotationArguments |
-            Ctr__Java__4 AnnotationDeclaration |
-            Ctr__Java__5 AnnotationElement |
-            Ctr__Java__6 AnnotationList |
-            Ctr__Java__7 AnnotationTypeElement |
-            Ctr__Java__8 AnnotationTypeElementList |
-            Ctr__Java__9 Arglist |
-            Ctr__Java__10 AssignmentOp |
-            Ctr__Java__11 CatchList |
-            Ctr__Java__12 ClassDeclaration |
-            Ctr__Java__13 CompilationUnit |
-            Ctr__Java__14 CompoundName |
-            Ctr__Java__15 CreationExpression |
-            Ctr__Java__16 DoStatement |
-            Ctr__Java__17 DocComment |
-            Ctr__Java__18 EnumConstant |
-            Ctr__Java__19 EnumConstantList |
-            Ctr__Java__20 EnumDeclaration |
-            Ctr__Java__21 EqualityOp |
-            Ctr__Java__22 Expression |
-            Ctr__Java__23 ExtendsList |
-            Ctr__Java__24 FieldDeclaration |
-            Ctr__Java__25 FieldDeclarationList |
-            Ctr__Java__26 ForStatement |
-            Ctr__Java__27 IfStatement |
-            Ctr__Java__28 ImplementsList |
-            Ctr__Java__29 ImportList |
-            Ctr__Java__30 ImportStatement |
-            Ctr__Java__31 InterfaceDeclaration |
-            Ctr__Java__32 Literal |
-            Ctr__Java__33 MemberAfterFirstId |
-            Ctr__Java__34 MemberDeclaration |
-            Ctr__Java__35 MemberRest |
-            Ctr__Java__36 Modifier |
-            Ctr__Java__37 ModifierList |
-            Ctr__Java__38 MoreTypeSpecifier |
-            Ctr__Java__39 MoreVariableDeclarators |
-            Ctr__Java__40 MultiplicativeOp |
-            Ctr__Java__41 NestedTypeDeclaration |
-            Ctr__Java__42 OptDocComment |
-            Ctr__Java__43 OptElsePart |
-            Ctr__Java__44 OptExpression |
-            Ctr__Java__45 OptFinally |
-            Ctr__Java__46 OptId |
-            Ctr__Java__47 OptVariableInitializer |
-            Ctr__Java__48 Package |
-            Ctr__Java__49 Parameter |
-            Ctr__Java__50 ParameterList |
-            Ctr__Java__51 PostfixOp |
-            Ctr__Java__52 PrefixOp |
-            Ctr__Java__53 PrimitiveTypeKeyword |
-            Ctr__Java__54 RelationalOp |
-            Ctr__Java__55 ShiftOp |
-            Ctr__Java__56 SquareBracketsList |
-            Ctr__Java__57 Statement |
-            Ctr__Java__58 StatementBlock |
-            Ctr__Java__59 StatementList |
-            Ctr__Java__60 StatementWithoutIf |
-            Ctr__Java__61 StaticInitializer |
-            Ctr__Java__62 SwitchCaseList |
-            Ctr__Java__63 SwitchStatement |
-            Ctr__Java__64 TryStatement |
-            Ctr__Java__65 Type |
-            Ctr__Java__66 TypeArgument |
-            Ctr__Java__67 TypeArguments |
-            Ctr__Java__68 TypeDeclaration |
-            Ctr__Java__69 TypeParameter |
-            Ctr__Java__70 TypeParameters |
-            Ctr__Java__71 TypeSpecifier |
-            Ctr__Java__72 VariableDeclaration |
-            Ctr__Java__73 VariableDeclarator |
-            Ctr__Java__74 VariableDeclaratorList |
-            Ctr__Java__75 VariableInitializer |
-            Ctr__Java__76 VariableInitializerList |
-            Ctr__Java__77 WhileStatement |
-            Ctr__Java__78 WildcardType |
+-- Source position of a node: every constructor except the Anti_* splice
+-- artifacts stores the position of its alternative's first symbol in its
+-- first field. Positions are transparent for equality and ordering, so two
+-- ASTs that differ only in source positions (e.g. a quasi-quote parsed at
+-- compile time vs the same construct parsed at run time) compare equal.
+newtype RtkPos = RtkPos L.AlexPosn deriving (Show, Gen.Data, Gen.Typeable)
+instance Eq RtkPos where _ == _ = True
+instance Ord RtkPos where compare _ _ = EQ
+
+-- The position used where no source token exists: empty productions, empty
+-- lists, absent optionals and Anti_* quasi-quote splices
+rtkNoPos :: RtkPos
+rtkNoPos = RtkPos (L.AlexPn 0 0 0)
+
+class RtkPosOf a where
+    rtkPosOf :: a -> RtkPos
+instance RtkPosOf L.PosToken where
+    rtkPosOf (L.PosToken p _) = RtkPos p
+instance RtkPosOf a => RtkPosOf [a] where
+    rtkPosOf (x : _) = rtkPosOf x
+    rtkPosOf []      = rtkNoPos
+instance RtkPosOf a => RtkPosOf (Maybe a) where
+    rtkPosOf (Just x) = rtkPosOf x
+    rtkPosOf Nothing  = rtkNoPos
+-- A Char carries no position; this also covers String token payloads
+instance RtkPosOf Char where
+    rtkPosOf _ = rtkNoPos
+
+-- Recover a token's payload from the whole positioned token: %token
+-- bindings keep the L.PosToken so semantic actions can read its position
+tkVal_doccomment :: L.PosToken -> String
+tkVal_doccomment (L.PosToken _ (L.Tk__doccomment v)) = v
+tkVal_doccomment t = error ("rtk internal error: token doccomment expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_id :: L.PosToken -> String
+tkVal_id (L.PosToken _ (L.Tk__id v)) = v
+tkVal_id t = error ("rtk internal error: token id expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_string :: L.PosToken -> String
+tkVal_string (L.PosToken _ (L.Tk__string v)) = v
+tkVal_string t = error ("rtk internal error: token string expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_char :: L.PosToken -> String
+tkVal_char (L.PosToken _ (L.Tk__char v)) = v
+tkVal_char t = error ("rtk internal error: token char expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_floatTypeSuffix :: L.PosToken -> String
+tkVal_floatTypeSuffix (L.PosToken _ (L.Tk__floatTypeSuffix v)) = v
+tkVal_floatTypeSuffix t = error ("rtk internal error: token floatTypeSuffix expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_exponentPart :: L.PosToken -> String
+tkVal_exponentPart (L.PosToken _ (L.Tk__exponentPart v)) = v
+tkVal_exponentPart t = error ("rtk internal error: token exponentPart expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_floatLiteral :: L.PosToken -> String
+tkVal_floatLiteral (L.PosToken _ (L.Tk__floatLiteral v)) = v
+tkVal_floatLiteral t = error ("rtk internal error: token floatLiteral expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_integerLiteral :: L.PosToken -> String
+tkVal_integerLiteral (L.PosToken _ (L.Tk__integerLiteral v)) = v
+tkVal_integerLiteral t = error ("rtk internal error: token integerLiteral expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_CompoundName :: L.PosToken -> String
+tkVal_qq_CompoundName (L.PosToken _ (L.Tk__qq_CompoundName v)) = v
+tkVal_qq_CompoundName t = error ("rtk internal error: token qq_CompoundName expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_Modifier :: L.PosToken -> String
+tkVal_qq_Modifier (L.PosToken _ (L.Tk__qq_Modifier v)) = v
+tkVal_qq_Modifier t = error ("rtk internal error: token qq_Modifier expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_TypeSpecifier :: L.PosToken -> String
+tkVal_qq_TypeSpecifier (L.PosToken _ (L.Tk__qq_TypeSpecifier v)) = v
+tkVal_qq_TypeSpecifier t = error ("rtk internal error: token qq_TypeSpecifier expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_Type :: L.PosToken -> String
+tkVal_qq_Type (L.PosToken _ (L.Tk__qq_Type v)) = v
+tkVal_qq_Type t = error ("rtk internal error: token qq_Type expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_TypeParameter :: L.PosToken -> String
+tkVal_qq_TypeParameter (L.PosToken _ (L.Tk__qq_TypeParameter v)) = v
+tkVal_qq_TypeParameter t = error ("rtk internal error: token qq_TypeParameter expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_TypeParameters :: L.PosToken -> String
+tkVal_qq_TypeParameters (L.PosToken _ (L.Tk__qq_TypeParameters v)) = v
+tkVal_qq_TypeParameters t = error ("rtk internal error: token qq_TypeParameters expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_WildcardType :: L.PosToken -> String
+tkVal_qq_WildcardType (L.PosToken _ (L.Tk__qq_WildcardType v)) = v
+tkVal_qq_WildcardType t = error ("rtk internal error: token qq_WildcardType expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_TypeArgument :: L.PosToken -> String
+tkVal_qq_TypeArgument (L.PosToken _ (L.Tk__qq_TypeArgument v)) = v
+tkVal_qq_TypeArgument t = error ("rtk internal error: token qq_TypeArgument expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_TypeArguments :: L.PosToken -> String
+tkVal_qq_TypeArguments (L.PosToken _ (L.Tk__qq_TypeArguments v)) = v
+tkVal_qq_TypeArguments t = error ("rtk internal error: token qq_TypeArguments expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_Arglist :: L.PosToken -> String
+tkVal_qq_Arglist (L.PosToken _ (L.Tk__qq_Arglist v)) = v
+tkVal_qq_Arglist t = error ("rtk internal error: token qq_Arglist expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_Literal :: L.PosToken -> String
+tkVal_qq_Literal (L.PosToken _ (L.Tk__qq_Literal v)) = v
+tkVal_qq_Literal t = error ("rtk internal error: token qq_Literal expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_CreationExpression :: L.PosToken -> String
+tkVal_qq_CreationExpression (L.PosToken _ (L.Tk__qq_CreationExpression v)) = v
+tkVal_qq_CreationExpression t = error ("rtk internal error: token qq_CreationExpression expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_PostfixOp :: L.PosToken -> String
+tkVal_qq_PostfixOp (L.PosToken _ (L.Tk__qq_PostfixOp v)) = v
+tkVal_qq_PostfixOp t = error ("rtk internal error: token qq_PostfixOp expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_PrefixOp :: L.PosToken -> String
+tkVal_qq_PrefixOp (L.PosToken _ (L.Tk__qq_PrefixOp v)) = v
+tkVal_qq_PrefixOp t = error ("rtk internal error: token qq_PrefixOp expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_MultiplicativeOp :: L.PosToken -> String
+tkVal_qq_MultiplicativeOp (L.PosToken _ (L.Tk__qq_MultiplicativeOp v)) = v
+tkVal_qq_MultiplicativeOp t = error ("rtk internal error: token qq_MultiplicativeOp expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_AdditiveOp :: L.PosToken -> String
+tkVal_qq_AdditiveOp (L.PosToken _ (L.Tk__qq_AdditiveOp v)) = v
+tkVal_qq_AdditiveOp t = error ("rtk internal error: token qq_AdditiveOp expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_ShiftOp :: L.PosToken -> String
+tkVal_qq_ShiftOp (L.PosToken _ (L.Tk__qq_ShiftOp v)) = v
+tkVal_qq_ShiftOp t = error ("rtk internal error: token qq_ShiftOp expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_RelationalOp :: L.PosToken -> String
+tkVal_qq_RelationalOp (L.PosToken _ (L.Tk__qq_RelationalOp v)) = v
+tkVal_qq_RelationalOp t = error ("rtk internal error: token qq_RelationalOp expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_EqualityOp :: L.PosToken -> String
+tkVal_qq_EqualityOp (L.PosToken _ (L.Tk__qq_EqualityOp v)) = v
+tkVal_qq_EqualityOp t = error ("rtk internal error: token qq_EqualityOp expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_AssignmentOp :: L.PosToken -> String
+tkVal_qq_AssignmentOp (L.PosToken _ (L.Tk__qq_AssignmentOp v)) = v
+tkVal_qq_AssignmentOp t = error ("rtk internal error: token qq_AssignmentOp expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_Expression :: L.PosToken -> String
+tkVal_qq_Expression (L.PosToken _ (L.Tk__qq_Expression v)) = v
+tkVal_qq_Expression t = error ("rtk internal error: token qq_Expression expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_SwitchStatement :: L.PosToken -> String
+tkVal_qq_SwitchStatement (L.PosToken _ (L.Tk__qq_SwitchStatement v)) = v
+tkVal_qq_SwitchStatement t = error ("rtk internal error: token qq_SwitchStatement expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_SwitchCaseList :: L.PosToken -> String
+tkVal_qq_SwitchCaseList (L.PosToken _ (L.Tk__qq_SwitchCaseList v)) = v
+tkVal_qq_SwitchCaseList t = error ("rtk internal error: token qq_SwitchCaseList expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_TryStatement :: L.PosToken -> String
+tkVal_qq_TryStatement (L.PosToken _ (L.Tk__qq_TryStatement v)) = v
+tkVal_qq_TryStatement t = error ("rtk internal error: token qq_TryStatement expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_OptFinally :: L.PosToken -> String
+tkVal_qq_OptFinally (L.PosToken _ (L.Tk__qq_OptFinally v)) = v
+tkVal_qq_OptFinally t = error ("rtk internal error: token qq_OptFinally expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_CatchList :: L.PosToken -> String
+tkVal_qq_CatchList (L.PosToken _ (L.Tk__qq_CatchList v)) = v
+tkVal_qq_CatchList t = error ("rtk internal error: token qq_CatchList expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_ForStatement :: L.PosToken -> String
+tkVal_qq_ForStatement (L.PosToken _ (L.Tk__qq_ForStatement v)) = v
+tkVal_qq_ForStatement t = error ("rtk internal error: token qq_ForStatement expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_WhileStatement :: L.PosToken -> String
+tkVal_qq_WhileStatement (L.PosToken _ (L.Tk__qq_WhileStatement v)) = v
+tkVal_qq_WhileStatement t = error ("rtk internal error: token qq_WhileStatement expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_DoStatement :: L.PosToken -> String
+tkVal_qq_DoStatement (L.PosToken _ (L.Tk__qq_DoStatement v)) = v
+tkVal_qq_DoStatement t = error ("rtk internal error: token qq_DoStatement expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_IfStatement :: L.PosToken -> String
+tkVal_qq_IfStatement (L.PosToken _ (L.Tk__qq_IfStatement v)) = v
+tkVal_qq_IfStatement t = error ("rtk internal error: token qq_IfStatement expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_OptElsePart :: L.PosToken -> String
+tkVal_qq_OptElsePart (L.PosToken _ (L.Tk__qq_OptElsePart v)) = v
+tkVal_qq_OptElsePart t = error ("rtk internal error: token qq_OptElsePart expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_StatementWithoutIf :: L.PosToken -> String
+tkVal_qq_StatementWithoutIf (L.PosToken _ (L.Tk__qq_StatementWithoutIf v)) = v
+tkVal_qq_StatementWithoutIf t = error ("rtk internal error: token qq_StatementWithoutIf expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_Statement :: L.PosToken -> String
+tkVal_qq_Statement (L.PosToken _ (L.Tk__qq_Statement v)) = v
+tkVal_qq_Statement t = error ("rtk internal error: token qq_Statement expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_OptId :: L.PosToken -> String
+tkVal_qq_OptId (L.PosToken _ (L.Tk__qq_OptId v)) = v
+tkVal_qq_OptId t = error ("rtk internal error: token qq_OptId expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_OptExpression :: L.PosToken -> String
+tkVal_qq_OptExpression (L.PosToken _ (L.Tk__qq_OptExpression v)) = v
+tkVal_qq_OptExpression t = error ("rtk internal error: token qq_OptExpression expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_StatementList :: L.PosToken -> String
+tkVal_qq_StatementList (L.PosToken _ (L.Tk__qq_StatementList v)) = v
+tkVal_qq_StatementList t = error ("rtk internal error: token qq_StatementList expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_Parameter :: L.PosToken -> String
+tkVal_qq_Parameter (L.PosToken _ (L.Tk__qq_Parameter v)) = v
+tkVal_qq_Parameter t = error ("rtk internal error: token qq_Parameter expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_ParameterList :: L.PosToken -> String
+tkVal_qq_ParameterList (L.PosToken _ (L.Tk__qq_ParameterList v)) = v
+tkVal_qq_ParameterList t = error ("rtk internal error: token qq_ParameterList expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_StaticInitializer :: L.PosToken -> String
+tkVal_qq_StaticInitializer (L.PosToken _ (L.Tk__qq_StaticInitializer v)) = v
+tkVal_qq_StaticInitializer t = error ("rtk internal error: token qq_StaticInitializer expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_VariableInitializer :: L.PosToken -> String
+tkVal_qq_VariableInitializer (L.PosToken _ (L.Tk__qq_VariableInitializer v)) = v
+tkVal_qq_VariableInitializer t = error ("rtk internal error: token qq_VariableInitializer expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_VariableInitializerList :: L.PosToken -> String
+tkVal_qq_VariableInitializerList (L.PosToken _ (L.Tk__qq_VariableInitializerList v)) = v
+tkVal_qq_VariableInitializerList t = error ("rtk internal error: token qq_VariableInitializerList expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_VariableDeclarator :: L.PosToken -> String
+tkVal_qq_VariableDeclarator (L.PosToken _ (L.Tk__qq_VariableDeclarator v)) = v
+tkVal_qq_VariableDeclarator t = error ("rtk internal error: token qq_VariableDeclarator expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_OptVariableInitializer :: L.PosToken -> String
+tkVal_qq_OptVariableInitializer (L.PosToken _ (L.Tk__qq_OptVariableInitializer v)) = v
+tkVal_qq_OptVariableInitializer t = error ("rtk internal error: token qq_OptVariableInitializer expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_VariableDeclaration :: L.PosToken -> String
+tkVal_qq_VariableDeclaration (L.PosToken _ (L.Tk__qq_VariableDeclaration v)) = v
+tkVal_qq_VariableDeclaration t = error ("rtk internal error: token qq_VariableDeclaration expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_VariableDeclaratorList :: L.PosToken -> String
+tkVal_qq_VariableDeclaratorList (L.PosToken _ (L.Tk__qq_VariableDeclaratorList v)) = v
+tkVal_qq_VariableDeclaratorList t = error ("rtk internal error: token qq_VariableDeclaratorList expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_StatementBlock :: L.PosToken -> String
+tkVal_qq_StatementBlock (L.PosToken _ (L.Tk__qq_StatementBlock v)) = v
+tkVal_qq_StatementBlock t = error ("rtk internal error: token qq_StatementBlock expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_MoreVariableDeclarators :: L.PosToken -> String
+tkVal_qq_MoreVariableDeclarators (L.PosToken _ (L.Tk__qq_MoreVariableDeclarators v)) = v
+tkVal_qq_MoreVariableDeclarators t = error ("rtk internal error: token qq_MoreVariableDeclarators expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_MemberRest :: L.PosToken -> String
+tkVal_qq_MemberRest (L.PosToken _ (L.Tk__qq_MemberRest v)) = v
+tkVal_qq_MemberRest t = error ("rtk internal error: token qq_MemberRest expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_MoreTypeSpecifier :: L.PosToken -> String
+tkVal_qq_MoreTypeSpecifier (L.PosToken _ (L.Tk__qq_MoreTypeSpecifier v)) = v
+tkVal_qq_MoreTypeSpecifier t = error ("rtk internal error: token qq_MoreTypeSpecifier expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_MemberAfterFirstId :: L.PosToken -> String
+tkVal_qq_MemberAfterFirstId (L.PosToken _ (L.Tk__qq_MemberAfterFirstId v)) = v
+tkVal_qq_MemberAfterFirstId t = error ("rtk internal error: token qq_MemberAfterFirstId expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_PrimitiveTypeKeyword :: L.PosToken -> String
+tkVal_qq_PrimitiveTypeKeyword (L.PosToken _ (L.Tk__qq_PrimitiveTypeKeyword v)) = v
+tkVal_qq_PrimitiveTypeKeyword t = error ("rtk internal error: token qq_PrimitiveTypeKeyword expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_MemberDeclaration :: L.PosToken -> String
+tkVal_qq_MemberDeclaration (L.PosToken _ (L.Tk__qq_MemberDeclaration v)) = v
+tkVal_qq_MemberDeclaration t = error ("rtk internal error: token qq_MemberDeclaration expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_SquareBracketsList :: L.PosToken -> String
+tkVal_qq_SquareBracketsList (L.PosToken _ (L.Tk__qq_SquareBracketsList v)) = v
+tkVal_qq_SquareBracketsList t = error ("rtk internal error: token qq_SquareBracketsList expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_FieldDeclaration :: L.PosToken -> String
+tkVal_qq_FieldDeclaration (L.PosToken _ (L.Tk__qq_FieldDeclaration v)) = v
+tkVal_qq_FieldDeclaration t = error ("rtk internal error: token qq_FieldDeclaration expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_NestedTypeDeclaration :: L.PosToken -> String
+tkVal_qq_NestedTypeDeclaration (L.PosToken _ (L.Tk__qq_NestedTypeDeclaration v)) = v
+tkVal_qq_NestedTypeDeclaration t = error ("rtk internal error: token qq_NestedTypeDeclaration expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_EnumDeclaration :: L.PosToken -> String
+tkVal_qq_EnumDeclaration (L.PosToken _ (L.Tk__qq_EnumDeclaration v)) = v
+tkVal_qq_EnumDeclaration t = error ("rtk internal error: token qq_EnumDeclaration expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_EnumConstantList :: L.PosToken -> String
+tkVal_qq_EnumConstantList (L.PosToken _ (L.Tk__qq_EnumConstantList v)) = v
+tkVal_qq_EnumConstantList t = error ("rtk internal error: token qq_EnumConstantList expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_EnumConstant :: L.PosToken -> String
+tkVal_qq_EnumConstant (L.PosToken _ (L.Tk__qq_EnumConstant v)) = v
+tkVal_qq_EnumConstant t = error ("rtk internal error: token qq_EnumConstant expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_AnnotationTypeElement :: L.PosToken -> String
+tkVal_qq_AnnotationTypeElement (L.PosToken _ (L.Tk__qq_AnnotationTypeElement v)) = v
+tkVal_qq_AnnotationTypeElement t = error ("rtk internal error: token qq_AnnotationTypeElement expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_AnnotationTypeElementList :: L.PosToken -> String
+tkVal_qq_AnnotationTypeElementList (L.PosToken _ (L.Tk__qq_AnnotationTypeElementList v)) = v
+tkVal_qq_AnnotationTypeElementList t = error ("rtk internal error: token qq_AnnotationTypeElementList expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_AnnotationDeclaration :: L.PosToken -> String
+tkVal_qq_AnnotationDeclaration (L.PosToken _ (L.Tk__qq_AnnotationDeclaration v)) = v
+tkVal_qq_AnnotationDeclaration t = error ("rtk internal error: token qq_AnnotationDeclaration expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_InterfaceDeclaration :: L.PosToken -> String
+tkVal_qq_InterfaceDeclaration (L.PosToken _ (L.Tk__qq_InterfaceDeclaration v)) = v
+tkVal_qq_InterfaceDeclaration t = error ("rtk internal error: token qq_InterfaceDeclaration expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_ClassDeclaration :: L.PosToken -> String
+tkVal_qq_ClassDeclaration (L.PosToken _ (L.Tk__qq_ClassDeclaration v)) = v
+tkVal_qq_ClassDeclaration t = error ("rtk internal error: token qq_ClassDeclaration expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_FieldDeclarationList :: L.PosToken -> String
+tkVal_qq_FieldDeclarationList (L.PosToken _ (L.Tk__qq_FieldDeclarationList v)) = v
+tkVal_qq_FieldDeclarationList t = error ("rtk internal error: token qq_FieldDeclarationList expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_ImplementsList :: L.PosToken -> String
+tkVal_qq_ImplementsList (L.PosToken _ (L.Tk__qq_ImplementsList v)) = v
+tkVal_qq_ImplementsList t = error ("rtk internal error: token qq_ImplementsList expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_ExtendsList :: L.PosToken -> String
+tkVal_qq_ExtendsList (L.PosToken _ (L.Tk__qq_ExtendsList v)) = v
+tkVal_qq_ExtendsList t = error ("rtk internal error: token qq_ExtendsList expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_ModifierList :: L.PosToken -> String
+tkVal_qq_ModifierList (L.PosToken _ (L.Tk__qq_ModifierList v)) = v
+tkVal_qq_ModifierList t = error ("rtk internal error: token qq_ModifierList expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_AnnotationList :: L.PosToken -> String
+tkVal_qq_AnnotationList (L.PosToken _ (L.Tk__qq_AnnotationList v)) = v
+tkVal_qq_AnnotationList t = error ("rtk internal error: token qq_AnnotationList expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_AnnotationElement :: L.PosToken -> String
+tkVal_qq_AnnotationElement (L.PosToken _ (L.Tk__qq_AnnotationElement v)) = v
+tkVal_qq_AnnotationElement t = error ("rtk internal error: token qq_AnnotationElement expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_AnnotationArguments :: L.PosToken -> String
+tkVal_qq_AnnotationArguments (L.PosToken _ (L.Tk__qq_AnnotationArguments v)) = v
+tkVal_qq_AnnotationArguments t = error ("rtk internal error: token qq_AnnotationArguments expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_Annotation :: L.PosToken -> String
+tkVal_qq_Annotation (L.PosToken _ (L.Tk__qq_Annotation v)) = v
+tkVal_qq_Annotation t = error ("rtk internal error: token qq_Annotation expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_DocComment :: L.PosToken -> String
+tkVal_qq_DocComment (L.PosToken _ (L.Tk__qq_DocComment v)) = v
+tkVal_qq_DocComment t = error ("rtk internal error: token qq_DocComment expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_ImportStatement :: L.PosToken -> String
+tkVal_qq_ImportStatement (L.PosToken _ (L.Tk__qq_ImportStatement v)) = v
+tkVal_qq_ImportStatement t = error ("rtk internal error: token qq_ImportStatement expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_Package :: L.PosToken -> String
+tkVal_qq_Package (L.PosToken _ (L.Tk__qq_Package v)) = v
+tkVal_qq_Package t = error ("rtk internal error: token qq_Package expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_CompilationUnit :: L.PosToken -> String
+tkVal_qq_CompilationUnit (L.PosToken _ (L.Tk__qq_CompilationUnit v)) = v
+tkVal_qq_CompilationUnit t = error ("rtk internal error: token qq_CompilationUnit expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_ImportList :: L.PosToken -> String
+tkVal_qq_ImportList (L.PosToken _ (L.Tk__qq_ImportList v)) = v
+tkVal_qq_ImportList t = error ("rtk internal error: token qq_ImportList expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_TypeDeclaration :: L.PosToken -> String
+tkVal_qq_TypeDeclaration (L.PosToken _ (L.Tk__qq_TypeDeclaration v)) = v
+tkVal_qq_TypeDeclaration t = error ("rtk internal error: token qq_TypeDeclaration expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_OptDocComment :: L.PosToken -> String
+tkVal_qq_OptDocComment (L.PosToken _ (L.Tk__qq_OptDocComment v)) = v
+tkVal_qq_OptDocComment t = error ("rtk internal error: token qq_OptDocComment expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_Java :: L.PosToken -> String
+tkVal_qq_Java (L.PosToken _ (L.Tk__qq_Java v)) = v
+tkVal_qq_Java t = error ("rtk internal error: token qq_Java expected, got " ++ showRtkToken (L.ptToken t))
+
+data Java = Ctr__Java__0 RtkPos Java |
+            Ctr__Java__1 RtkPos AdditiveOp |
+            Ctr__Java__2 RtkPos Annotation |
+            Ctr__Java__3 RtkPos AnnotationArguments |
+            Ctr__Java__4 RtkPos AnnotationDeclaration |
+            Ctr__Java__5 RtkPos AnnotationElement |
+            Ctr__Java__6 RtkPos AnnotationList |
+            Ctr__Java__7 RtkPos AnnotationTypeElement |
+            Ctr__Java__8 RtkPos AnnotationTypeElementList |
+            Ctr__Java__9 RtkPos Arglist |
+            Ctr__Java__10 RtkPos AssignmentOp |
+            Ctr__Java__11 RtkPos CatchList |
+            Ctr__Java__12 RtkPos ClassDeclaration |
+            Ctr__Java__13 RtkPos CompilationUnit |
+            Ctr__Java__14 RtkPos CompoundName |
+            Ctr__Java__15 RtkPos CreationExpression |
+            Ctr__Java__16 RtkPos DoStatement |
+            Ctr__Java__17 RtkPos DocComment |
+            Ctr__Java__18 RtkPos EnumConstant |
+            Ctr__Java__19 RtkPos EnumConstantList |
+            Ctr__Java__20 RtkPos EnumDeclaration |
+            Ctr__Java__21 RtkPos EqualityOp |
+            Ctr__Java__22 RtkPos Expression |
+            Ctr__Java__23 RtkPos ExtendsList |
+            Ctr__Java__24 RtkPos FieldDeclaration |
+            Ctr__Java__25 RtkPos FieldDeclarationList |
+            Ctr__Java__26 RtkPos ForStatement |
+            Ctr__Java__27 RtkPos IfStatement |
+            Ctr__Java__28 RtkPos ImplementsList |
+            Ctr__Java__29 RtkPos ImportList |
+            Ctr__Java__30 RtkPos ImportStatement |
+            Ctr__Java__31 RtkPos InterfaceDeclaration |
+            Ctr__Java__32 RtkPos Literal |
+            Ctr__Java__33 RtkPos MemberAfterFirstId |
+            Ctr__Java__34 RtkPos MemberDeclaration |
+            Ctr__Java__35 RtkPos MemberRest |
+            Ctr__Java__36 RtkPos Modifier |
+            Ctr__Java__37 RtkPos ModifierList |
+            Ctr__Java__38 RtkPos MoreTypeSpecifier |
+            Ctr__Java__39 RtkPos MoreVariableDeclarators |
+            Ctr__Java__40 RtkPos MultiplicativeOp |
+            Ctr__Java__41 RtkPos NestedTypeDeclaration |
+            Ctr__Java__42 RtkPos OptDocComment |
+            Ctr__Java__43 RtkPos OptElsePart |
+            Ctr__Java__44 RtkPos OptExpression |
+            Ctr__Java__45 RtkPos OptFinally |
+            Ctr__Java__46 RtkPos OptId |
+            Ctr__Java__47 RtkPos OptVariableInitializer |
+            Ctr__Java__48 RtkPos Package |
+            Ctr__Java__49 RtkPos Parameter |
+            Ctr__Java__50 RtkPos ParameterList |
+            Ctr__Java__51 RtkPos PostfixOp |
+            Ctr__Java__52 RtkPos PrefixOp |
+            Ctr__Java__53 RtkPos PrimitiveTypeKeyword |
+            Ctr__Java__54 RtkPos RelationalOp |
+            Ctr__Java__55 RtkPos ShiftOp |
+            Ctr__Java__56 RtkPos SquareBracketsList |
+            Ctr__Java__57 RtkPos Statement |
+            Ctr__Java__58 RtkPos StatementBlock |
+            Ctr__Java__59 RtkPos StatementList |
+            Ctr__Java__60 RtkPos StatementWithoutIf |
+            Ctr__Java__61 RtkPos StaticInitializer |
+            Ctr__Java__62 RtkPos SwitchCaseList |
+            Ctr__Java__63 RtkPos SwitchStatement |
+            Ctr__Java__64 RtkPos TryStatement |
+            Ctr__Java__65 RtkPos Type |
+            Ctr__Java__66 RtkPos TypeArgument |
+            Ctr__Java__67 RtkPos TypeArguments |
+            Ctr__Java__68 RtkPos TypeDeclaration |
+            Ctr__Java__69 RtkPos TypeParameter |
+            Ctr__Java__70 RtkPos TypeParameters |
+            Ctr__Java__71 RtkPos TypeSpecifier |
+            Ctr__Java__72 RtkPos VariableDeclaration |
+            Ctr__Java__73 RtkPos VariableDeclarator |
+            Ctr__Java__74 RtkPos VariableDeclaratorList |
+            Ctr__Java__75 RtkPos VariableInitializer |
+            Ctr__Java__76 RtkPos VariableInitializerList |
+            Ctr__Java__77 RtkPos WhileStatement |
+            Ctr__Java__78 RtkPos WildcardType |
             Anti_Java String |
-            Ctr__Java__79 CompilationUnit
+            Ctr__Java__79 RtkPos CompilationUnit
             deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Java where
+    rtkPosOf (Ctr__Java__0 p _) = p
+    rtkPosOf (Ctr__Java__1 p _) = p
+    rtkPosOf (Ctr__Java__2 p _) = p
+    rtkPosOf (Ctr__Java__3 p _) = p
+    rtkPosOf (Ctr__Java__4 p _) = p
+    rtkPosOf (Ctr__Java__5 p _) = p
+    rtkPosOf (Ctr__Java__6 p _) = p
+    rtkPosOf (Ctr__Java__7 p _) = p
+    rtkPosOf (Ctr__Java__8 p _) = p
+    rtkPosOf (Ctr__Java__9 p _) = p
+    rtkPosOf (Ctr__Java__10 p _) = p
+    rtkPosOf (Ctr__Java__11 p _) = p
+    rtkPosOf (Ctr__Java__12 p _) = p
+    rtkPosOf (Ctr__Java__13 p _) = p
+    rtkPosOf (Ctr__Java__14 p _) = p
+    rtkPosOf (Ctr__Java__15 p _) = p
+    rtkPosOf (Ctr__Java__16 p _) = p
+    rtkPosOf (Ctr__Java__17 p _) = p
+    rtkPosOf (Ctr__Java__18 p _) = p
+    rtkPosOf (Ctr__Java__19 p _) = p
+    rtkPosOf (Ctr__Java__20 p _) = p
+    rtkPosOf (Ctr__Java__21 p _) = p
+    rtkPosOf (Ctr__Java__22 p _) = p
+    rtkPosOf (Ctr__Java__23 p _) = p
+    rtkPosOf (Ctr__Java__24 p _) = p
+    rtkPosOf (Ctr__Java__25 p _) = p
+    rtkPosOf (Ctr__Java__26 p _) = p
+    rtkPosOf (Ctr__Java__27 p _) = p
+    rtkPosOf (Ctr__Java__28 p _) = p
+    rtkPosOf (Ctr__Java__29 p _) = p
+    rtkPosOf (Ctr__Java__30 p _) = p
+    rtkPosOf (Ctr__Java__31 p _) = p
+    rtkPosOf (Ctr__Java__32 p _) = p
+    rtkPosOf (Ctr__Java__33 p _) = p
+    rtkPosOf (Ctr__Java__34 p _) = p
+    rtkPosOf (Ctr__Java__35 p _) = p
+    rtkPosOf (Ctr__Java__36 p _) = p
+    rtkPosOf (Ctr__Java__37 p _) = p
+    rtkPosOf (Ctr__Java__38 p _) = p
+    rtkPosOf (Ctr__Java__39 p _) = p
+    rtkPosOf (Ctr__Java__40 p _) = p
+    rtkPosOf (Ctr__Java__41 p _) = p
+    rtkPosOf (Ctr__Java__42 p _) = p
+    rtkPosOf (Ctr__Java__43 p _) = p
+    rtkPosOf (Ctr__Java__44 p _) = p
+    rtkPosOf (Ctr__Java__45 p _) = p
+    rtkPosOf (Ctr__Java__46 p _) = p
+    rtkPosOf (Ctr__Java__47 p _) = p
+    rtkPosOf (Ctr__Java__48 p _) = p
+    rtkPosOf (Ctr__Java__49 p _) = p
+    rtkPosOf (Ctr__Java__50 p _) = p
+    rtkPosOf (Ctr__Java__51 p _) = p
+    rtkPosOf (Ctr__Java__52 p _) = p
+    rtkPosOf (Ctr__Java__53 p _) = p
+    rtkPosOf (Ctr__Java__54 p _) = p
+    rtkPosOf (Ctr__Java__55 p _) = p
+    rtkPosOf (Ctr__Java__56 p _) = p
+    rtkPosOf (Ctr__Java__57 p _) = p
+    rtkPosOf (Ctr__Java__58 p _) = p
+    rtkPosOf (Ctr__Java__59 p _) = p
+    rtkPosOf (Ctr__Java__60 p _) = p
+    rtkPosOf (Ctr__Java__61 p _) = p
+    rtkPosOf (Ctr__Java__62 p _) = p
+    rtkPosOf (Ctr__Java__63 p _) = p
+    rtkPosOf (Ctr__Java__64 p _) = p
+    rtkPosOf (Ctr__Java__65 p _) = p
+    rtkPosOf (Ctr__Java__66 p _) = p
+    rtkPosOf (Ctr__Java__67 p _) = p
+    rtkPosOf (Ctr__Java__68 p _) = p
+    rtkPosOf (Ctr__Java__69 p _) = p
+    rtkPosOf (Ctr__Java__70 p _) = p
+    rtkPosOf (Ctr__Java__71 p _) = p
+    rtkPosOf (Ctr__Java__72 p _) = p
+    rtkPosOf (Ctr__Java__73 p _) = p
+    rtkPosOf (Ctr__Java__74 p _) = p
+    rtkPosOf (Ctr__Java__75 p _) = p
+    rtkPosOf (Ctr__Java__76 p _) = p
+    rtkPosOf (Ctr__Java__77 p _) = p
+    rtkPosOf (Ctr__Java__78 p _) = p
+    rtkPosOf (Anti_Java _) = rtkNoPos
+    rtkPosOf (Ctr__Java__79 p _) = p
 data AdditiveOp = Anti_AdditiveOp String |
-                  Ctr__AdditiveOp__0 |
-                  Ctr__AdditiveOp__1
+                  Ctr__AdditiveOp__0 RtkPos |
+                  Ctr__AdditiveOp__1 RtkPos
                   deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf AdditiveOp where
+    rtkPosOf (Anti_AdditiveOp _) = rtkNoPos
+    rtkPosOf (Ctr__AdditiveOp__0 p) = p
+    rtkPosOf (Ctr__AdditiveOp__1 p) = p
 data Annotation = Anti_Annotation String |
-                  Ctr__Annotation__1 CompoundName Rule_10
+                  Ctr__Annotation__1 RtkPos CompoundName Rule_10
                   deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Annotation where
+    rtkPosOf (Anti_Annotation _) = rtkNoPos
+    rtkPosOf (Ctr__Annotation__1 p _ _) = p
 data AnnotationArguments = Anti_AnnotationArguments String |
-                           Ctr__AnnotationArguments__0 AnnotationElement Rule_13
+                           Ctr__AnnotationArguments__0 RtkPos AnnotationElement Rule_13
                            deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf AnnotationArguments where
+    rtkPosOf (Anti_AnnotationArguments _) = rtkNoPos
+    rtkPosOf (Ctr__AnnotationArguments__0 p _ _) = p
 data AnnotationDeclaration = Anti_AnnotationDeclaration String |
-                             Ctr__AnnotationDeclaration__0 ModifierList String AnnotationTypeElementList
+                             Ctr__AnnotationDeclaration__0 RtkPos ModifierList String AnnotationTypeElementList
                              deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf AnnotationDeclaration where
+    rtkPosOf (Anti_AnnotationDeclaration _) = rtkNoPos
+    rtkPosOf (Ctr__AnnotationDeclaration__0 p _ _ _) = p
 data AnnotationElement = Anti_AnnotationElement String |
-                         Ctr__AnnotationElement__0 String Expression |
-                         Ctr__AnnotationElement__1 Expression
+                         Ctr__AnnotationElement__0 RtkPos String Expression |
+                         Ctr__AnnotationElement__1 RtkPos Expression
                          deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf AnnotationElement where
+    rtkPosOf (Anti_AnnotationElement _) = rtkNoPos
+    rtkPosOf (Ctr__AnnotationElement__0 p _ _) = p
+    rtkPosOf (Ctr__AnnotationElement__1 p _) = p
 type AnnotationList = [Annotation]
 data AnnotationTypeElement = Anti_AnnotationTypeElement String |
-                             Ctr__AnnotationTypeElement__0 FieldDeclaration
+                             Ctr__AnnotationTypeElement__0 RtkPos FieldDeclaration
                              deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf AnnotationTypeElement where
+    rtkPosOf (Anti_AnnotationTypeElement _) = rtkNoPos
+    rtkPosOf (Ctr__AnnotationTypeElement__0 p _) = p
 type AnnotationTypeElementList = [AnnotationTypeElement]
 data Arglist = Anti_Arglist String |
-               Ctr__Arglist__0 |
-               Ctr__Arglist__1 Rule_77
+               Ctr__Arglist__0 RtkPos |
+               Ctr__Arglist__1 RtkPos Rule_77
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Arglist where
+    rtkPosOf (Anti_Arglist _) = rtkNoPos
+    rtkPosOf (Ctr__Arglist__0 p) = p
+    rtkPosOf (Ctr__Arglist__1 p _) = p
 data AssignmentOp = Anti_AssignmentOp String |
-                    Ctr__AssignmentOp__0 |
-                    Ctr__AssignmentOp__1 |
-                    Ctr__AssignmentOp__2 |
-                    Ctr__AssignmentOp__3 |
-                    Ctr__AssignmentOp__4 |
-                    Ctr__AssignmentOp__5 |
-                    Ctr__AssignmentOp__6 |
-                    Ctr__AssignmentOp__7 |
-                    Ctr__AssignmentOp__8 |
-                    Ctr__AssignmentOp__9 |
-                    Ctr__AssignmentOp__10 |
-                    Ctr__AssignmentOp__11
+                    Ctr__AssignmentOp__0 RtkPos |
+                    Ctr__AssignmentOp__1 RtkPos |
+                    Ctr__AssignmentOp__2 RtkPos |
+                    Ctr__AssignmentOp__3 RtkPos |
+                    Ctr__AssignmentOp__4 RtkPos |
+                    Ctr__AssignmentOp__5 RtkPos |
+                    Ctr__AssignmentOp__6 RtkPos |
+                    Ctr__AssignmentOp__7 RtkPos |
+                    Ctr__AssignmentOp__8 RtkPos |
+                    Ctr__AssignmentOp__9 RtkPos |
+                    Ctr__AssignmentOp__10 RtkPos |
+                    Ctr__AssignmentOp__11 RtkPos
                     deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf AssignmentOp where
+    rtkPosOf (Anti_AssignmentOp _) = rtkNoPos
+    rtkPosOf (Ctr__AssignmentOp__0 p) = p
+    rtkPosOf (Ctr__AssignmentOp__1 p) = p
+    rtkPosOf (Ctr__AssignmentOp__2 p) = p
+    rtkPosOf (Ctr__AssignmentOp__3 p) = p
+    rtkPosOf (Ctr__AssignmentOp__4 p) = p
+    rtkPosOf (Ctr__AssignmentOp__5 p) = p
+    rtkPosOf (Ctr__AssignmentOp__6 p) = p
+    rtkPosOf (Ctr__AssignmentOp__7 p) = p
+    rtkPosOf (Ctr__AssignmentOp__8 p) = p
+    rtkPosOf (Ctr__AssignmentOp__9 p) = p
+    rtkPosOf (Ctr__AssignmentOp__10 p) = p
+    rtkPosOf (Ctr__AssignmentOp__11 p) = p
 type CatchList = [Rule_63]
 data ClassDeclaration = Anti_ClassDeclaration String |
-                        Ctr__ClassDeclaration__0 ModifierList String TypeParameters Rule_22 Rule_23 FieldDeclarationList
+                        Ctr__ClassDeclaration__0 RtkPos ModifierList String TypeParameters Rule_22 Rule_23 FieldDeclarationList
                         deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf ClassDeclaration where
+    rtkPosOf (Anti_ClassDeclaration _) = rtkNoPos
+    rtkPosOf (Ctr__ClassDeclaration__0 p _ _ _ _ _ _) = p
 data CompilationUnit = Anti_CompilationUnit String |
-                       Ctr__CompilationUnit__0 Rule_4 ImportList Rule_6
+                       Ctr__CompilationUnit__0 RtkPos Rule_4 ImportList Rule_6
                        deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf CompilationUnit where
+    rtkPosOf (Anti_CompilationUnit _) = rtkNoPos
+    rtkPosOf (Ctr__CompilationUnit__0 p _ _ _) = p
 data CompoundName = Anti_CompoundName String |
-                    Ctr__CompoundName__0 String Rule_90
+                    Ctr__CompoundName__0 RtkPos String Rule_90
                     deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf CompoundName where
+    rtkPosOf (Anti_CompoundName _) = rtkNoPos
+    rtkPosOf (Ctr__CompoundName__0 p _ _) = p
 data CreationExpression = Anti_CreationExpression String |
-                          Ctr__CreationExpression__0 Type Rule_76
+                          Ctr__CreationExpression__0 RtkPos Type Rule_76
                           deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf CreationExpression where
+    rtkPosOf (Anti_CreationExpression _) = rtkNoPos
+    rtkPosOf (Ctr__CreationExpression__0 p _ _) = p
 data DoStatement = Anti_DoStatement String |
-                   Ctr__DoStatement__0 Statement Expression
+                   Ctr__DoStatement__0 RtkPos Statement Expression
                    deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf DoStatement where
+    rtkPosOf (Anti_DoStatement _) = rtkNoPos
+    rtkPosOf (Ctr__DoStatement__0 p _ _) = p
 data DocComment = Anti_DocComment String |
-                  Ctr__DocComment__0 String
+                  Ctr__DocComment__0 RtkPos String
                   deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf DocComment where
+    rtkPosOf (Anti_DocComment _) = rtkNoPos
+    rtkPosOf (Ctr__DocComment__0 p _) = p
 data EnumConstant = Anti_EnumConstant String |
-                    Ctr__EnumConstant__0 AnnotationList String Rule_26 Rule_28
+                    Ctr__EnumConstant__0 RtkPos AnnotationList String Rule_26 Rule_28
                     deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf EnumConstant where
+    rtkPosOf (Anti_EnumConstant _) = rtkNoPos
+    rtkPosOf (Ctr__EnumConstant__0 p _ _ _ _) = p
 data EnumConstantList = Anti_EnumConstantList String |
-                        Ctr__EnumConstantList__0 EnumConstant Rule_30 Rule_32
+                        Ctr__EnumConstantList__0 RtkPos EnumConstant Rule_30 Rule_32
                         deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf EnumConstantList where
+    rtkPosOf (Anti_EnumConstantList _) = rtkNoPos
+    rtkPosOf (Ctr__EnumConstantList__0 p _ _ _) = p
 data EnumDeclaration = Anti_EnumDeclaration String |
-                       Ctr__EnumDeclaration__0 ModifierList String Rule_34 EnumConstantList Rule_35
+                       Ctr__EnumDeclaration__0 RtkPos ModifierList String Rule_34 EnumConstantList Rule_35
                        deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf EnumDeclaration where
+    rtkPosOf (Anti_EnumDeclaration _) = rtkNoPos
+    rtkPosOf (Ctr__EnumDeclaration__0 p _ _ _ _ _) = p
 data EqualityOp = Anti_EqualityOp String |
-                  Ctr__EqualityOp__0 |
-                  Ctr__EqualityOp__1
+                  Ctr__EqualityOp__0 RtkPos |
+                  Ctr__EqualityOp__1 RtkPos
                   deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf EqualityOp where
+    rtkPosOf (Anti_EqualityOp _) = rtkNoPos
+    rtkPosOf (Ctr__EqualityOp__0 p) = p
+    rtkPosOf (Ctr__EqualityOp__1 p) = p
 data Expression = Anti_Expression String |
-                  Ctr__Expression__0 Literal |
-                  Ctr__Expression__1 |
-                  Ctr__Expression__2 Expression |
-                  Ctr__Expression__3 CreationExpression |
-                  Ctr__Expression__4 CompoundName Rule_72 |
-                  Ctr__Expression__5 String Rule_74 |
-                  Ctr__Expression__6 Expression |
-                  Ctr__Expression__7 Expression PostfixOp |
-                  Ctr__Expression__8 Expression String |
-                  Ctr__Expression__9 Expression String Arglist |
-                  Ctr__Expression__10 Expression Expression |
-                  Ctr__Expression__11 Expression |
-                  Ctr__Expression__12 Expression |
-                  Ctr__Expression__13 Expression |
-                  Ctr__Expression__14 Expression |
-                  Ctr__Expression__15 PrefixOp Expression |
-                  Ctr__Expression__16 Expression |
-                  Ctr__Expression__17 Type Expression |
-                  Ctr__Expression__18 Expression |
-                  Ctr__Expression__19 Expression MultiplicativeOp Expression |
-                  Ctr__Expression__20 Expression |
-                  Ctr__Expression__21 Expression AdditiveOp Expression |
-                  Ctr__Expression__22 Expression |
-                  Ctr__Expression__23 Expression ShiftOp Expression |
-                  Ctr__Expression__24 Expression |
-                  Ctr__Expression__25 Expression RelationalOp Expression |
-                  Ctr__Expression__26 Expression Type |
-                  Ctr__Expression__27 Expression |
-                  Ctr__Expression__28 Expression EqualityOp Expression |
-                  Ctr__Expression__29 Expression |
-                  Ctr__Expression__30 Expression Expression |
-                  Ctr__Expression__31 Expression |
-                  Ctr__Expression__32 Expression Expression |
-                  Ctr__Expression__33 Expression |
-                  Ctr__Expression__34 Expression Expression |
-                  Ctr__Expression__35 Expression |
-                  Ctr__Expression__36 Expression Expression |
-                  Ctr__Expression__37 Expression |
-                  Ctr__Expression__38 Expression Expression |
-                  Ctr__Expression__39 Expression |
-                  Ctr__Expression__40 Expression Expression Expression |
-                  Ctr__Expression__41 Expression Rule_70 |
-                  Ctr__Expression__42 Expression
+                  Ctr__Expression__0 RtkPos Literal |
+                  Ctr__Expression__1 RtkPos |
+                  Ctr__Expression__2 RtkPos Expression |
+                  Ctr__Expression__3 RtkPos CreationExpression |
+                  Ctr__Expression__4 RtkPos CompoundName Rule_72 |
+                  Ctr__Expression__5 RtkPos String Rule_74 |
+                  Ctr__Expression__6 RtkPos Expression |
+                  Ctr__Expression__7 RtkPos Expression PostfixOp |
+                  Ctr__Expression__8 RtkPos Expression String |
+                  Ctr__Expression__9 RtkPos Expression String Arglist |
+                  Ctr__Expression__10 RtkPos Expression Expression |
+                  Ctr__Expression__11 RtkPos Expression |
+                  Ctr__Expression__12 RtkPos Expression |
+                  Ctr__Expression__13 RtkPos Expression |
+                  Ctr__Expression__14 RtkPos Expression |
+                  Ctr__Expression__15 RtkPos PrefixOp Expression |
+                  Ctr__Expression__16 RtkPos Expression |
+                  Ctr__Expression__17 RtkPos Type Expression |
+                  Ctr__Expression__18 RtkPos Expression |
+                  Ctr__Expression__19 RtkPos Expression MultiplicativeOp Expression |
+                  Ctr__Expression__20 RtkPos Expression |
+                  Ctr__Expression__21 RtkPos Expression AdditiveOp Expression |
+                  Ctr__Expression__22 RtkPos Expression |
+                  Ctr__Expression__23 RtkPos Expression ShiftOp Expression |
+                  Ctr__Expression__24 RtkPos Expression |
+                  Ctr__Expression__25 RtkPos Expression RelationalOp Expression |
+                  Ctr__Expression__26 RtkPos Expression Type |
+                  Ctr__Expression__27 RtkPos Expression |
+                  Ctr__Expression__28 RtkPos Expression EqualityOp Expression |
+                  Ctr__Expression__29 RtkPos Expression |
+                  Ctr__Expression__30 RtkPos Expression Expression |
+                  Ctr__Expression__31 RtkPos Expression |
+                  Ctr__Expression__32 RtkPos Expression Expression |
+                  Ctr__Expression__33 RtkPos Expression |
+                  Ctr__Expression__34 RtkPos Expression Expression |
+                  Ctr__Expression__35 RtkPos Expression |
+                  Ctr__Expression__36 RtkPos Expression Expression |
+                  Ctr__Expression__37 RtkPos Expression |
+                  Ctr__Expression__38 RtkPos Expression Expression |
+                  Ctr__Expression__39 RtkPos Expression |
+                  Ctr__Expression__40 RtkPos Expression Expression Expression |
+                  Ctr__Expression__41 RtkPos Expression Rule_70 |
+                  Ctr__Expression__42 RtkPos Expression
                   deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Expression where
+    rtkPosOf (Anti_Expression _) = rtkNoPos
+    rtkPosOf (Ctr__Expression__0 p _) = p
+    rtkPosOf (Ctr__Expression__1 p) = p
+    rtkPosOf (Ctr__Expression__2 p _) = p
+    rtkPosOf (Ctr__Expression__3 p _) = p
+    rtkPosOf (Ctr__Expression__4 p _ _) = p
+    rtkPosOf (Ctr__Expression__5 p _ _) = p
+    rtkPosOf (Ctr__Expression__6 p _) = p
+    rtkPosOf (Ctr__Expression__7 p _ _) = p
+    rtkPosOf (Ctr__Expression__8 p _ _) = p
+    rtkPosOf (Ctr__Expression__9 p _ _ _) = p
+    rtkPosOf (Ctr__Expression__10 p _ _) = p
+    rtkPosOf (Ctr__Expression__11 p _) = p
+    rtkPosOf (Ctr__Expression__12 p _) = p
+    rtkPosOf (Ctr__Expression__13 p _) = p
+    rtkPosOf (Ctr__Expression__14 p _) = p
+    rtkPosOf (Ctr__Expression__15 p _ _) = p
+    rtkPosOf (Ctr__Expression__16 p _) = p
+    rtkPosOf (Ctr__Expression__17 p _ _) = p
+    rtkPosOf (Ctr__Expression__18 p _) = p
+    rtkPosOf (Ctr__Expression__19 p _ _ _) = p
+    rtkPosOf (Ctr__Expression__20 p _) = p
+    rtkPosOf (Ctr__Expression__21 p _ _ _) = p
+    rtkPosOf (Ctr__Expression__22 p _) = p
+    rtkPosOf (Ctr__Expression__23 p _ _ _) = p
+    rtkPosOf (Ctr__Expression__24 p _) = p
+    rtkPosOf (Ctr__Expression__25 p _ _ _) = p
+    rtkPosOf (Ctr__Expression__26 p _ _) = p
+    rtkPosOf (Ctr__Expression__27 p _) = p
+    rtkPosOf (Ctr__Expression__28 p _ _ _) = p
+    rtkPosOf (Ctr__Expression__29 p _) = p
+    rtkPosOf (Ctr__Expression__30 p _ _) = p
+    rtkPosOf (Ctr__Expression__31 p _) = p
+    rtkPosOf (Ctr__Expression__32 p _ _) = p
+    rtkPosOf (Ctr__Expression__33 p _) = p
+    rtkPosOf (Ctr__Expression__34 p _ _) = p
+    rtkPosOf (Ctr__Expression__35 p _) = p
+    rtkPosOf (Ctr__Expression__36 p _ _) = p
+    rtkPosOf (Ctr__Expression__37 p _) = p
+    rtkPosOf (Ctr__Expression__38 p _ _) = p
+    rtkPosOf (Ctr__Expression__39 p _) = p
+    rtkPosOf (Ctr__Expression__40 p _ _ _) = p
+    rtkPosOf (Ctr__Expression__41 p _ _) = p
+    rtkPosOf (Ctr__Expression__42 p _) = p
 data ExtendsList = Anti_ExtendsList String |
-                   Ctr__ExtendsList__0 CompoundName Rule_18
+                   Ctr__ExtendsList__0 RtkPos CompoundName Rule_18
                    deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf ExtendsList where
+    rtkPosOf (Anti_ExtendsList _) = rtkNoPos
+    rtkPosOf (Ctr__ExtendsList__0 p _ _) = p
 data FieldDeclaration = Anti_FieldDeclaration String |
-                        Ctr__FieldDeclaration__0 OptDocComment Rule_37 |
-                        Ctr__FieldDeclaration__1
+                        Ctr__FieldDeclaration__0 RtkPos OptDocComment Rule_37 |
+                        Ctr__FieldDeclaration__1 RtkPos
                         deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf FieldDeclaration where
+    rtkPosOf (Anti_FieldDeclaration _) = rtkNoPos
+    rtkPosOf (Ctr__FieldDeclaration__0 p _ _) = p
+    rtkPosOf (Ctr__FieldDeclaration__1 p) = p
 type FieldDeclarationList = [FieldDeclaration]
 data ForStatement = Anti_ForStatement String |
-                    Ctr__ForStatement__0 Rule_61 OptExpression OptExpression Statement
+                    Ctr__ForStatement__0 RtkPos Rule_61 OptExpression OptExpression Statement
                     deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf ForStatement where
+    rtkPosOf (Anti_ForStatement _) = rtkNoPos
+    rtkPosOf (Ctr__ForStatement__0 p _ _ _ _) = p
 data IfStatement = Anti_IfStatement String |
-                   Ctr__IfStatement__0 Expression StatementWithoutIf OptElsePart
+                   Ctr__IfStatement__0 RtkPos Expression StatementWithoutIf OptElsePart
                    deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf IfStatement where
+    rtkPosOf (Anti_IfStatement _) = rtkNoPos
+    rtkPosOf (Ctr__IfStatement__0 p _ _ _) = p
 data ImplementsList = Anti_ImplementsList String |
-                      Ctr__ImplementsList__0 Rule_20
+                      Ctr__ImplementsList__0 RtkPos Rule_20
                       deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf ImplementsList where
+    rtkPosOf (Anti_ImplementsList _) = rtkNoPos
+    rtkPosOf (Ctr__ImplementsList__0 p _) = p
 type ImportList = [Rule_2]
 data ImportStatement = Anti_ImportStatement String |
-                       Ctr__ImportStatement__0 Rule_8
+                       Ctr__ImportStatement__0 RtkPos Rule_8
                        deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf ImportStatement where
+    rtkPosOf (Anti_ImportStatement _) = rtkNoPos
+    rtkPosOf (Ctr__ImportStatement__0 p _) = p
 data InterfaceDeclaration = Anti_InterfaceDeclaration String |
-                            Ctr__InterfaceDeclaration__0 ModifierList String TypeParameters Rule_24 FieldDeclarationList
+                            Ctr__InterfaceDeclaration__0 RtkPos ModifierList String TypeParameters Rule_24 FieldDeclarationList
                             deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf InterfaceDeclaration where
+    rtkPosOf (Anti_InterfaceDeclaration _) = rtkNoPos
+    rtkPosOf (Ctr__InterfaceDeclaration__0 p _ _ _ _ _) = p
 data Literal = Anti_Literal String |
-               Ctr__Literal__0 String |
-               Ctr__Literal__1 String |
-               Ctr__Literal__2 |
-               Ctr__Literal__3 |
-               Ctr__Literal__4 String |
-               Ctr__Literal__5 String |
-               Ctr__Literal__6
+               Ctr__Literal__0 RtkPos String |
+               Ctr__Literal__1 RtkPos String |
+               Ctr__Literal__2 RtkPos |
+               Ctr__Literal__3 RtkPos |
+               Ctr__Literal__4 RtkPos String |
+               Ctr__Literal__5 RtkPos String |
+               Ctr__Literal__6 RtkPos
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Literal where
+    rtkPosOf (Anti_Literal _) = rtkNoPos
+    rtkPosOf (Ctr__Literal__0 p _) = p
+    rtkPosOf (Ctr__Literal__1 p _) = p
+    rtkPosOf (Ctr__Literal__2 p) = p
+    rtkPosOf (Ctr__Literal__3 p) = p
+    rtkPosOf (Ctr__Literal__4 p _) = p
+    rtkPosOf (Ctr__Literal__5 p _) = p
+    rtkPosOf (Ctr__Literal__6 p) = p
 data MemberAfterFirstId = Anti_MemberAfterFirstId String |
-                          Ctr__MemberAfterFirstId__0 Rule_42 StatementBlock |
-                          Ctr__MemberAfterFirstId__1 MoreTypeSpecifier String MemberRest
+                          Ctr__MemberAfterFirstId__0 RtkPos Rule_42 StatementBlock |
+                          Ctr__MemberAfterFirstId__1 RtkPos MoreTypeSpecifier String MemberRest
                           deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf MemberAfterFirstId where
+    rtkPosOf (Anti_MemberAfterFirstId _) = rtkNoPos
+    rtkPosOf (Ctr__MemberAfterFirstId__0 p _ _) = p
+    rtkPosOf (Ctr__MemberAfterFirstId__1 p _ _ _) = p
 data MemberDeclaration = Anti_MemberDeclaration String |
-                         Ctr__MemberDeclaration__0 PrimitiveTypeKeyword SquareBracketsList String MemberRest |
-                         Ctr__MemberDeclaration__1 TypeParameters String MoreTypeSpecifier String MemberRest |
-                         Ctr__MemberDeclaration__2 String MemberAfterFirstId
+                         Ctr__MemberDeclaration__0 RtkPos PrimitiveTypeKeyword SquareBracketsList String MemberRest |
+                         Ctr__MemberDeclaration__1 RtkPos TypeParameters String MoreTypeSpecifier String MemberRest |
+                         Ctr__MemberDeclaration__2 RtkPos String MemberAfterFirstId
                          deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf MemberDeclaration where
+    rtkPosOf (Anti_MemberDeclaration _) = rtkNoPos
+    rtkPosOf (Ctr__MemberDeclaration__0 p _ _ _ _) = p
+    rtkPosOf (Ctr__MemberDeclaration__1 p _ _ _ _ _) = p
+    rtkPosOf (Ctr__MemberDeclaration__2 p _ _) = p
 data MemberRest = Anti_MemberRest String |
-                  Ctr__MemberRest__0 Rule_43 SquareBracketsList Rule_44 |
-                  Ctr__MemberRest__1 SquareBracketsList OptVariableInitializer MoreVariableDeclarators
+                  Ctr__MemberRest__0 RtkPos Rule_43 SquareBracketsList Rule_44 |
+                  Ctr__MemberRest__1 RtkPos SquareBracketsList OptVariableInitializer MoreVariableDeclarators
                   deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf MemberRest where
+    rtkPosOf (Anti_MemberRest _) = rtkNoPos
+    rtkPosOf (Ctr__MemberRest__0 p _ _ _) = p
+    rtkPosOf (Ctr__MemberRest__1 p _ _ _) = p
 data Modifier = Anti_Modifier String |
-                Ctr__Modifier__0 |
-                Ctr__Modifier__1 |
-                Ctr__Modifier__2 |
-                Ctr__Modifier__3 |
-                Ctr__Modifier__4 |
-                Ctr__Modifier__5 |
-                Ctr__Modifier__6 |
-                Ctr__Modifier__7 |
-                Ctr__Modifier__8 |
-                Ctr__Modifier__9
+                Ctr__Modifier__0 RtkPos |
+                Ctr__Modifier__1 RtkPos |
+                Ctr__Modifier__2 RtkPos |
+                Ctr__Modifier__3 RtkPos |
+                Ctr__Modifier__4 RtkPos |
+                Ctr__Modifier__5 RtkPos |
+                Ctr__Modifier__6 RtkPos |
+                Ctr__Modifier__7 RtkPos |
+                Ctr__Modifier__8 RtkPos |
+                Ctr__Modifier__9 RtkPos
                 deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Modifier where
+    rtkPosOf (Anti_Modifier _) = rtkNoPos
+    rtkPosOf (Ctr__Modifier__0 p) = p
+    rtkPosOf (Ctr__Modifier__1 p) = p
+    rtkPosOf (Ctr__Modifier__2 p) = p
+    rtkPosOf (Ctr__Modifier__3 p) = p
+    rtkPosOf (Ctr__Modifier__4 p) = p
+    rtkPosOf (Ctr__Modifier__5 p) = p
+    rtkPosOf (Ctr__Modifier__6 p) = p
+    rtkPosOf (Ctr__Modifier__7 p) = p
+    rtkPosOf (Ctr__Modifier__8 p) = p
+    rtkPosOf (Ctr__Modifier__9 p) = p
 type ModifierList = [Rule_16]
 data MoreTypeSpecifier = Anti_MoreTypeSpecifier String |
-                         Ctr__MoreTypeSpecifier__0 String MoreTypeSpecifier |
-                         Ctr__MoreTypeSpecifier__1 TypeArguments SquareBracketsList
+                         Ctr__MoreTypeSpecifier__0 RtkPos String MoreTypeSpecifier |
+                         Ctr__MoreTypeSpecifier__1 RtkPos TypeArguments SquareBracketsList
                          deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf MoreTypeSpecifier where
+    rtkPosOf (Anti_MoreTypeSpecifier _) = rtkNoPos
+    rtkPosOf (Ctr__MoreTypeSpecifier__0 p _ _) = p
+    rtkPosOf (Ctr__MoreTypeSpecifier__1 p _ _) = p
 type MoreVariableDeclarators = [Rule_47]
 data MultiplicativeOp = Anti_MultiplicativeOp String |
-                        Ctr__MultiplicativeOp__0 |
-                        Ctr__MultiplicativeOp__1 |
-                        Ctr__MultiplicativeOp__2
+                        Ctr__MultiplicativeOp__0 RtkPos |
+                        Ctr__MultiplicativeOp__1 RtkPos |
+                        Ctr__MultiplicativeOp__2 RtkPos
                         deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf MultiplicativeOp where
+    rtkPosOf (Anti_MultiplicativeOp _) = rtkNoPos
+    rtkPosOf (Ctr__MultiplicativeOp__0 p) = p
+    rtkPosOf (Ctr__MultiplicativeOp__1 p) = p
+    rtkPosOf (Ctr__MultiplicativeOp__2 p) = p
 data NestedTypeDeclaration = Anti_NestedTypeDeclaration String |
-                             Ctr__NestedTypeDeclaration__0 ClassDeclaration |
-                             Ctr__NestedTypeDeclaration__1 InterfaceDeclaration |
-                             Ctr__NestedTypeDeclaration__2 EnumDeclaration |
-                             Ctr__NestedTypeDeclaration__3 AnnotationDeclaration
+                             Ctr__NestedTypeDeclaration__0 RtkPos ClassDeclaration |
+                             Ctr__NestedTypeDeclaration__1 RtkPos InterfaceDeclaration |
+                             Ctr__NestedTypeDeclaration__2 RtkPos EnumDeclaration |
+                             Ctr__NestedTypeDeclaration__3 RtkPos AnnotationDeclaration
                              deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf NestedTypeDeclaration where
+    rtkPosOf (Anti_NestedTypeDeclaration _) = rtkNoPos
+    rtkPosOf (Ctr__NestedTypeDeclaration__0 p _) = p
+    rtkPosOf (Ctr__NestedTypeDeclaration__1 p _) = p
+    rtkPosOf (Ctr__NestedTypeDeclaration__2 p _) = p
+    rtkPosOf (Ctr__NestedTypeDeclaration__3 p _) = p
 data OptDocComment = Anti_OptDocComment String |
-                     Ctr__OptDocComment__0 |
-                     Ctr__OptDocComment__1 Rule_0
+                     Ctr__OptDocComment__0 RtkPos |
+                     Ctr__OptDocComment__1 RtkPos Rule_0
                      deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf OptDocComment where
+    rtkPosOf (Anti_OptDocComment _) = rtkNoPos
+    rtkPosOf (Ctr__OptDocComment__0 p) = p
+    rtkPosOf (Ctr__OptDocComment__1 p _) = p
 data OptElsePart = Anti_OptElsePart String |
-                   Ctr__OptElsePart__0 |
-                   Ctr__OptElsePart__1 Rule_60
+                   Ctr__OptElsePart__0 RtkPos |
+                   Ctr__OptElsePart__1 RtkPos Rule_60
                    deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf OptElsePart where
+    rtkPosOf (Anti_OptElsePart _) = rtkNoPos
+    rtkPosOf (Ctr__OptElsePart__0 p) = p
+    rtkPosOf (Ctr__OptElsePart__1 p _) = p
 data OptExpression = Anti_OptExpression String |
-                     Ctr__OptExpression__0 |
-                     Ctr__OptExpression__1 Expression
+                     Ctr__OptExpression__0 RtkPos |
+                     Ctr__OptExpression__1 RtkPos Expression
                      deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf OptExpression where
+    rtkPosOf (Anti_OptExpression _) = rtkNoPos
+    rtkPosOf (Ctr__OptExpression__0 p) = p
+    rtkPosOf (Ctr__OptExpression__1 p _) = p
 data OptFinally = Anti_OptFinally String |
-                  Ctr__OptFinally__0 |
-                  Ctr__OptFinally__1 Rule_65
+                  Ctr__OptFinally__0 RtkPos |
+                  Ctr__OptFinally__1 RtkPos Rule_65
                   deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf OptFinally where
+    rtkPosOf (Anti_OptFinally _) = rtkNoPos
+    rtkPosOf (Ctr__OptFinally__0 p) = p
+    rtkPosOf (Ctr__OptFinally__1 p _) = p
 data OptId = Anti_OptId String |
-             Ctr__OptId__0 |
-             Ctr__OptId__1 String
+             Ctr__OptId__0 RtkPos |
+             Ctr__OptId__1 RtkPos String
              deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf OptId where
+    rtkPosOf (Anti_OptId _) = rtkNoPos
+    rtkPosOf (Ctr__OptId__0 p) = p
+    rtkPosOf (Ctr__OptId__1 p _) = p
 data OptVariableInitializer = Anti_OptVariableInitializer String |
-                              Ctr__OptVariableInitializer__0 |
-                              Ctr__OptVariableInitializer__1 Rule_51
+                              Ctr__OptVariableInitializer__0 RtkPos |
+                              Ctr__OptVariableInitializer__1 RtkPos Rule_51
                               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf OptVariableInitializer where
+    rtkPosOf (Anti_OptVariableInitializer _) = rtkNoPos
+    rtkPosOf (Ctr__OptVariableInitializer__0 p) = p
+    rtkPosOf (Ctr__OptVariableInitializer__1 p _) = p
 data Package = Anti_Package String |
-               Ctr__Package__0 CompoundName
+               Ctr__Package__0 RtkPos CompoundName
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Package where
+    rtkPosOf (Anti_Package _) = rtkNoPos
+    rtkPosOf (Ctr__Package__0 p _) = p
 data Parameter = Anti_Parameter String |
-                 Ctr__Parameter__0 Type String SquareBracketsList
+                 Ctr__Parameter__0 RtkPos Type String SquareBracketsList
                  deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Parameter where
+    rtkPosOf (Anti_Parameter _) = rtkNoPos
+    rtkPosOf (Ctr__Parameter__0 p _ _ _) = p
 data ParameterList = Anti_ParameterList String |
-                     Ctr__ParameterList__0 Parameter Rule_57
+                     Ctr__ParameterList__0 RtkPos Parameter Rule_57
                      deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf ParameterList where
+    rtkPosOf (Anti_ParameterList _) = rtkNoPos
+    rtkPosOf (Ctr__ParameterList__0 p _ _) = p
 data PostfixOp = Anti_PostfixOp String |
-                 Ctr__PostfixOp__0 |
-                 Ctr__PostfixOp__1
+                 Ctr__PostfixOp__0 RtkPos |
+                 Ctr__PostfixOp__1 RtkPos
                  deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf PostfixOp where
+    rtkPosOf (Anti_PostfixOp _) = rtkNoPos
+    rtkPosOf (Ctr__PostfixOp__0 p) = p
+    rtkPosOf (Ctr__PostfixOp__1 p) = p
 data PrefixOp = Anti_PrefixOp String |
-                Ctr__PrefixOp__0 |
-                Ctr__PrefixOp__1 |
-                Ctr__PrefixOp__2 |
-                Ctr__PrefixOp__3
+                Ctr__PrefixOp__0 RtkPos |
+                Ctr__PrefixOp__1 RtkPos |
+                Ctr__PrefixOp__2 RtkPos |
+                Ctr__PrefixOp__3 RtkPos
                 deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf PrefixOp where
+    rtkPosOf (Anti_PrefixOp _) = rtkNoPos
+    rtkPosOf (Ctr__PrefixOp__0 p) = p
+    rtkPosOf (Ctr__PrefixOp__1 p) = p
+    rtkPosOf (Ctr__PrefixOp__2 p) = p
+    rtkPosOf (Ctr__PrefixOp__3 p) = p
 data PrimitiveTypeKeyword = Anti_PrimitiveTypeKeyword String |
-                            Ctr__PrimitiveTypeKeyword__0 |
-                            Ctr__PrimitiveTypeKeyword__1 |
-                            Ctr__PrimitiveTypeKeyword__2 |
-                            Ctr__PrimitiveTypeKeyword__3 |
-                            Ctr__PrimitiveTypeKeyword__4 |
-                            Ctr__PrimitiveTypeKeyword__5 |
-                            Ctr__PrimitiveTypeKeyword__6 |
-                            Ctr__PrimitiveTypeKeyword__7 |
-                            Ctr__PrimitiveTypeKeyword__8
+                            Ctr__PrimitiveTypeKeyword__0 RtkPos |
+                            Ctr__PrimitiveTypeKeyword__1 RtkPos |
+                            Ctr__PrimitiveTypeKeyword__2 RtkPos |
+                            Ctr__PrimitiveTypeKeyword__3 RtkPos |
+                            Ctr__PrimitiveTypeKeyword__4 RtkPos |
+                            Ctr__PrimitiveTypeKeyword__5 RtkPos |
+                            Ctr__PrimitiveTypeKeyword__6 RtkPos |
+                            Ctr__PrimitiveTypeKeyword__7 RtkPos |
+                            Ctr__PrimitiveTypeKeyword__8 RtkPos
                             deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf PrimitiveTypeKeyword where
+    rtkPosOf (Anti_PrimitiveTypeKeyword _) = rtkNoPos
+    rtkPosOf (Ctr__PrimitiveTypeKeyword__0 p) = p
+    rtkPosOf (Ctr__PrimitiveTypeKeyword__1 p) = p
+    rtkPosOf (Ctr__PrimitiveTypeKeyword__2 p) = p
+    rtkPosOf (Ctr__PrimitiveTypeKeyword__3 p) = p
+    rtkPosOf (Ctr__PrimitiveTypeKeyword__4 p) = p
+    rtkPosOf (Ctr__PrimitiveTypeKeyword__5 p) = p
+    rtkPosOf (Ctr__PrimitiveTypeKeyword__6 p) = p
+    rtkPosOf (Ctr__PrimitiveTypeKeyword__7 p) = p
+    rtkPosOf (Ctr__PrimitiveTypeKeyword__8 p) = p
 data RelationalOp = Anti_RelationalOp String |
-                    Ctr__RelationalOp__0 |
-                    Ctr__RelationalOp__1 |
-                    Ctr__RelationalOp__2 |
-                    Ctr__RelationalOp__3
+                    Ctr__RelationalOp__0 RtkPos |
+                    Ctr__RelationalOp__1 RtkPos |
+                    Ctr__RelationalOp__2 RtkPos |
+                    Ctr__RelationalOp__3 RtkPos
                     deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_0 = Ctr__Rule_0__0 DocComment
+instance RtkPosOf RelationalOp where
+    rtkPosOf (Anti_RelationalOp _) = rtkNoPos
+    rtkPosOf (Ctr__RelationalOp__0 p) = p
+    rtkPosOf (Ctr__RelationalOp__1 p) = p
+    rtkPosOf (Ctr__RelationalOp__2 p) = p
+    rtkPosOf (Ctr__RelationalOp__3 p) = p
+data Rule_0 = Ctr__Rule_0__0 RtkPos DocComment
               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_1 = Ctr__Rule_1__0 ClassDeclaration |
-              Ctr__Rule_1__1 InterfaceDeclaration |
-              Ctr__Rule_1__2 EnumDeclaration |
-              Ctr__Rule_1__3 AnnotationDeclaration
+instance RtkPosOf Rule_0 where
+    rtkPosOf (Ctr__Rule_0__0 p _) = p
+data Rule_1 = Ctr__Rule_1__0 RtkPos ClassDeclaration |
+              Ctr__Rule_1__1 RtkPos InterfaceDeclaration |
+              Ctr__Rule_1__2 RtkPos EnumDeclaration |
+              Ctr__Rule_1__3 RtkPos AnnotationDeclaration
               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_10 = Ctr__Rule_10__0 |
-               Ctr__Rule_10__1 Rule_11
+instance RtkPosOf Rule_1 where
+    rtkPosOf (Ctr__Rule_1__0 p _) = p
+    rtkPosOf (Ctr__Rule_1__1 p _) = p
+    rtkPosOf (Ctr__Rule_1__2 p _) = p
+    rtkPosOf (Ctr__Rule_1__3 p _) = p
+data Rule_10 = Ctr__Rule_10__0 RtkPos |
+               Ctr__Rule_10__1 RtkPos Rule_11
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_11 = Ctr__Rule_11__0 Rule_12
+instance RtkPosOf Rule_10 where
+    rtkPosOf (Ctr__Rule_10__0 p) = p
+    rtkPosOf (Ctr__Rule_10__1 p _) = p
+data Rule_11 = Ctr__Rule_11__0 RtkPos Rule_12
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_12 = Ctr__Rule_12__0 |
-               Ctr__Rule_12__1 AnnotationArguments
+instance RtkPosOf Rule_11 where
+    rtkPosOf (Ctr__Rule_11__0 p _) = p
+data Rule_12 = Ctr__Rule_12__0 RtkPos |
+               Ctr__Rule_12__1 RtkPos AnnotationArguments
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_12 where
+    rtkPosOf (Ctr__Rule_12__0 p) = p
+    rtkPosOf (Ctr__Rule_12__1 p _) = p
 type Rule_13 = [Rule_14]
-data Rule_14 = Ctr__Rule_14__0 AnnotationElement
+data Rule_14 = Ctr__Rule_14__0 RtkPos AnnotationElement
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_14 where
+    rtkPosOf (Ctr__Rule_14__0 p _) = p
 data Rule_16 = Anti_Rule_16 String |
-               Ctr__Rule_16__1 Modifier |
-               Ctr__Rule_16__2 Annotation
+               Ctr__Rule_16__1 RtkPos Modifier |
+               Ctr__Rule_16__2 RtkPos Annotation
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_16 where
+    rtkPosOf (Anti_Rule_16 _) = rtkNoPos
+    rtkPosOf (Ctr__Rule_16__1 p _) = p
+    rtkPosOf (Ctr__Rule_16__2 p _) = p
 type Rule_18 = [Rule_19]
-data Rule_19 = Ctr__Rule_19__0 CompoundName
+data Rule_19 = Ctr__Rule_19__0 RtkPos CompoundName
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_19 where
+    rtkPosOf (Ctr__Rule_19__0 p _) = p
 data Rule_2 = Anti_Rule_2 String |
-              Ctr__Rule_2__1 ImportStatement
+              Ctr__Rule_2__1 RtkPos ImportStatement
               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_2 where
+    rtkPosOf (Anti_Rule_2 _) = rtkNoPos
+    rtkPosOf (Ctr__Rule_2__1 p _) = p
 type Rule_20 = [CompoundName]
-data Rule_22 = Ctr__Rule_22__0 |
-               Ctr__Rule_22__1 ExtendsList
+data Rule_22 = Ctr__Rule_22__0 RtkPos |
+               Ctr__Rule_22__1 RtkPos ExtendsList
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_23 = Ctr__Rule_23__0 |
-               Ctr__Rule_23__1 ImplementsList
+instance RtkPosOf Rule_22 where
+    rtkPosOf (Ctr__Rule_22__0 p) = p
+    rtkPosOf (Ctr__Rule_22__1 p _) = p
+data Rule_23 = Ctr__Rule_23__0 RtkPos |
+               Ctr__Rule_23__1 RtkPos ImplementsList
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_24 = Ctr__Rule_24__0 |
-               Ctr__Rule_24__1 ExtendsList
+instance RtkPosOf Rule_23 where
+    rtkPosOf (Ctr__Rule_23__0 p) = p
+    rtkPosOf (Ctr__Rule_23__1 p _) = p
+data Rule_24 = Ctr__Rule_24__0 RtkPos |
+               Ctr__Rule_24__1 RtkPos ExtendsList
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_26 = Ctr__Rule_26__0 |
-               Ctr__Rule_26__1 Rule_27
+instance RtkPosOf Rule_24 where
+    rtkPosOf (Ctr__Rule_24__0 p) = p
+    rtkPosOf (Ctr__Rule_24__1 p _) = p
+data Rule_26 = Ctr__Rule_26__0 RtkPos |
+               Ctr__Rule_26__1 RtkPos Rule_27
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_27 = Ctr__Rule_27__0 Arglist
+instance RtkPosOf Rule_26 where
+    rtkPosOf (Ctr__Rule_26__0 p) = p
+    rtkPosOf (Ctr__Rule_26__1 p _) = p
+data Rule_27 = Ctr__Rule_27__0 RtkPos Arglist
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_28 = Ctr__Rule_28__0 |
-               Ctr__Rule_28__1 Rule_29
+instance RtkPosOf Rule_27 where
+    rtkPosOf (Ctr__Rule_27__0 p _) = p
+data Rule_28 = Ctr__Rule_28__0 RtkPos |
+               Ctr__Rule_28__1 RtkPos Rule_29
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_29 = Ctr__Rule_29__0 FieldDeclarationList
+instance RtkPosOf Rule_28 where
+    rtkPosOf (Ctr__Rule_28__0 p) = p
+    rtkPosOf (Ctr__Rule_28__1 p _) = p
+data Rule_29 = Ctr__Rule_29__0 RtkPos FieldDeclarationList
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_29 where
+    rtkPosOf (Ctr__Rule_29__0 p _) = p
 type Rule_30 = [Rule_31]
-data Rule_31 = Ctr__Rule_31__0 EnumConstant
+data Rule_31 = Ctr__Rule_31__0 RtkPos EnumConstant
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_32 = Ctr__Rule_32__0 |
-               Ctr__Rule_32__1 Rule_33
+instance RtkPosOf Rule_31 where
+    rtkPosOf (Ctr__Rule_31__0 p _) = p
+data Rule_32 = Ctr__Rule_32__0 RtkPos |
+               Ctr__Rule_32__1 RtkPos Rule_33
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_33 = Ctr__Rule_33__0
+instance RtkPosOf Rule_32 where
+    rtkPosOf (Ctr__Rule_32__0 p) = p
+    rtkPosOf (Ctr__Rule_32__1 p _) = p
+data Rule_33 = Ctr__Rule_33__0 RtkPos
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_34 = Ctr__Rule_34__0 |
-               Ctr__Rule_34__1 ImplementsList
+instance RtkPosOf Rule_33 where
+    rtkPosOf (Ctr__Rule_33__0 p) = p
+data Rule_34 = Ctr__Rule_34__0 RtkPos |
+               Ctr__Rule_34__1 RtkPos ImplementsList
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_35 = Ctr__Rule_35__0 |
-               Ctr__Rule_35__1 Rule_36
+instance RtkPosOf Rule_34 where
+    rtkPosOf (Ctr__Rule_34__0 p) = p
+    rtkPosOf (Ctr__Rule_34__1 p _) = p
+data Rule_35 = Ctr__Rule_35__0 RtkPos |
+               Ctr__Rule_35__1 RtkPos Rule_36
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_36 = Ctr__Rule_36__0 FieldDeclarationList
+instance RtkPosOf Rule_35 where
+    rtkPosOf (Ctr__Rule_35__0 p) = p
+    rtkPosOf (Ctr__Rule_35__1 p _) = p
+data Rule_36 = Ctr__Rule_36__0 RtkPos FieldDeclarationList
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_37 = Ctr__Rule_37__0 ModifierList Rule_38
+instance RtkPosOf Rule_36 where
+    rtkPosOf (Ctr__Rule_36__0 p _) = p
+data Rule_37 = Ctr__Rule_37__0 RtkPos ModifierList Rule_38
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_38 = Ctr__Rule_38__0 Rule_39 |
-               Ctr__Rule_38__1 StaticInitializer
+instance RtkPosOf Rule_37 where
+    rtkPosOf (Ctr__Rule_37__0 p _ _) = p
+data Rule_38 = Ctr__Rule_38__0 RtkPos Rule_39 |
+               Ctr__Rule_38__1 RtkPos StaticInitializer
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_39 = Ctr__Rule_39__0 MemberDeclaration |
-               Ctr__Rule_39__1 NestedTypeDeclaration
+instance RtkPosOf Rule_38 where
+    rtkPosOf (Ctr__Rule_38__0 p _) = p
+    rtkPosOf (Ctr__Rule_38__1 p _) = p
+data Rule_39 = Ctr__Rule_39__0 RtkPos MemberDeclaration |
+               Ctr__Rule_39__1 RtkPos NestedTypeDeclaration
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_4 = Ctr__Rule_4__0 |
-              Ctr__Rule_4__1 Rule_5
+instance RtkPosOf Rule_39 where
+    rtkPosOf (Ctr__Rule_39__0 p _) = p
+    rtkPosOf (Ctr__Rule_39__1 p _) = p
+data Rule_4 = Ctr__Rule_4__0 RtkPos |
+              Ctr__Rule_4__1 RtkPos Rule_5
               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_4 where
+    rtkPosOf (Ctr__Rule_4__0 p) = p
+    rtkPosOf (Ctr__Rule_4__1 p _) = p
 data Rule_40 = Anti_Rule_40 String |
-               Ctr__Rule_40__1 OptExpression
+               Ctr__Rule_40__1 RtkPos OptExpression
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_42 = Ctr__Rule_42__0 |
-               Ctr__Rule_42__1 ParameterList
+instance RtkPosOf Rule_40 where
+    rtkPosOf (Anti_Rule_40 _) = rtkNoPos
+    rtkPosOf (Ctr__Rule_40__1 p _) = p
+data Rule_42 = Ctr__Rule_42__0 RtkPos |
+               Ctr__Rule_42__1 RtkPos ParameterList
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_43 = Ctr__Rule_43__0 |
-               Ctr__Rule_43__1 ParameterList
+instance RtkPosOf Rule_42 where
+    rtkPosOf (Ctr__Rule_42__0 p) = p
+    rtkPosOf (Ctr__Rule_42__1 p _) = p
+data Rule_43 = Ctr__Rule_43__0 RtkPos |
+               Ctr__Rule_43__1 RtkPos ParameterList
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_44 = Ctr__Rule_44__0 StatementBlock |
-               Ctr__Rule_44__1 Rule_45
+instance RtkPosOf Rule_43 where
+    rtkPosOf (Ctr__Rule_43__0 p) = p
+    rtkPosOf (Ctr__Rule_43__1 p _) = p
+data Rule_44 = Ctr__Rule_44__0 RtkPos StatementBlock |
+               Ctr__Rule_44__1 RtkPos Rule_45
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_45 = Ctr__Rule_45__0 |
-               Ctr__Rule_45__1 Rule_46
+instance RtkPosOf Rule_44 where
+    rtkPosOf (Ctr__Rule_44__0 p _) = p
+    rtkPosOf (Ctr__Rule_44__1 p _) = p
+data Rule_45 = Ctr__Rule_45__0 RtkPos |
+               Ctr__Rule_45__1 RtkPos Rule_46
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_46 = Ctr__Rule_46__0 Expression
+instance RtkPosOf Rule_45 where
+    rtkPosOf (Ctr__Rule_45__0 p) = p
+    rtkPosOf (Ctr__Rule_45__1 p _) = p
+data Rule_46 = Ctr__Rule_46__0 RtkPos Expression
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_46 where
+    rtkPosOf (Ctr__Rule_46__0 p _) = p
 data Rule_47 = Anti_Rule_47 String |
-               Ctr__Rule_47__1 VariableDeclarator
+               Ctr__Rule_47__1 RtkPos VariableDeclarator
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_47 where
+    rtkPosOf (Anti_Rule_47 _) = rtkNoPos
+    rtkPosOf (Ctr__Rule_47__1 p _) = p
 type Rule_49 = [Rule_50]
-data Rule_5 = Ctr__Rule_5__0 Package
+data Rule_5 = Ctr__Rule_5__0 RtkPos Package
               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_50 = Ctr__Rule_50__0 VariableDeclarator
+instance RtkPosOf Rule_5 where
+    rtkPosOf (Ctr__Rule_5__0 p _) = p
+data Rule_50 = Ctr__Rule_50__0 RtkPos VariableDeclarator
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_51 = Ctr__Rule_51__0 VariableInitializer
+instance RtkPosOf Rule_50 where
+    rtkPosOf (Ctr__Rule_50__0 p _) = p
+data Rule_51 = Ctr__Rule_51__0 RtkPos VariableInitializer
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_52 = Ctr__Rule_52__0 VariableInitializer Rule_53 Rule_55
+instance RtkPosOf Rule_51 where
+    rtkPosOf (Ctr__Rule_51__0 p _) = p
+data Rule_52 = Ctr__Rule_52__0 RtkPos VariableInitializer Rule_53 Rule_55
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_52 where
+    rtkPosOf (Ctr__Rule_52__0 p _ _ _) = p
 type Rule_53 = [Rule_54]
-data Rule_54 = Ctr__Rule_54__0 VariableInitializer
+data Rule_54 = Ctr__Rule_54__0 RtkPos VariableInitializer
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_55 = Ctr__Rule_55__0 |
-               Ctr__Rule_55__1 Rule_56
+instance RtkPosOf Rule_54 where
+    rtkPosOf (Ctr__Rule_54__0 p _) = p
+data Rule_55 = Ctr__Rule_55__0 RtkPos |
+               Ctr__Rule_55__1 RtkPos Rule_56
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_56 = Ctr__Rule_56__0
+instance RtkPosOf Rule_55 where
+    rtkPosOf (Ctr__Rule_55__0 p) = p
+    rtkPosOf (Ctr__Rule_55__1 p _) = p
+data Rule_56 = Ctr__Rule_56__0 RtkPos
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_56 where
+    rtkPosOf (Ctr__Rule_56__0 p) = p
 type Rule_57 = [Rule_58]
-data Rule_58 = Ctr__Rule_58__0 Parameter
+data Rule_58 = Ctr__Rule_58__0 RtkPos Parameter
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_6 = Ctr__Rule_6__0 |
-              Ctr__Rule_6__1 Rule_7
+instance RtkPosOf Rule_58 where
+    rtkPosOf (Ctr__Rule_58__0 p _) = p
+data Rule_6 = Ctr__Rule_6__0 RtkPos |
+              Ctr__Rule_6__1 RtkPos Rule_7
               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_60 = Ctr__Rule_60__0 Statement
+instance RtkPosOf Rule_6 where
+    rtkPosOf (Ctr__Rule_6__0 p) = p
+    rtkPosOf (Ctr__Rule_6__1 p _) = p
+data Rule_60 = Ctr__Rule_60__0 RtkPos Statement
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_61 = Ctr__Rule_61__0 VariableDeclaration |
-               Ctr__Rule_61__1 Rule_62 |
-               Ctr__Rule_61__2
+instance RtkPosOf Rule_60 where
+    rtkPosOf (Ctr__Rule_60__0 p _) = p
+data Rule_61 = Ctr__Rule_61__0 RtkPos VariableDeclaration |
+               Ctr__Rule_61__1 RtkPos Rule_62 |
+               Ctr__Rule_61__2 RtkPos
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_62 = Ctr__Rule_62__0 Expression
+instance RtkPosOf Rule_61 where
+    rtkPosOf (Ctr__Rule_61__0 p _) = p
+    rtkPosOf (Ctr__Rule_61__1 p _) = p
+    rtkPosOf (Ctr__Rule_61__2 p) = p
+data Rule_62 = Ctr__Rule_62__0 RtkPos Expression
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_62 where
+    rtkPosOf (Ctr__Rule_62__0 p _) = p
 data Rule_63 = Anti_Rule_63 String |
-               Ctr__Rule_63__1 Parameter Statement
+               Ctr__Rule_63__1 RtkPos Parameter Statement
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_65 = Ctr__Rule_65__0 Statement
+instance RtkPosOf Rule_63 where
+    rtkPosOf (Anti_Rule_63 _) = rtkNoPos
+    rtkPosOf (Ctr__Rule_63__1 p _ _) = p
+data Rule_65 = Ctr__Rule_65__0 RtkPos Statement
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_65 where
+    rtkPosOf (Ctr__Rule_65__0 p _) = p
 data Rule_66 = Anti_Rule_66 String |
-               Ctr__Rule_66__1 Rule_67 |
-               Ctr__Rule_66__2 Rule_68 |
-               Ctr__Rule_66__3 Statement
+               Ctr__Rule_66__1 RtkPos Rule_67 |
+               Ctr__Rule_66__2 RtkPos Rule_68 |
+               Ctr__Rule_66__3 RtkPos Statement
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_67 = Ctr__Rule_67__0 Expression
+instance RtkPosOf Rule_66 where
+    rtkPosOf (Anti_Rule_66 _) = rtkNoPos
+    rtkPosOf (Ctr__Rule_66__1 p _) = p
+    rtkPosOf (Ctr__Rule_66__2 p _) = p
+    rtkPosOf (Ctr__Rule_66__3 p _) = p
+data Rule_67 = Ctr__Rule_67__0 RtkPos Expression
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_68 = Ctr__Rule_68__0
+instance RtkPosOf Rule_67 where
+    rtkPosOf (Ctr__Rule_67__0 p _) = p
+data Rule_68 = Ctr__Rule_68__0 RtkPos
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_7 = Ctr__Rule_7__0 TypeDeclaration
+instance RtkPosOf Rule_68 where
+    rtkPosOf (Ctr__Rule_68__0 p) = p
+data Rule_7 = Ctr__Rule_7__0 RtkPos TypeDeclaration
               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_70 = Ctr__Rule_70__0 |
-               Ctr__Rule_70__1 Rule_71
+instance RtkPosOf Rule_7 where
+    rtkPosOf (Ctr__Rule_7__0 p _) = p
+data Rule_70 = Ctr__Rule_70__0 RtkPos |
+               Ctr__Rule_70__1 RtkPos Rule_71
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_71 = Ctr__Rule_71__0 AssignmentOp Expression
+instance RtkPosOf Rule_70 where
+    rtkPosOf (Ctr__Rule_70__0 p) = p
+    rtkPosOf (Ctr__Rule_70__1 p _) = p
+data Rule_71 = Ctr__Rule_71__0 RtkPos AssignmentOp Expression
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_72 = Ctr__Rule_72__0 |
-               Ctr__Rule_72__1 Rule_73
+instance RtkPosOf Rule_71 where
+    rtkPosOf (Ctr__Rule_71__0 p _ _) = p
+data Rule_72 = Ctr__Rule_72__0 RtkPos |
+               Ctr__Rule_72__1 RtkPos Rule_73
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_73 = Ctr__Rule_73__0 Arglist
+instance RtkPosOf Rule_72 where
+    rtkPosOf (Ctr__Rule_72__0 p) = p
+    rtkPosOf (Ctr__Rule_72__1 p _) = p
+data Rule_73 = Ctr__Rule_73__0 RtkPos Arglist
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_74 = Ctr__Rule_74__0 |
-               Ctr__Rule_74__1 Rule_75
+instance RtkPosOf Rule_73 where
+    rtkPosOf (Ctr__Rule_73__0 p _) = p
+data Rule_74 = Ctr__Rule_74__0 RtkPos |
+               Ctr__Rule_74__1 RtkPos Rule_75
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_75 = Ctr__Rule_75__0 Arglist
+instance RtkPosOf Rule_74 where
+    rtkPosOf (Ctr__Rule_74__0 p) = p
+    rtkPosOf (Ctr__Rule_74__1 p _) = p
+data Rule_75 = Ctr__Rule_75__0 RtkPos Arglist
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_76 = Ctr__Rule_76__0 Arglist |
-               Ctr__Rule_76__1 SquareBracketsList
+instance RtkPosOf Rule_75 where
+    rtkPosOf (Ctr__Rule_75__0 p _) = p
+data Rule_76 = Ctr__Rule_76__0 RtkPos Arglist |
+               Ctr__Rule_76__1 RtkPos SquareBracketsList
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_77 = Ctr__Rule_77__0 Expression Rule_78
+instance RtkPosOf Rule_76 where
+    rtkPosOf (Ctr__Rule_76__0 p _) = p
+    rtkPosOf (Ctr__Rule_76__1 p _) = p
+data Rule_77 = Ctr__Rule_77__0 RtkPos Expression Rule_78
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_77 where
+    rtkPosOf (Ctr__Rule_77__0 p _ _) = p
 type Rule_78 = [Rule_79]
-data Rule_79 = Ctr__Rule_79__0 Expression
+data Rule_79 = Ctr__Rule_79__0 RtkPos Expression
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_8 = Ctr__Rule_8__0 Rule_9 |
-              Ctr__Rule_8__1 CompoundName
+instance RtkPosOf Rule_79 where
+    rtkPosOf (Ctr__Rule_79__0 p _) = p
+data Rule_8 = Ctr__Rule_8__0 RtkPos Rule_9 |
+              Ctr__Rule_8__1 RtkPos CompoundName
               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_80 = Ctr__Rule_80__0 TypeArgument Rule_81
+instance RtkPosOf Rule_8 where
+    rtkPosOf (Ctr__Rule_8__0 p _) = p
+    rtkPosOf (Ctr__Rule_8__1 p _) = p
+data Rule_80 = Ctr__Rule_80__0 RtkPos TypeArgument Rule_81
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_80 where
+    rtkPosOf (Ctr__Rule_80__0 p _ _) = p
 type Rule_81 = [Rule_82]
-data Rule_82 = Ctr__Rule_82__0 TypeArgument
+data Rule_82 = Ctr__Rule_82__0 RtkPos TypeArgument
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_83 = Ctr__Rule_83__0 TypeParameter Rule_84
+instance RtkPosOf Rule_82 where
+    rtkPosOf (Ctr__Rule_82__0 p _) = p
+data Rule_83 = Ctr__Rule_83__0 RtkPos TypeParameter Rule_84
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_83 where
+    rtkPosOf (Ctr__Rule_83__0 p _ _) = p
 type Rule_84 = [Rule_85]
-data Rule_85 = Ctr__Rule_85__0 TypeParameter
+data Rule_85 = Ctr__Rule_85__0 RtkPos TypeParameter
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_86 = Ctr__Rule_86__0 |
-               Ctr__Rule_86__1 Rule_87
+instance RtkPosOf Rule_85 where
+    rtkPosOf (Ctr__Rule_85__0 p _) = p
+data Rule_86 = Ctr__Rule_86__0 RtkPos |
+               Ctr__Rule_86__1 RtkPos Rule_87
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_87 = Ctr__Rule_87__0 Type Rule_88
+instance RtkPosOf Rule_86 where
+    rtkPosOf (Ctr__Rule_86__0 p) = p
+    rtkPosOf (Ctr__Rule_86__1 p _) = p
+data Rule_87 = Ctr__Rule_87__0 RtkPos Type Rule_88
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_87 where
+    rtkPosOf (Ctr__Rule_87__0 p _ _) = p
 type Rule_88 = [Rule_89]
-data Rule_89 = Ctr__Rule_89__0 Type
+data Rule_89 = Ctr__Rule_89__0 RtkPos Type
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_9 = Ctr__Rule_9__0 CompoundName
+instance RtkPosOf Rule_89 where
+    rtkPosOf (Ctr__Rule_89__0 p _) = p
+data Rule_9 = Ctr__Rule_9__0 RtkPos CompoundName
               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_9 where
+    rtkPosOf (Ctr__Rule_9__0 p _) = p
 type Rule_90 = [Rule_91]
-data Rule_91 = Ctr__Rule_91__0 String
+data Rule_91 = Ctr__Rule_91__0 RtkPos String
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_91 where
+    rtkPosOf (Ctr__Rule_91__0 p _) = p
 data ShiftOp = Anti_ShiftOp String |
-               Ctr__ShiftOp__0 |
-               Ctr__ShiftOp__1 |
-               Ctr__ShiftOp__2
+               Ctr__ShiftOp__0 RtkPos |
+               Ctr__ShiftOp__1 RtkPos |
+               Ctr__ShiftOp__2 RtkPos
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf ShiftOp where
+    rtkPosOf (Anti_ShiftOp _) = rtkNoPos
+    rtkPosOf (Ctr__ShiftOp__0 p) = p
+    rtkPosOf (Ctr__ShiftOp__1 p) = p
+    rtkPosOf (Ctr__ShiftOp__2 p) = p
 type SquareBracketsList = [Rule_40]
 data Statement = Anti_Statement String |
-                 Ctr__Statement__0 StatementWithoutIf |
-                 Ctr__Statement__1 IfStatement
+                 Ctr__Statement__0 RtkPos StatementWithoutIf |
+                 Ctr__Statement__1 RtkPos IfStatement
                  deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Statement where
+    rtkPosOf (Anti_Statement _) = rtkNoPos
+    rtkPosOf (Ctr__Statement__0 p _) = p
+    rtkPosOf (Ctr__Statement__1 p _) = p
 data StatementBlock = Anti_StatementBlock String |
-                      Ctr__StatementBlock__0 StatementList
+                      Ctr__StatementBlock__0 RtkPos StatementList
                       deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf StatementBlock where
+    rtkPosOf (Anti_StatementBlock _) = rtkNoPos
+    rtkPosOf (Ctr__StatementBlock__0 p _) = p
 type StatementList = [Statement]
 data StatementWithoutIf = Anti_StatementWithoutIf String |
-                          Ctr__StatementWithoutIf__0 VariableDeclaration |
-                          Ctr__StatementWithoutIf__1 OptExpression |
-                          Ctr__StatementWithoutIf__2 Expression |
-                          Ctr__StatementWithoutIf__3 StatementBlock |
-                          Ctr__StatementWithoutIf__4 DoStatement |
-                          Ctr__StatementWithoutIf__5 WhileStatement |
-                          Ctr__StatementWithoutIf__6 ForStatement |
-                          Ctr__StatementWithoutIf__7 TryStatement |
-                          Ctr__StatementWithoutIf__8 SwitchStatement |
-                          Ctr__StatementWithoutIf__9 Expression Statement |
-                          Ctr__StatementWithoutIf__10 Expression |
-                          Ctr__StatementWithoutIf__11 String Statement |
-                          Ctr__StatementWithoutIf__12 OptId |
-                          Ctr__StatementWithoutIf__13 OptId |
-                          Ctr__StatementWithoutIf__14
+                          Ctr__StatementWithoutIf__0 RtkPos VariableDeclaration |
+                          Ctr__StatementWithoutIf__1 RtkPos OptExpression |
+                          Ctr__StatementWithoutIf__2 RtkPos Expression |
+                          Ctr__StatementWithoutIf__3 RtkPos StatementBlock |
+                          Ctr__StatementWithoutIf__4 RtkPos DoStatement |
+                          Ctr__StatementWithoutIf__5 RtkPos WhileStatement |
+                          Ctr__StatementWithoutIf__6 RtkPos ForStatement |
+                          Ctr__StatementWithoutIf__7 RtkPos TryStatement |
+                          Ctr__StatementWithoutIf__8 RtkPos SwitchStatement |
+                          Ctr__StatementWithoutIf__9 RtkPos Expression Statement |
+                          Ctr__StatementWithoutIf__10 RtkPos Expression |
+                          Ctr__StatementWithoutIf__11 RtkPos String Statement |
+                          Ctr__StatementWithoutIf__12 RtkPos OptId |
+                          Ctr__StatementWithoutIf__13 RtkPos OptId |
+                          Ctr__StatementWithoutIf__14 RtkPos
                           deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf StatementWithoutIf where
+    rtkPosOf (Anti_StatementWithoutIf _) = rtkNoPos
+    rtkPosOf (Ctr__StatementWithoutIf__0 p _) = p
+    rtkPosOf (Ctr__StatementWithoutIf__1 p _) = p
+    rtkPosOf (Ctr__StatementWithoutIf__2 p _) = p
+    rtkPosOf (Ctr__StatementWithoutIf__3 p _) = p
+    rtkPosOf (Ctr__StatementWithoutIf__4 p _) = p
+    rtkPosOf (Ctr__StatementWithoutIf__5 p _) = p
+    rtkPosOf (Ctr__StatementWithoutIf__6 p _) = p
+    rtkPosOf (Ctr__StatementWithoutIf__7 p _) = p
+    rtkPosOf (Ctr__StatementWithoutIf__8 p _) = p
+    rtkPosOf (Ctr__StatementWithoutIf__9 p _ _) = p
+    rtkPosOf (Ctr__StatementWithoutIf__10 p _) = p
+    rtkPosOf (Ctr__StatementWithoutIf__11 p _ _) = p
+    rtkPosOf (Ctr__StatementWithoutIf__12 p _) = p
+    rtkPosOf (Ctr__StatementWithoutIf__13 p _) = p
+    rtkPosOf (Ctr__StatementWithoutIf__14 p) = p
 data StaticInitializer = Anti_StaticInitializer String |
-                         Ctr__StaticInitializer__0 StatementBlock
+                         Ctr__StaticInitializer__0 RtkPos StatementBlock
                          deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf StaticInitializer where
+    rtkPosOf (Anti_StaticInitializer _) = rtkNoPos
+    rtkPosOf (Ctr__StaticInitializer__0 p _) = p
 type SwitchCaseList = [Rule_66]
 data SwitchStatement = Anti_SwitchStatement String |
-                       Ctr__SwitchStatement__0 Expression SwitchCaseList
+                       Ctr__SwitchStatement__0 RtkPos Expression SwitchCaseList
                        deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf SwitchStatement where
+    rtkPosOf (Anti_SwitchStatement _) = rtkNoPos
+    rtkPosOf (Ctr__SwitchStatement__0 p _ _) = p
 data TryStatement = Anti_TryStatement String |
-                    Ctr__TryStatement__0 Statement CatchList OptFinally
+                    Ctr__TryStatement__0 RtkPos Statement CatchList OptFinally
                     deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf TryStatement where
+    rtkPosOf (Anti_TryStatement _) = rtkNoPos
+    rtkPosOf (Ctr__TryStatement__0 p _ _ _) = p
 data Type = Anti_Type String |
-            Ctr__Type__0 TypeSpecifier SquareBracketsList
+            Ctr__Type__0 RtkPos TypeSpecifier SquareBracketsList
             deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Type where
+    rtkPosOf (Anti_Type _) = rtkNoPos
+    rtkPosOf (Ctr__Type__0 p _ _) = p
 data TypeArgument = Anti_TypeArgument String |
-                    Ctr__TypeArgument__0 Type |
-                    Ctr__TypeArgument__1 WildcardType
+                    Ctr__TypeArgument__0 RtkPos Type |
+                    Ctr__TypeArgument__1 RtkPos WildcardType
                     deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf TypeArgument where
+    rtkPosOf (Anti_TypeArgument _) = rtkNoPos
+    rtkPosOf (Ctr__TypeArgument__0 p _) = p
+    rtkPosOf (Ctr__TypeArgument__1 p _) = p
 data TypeArguments = Anti_TypeArguments String |
-                     Ctr__TypeArguments__0 |
-                     Ctr__TypeArguments__1 Rule_80
+                     Ctr__TypeArguments__0 RtkPos |
+                     Ctr__TypeArguments__1 RtkPos Rule_80
                      deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf TypeArguments where
+    rtkPosOf (Anti_TypeArguments _) = rtkNoPos
+    rtkPosOf (Ctr__TypeArguments__0 p) = p
+    rtkPosOf (Ctr__TypeArguments__1 p _) = p
 data TypeDeclaration = Anti_TypeDeclaration String |
-                       Ctr__TypeDeclaration__0 OptDocComment Rule_1
+                       Ctr__TypeDeclaration__0 RtkPos OptDocComment Rule_1
                        deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf TypeDeclaration where
+    rtkPosOf (Anti_TypeDeclaration _) = rtkNoPos
+    rtkPosOf (Ctr__TypeDeclaration__0 p _ _) = p
 data TypeParameter = Anti_TypeParameter String |
-                     Ctr__TypeParameter__0 String Rule_86
+                     Ctr__TypeParameter__0 RtkPos String Rule_86
                      deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf TypeParameter where
+    rtkPosOf (Anti_TypeParameter _) = rtkNoPos
+    rtkPosOf (Ctr__TypeParameter__0 p _ _) = p
 data TypeParameters = Anti_TypeParameters String |
-                      Ctr__TypeParameters__0 |
-                      Ctr__TypeParameters__1 Rule_83
+                      Ctr__TypeParameters__0 RtkPos |
+                      Ctr__TypeParameters__1 RtkPos Rule_83
                       deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf TypeParameters where
+    rtkPosOf (Anti_TypeParameters _) = rtkNoPos
+    rtkPosOf (Ctr__TypeParameters__0 p) = p
+    rtkPosOf (Ctr__TypeParameters__1 p _) = p
 data TypeSpecifier = Anti_TypeSpecifier String |
-                     Ctr__TypeSpecifier__0 |
-                     Ctr__TypeSpecifier__1 |
-                     Ctr__TypeSpecifier__2 |
-                     Ctr__TypeSpecifier__3 |
-                     Ctr__TypeSpecifier__4 |
-                     Ctr__TypeSpecifier__5 |
-                     Ctr__TypeSpecifier__6 |
-                     Ctr__TypeSpecifier__7 |
-                     Ctr__TypeSpecifier__8 |
-                     Ctr__TypeSpecifier__9 CompoundName TypeArguments
+                     Ctr__TypeSpecifier__0 RtkPos |
+                     Ctr__TypeSpecifier__1 RtkPos |
+                     Ctr__TypeSpecifier__2 RtkPos |
+                     Ctr__TypeSpecifier__3 RtkPos |
+                     Ctr__TypeSpecifier__4 RtkPos |
+                     Ctr__TypeSpecifier__5 RtkPos |
+                     Ctr__TypeSpecifier__6 RtkPos |
+                     Ctr__TypeSpecifier__7 RtkPos |
+                     Ctr__TypeSpecifier__8 RtkPos |
+                     Ctr__TypeSpecifier__9 RtkPos CompoundName TypeArguments
                      deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf TypeSpecifier where
+    rtkPosOf (Anti_TypeSpecifier _) = rtkNoPos
+    rtkPosOf (Ctr__TypeSpecifier__0 p) = p
+    rtkPosOf (Ctr__TypeSpecifier__1 p) = p
+    rtkPosOf (Ctr__TypeSpecifier__2 p) = p
+    rtkPosOf (Ctr__TypeSpecifier__3 p) = p
+    rtkPosOf (Ctr__TypeSpecifier__4 p) = p
+    rtkPosOf (Ctr__TypeSpecifier__5 p) = p
+    rtkPosOf (Ctr__TypeSpecifier__6 p) = p
+    rtkPosOf (Ctr__TypeSpecifier__7 p) = p
+    rtkPosOf (Ctr__TypeSpecifier__8 p) = p
+    rtkPosOf (Ctr__TypeSpecifier__9 p _ _) = p
 data VariableDeclaration = Anti_VariableDeclaration String |
-                           Ctr__VariableDeclaration__0 Type VariableDeclaratorList
+                           Ctr__VariableDeclaration__0 RtkPos Type VariableDeclaratorList
                            deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf VariableDeclaration where
+    rtkPosOf (Anti_VariableDeclaration _) = rtkNoPos
+    rtkPosOf (Ctr__VariableDeclaration__0 p _ _) = p
 data VariableDeclarator = Anti_VariableDeclarator String |
-                          Ctr__VariableDeclarator__0 String SquareBracketsList OptVariableInitializer
+                          Ctr__VariableDeclarator__0 RtkPos String SquareBracketsList OptVariableInitializer
                           deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf VariableDeclarator where
+    rtkPosOf (Anti_VariableDeclarator _) = rtkNoPos
+    rtkPosOf (Ctr__VariableDeclarator__0 p _ _ _) = p
 data VariableDeclaratorList = Anti_VariableDeclaratorList String |
-                              Ctr__VariableDeclaratorList__0 VariableDeclarator Rule_49
+                              Ctr__VariableDeclaratorList__0 RtkPos VariableDeclarator Rule_49
                               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf VariableDeclaratorList where
+    rtkPosOf (Anti_VariableDeclaratorList _) = rtkNoPos
+    rtkPosOf (Ctr__VariableDeclaratorList__0 p _ _) = p
 data VariableInitializer = Anti_VariableInitializer String |
-                           Ctr__VariableInitializer__0 Expression |
-                           Ctr__VariableInitializer__1 VariableInitializerList
+                           Ctr__VariableInitializer__0 RtkPos Expression |
+                           Ctr__VariableInitializer__1 RtkPos VariableInitializerList
                            deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf VariableInitializer where
+    rtkPosOf (Anti_VariableInitializer _) = rtkNoPos
+    rtkPosOf (Ctr__VariableInitializer__0 p _) = p
+    rtkPosOf (Ctr__VariableInitializer__1 p _) = p
 data VariableInitializerList = Anti_VariableInitializerList String |
-                               Ctr__VariableInitializerList__0 |
-                               Ctr__VariableInitializerList__1 Rule_52
+                               Ctr__VariableInitializerList__0 RtkPos |
+                               Ctr__VariableInitializerList__1 RtkPos Rule_52
                                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf VariableInitializerList where
+    rtkPosOf (Anti_VariableInitializerList _) = rtkNoPos
+    rtkPosOf (Ctr__VariableInitializerList__0 p) = p
+    rtkPosOf (Ctr__VariableInitializerList__1 p _) = p
 data WhileStatement = Anti_WhileStatement String |
-                      Ctr__WhileStatement__0 Expression Statement
+                      Ctr__WhileStatement__0 RtkPos Expression Statement
                       deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf WhileStatement where
+    rtkPosOf (Anti_WhileStatement _) = rtkNoPos
+    rtkPosOf (Ctr__WhileStatement__0 p _ _) = p
 data WildcardType = Anti_WildcardType String |
-                    Ctr__WildcardType__0 |
-                    Ctr__WildcardType__1 Type |
-                    Ctr__WildcardType__2 Type
+                    Ctr__WildcardType__0 RtkPos |
+                    Ctr__WildcardType__1 RtkPos Type |
+                    Ctr__WildcardType__2 RtkPos Type
                     deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf WildcardType where
+    rtkPosOf (Anti_WildcardType _) = rtkNoPos
+    rtkPosOf (Ctr__WildcardType__0 p) = p
+    rtkPosOf (Ctr__WildcardType__1 p _) = p
+    rtkPosOf (Ctr__WildcardType__2 p _) = p
 }

--- a/test/golden/java/JavaQQ.hs
+++ b/test/golden/java/JavaQQ.hs
@@ -51,6 +51,14 @@ replaceAllPatterns str = init <$> replaceAllPatterns1 (str ++ " ")
 
 qqShortcuts = M.fromList [ ("java","Java"),("additiveOp","AdditiveOp"),("annotation","Annotation"),("annotationArguments","AnnotationArguments"),("annotationDeclaration","AnnotationDeclaration"),("annotationElement","AnnotationElement"),("annotationList","AnnotationList"),("annotationTypeElement","AnnotationTypeElement"),("annotationTypeElementList","AnnotationTypeElementList"),("arglist","Arglist"),("assignmentOp","AssignmentOp"),("catchList","CatchList"),("classDeclaration","ClassDeclaration"),("compilationUnit","CompilationUnit"),("compoundName","CompoundName"),("creationExpression","CreationExpression"),("doStatement","DoStatement"),("docComment","DocComment"),("enumConstant","EnumConstant"),("enumConstantList","EnumConstantList"),("enumDeclaration","EnumDeclaration"),("equalityOp","EqualityOp"),("expression","Expression"),("extendsList","ExtendsList"),("fieldDeclaration","FieldDeclaration"),("fieldDeclarationList","FieldDeclarationList"),("forStatement","ForStatement"),("ifStatement","IfStatement"),("implementsList","ImplementsList"),("importList","ImportList"),("importStatement","ImportStatement"),("interfaceDeclaration","InterfaceDeclaration"),("literal","Literal"),("memberAfterFirstId","MemberAfterFirstId"),("memberDeclaration","MemberDeclaration"),("memberRest","MemberRest"),("modifier","Modifier"),("modifierList","ModifierList"),("moreTypeSpecifier","MoreTypeSpecifier"),("moreVariableDeclarators","MoreVariableDeclarators"),("multiplicativeOp","MultiplicativeOp"),("nestedTypeDeclaration","NestedTypeDeclaration"),("optDocComment","OptDocComment"),("optElsePart","OptElsePart"),("optExpression","OptExpression"),("optFinally","OptFinally"),("optId","OptId"),("optVariableInitializer","OptVariableInitializer"),("package","Package"),("parameter","Parameter"),("parameterList","ParameterList"),("postfixOp","PostfixOp"),("prefixOp","PrefixOp"),("primitiveTypeKeyword","PrimitiveTypeKeyword"),("relationalOp","RelationalOp"),("shiftOp","ShiftOp"),("squareBracketsList","SquareBracketsList"),("statement","Statement"),("statementBlock","StatementBlock"),("statementList","StatementList"),("statementWithoutIf","StatementWithoutIf"),("staticInitializer","StaticInitializer"),("switchCaseList","SwitchCaseList"),("switchStatement","SwitchStatement"),("tryStatement","TryStatement"),("type","Type"),("typeArgument","TypeArgument"),("typeArguments","TypeArguments"),("typeDeclaration","TypeDeclaration"),("typeParameter","TypeParameter"),("typeParameters","TypeParameters"),("typeSpecifier","TypeSpecifier"),("variableDeclaration","VariableDeclaration"),("variableDeclarator","VariableDeclarator"),("variableDeclaratorList","VariableDeclaratorList"),("variableInitializer","VariableInitializer"),("variableInitializerList","VariableInitializerList"),("whileStatement","WhileStatement"),("wildcardType","WildcardType")]
 
+-- A quasi-quote pattern must match an AST parsed from anywhere in a source
+-- file, while the pattern itself was parsed from the quote body - so every
+-- RtkPos position field becomes a wildcard in generated patterns.
+-- (Expressions need no special case: the compile-time position they embed
+-- is equality-transparent.)
+rtkPosWildPat :: RtkPos -> Maybe (TH.Q TH.Pat)
+rtkPosWildPat _ = Just TH.wildP
+
 quoteJavaExp :: Data.Data a => String -> (Java -> a) -> String -> TH.ExpQ
 quoteJavaExp dummy func s = do
   s1 <- either fail return (replaceAllPatterns s)
@@ -66,7 +74,7 @@ quoteJavaPat dummy func s = do
            Left err -> fail err
            Right a -> return a
   let expr = func ast
-  dataToPatQ (const Nothing `Generics.extQ` antiJavaPat `Generics.extQ` antiOptDocCommentPat `Generics.extQ` antiTypeDeclarationPat `Generics.extQ` antiRule_2Pat `Generics.extQ` antiCompilationUnitPat `Generics.extQ` antiPackagePat `Generics.extQ` antiImportStatementPat `Generics.extQ` antiDocCommentPat `Generics.extQ` antiAnnotationPat `Generics.extQ` antiAnnotationArgumentsPat `Generics.extQ` antiAnnotationElementPat `Generics.extQ` antiRule_16Pat `Generics.extQ` antiExtendsListPat `Generics.extQ` antiImplementsListPat `Generics.extQ` antiFieldDeclarationPat `Generics.extQ` antiClassDeclarationPat `Generics.extQ` antiInterfaceDeclarationPat `Generics.extQ` antiAnnotationDeclarationPat `Generics.extQ` antiAnnotationTypeElementPat `Generics.extQ` antiEnumConstantPat `Generics.extQ` antiEnumConstantListPat `Generics.extQ` antiEnumDeclarationPat `Generics.extQ` antiNestedTypeDeclarationPat `Generics.extQ` antiRule_40Pat `Generics.extQ` antiMemberDeclarationPat `Generics.extQ` antiPrimitiveTypeKeywordPat `Generics.extQ` antiMemberAfterFirstIdPat `Generics.extQ` antiMoreTypeSpecifierPat `Generics.extQ` antiMemberRestPat `Generics.extQ` antiRule_47Pat `Generics.extQ` antiStatementBlockPat `Generics.extQ` antiVariableDeclaratorListPat `Generics.extQ` antiVariableDeclarationPat `Generics.extQ` antiOptVariableInitializerPat `Generics.extQ` antiVariableDeclaratorPat `Generics.extQ` antiVariableInitializerListPat `Generics.extQ` antiVariableInitializerPat `Generics.extQ` antiStaticInitializerPat `Generics.extQ` antiParameterListPat `Generics.extQ` antiParameterPat `Generics.extQ` antiStatementPat `Generics.extQ` antiOptExpressionPat `Generics.extQ` antiOptIdPat `Generics.extQ` antiStatementWithoutIfPat `Generics.extQ` antiOptElsePartPat `Generics.extQ` antiIfStatementPat `Generics.extQ` antiDoStatementPat `Generics.extQ` antiWhileStatementPat `Generics.extQ` antiForStatementPat `Generics.extQ` antiRule_63Pat `Generics.extQ` antiOptFinallyPat `Generics.extQ` antiTryStatementPat `Generics.extQ` antiRule_66Pat `Generics.extQ` antiSwitchStatementPat `Generics.extQ` antiExpressionPat `Generics.extQ` antiAssignmentOpPat `Generics.extQ` antiEqualityOpPat `Generics.extQ` antiRelationalOpPat `Generics.extQ` antiShiftOpPat `Generics.extQ` antiAdditiveOpPat `Generics.extQ` antiMultiplicativeOpPat `Generics.extQ` antiPrefixOpPat `Generics.extQ` antiPostfixOpPat `Generics.extQ` antiCreationExpressionPat `Generics.extQ` antiLiteralPat `Generics.extQ` antiArglistPat `Generics.extQ` antiTypeArgumentsPat `Generics.extQ` antiTypeArgumentPat `Generics.extQ` antiWildcardTypePat `Generics.extQ` antiTypeParametersPat `Generics.extQ` antiTypeParameterPat `Generics.extQ` antiTypePat `Generics.extQ` antiTypeSpecifierPat `Generics.extQ` antiModifierPat `Generics.extQ` antiCompoundNamePat) expr
+  dataToPatQ (const Nothing `Generics.extQ` rtkPosWildPat `Generics.extQ` antiJavaPat `Generics.extQ` antiOptDocCommentPat `Generics.extQ` antiTypeDeclarationPat `Generics.extQ` antiRule_2Pat `Generics.extQ` antiCompilationUnitPat `Generics.extQ` antiPackagePat `Generics.extQ` antiImportStatementPat `Generics.extQ` antiDocCommentPat `Generics.extQ` antiAnnotationPat `Generics.extQ` antiAnnotationArgumentsPat `Generics.extQ` antiAnnotationElementPat `Generics.extQ` antiRule_16Pat `Generics.extQ` antiExtendsListPat `Generics.extQ` antiImplementsListPat `Generics.extQ` antiFieldDeclarationPat `Generics.extQ` antiClassDeclarationPat `Generics.extQ` antiInterfaceDeclarationPat `Generics.extQ` antiAnnotationDeclarationPat `Generics.extQ` antiAnnotationTypeElementPat `Generics.extQ` antiEnumConstantPat `Generics.extQ` antiEnumConstantListPat `Generics.extQ` antiEnumDeclarationPat `Generics.extQ` antiNestedTypeDeclarationPat `Generics.extQ` antiRule_40Pat `Generics.extQ` antiMemberDeclarationPat `Generics.extQ` antiPrimitiveTypeKeywordPat `Generics.extQ` antiMemberAfterFirstIdPat `Generics.extQ` antiMoreTypeSpecifierPat `Generics.extQ` antiMemberRestPat `Generics.extQ` antiRule_47Pat `Generics.extQ` antiStatementBlockPat `Generics.extQ` antiVariableDeclaratorListPat `Generics.extQ` antiVariableDeclarationPat `Generics.extQ` antiOptVariableInitializerPat `Generics.extQ` antiVariableDeclaratorPat `Generics.extQ` antiVariableInitializerListPat `Generics.extQ` antiVariableInitializerPat `Generics.extQ` antiStaticInitializerPat `Generics.extQ` antiParameterListPat `Generics.extQ` antiParameterPat `Generics.extQ` antiStatementPat `Generics.extQ` antiOptExpressionPat `Generics.extQ` antiOptIdPat `Generics.extQ` antiStatementWithoutIfPat `Generics.extQ` antiOptElsePartPat `Generics.extQ` antiIfStatementPat `Generics.extQ` antiDoStatementPat `Generics.extQ` antiWhileStatementPat `Generics.extQ` antiForStatementPat `Generics.extQ` antiRule_63Pat `Generics.extQ` antiOptFinallyPat `Generics.extQ` antiTryStatementPat `Generics.extQ` antiRule_66Pat `Generics.extQ` antiSwitchStatementPat `Generics.extQ` antiExpressionPat `Generics.extQ` antiAssignmentOpPat `Generics.extQ` antiEqualityOpPat `Generics.extQ` antiRelationalOpPat `Generics.extQ` antiShiftOpPat `Generics.extQ` antiAdditiveOpPat `Generics.extQ` antiMultiplicativeOpPat `Generics.extQ` antiPrefixOpPat `Generics.extQ` antiPostfixOpPat `Generics.extQ` antiCreationExpressionPat `Generics.extQ` antiLiteralPat `Generics.extQ` antiArglistPat `Generics.extQ` antiTypeArgumentsPat `Generics.extQ` antiTypeArgumentPat `Generics.extQ` antiWildcardTypePat `Generics.extQ` antiTypeParametersPat `Generics.extQ` antiTypeParameterPat `Generics.extQ` antiTypePat `Generics.extQ` antiTypeSpecifierPat `Generics.extQ` antiModifierPat `Generics.extQ` antiCompoundNamePat) expr
 
 antiCompoundNameExp :: CompoundName -> Maybe (TH.Q TH.Exp )
 antiCompoundNameExp ( Anti_CompoundName v) = Just $ TH.varE (TH.mkName v)
@@ -850,397 +858,397 @@ antiJavaPat _ = Nothing
 quoteJavaType s = return TH.ListT
 quoteJavaDecs s = return []
 
-getJava ( Ctr__Java__0 s) = s
+getJava ( Ctr__Java__0 _ s) = s
 
 java :: QuasiQuoter
 java = QuasiQuoter (quoteJavaExp "tok_Java_dummy_170" getJava ) (quoteJavaPat "tok_Java_dummy_170" getJava ) quoteJavaType quoteJavaDecs
 
-getAdditiveOp ( Ctr__Java__1 s) = s
+getAdditiveOp ( Ctr__Java__1 _ s) = s
 
 additiveOp :: QuasiQuoter
 additiveOp = QuasiQuoter (quoteJavaExp "tok_AdditiveOp_dummy_169" getAdditiveOp ) (quoteJavaPat "tok_AdditiveOp_dummy_169" getAdditiveOp ) quoteJavaType quoteJavaDecs
 
-getAnnotation ( Ctr__Java__2 s) = s
+getAnnotation ( Ctr__Java__2 _ s) = s
 
 annotation :: QuasiQuoter
 annotation = QuasiQuoter (quoteJavaExp "tok_Annotation_dummy_168" getAnnotation ) (quoteJavaPat "tok_Annotation_dummy_168" getAnnotation ) quoteJavaType quoteJavaDecs
 
-getAnnotationArguments ( Ctr__Java__3 s) = s
+getAnnotationArguments ( Ctr__Java__3 _ s) = s
 
 annotationArguments :: QuasiQuoter
 annotationArguments = QuasiQuoter (quoteJavaExp "tok_AnnotationArguments_dummy_167" getAnnotationArguments ) (quoteJavaPat "tok_AnnotationArguments_dummy_167" getAnnotationArguments ) quoteJavaType quoteJavaDecs
 
-getAnnotationDeclaration ( Ctr__Java__4 s) = s
+getAnnotationDeclaration ( Ctr__Java__4 _ s) = s
 
 annotationDeclaration :: QuasiQuoter
 annotationDeclaration = QuasiQuoter (quoteJavaExp "tok_AnnotationDeclaration_dummy_166" getAnnotationDeclaration ) (quoteJavaPat "tok_AnnotationDeclaration_dummy_166" getAnnotationDeclaration ) quoteJavaType quoteJavaDecs
 
-getAnnotationElement ( Ctr__Java__5 s) = s
+getAnnotationElement ( Ctr__Java__5 _ s) = s
 
 annotationElement :: QuasiQuoter
 annotationElement = QuasiQuoter (quoteJavaExp "tok_AnnotationElement_dummy_165" getAnnotationElement ) (quoteJavaPat "tok_AnnotationElement_dummy_165" getAnnotationElement ) quoteJavaType quoteJavaDecs
 
-getAnnotationList ( Ctr__Java__6 s) = s
+getAnnotationList ( Ctr__Java__6 _ s) = s
 
 annotationList :: QuasiQuoter
 annotationList = QuasiQuoter (quoteJavaExp "tok_AnnotationList_dummy_164" getAnnotationList ) (quoteJavaPat "tok_AnnotationList_dummy_164" getAnnotationList ) quoteJavaType quoteJavaDecs
 
-getAnnotationTypeElement ( Ctr__Java__7 s) = s
+getAnnotationTypeElement ( Ctr__Java__7 _ s) = s
 
 annotationTypeElement :: QuasiQuoter
 annotationTypeElement = QuasiQuoter (quoteJavaExp "tok_AnnotationTypeElement_dummy_163" getAnnotationTypeElement ) (quoteJavaPat "tok_AnnotationTypeElement_dummy_163" getAnnotationTypeElement ) quoteJavaType quoteJavaDecs
 
-getAnnotationTypeElementList ( Ctr__Java__8 s) = s
+getAnnotationTypeElementList ( Ctr__Java__8 _ s) = s
 
 annotationTypeElementList :: QuasiQuoter
 annotationTypeElementList = QuasiQuoter (quoteJavaExp "tok_AnnotationTypeElementList_dummy_162" getAnnotationTypeElementList ) (quoteJavaPat "tok_AnnotationTypeElementList_dummy_162" getAnnotationTypeElementList ) quoteJavaType quoteJavaDecs
 
-getArglist ( Ctr__Java__9 s) = s
+getArglist ( Ctr__Java__9 _ s) = s
 
 arglist :: QuasiQuoter
 arglist = QuasiQuoter (quoteJavaExp "tok_Arglist_dummy_161" getArglist ) (quoteJavaPat "tok_Arglist_dummy_161" getArglist ) quoteJavaType quoteJavaDecs
 
-getAssignmentOp ( Ctr__Java__10 s) = s
+getAssignmentOp ( Ctr__Java__10 _ s) = s
 
 assignmentOp :: QuasiQuoter
 assignmentOp = QuasiQuoter (quoteJavaExp "tok_AssignmentOp_dummy_160" getAssignmentOp ) (quoteJavaPat "tok_AssignmentOp_dummy_160" getAssignmentOp ) quoteJavaType quoteJavaDecs
 
-getCatchList ( Ctr__Java__11 s) = s
+getCatchList ( Ctr__Java__11 _ s) = s
 
 catchList :: QuasiQuoter
 catchList = QuasiQuoter (quoteJavaExp "tok_CatchList_dummy_159" getCatchList ) (quoteJavaPat "tok_CatchList_dummy_159" getCatchList ) quoteJavaType quoteJavaDecs
 
-getClassDeclaration ( Ctr__Java__12 s) = s
+getClassDeclaration ( Ctr__Java__12 _ s) = s
 
 classDeclaration :: QuasiQuoter
 classDeclaration = QuasiQuoter (quoteJavaExp "tok_ClassDeclaration_dummy_158" getClassDeclaration ) (quoteJavaPat "tok_ClassDeclaration_dummy_158" getClassDeclaration ) quoteJavaType quoteJavaDecs
 
-getCompilationUnit ( Ctr__Java__13 s) = s
+getCompilationUnit ( Ctr__Java__13 _ s) = s
 
 compilationUnit :: QuasiQuoter
 compilationUnit = QuasiQuoter (quoteJavaExp "tok_CompilationUnit_dummy_157" getCompilationUnit ) (quoteJavaPat "tok_CompilationUnit_dummy_157" getCompilationUnit ) quoteJavaType quoteJavaDecs
 
-getCompoundName ( Ctr__Java__14 s) = s
+getCompoundName ( Ctr__Java__14 _ s) = s
 
 compoundName :: QuasiQuoter
 compoundName = QuasiQuoter (quoteJavaExp "tok_CompoundName_dummy_156" getCompoundName ) (quoteJavaPat "tok_CompoundName_dummy_156" getCompoundName ) quoteJavaType quoteJavaDecs
 
-getCreationExpression ( Ctr__Java__15 s) = s
+getCreationExpression ( Ctr__Java__15 _ s) = s
 
 creationExpression :: QuasiQuoter
 creationExpression = QuasiQuoter (quoteJavaExp "tok_CreationExpression_dummy_155" getCreationExpression ) (quoteJavaPat "tok_CreationExpression_dummy_155" getCreationExpression ) quoteJavaType quoteJavaDecs
 
-getDoStatement ( Ctr__Java__16 s) = s
+getDoStatement ( Ctr__Java__16 _ s) = s
 
 doStatement :: QuasiQuoter
 doStatement = QuasiQuoter (quoteJavaExp "tok_DoStatement_dummy_154" getDoStatement ) (quoteJavaPat "tok_DoStatement_dummy_154" getDoStatement ) quoteJavaType quoteJavaDecs
 
-getDocComment ( Ctr__Java__17 s) = s
+getDocComment ( Ctr__Java__17 _ s) = s
 
 docComment :: QuasiQuoter
 docComment = QuasiQuoter (quoteJavaExp "tok_DocComment_dummy_153" getDocComment ) (quoteJavaPat "tok_DocComment_dummy_153" getDocComment ) quoteJavaType quoteJavaDecs
 
-getEnumConstant ( Ctr__Java__18 s) = s
+getEnumConstant ( Ctr__Java__18 _ s) = s
 
 enumConstant :: QuasiQuoter
 enumConstant = QuasiQuoter (quoteJavaExp "tok_EnumConstant_dummy_152" getEnumConstant ) (quoteJavaPat "tok_EnumConstant_dummy_152" getEnumConstant ) quoteJavaType quoteJavaDecs
 
-getEnumConstantList ( Ctr__Java__19 s) = s
+getEnumConstantList ( Ctr__Java__19 _ s) = s
 
 enumConstantList :: QuasiQuoter
 enumConstantList = QuasiQuoter (quoteJavaExp "tok_EnumConstantList_dummy_151" getEnumConstantList ) (quoteJavaPat "tok_EnumConstantList_dummy_151" getEnumConstantList ) quoteJavaType quoteJavaDecs
 
-getEnumDeclaration ( Ctr__Java__20 s) = s
+getEnumDeclaration ( Ctr__Java__20 _ s) = s
 
 enumDeclaration :: QuasiQuoter
 enumDeclaration = QuasiQuoter (quoteJavaExp "tok_EnumDeclaration_dummy_150" getEnumDeclaration ) (quoteJavaPat "tok_EnumDeclaration_dummy_150" getEnumDeclaration ) quoteJavaType quoteJavaDecs
 
-getEqualityOp ( Ctr__Java__21 s) = s
+getEqualityOp ( Ctr__Java__21 _ s) = s
 
 equalityOp :: QuasiQuoter
 equalityOp = QuasiQuoter (quoteJavaExp "tok_EqualityOp_dummy_149" getEqualityOp ) (quoteJavaPat "tok_EqualityOp_dummy_149" getEqualityOp ) quoteJavaType quoteJavaDecs
 
-getExpression ( Ctr__Java__22 s) = s
+getExpression ( Ctr__Java__22 _ s) = s
 
 expression :: QuasiQuoter
 expression = QuasiQuoter (quoteJavaExp "tok_Expression_dummy_148" getExpression ) (quoteJavaPat "tok_Expression_dummy_148" getExpression ) quoteJavaType quoteJavaDecs
 
-getExtendsList ( Ctr__Java__23 s) = s
+getExtendsList ( Ctr__Java__23 _ s) = s
 
 extendsList :: QuasiQuoter
 extendsList = QuasiQuoter (quoteJavaExp "tok_ExtendsList_dummy_147" getExtendsList ) (quoteJavaPat "tok_ExtendsList_dummy_147" getExtendsList ) quoteJavaType quoteJavaDecs
 
-getFieldDeclaration ( Ctr__Java__24 s) = s
+getFieldDeclaration ( Ctr__Java__24 _ s) = s
 
 fieldDeclaration :: QuasiQuoter
 fieldDeclaration = QuasiQuoter (quoteJavaExp "tok_FieldDeclaration_dummy_146" getFieldDeclaration ) (quoteJavaPat "tok_FieldDeclaration_dummy_146" getFieldDeclaration ) quoteJavaType quoteJavaDecs
 
-getFieldDeclarationList ( Ctr__Java__25 s) = s
+getFieldDeclarationList ( Ctr__Java__25 _ s) = s
 
 fieldDeclarationList :: QuasiQuoter
 fieldDeclarationList = QuasiQuoter (quoteJavaExp "tok_FieldDeclarationList_dummy_145" getFieldDeclarationList ) (quoteJavaPat "tok_FieldDeclarationList_dummy_145" getFieldDeclarationList ) quoteJavaType quoteJavaDecs
 
-getForStatement ( Ctr__Java__26 s) = s
+getForStatement ( Ctr__Java__26 _ s) = s
 
 forStatement :: QuasiQuoter
 forStatement = QuasiQuoter (quoteJavaExp "tok_ForStatement_dummy_144" getForStatement ) (quoteJavaPat "tok_ForStatement_dummy_144" getForStatement ) quoteJavaType quoteJavaDecs
 
-getIfStatement ( Ctr__Java__27 s) = s
+getIfStatement ( Ctr__Java__27 _ s) = s
 
 ifStatement :: QuasiQuoter
 ifStatement = QuasiQuoter (quoteJavaExp "tok_IfStatement_dummy_143" getIfStatement ) (quoteJavaPat "tok_IfStatement_dummy_143" getIfStatement ) quoteJavaType quoteJavaDecs
 
-getImplementsList ( Ctr__Java__28 s) = s
+getImplementsList ( Ctr__Java__28 _ s) = s
 
 implementsList :: QuasiQuoter
 implementsList = QuasiQuoter (quoteJavaExp "tok_ImplementsList_dummy_142" getImplementsList ) (quoteJavaPat "tok_ImplementsList_dummy_142" getImplementsList ) quoteJavaType quoteJavaDecs
 
-getImportList ( Ctr__Java__29 s) = s
+getImportList ( Ctr__Java__29 _ s) = s
 
 importList :: QuasiQuoter
 importList = QuasiQuoter (quoteJavaExp "tok_ImportList_dummy_141" getImportList ) (quoteJavaPat "tok_ImportList_dummy_141" getImportList ) quoteJavaType quoteJavaDecs
 
-getImportStatement ( Ctr__Java__30 s) = s
+getImportStatement ( Ctr__Java__30 _ s) = s
 
 importStatement :: QuasiQuoter
 importStatement = QuasiQuoter (quoteJavaExp "tok_ImportStatement_dummy_140" getImportStatement ) (quoteJavaPat "tok_ImportStatement_dummy_140" getImportStatement ) quoteJavaType quoteJavaDecs
 
-getInterfaceDeclaration ( Ctr__Java__31 s) = s
+getInterfaceDeclaration ( Ctr__Java__31 _ s) = s
 
 interfaceDeclaration :: QuasiQuoter
 interfaceDeclaration = QuasiQuoter (quoteJavaExp "tok_InterfaceDeclaration_dummy_139" getInterfaceDeclaration ) (quoteJavaPat "tok_InterfaceDeclaration_dummy_139" getInterfaceDeclaration ) quoteJavaType quoteJavaDecs
 
-getLiteral ( Ctr__Java__32 s) = s
+getLiteral ( Ctr__Java__32 _ s) = s
 
 literal :: QuasiQuoter
 literal = QuasiQuoter (quoteJavaExp "tok_Literal_dummy_138" getLiteral ) (quoteJavaPat "tok_Literal_dummy_138" getLiteral ) quoteJavaType quoteJavaDecs
 
-getMemberAfterFirstId ( Ctr__Java__33 s) = s
+getMemberAfterFirstId ( Ctr__Java__33 _ s) = s
 
 memberAfterFirstId :: QuasiQuoter
 memberAfterFirstId = QuasiQuoter (quoteJavaExp "tok_MemberAfterFirstId_dummy_137" getMemberAfterFirstId ) (quoteJavaPat "tok_MemberAfterFirstId_dummy_137" getMemberAfterFirstId ) quoteJavaType quoteJavaDecs
 
-getMemberDeclaration ( Ctr__Java__34 s) = s
+getMemberDeclaration ( Ctr__Java__34 _ s) = s
 
 memberDeclaration :: QuasiQuoter
 memberDeclaration = QuasiQuoter (quoteJavaExp "tok_MemberDeclaration_dummy_136" getMemberDeclaration ) (quoteJavaPat "tok_MemberDeclaration_dummy_136" getMemberDeclaration ) quoteJavaType quoteJavaDecs
 
-getMemberRest ( Ctr__Java__35 s) = s
+getMemberRest ( Ctr__Java__35 _ s) = s
 
 memberRest :: QuasiQuoter
 memberRest = QuasiQuoter (quoteJavaExp "tok_MemberRest_dummy_135" getMemberRest ) (quoteJavaPat "tok_MemberRest_dummy_135" getMemberRest ) quoteJavaType quoteJavaDecs
 
-getModifier ( Ctr__Java__36 s) = s
+getModifier ( Ctr__Java__36 _ s) = s
 
 modifier :: QuasiQuoter
 modifier = QuasiQuoter (quoteJavaExp "tok_Modifier_dummy_134" getModifier ) (quoteJavaPat "tok_Modifier_dummy_134" getModifier ) quoteJavaType quoteJavaDecs
 
-getModifierList ( Ctr__Java__37 s) = s
+getModifierList ( Ctr__Java__37 _ s) = s
 
 modifierList :: QuasiQuoter
 modifierList = QuasiQuoter (quoteJavaExp "tok_ModifierList_dummy_133" getModifierList ) (quoteJavaPat "tok_ModifierList_dummy_133" getModifierList ) quoteJavaType quoteJavaDecs
 
-getMoreTypeSpecifier ( Ctr__Java__38 s) = s
+getMoreTypeSpecifier ( Ctr__Java__38 _ s) = s
 
 moreTypeSpecifier :: QuasiQuoter
 moreTypeSpecifier = QuasiQuoter (quoteJavaExp "tok_MoreTypeSpecifier_dummy_132" getMoreTypeSpecifier ) (quoteJavaPat "tok_MoreTypeSpecifier_dummy_132" getMoreTypeSpecifier ) quoteJavaType quoteJavaDecs
 
-getMoreVariableDeclarators ( Ctr__Java__39 s) = s
+getMoreVariableDeclarators ( Ctr__Java__39 _ s) = s
 
 moreVariableDeclarators :: QuasiQuoter
 moreVariableDeclarators = QuasiQuoter (quoteJavaExp "tok_MoreVariableDeclarators_dummy_131" getMoreVariableDeclarators ) (quoteJavaPat "tok_MoreVariableDeclarators_dummy_131" getMoreVariableDeclarators ) quoteJavaType quoteJavaDecs
 
-getMultiplicativeOp ( Ctr__Java__40 s) = s
+getMultiplicativeOp ( Ctr__Java__40 _ s) = s
 
 multiplicativeOp :: QuasiQuoter
 multiplicativeOp = QuasiQuoter (quoteJavaExp "tok_MultiplicativeOp_dummy_130" getMultiplicativeOp ) (quoteJavaPat "tok_MultiplicativeOp_dummy_130" getMultiplicativeOp ) quoteJavaType quoteJavaDecs
 
-getNestedTypeDeclaration ( Ctr__Java__41 s) = s
+getNestedTypeDeclaration ( Ctr__Java__41 _ s) = s
 
 nestedTypeDeclaration :: QuasiQuoter
 nestedTypeDeclaration = QuasiQuoter (quoteJavaExp "tok_NestedTypeDeclaration_dummy_129" getNestedTypeDeclaration ) (quoteJavaPat "tok_NestedTypeDeclaration_dummy_129" getNestedTypeDeclaration ) quoteJavaType quoteJavaDecs
 
-getOptDocComment ( Ctr__Java__42 s) = s
+getOptDocComment ( Ctr__Java__42 _ s) = s
 
 optDocComment :: QuasiQuoter
 optDocComment = QuasiQuoter (quoteJavaExp "tok_OptDocComment_dummy_128" getOptDocComment ) (quoteJavaPat "tok_OptDocComment_dummy_128" getOptDocComment ) quoteJavaType quoteJavaDecs
 
-getOptElsePart ( Ctr__Java__43 s) = s
+getOptElsePart ( Ctr__Java__43 _ s) = s
 
 optElsePart :: QuasiQuoter
 optElsePart = QuasiQuoter (quoteJavaExp "tok_OptElsePart_dummy_127" getOptElsePart ) (quoteJavaPat "tok_OptElsePart_dummy_127" getOptElsePart ) quoteJavaType quoteJavaDecs
 
-getOptExpression ( Ctr__Java__44 s) = s
+getOptExpression ( Ctr__Java__44 _ s) = s
 
 optExpression :: QuasiQuoter
 optExpression = QuasiQuoter (quoteJavaExp "tok_OptExpression_dummy_126" getOptExpression ) (quoteJavaPat "tok_OptExpression_dummy_126" getOptExpression ) quoteJavaType quoteJavaDecs
 
-getOptFinally ( Ctr__Java__45 s) = s
+getOptFinally ( Ctr__Java__45 _ s) = s
 
 optFinally :: QuasiQuoter
 optFinally = QuasiQuoter (quoteJavaExp "tok_OptFinally_dummy_125" getOptFinally ) (quoteJavaPat "tok_OptFinally_dummy_125" getOptFinally ) quoteJavaType quoteJavaDecs
 
-getOptId ( Ctr__Java__46 s) = s
+getOptId ( Ctr__Java__46 _ s) = s
 
 optId :: QuasiQuoter
 optId = QuasiQuoter (quoteJavaExp "tok_OptId_dummy_124" getOptId ) (quoteJavaPat "tok_OptId_dummy_124" getOptId ) quoteJavaType quoteJavaDecs
 
-getOptVariableInitializer ( Ctr__Java__47 s) = s
+getOptVariableInitializer ( Ctr__Java__47 _ s) = s
 
 optVariableInitializer :: QuasiQuoter
 optVariableInitializer = QuasiQuoter (quoteJavaExp "tok_OptVariableInitializer_dummy_123" getOptVariableInitializer ) (quoteJavaPat "tok_OptVariableInitializer_dummy_123" getOptVariableInitializer ) quoteJavaType quoteJavaDecs
 
-getPackage ( Ctr__Java__48 s) = s
+getPackage ( Ctr__Java__48 _ s) = s
 
 package :: QuasiQuoter
 package = QuasiQuoter (quoteJavaExp "tok_Package_dummy_122" getPackage ) (quoteJavaPat "tok_Package_dummy_122" getPackage ) quoteJavaType quoteJavaDecs
 
-getParameter ( Ctr__Java__49 s) = s
+getParameter ( Ctr__Java__49 _ s) = s
 
 parameter :: QuasiQuoter
 parameter = QuasiQuoter (quoteJavaExp "tok_Parameter_dummy_121" getParameter ) (quoteJavaPat "tok_Parameter_dummy_121" getParameter ) quoteJavaType quoteJavaDecs
 
-getParameterList ( Ctr__Java__50 s) = s
+getParameterList ( Ctr__Java__50 _ s) = s
 
 parameterList :: QuasiQuoter
 parameterList = QuasiQuoter (quoteJavaExp "tok_ParameterList_dummy_120" getParameterList ) (quoteJavaPat "tok_ParameterList_dummy_120" getParameterList ) quoteJavaType quoteJavaDecs
 
-getPostfixOp ( Ctr__Java__51 s) = s
+getPostfixOp ( Ctr__Java__51 _ s) = s
 
 postfixOp :: QuasiQuoter
 postfixOp = QuasiQuoter (quoteJavaExp "tok_PostfixOp_dummy_119" getPostfixOp ) (quoteJavaPat "tok_PostfixOp_dummy_119" getPostfixOp ) quoteJavaType quoteJavaDecs
 
-getPrefixOp ( Ctr__Java__52 s) = s
+getPrefixOp ( Ctr__Java__52 _ s) = s
 
 prefixOp :: QuasiQuoter
 prefixOp = QuasiQuoter (quoteJavaExp "tok_PrefixOp_dummy_118" getPrefixOp ) (quoteJavaPat "tok_PrefixOp_dummy_118" getPrefixOp ) quoteJavaType quoteJavaDecs
 
-getPrimitiveTypeKeyword ( Ctr__Java__53 s) = s
+getPrimitiveTypeKeyword ( Ctr__Java__53 _ s) = s
 
 primitiveTypeKeyword :: QuasiQuoter
 primitiveTypeKeyword = QuasiQuoter (quoteJavaExp "tok_PrimitiveTypeKeyword_dummy_117" getPrimitiveTypeKeyword ) (quoteJavaPat "tok_PrimitiveTypeKeyword_dummy_117" getPrimitiveTypeKeyword ) quoteJavaType quoteJavaDecs
 
-getRelationalOp ( Ctr__Java__54 s) = s
+getRelationalOp ( Ctr__Java__54 _ s) = s
 
 relationalOp :: QuasiQuoter
 relationalOp = QuasiQuoter (quoteJavaExp "tok_RelationalOp_dummy_116" getRelationalOp ) (quoteJavaPat "tok_RelationalOp_dummy_116" getRelationalOp ) quoteJavaType quoteJavaDecs
 
-getShiftOp ( Ctr__Java__55 s) = s
+getShiftOp ( Ctr__Java__55 _ s) = s
 
 shiftOp :: QuasiQuoter
 shiftOp = QuasiQuoter (quoteJavaExp "tok_ShiftOp_dummy_115" getShiftOp ) (quoteJavaPat "tok_ShiftOp_dummy_115" getShiftOp ) quoteJavaType quoteJavaDecs
 
-getSquareBracketsList ( Ctr__Java__56 s) = s
+getSquareBracketsList ( Ctr__Java__56 _ s) = s
 
 squareBracketsList :: QuasiQuoter
 squareBracketsList = QuasiQuoter (quoteJavaExp "tok_SquareBracketsList_dummy_114" getSquareBracketsList ) (quoteJavaPat "tok_SquareBracketsList_dummy_114" getSquareBracketsList ) quoteJavaType quoteJavaDecs
 
-getStatement ( Ctr__Java__57 s) = s
+getStatement ( Ctr__Java__57 _ s) = s
 
 statement :: QuasiQuoter
 statement = QuasiQuoter (quoteJavaExp "tok_Statement_dummy_113" getStatement ) (quoteJavaPat "tok_Statement_dummy_113" getStatement ) quoteJavaType quoteJavaDecs
 
-getStatementBlock ( Ctr__Java__58 s) = s
+getStatementBlock ( Ctr__Java__58 _ s) = s
 
 statementBlock :: QuasiQuoter
 statementBlock = QuasiQuoter (quoteJavaExp "tok_StatementBlock_dummy_112" getStatementBlock ) (quoteJavaPat "tok_StatementBlock_dummy_112" getStatementBlock ) quoteJavaType quoteJavaDecs
 
-getStatementList ( Ctr__Java__59 s) = s
+getStatementList ( Ctr__Java__59 _ s) = s
 
 statementList :: QuasiQuoter
 statementList = QuasiQuoter (quoteJavaExp "tok_StatementList_dummy_111" getStatementList ) (quoteJavaPat "tok_StatementList_dummy_111" getStatementList ) quoteJavaType quoteJavaDecs
 
-getStatementWithoutIf ( Ctr__Java__60 s) = s
+getStatementWithoutIf ( Ctr__Java__60 _ s) = s
 
 statementWithoutIf :: QuasiQuoter
 statementWithoutIf = QuasiQuoter (quoteJavaExp "tok_StatementWithoutIf_dummy_110" getStatementWithoutIf ) (quoteJavaPat "tok_StatementWithoutIf_dummy_110" getStatementWithoutIf ) quoteJavaType quoteJavaDecs
 
-getStaticInitializer ( Ctr__Java__61 s) = s
+getStaticInitializer ( Ctr__Java__61 _ s) = s
 
 staticInitializer :: QuasiQuoter
 staticInitializer = QuasiQuoter (quoteJavaExp "tok_StaticInitializer_dummy_109" getStaticInitializer ) (quoteJavaPat "tok_StaticInitializer_dummy_109" getStaticInitializer ) quoteJavaType quoteJavaDecs
 
-getSwitchCaseList ( Ctr__Java__62 s) = s
+getSwitchCaseList ( Ctr__Java__62 _ s) = s
 
 switchCaseList :: QuasiQuoter
 switchCaseList = QuasiQuoter (quoteJavaExp "tok_SwitchCaseList_dummy_108" getSwitchCaseList ) (quoteJavaPat "tok_SwitchCaseList_dummy_108" getSwitchCaseList ) quoteJavaType quoteJavaDecs
 
-getSwitchStatement ( Ctr__Java__63 s) = s
+getSwitchStatement ( Ctr__Java__63 _ s) = s
 
 switchStatement :: QuasiQuoter
 switchStatement = QuasiQuoter (quoteJavaExp "tok_SwitchStatement_dummy_107" getSwitchStatement ) (quoteJavaPat "tok_SwitchStatement_dummy_107" getSwitchStatement ) quoteJavaType quoteJavaDecs
 
-getTryStatement ( Ctr__Java__64 s) = s
+getTryStatement ( Ctr__Java__64 _ s) = s
 
 tryStatement :: QuasiQuoter
 tryStatement = QuasiQuoter (quoteJavaExp "tok_TryStatement_dummy_106" getTryStatement ) (quoteJavaPat "tok_TryStatement_dummy_106" getTryStatement ) quoteJavaType quoteJavaDecs
 
-getType ( Ctr__Java__65 s) = s
+getType ( Ctr__Java__65 _ s) = s
 
 __type :: QuasiQuoter
 __type = QuasiQuoter (quoteJavaExp "tok_Type_dummy_105" getType ) (quoteJavaPat "tok_Type_dummy_105" getType ) quoteJavaType quoteJavaDecs
 
-getTypeArgument ( Ctr__Java__66 s) = s
+getTypeArgument ( Ctr__Java__66 _ s) = s
 
 typeArgument :: QuasiQuoter
 typeArgument = QuasiQuoter (quoteJavaExp "tok_TypeArgument_dummy_104" getTypeArgument ) (quoteJavaPat "tok_TypeArgument_dummy_104" getTypeArgument ) quoteJavaType quoteJavaDecs
 
-getTypeArguments ( Ctr__Java__67 s) = s
+getTypeArguments ( Ctr__Java__67 _ s) = s
 
 typeArguments :: QuasiQuoter
 typeArguments = QuasiQuoter (quoteJavaExp "tok_TypeArguments_dummy_103" getTypeArguments ) (quoteJavaPat "tok_TypeArguments_dummy_103" getTypeArguments ) quoteJavaType quoteJavaDecs
 
-getTypeDeclaration ( Ctr__Java__68 s) = s
+getTypeDeclaration ( Ctr__Java__68 _ s) = s
 
 typeDeclaration :: QuasiQuoter
 typeDeclaration = QuasiQuoter (quoteJavaExp "tok_TypeDeclaration_dummy_102" getTypeDeclaration ) (quoteJavaPat "tok_TypeDeclaration_dummy_102" getTypeDeclaration ) quoteJavaType quoteJavaDecs
 
-getTypeParameter ( Ctr__Java__69 s) = s
+getTypeParameter ( Ctr__Java__69 _ s) = s
 
 typeParameter :: QuasiQuoter
 typeParameter = QuasiQuoter (quoteJavaExp "tok_TypeParameter_dummy_101" getTypeParameter ) (quoteJavaPat "tok_TypeParameter_dummy_101" getTypeParameter ) quoteJavaType quoteJavaDecs
 
-getTypeParameters ( Ctr__Java__70 s) = s
+getTypeParameters ( Ctr__Java__70 _ s) = s
 
 typeParameters :: QuasiQuoter
 typeParameters = QuasiQuoter (quoteJavaExp "tok_TypeParameters_dummy_100" getTypeParameters ) (quoteJavaPat "tok_TypeParameters_dummy_100" getTypeParameters ) quoteJavaType quoteJavaDecs
 
-getTypeSpecifier ( Ctr__Java__71 s) = s
+getTypeSpecifier ( Ctr__Java__71 _ s) = s
 
 typeSpecifier :: QuasiQuoter
 typeSpecifier = QuasiQuoter (quoteJavaExp "tok_TypeSpecifier_dummy_99" getTypeSpecifier ) (quoteJavaPat "tok_TypeSpecifier_dummy_99" getTypeSpecifier ) quoteJavaType quoteJavaDecs
 
-getVariableDeclaration ( Ctr__Java__72 s) = s
+getVariableDeclaration ( Ctr__Java__72 _ s) = s
 
 variableDeclaration :: QuasiQuoter
 variableDeclaration = QuasiQuoter (quoteJavaExp "tok_VariableDeclaration_dummy_98" getVariableDeclaration ) (quoteJavaPat "tok_VariableDeclaration_dummy_98" getVariableDeclaration ) quoteJavaType quoteJavaDecs
 
-getVariableDeclarator ( Ctr__Java__73 s) = s
+getVariableDeclarator ( Ctr__Java__73 _ s) = s
 
 variableDeclarator :: QuasiQuoter
 variableDeclarator = QuasiQuoter (quoteJavaExp "tok_VariableDeclarator_dummy_97" getVariableDeclarator ) (quoteJavaPat "tok_VariableDeclarator_dummy_97" getVariableDeclarator ) quoteJavaType quoteJavaDecs
 
-getVariableDeclaratorList ( Ctr__Java__74 s) = s
+getVariableDeclaratorList ( Ctr__Java__74 _ s) = s
 
 variableDeclaratorList :: QuasiQuoter
 variableDeclaratorList = QuasiQuoter (quoteJavaExp "tok_VariableDeclaratorList_dummy_96" getVariableDeclaratorList ) (quoteJavaPat "tok_VariableDeclaratorList_dummy_96" getVariableDeclaratorList ) quoteJavaType quoteJavaDecs
 
-getVariableInitializer ( Ctr__Java__75 s) = s
+getVariableInitializer ( Ctr__Java__75 _ s) = s
 
 variableInitializer :: QuasiQuoter
 variableInitializer = QuasiQuoter (quoteJavaExp "tok_VariableInitializer_dummy_95" getVariableInitializer ) (quoteJavaPat "tok_VariableInitializer_dummy_95" getVariableInitializer ) quoteJavaType quoteJavaDecs
 
-getVariableInitializerList ( Ctr__Java__76 s) = s
+getVariableInitializerList ( Ctr__Java__76 _ s) = s
 
 variableInitializerList :: QuasiQuoter
 variableInitializerList = QuasiQuoter (quoteJavaExp "tok_VariableInitializerList_dummy_94" getVariableInitializerList ) (quoteJavaPat "tok_VariableInitializerList_dummy_94" getVariableInitializerList ) quoteJavaType quoteJavaDecs
 
-getWhileStatement ( Ctr__Java__77 s) = s
+getWhileStatement ( Ctr__Java__77 _ s) = s
 
 whileStatement :: QuasiQuoter
 whileStatement = QuasiQuoter (quoteJavaExp "tok_WhileStatement_dummy_93" getWhileStatement ) (quoteJavaPat "tok_WhileStatement_dummy_93" getWhileStatement ) quoteJavaType quoteJavaDecs
 
-getWildcardType ( Ctr__Java__78 s) = s
+getWildcardType ( Ctr__Java__78 _ s) = s
 
 wildcardType :: QuasiQuoter
 wildcardType = QuasiQuoter (quoteJavaExp "tok_WildcardType_dummy_92" getWildcardType ) (quoteJavaPat "tok_WildcardType_dummy_92" getWildcardType ) quoteJavaType quoteJavaDecs

--- a/test/golden/p/PLexer.x
+++ b/test/golden/p/PLexer.x
@@ -1,6 +1,8 @@
 {
+{-# LANGUAGE StandaloneDeriving, DeriveDataTypeable #-}
 module PLexer(scanTokens, alexScanTokens, Token(..), PosToken(..), AlexPosn(..))
 where
+import Data.Data (Data)
 
  }
 %wrapper "monad"
@@ -66,6 +68,11 @@ data Token = EndOfFile |
              Tk__qq_E String |
              Tk__qq_P String
              deriving (Show)
+
+-- AlexPosn is defined by the alex wrapper, so the Data instance (required by
+-- the parser's RtkPos position type) can only be attached via standalone
+-- deriving - the same solution as the hand-written Lexer.x
+deriving instance Data AlexPosn
 
 -- A token together with the source position where it starts
 data PosToken = PosToken { ptPos :: AlexPosn, ptToken :: Token }

--- a/test/golden/p/PParser.y
+++ b/test/golden/p/PParser.y
@@ -34,50 +34,50 @@ tok_1_4 { L.PosToken _ L.Tk__tok_1_4 }
 tok_0_3 { L.PosToken _ L.Tk__tok_0_3 }
 tok__rparen__2 { L.PosToken _ L.Tk__tok__rparen__2 }
 tok__lparen__0 { L.PosToken _ L.Tk__tok__lparen__0 }
-id { L.PosToken _ (L.Tk__id $$) }
-qq_Id { L.PosToken _ (L.Tk__qq_Id $$) }
-qq_Op2 { L.PosToken _ (L.Tk__qq_Op2 $$) }
-qq_Op1 { L.PosToken _ (L.Tk__qq_Op1 $$) }
-qq_E { L.PosToken _ (L.Tk__qq_E $$) }
-qq_P { L.PosToken _ (L.Tk__qq_P $$) }
+id { L.PosToken _ (L.Tk__id _) }
+qq_Id { L.PosToken _ (L.Tk__qq_Id _) }
+qq_Op2 { L.PosToken _ (L.Tk__qq_Op2 _) }
+qq_Op1 { L.PosToken _ (L.Tk__qq_Op1 _) }
+qq_E { L.PosToken _ (L.Tk__qq_E _) }
+qq_P { L.PosToken _ (L.Tk__qq_P _) }
 
 %%
 
 P__top : P rtk__eof { $1 }
 
-P : tok_P_dummy_4 P tok_P_dummy_4 { Ctr__P__0 $2 } |
-    tok_E_dummy_3 E tok_E_dummy_3 { Ctr__P__1 $2 } |
-    tok_Id_dummy_2 Id tok_Id_dummy_2 { Ctr__P__2 $2 } |
-    tok_Op1_dummy_1 Op1 tok_Op1_dummy_1 { Ctr__P__3 $2 } |
-    tok_Op2_dummy_0 Op2 tok_Op2_dummy_0 { Ctr__P__4 $2 }
+P : tok_P_dummy_4 P tok_P_dummy_4 { Ctr__P__0 (rtkPosOf $1) $2 } |
+    tok_E_dummy_3 E tok_E_dummy_3 { Ctr__P__1 (rtkPosOf $1) $2 } |
+    tok_Id_dummy_2 Id tok_Id_dummy_2 { Ctr__P__2 (rtkPosOf $1) $2 } |
+    tok_Op1_dummy_1 Op1 tok_Op1_dummy_1 { Ctr__P__3 (rtkPosOf $1) $2 } |
+    tok_Op2_dummy_0 Op2 tok_Op2_dummy_0 { Ctr__P__4 (rtkPosOf $1) $2 }
 
-P : qq_P { Anti_P $1 } |
-    tok__lparen__0 tok_lambda_1 tok__lparen__0 Id tok__rparen__2 E tok__rparen__2 { Ctr__P__5 $4 $6 }
+P : qq_P { Anti_P (tkVal_qq_P $1) } |
+    tok__lparen__0 tok_lambda_1 tok__lparen__0 Id tok__rparen__2 E tok__rparen__2 { Ctr__P__5 (rtkPosOf $1) $4 $6 }
 
-E : qq_E { Anti_E $1 } |
-    tok_0_3 { Ctr__E__0 } |
-    tok_1_4 { Ctr__E__1 } |
-    Id { Ctr__E__2 $1 } |
-    tok__lparen__0 tok_if0_5 E E E tok__rparen__2 { Ctr__E__3 $3 $4 $5 } |
-    tok__lparen__0 tok_fold_6 E E tok__lparen__0 tok_lambda_1 tok__lparen__0 Id Id tok__rparen__2 E tok__rparen__2 tok__rparen__2 { Ctr__E__4 $3 $4 $8 $9 $11 } |
-    tok__lparen__0 Op1 E tok__rparen__2 { Ctr__E__5 $2 $3 } |
-    tok__lparen__0 Op2 E E tok__rparen__2 { Ctr__E__6 $2 $3 $4 }
+E : qq_E { Anti_E (tkVal_qq_E $1) } |
+    tok_0_3 { Ctr__E__0 (rtkPosOf $1) } |
+    tok_1_4 { Ctr__E__1 (rtkPosOf $1) } |
+    Id { Ctr__E__2 (rtkPosOf $1) $1 } |
+    tok__lparen__0 tok_if0_5 E E E tok__rparen__2 { Ctr__E__3 (rtkPosOf $1) $3 $4 $5 } |
+    tok__lparen__0 tok_fold_6 E E tok__lparen__0 tok_lambda_1 tok__lparen__0 Id Id tok__rparen__2 E tok__rparen__2 tok__rparen__2 { Ctr__E__4 (rtkPosOf $1) $3 $4 $8 $9 $11 } |
+    tok__lparen__0 Op1 E tok__rparen__2 { Ctr__E__5 (rtkPosOf $1) $2 $3 } |
+    tok__lparen__0 Op2 E E tok__rparen__2 { Ctr__E__6 (rtkPosOf $1) $2 $3 $4 }
 
-Id : qq_Id { Anti_Id $1 } |
-     id { Ctr__Id__0 $1 }
+Id : qq_Id { Anti_Id (tkVal_qq_Id $1) } |
+     id { Ctr__Id__0 (rtkPosOf $1) (tkVal_id $1) }
 
-Op1 : qq_Op1 { Anti_Op1 $1 } |
-      tok_not_7 { Ctr__Op1__0 } |
-      tok_shl1_8 { Ctr__Op1__1 } |
-      tok_shr1_9 { Ctr__Op1__2 } |
-      tok_shr4_10 { Ctr__Op1__3 } |
-      tok_shr16_11 { Ctr__Op1__4 }
+Op1 : qq_Op1 { Anti_Op1 (tkVal_qq_Op1 $1) } |
+      tok_not_7 { Ctr__Op1__0 (rtkPosOf $1) } |
+      tok_shl1_8 { Ctr__Op1__1 (rtkPosOf $1) } |
+      tok_shr1_9 { Ctr__Op1__2 (rtkPosOf $1) } |
+      tok_shr4_10 { Ctr__Op1__3 (rtkPosOf $1) } |
+      tok_shr16_11 { Ctr__Op1__4 (rtkPosOf $1) }
 
-Op2 : qq_Op2 { Anti_Op2 $1 } |
-      tok_and_12 { Ctr__Op2__0 } |
-      tok_or_13 { Ctr__Op2__1 } |
-      tok_xor_14 { Ctr__Op2__2 } |
-      tok_plus_15 { Ctr__Op2__3 }
+Op2 : qq_Op2 { Anti_Op2 (tkVal_qq_Op2 $1) } |
+      tok_and_12 { Ctr__Op2__0 (rtkPosOf $1) } |
+      tok_or_13 { Ctr__Op2__1 (rtkPosOf $1) } |
+      tok_xor_14 { Ctr__Op2__2 (rtkPosOf $1) } |
+      tok_plus_15 { Ctr__Op2__3 (rtkPosOf $1) }
 
 
 {
@@ -117,37 +117,119 @@ showRtkToken (L.Tk__qq_Op1 v) = "qq_Op1 " ++ show v
 showRtkToken (L.Tk__qq_E v) = "qq_E " ++ show v
 showRtkToken (L.Tk__qq_P v) = "qq_P " ++ show v
 
-data P = Ctr__P__0 P |
-         Ctr__P__1 E |
-         Ctr__P__2 Id |
-         Ctr__P__3 Op1 |
-         Ctr__P__4 Op2 |
+-- Source position of a node: every constructor except the Anti_* splice
+-- artifacts stores the position of its alternative's first symbol in its
+-- first field. Positions are transparent for equality and ordering, so two
+-- ASTs that differ only in source positions (e.g. a quasi-quote parsed at
+-- compile time vs the same construct parsed at run time) compare equal.
+newtype RtkPos = RtkPos L.AlexPosn deriving (Show, Gen.Data, Gen.Typeable)
+instance Eq RtkPos where _ == _ = True
+instance Ord RtkPos where compare _ _ = EQ
+
+-- The position used where no source token exists: empty productions, empty
+-- lists, absent optionals and Anti_* quasi-quote splices
+rtkNoPos :: RtkPos
+rtkNoPos = RtkPos (L.AlexPn 0 0 0)
+
+class RtkPosOf a where
+    rtkPosOf :: a -> RtkPos
+instance RtkPosOf L.PosToken where
+    rtkPosOf (L.PosToken p _) = RtkPos p
+instance RtkPosOf a => RtkPosOf [a] where
+    rtkPosOf (x : _) = rtkPosOf x
+    rtkPosOf []      = rtkNoPos
+instance RtkPosOf a => RtkPosOf (Maybe a) where
+    rtkPosOf (Just x) = rtkPosOf x
+    rtkPosOf Nothing  = rtkNoPos
+-- A Char carries no position; this also covers String token payloads
+instance RtkPosOf Char where
+    rtkPosOf _ = rtkNoPos
+
+-- Recover a token's payload from the whole positioned token: %token
+-- bindings keep the L.PosToken so semantic actions can read its position
+tkVal_id :: L.PosToken -> String
+tkVal_id (L.PosToken _ (L.Tk__id v)) = v
+tkVal_id t = error ("rtk internal error: token id expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_Id :: L.PosToken -> String
+tkVal_qq_Id (L.PosToken _ (L.Tk__qq_Id v)) = v
+tkVal_qq_Id t = error ("rtk internal error: token qq_Id expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_Op2 :: L.PosToken -> String
+tkVal_qq_Op2 (L.PosToken _ (L.Tk__qq_Op2 v)) = v
+tkVal_qq_Op2 t = error ("rtk internal error: token qq_Op2 expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_Op1 :: L.PosToken -> String
+tkVal_qq_Op1 (L.PosToken _ (L.Tk__qq_Op1 v)) = v
+tkVal_qq_Op1 t = error ("rtk internal error: token qq_Op1 expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_E :: L.PosToken -> String
+tkVal_qq_E (L.PosToken _ (L.Tk__qq_E v)) = v
+tkVal_qq_E t = error ("rtk internal error: token qq_E expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_P :: L.PosToken -> String
+tkVal_qq_P (L.PosToken _ (L.Tk__qq_P v)) = v
+tkVal_qq_P t = error ("rtk internal error: token qq_P expected, got " ++ showRtkToken (L.ptToken t))
+
+data P = Ctr__P__0 RtkPos P |
+         Ctr__P__1 RtkPos E |
+         Ctr__P__2 RtkPos Id |
+         Ctr__P__3 RtkPos Op1 |
+         Ctr__P__4 RtkPos Op2 |
          Anti_P String |
-         Ctr__P__5 Id E
+         Ctr__P__5 RtkPos Id E
          deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf P where
+    rtkPosOf (Ctr__P__0 p _) = p
+    rtkPosOf (Ctr__P__1 p _) = p
+    rtkPosOf (Ctr__P__2 p _) = p
+    rtkPosOf (Ctr__P__3 p _) = p
+    rtkPosOf (Ctr__P__4 p _) = p
+    rtkPosOf (Anti_P _) = rtkNoPos
+    rtkPosOf (Ctr__P__5 p _ _) = p
 data E = Anti_E String |
-         Ctr__E__0 |
-         Ctr__E__1 |
-         Ctr__E__2 Id |
-         Ctr__E__3 E E E |
-         Ctr__E__4 E E Id Id E |
-         Ctr__E__5 Op1 E |
-         Ctr__E__6 Op2 E E
+         Ctr__E__0 RtkPos |
+         Ctr__E__1 RtkPos |
+         Ctr__E__2 RtkPos Id |
+         Ctr__E__3 RtkPos E E E |
+         Ctr__E__4 RtkPos E E Id Id E |
+         Ctr__E__5 RtkPos Op1 E |
+         Ctr__E__6 RtkPos Op2 E E
          deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf E where
+    rtkPosOf (Anti_E _) = rtkNoPos
+    rtkPosOf (Ctr__E__0 p) = p
+    rtkPosOf (Ctr__E__1 p) = p
+    rtkPosOf (Ctr__E__2 p _) = p
+    rtkPosOf (Ctr__E__3 p _ _ _) = p
+    rtkPosOf (Ctr__E__4 p _ _ _ _ _) = p
+    rtkPosOf (Ctr__E__5 p _ _) = p
+    rtkPosOf (Ctr__E__6 p _ _ _) = p
 data Id = Anti_Id String |
-          Ctr__Id__0 String
+          Ctr__Id__0 RtkPos String
           deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Id where
+    rtkPosOf (Anti_Id _) = rtkNoPos
+    rtkPosOf (Ctr__Id__0 p _) = p
 data Op1 = Anti_Op1 String |
-           Ctr__Op1__0 |
-           Ctr__Op1__1 |
-           Ctr__Op1__2 |
-           Ctr__Op1__3 |
-           Ctr__Op1__4
+           Ctr__Op1__0 RtkPos |
+           Ctr__Op1__1 RtkPos |
+           Ctr__Op1__2 RtkPos |
+           Ctr__Op1__3 RtkPos |
+           Ctr__Op1__4 RtkPos
            deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Op1 where
+    rtkPosOf (Anti_Op1 _) = rtkNoPos
+    rtkPosOf (Ctr__Op1__0 p) = p
+    rtkPosOf (Ctr__Op1__1 p) = p
+    rtkPosOf (Ctr__Op1__2 p) = p
+    rtkPosOf (Ctr__Op1__3 p) = p
+    rtkPosOf (Ctr__Op1__4 p) = p
 data Op2 = Anti_Op2 String |
-           Ctr__Op2__0 |
-           Ctr__Op2__1 |
-           Ctr__Op2__2 |
-           Ctr__Op2__3
+           Ctr__Op2__0 RtkPos |
+           Ctr__Op2__1 RtkPos |
+           Ctr__Op2__2 RtkPos |
+           Ctr__Op2__3 RtkPos
            deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Op2 where
+    rtkPosOf (Anti_Op2 _) = rtkNoPos
+    rtkPosOf (Ctr__Op2__0 p) = p
+    rtkPosOf (Ctr__Op2__1 p) = p
+    rtkPosOf (Ctr__Op2__2 p) = p
+    rtkPosOf (Ctr__Op2__3 p) = p
 }

--- a/test/golden/p/PQQ.hs
+++ b/test/golden/p/PQQ.hs
@@ -51,6 +51,14 @@ replaceAllPatterns str = init <$> replaceAllPatterns1 (str ++ " ")
 
 qqShortcuts = M.fromList [ ("p","P"),("e","E"),("id","Id"),("op1","Op1"),("op2","Op2")]
 
+-- A quasi-quote pattern must match an AST parsed from anywhere in a source
+-- file, while the pattern itself was parsed from the quote body - so every
+-- RtkPos position field becomes a wildcard in generated patterns.
+-- (Expressions need no special case: the compile-time position they embed
+-- is equality-transparent.)
+rtkPosWildPat :: RtkPos -> Maybe (TH.Q TH.Pat)
+rtkPosWildPat _ = Just TH.wildP
+
 quotePExp :: Data.Data a => String -> (P -> a) -> String -> TH.ExpQ
 quotePExp dummy func s = do
   s1 <- either fail return (replaceAllPatterns s)
@@ -66,7 +74,7 @@ quotePPat dummy func s = do
            Left err -> fail err
            Right a -> return a
   let expr = func ast
-  dataToPatQ (const Nothing `Generics.extQ` antiPPat `Generics.extQ` antiEPat `Generics.extQ` antiOp1Pat `Generics.extQ` antiOp2Pat `Generics.extQ` antiIdPat) expr
+  dataToPatQ (const Nothing `Generics.extQ` rtkPosWildPat `Generics.extQ` antiPPat `Generics.extQ` antiEPat `Generics.extQ` antiOp1Pat `Generics.extQ` antiOp2Pat `Generics.extQ` antiIdPat) expr
 
 antiIdExp :: Id -> Maybe (TH.Q TH.Exp )
 antiIdExp ( Anti_Id v) = Just $ TH.varE (TH.mkName v)
@@ -123,27 +131,27 @@ antiPPat _ = Nothing
 quotePType s = return TH.ListT
 quotePDecs s = return []
 
-getP ( Ctr__P__0 s) = s
+getP ( Ctr__P__0 _ s) = s
 
 p :: QuasiQuoter
 p = QuasiQuoter (quotePExp "tok_P_dummy_4" getP ) (quotePPat "tok_P_dummy_4" getP ) quotePType quotePDecs
 
-getE ( Ctr__P__1 s) = s
+getE ( Ctr__P__1 _ s) = s
 
 e :: QuasiQuoter
 e = QuasiQuoter (quotePExp "tok_E_dummy_3" getE ) (quotePPat "tok_E_dummy_3" getE ) quotePType quotePDecs
 
-getId ( Ctr__P__2 s) = s
+getId ( Ctr__P__2 _ s) = s
 
 id :: QuasiQuoter
 id = QuasiQuoter (quotePExp "tok_Id_dummy_2" getId ) (quotePPat "tok_Id_dummy_2" getId ) quotePType quotePDecs
 
-getOp1 ( Ctr__P__3 s) = s
+getOp1 ( Ctr__P__3 _ s) = s
 
 op1 :: QuasiQuoter
 op1 = QuasiQuoter (quotePExp "tok_Op1_dummy_1" getOp1 ) (quotePPat "tok_Op1_dummy_1" getOp1 ) quotePType quotePDecs
 
-getOp2 ( Ctr__P__4 s) = s
+getOp2 ( Ctr__P__4 _ s) = s
 
 op2 :: QuasiQuoter
 op2 = QuasiQuoter (quotePExp "tok_Op2_dummy_0" getOp2 ) (quotePPat "tok_Op2_dummy_0" getOp2 ) quotePType quotePDecs

--- a/test/golden/sandbox/SandboxLexer.x
+++ b/test/golden/sandbox/SandboxLexer.x
@@ -1,6 +1,8 @@
 {
+{-# LANGUAGE StandaloneDeriving, DeriveDataTypeable #-}
 module SandboxLexer(scanTokens, alexScanTokens, Token(..), PosToken(..), AlexPosn(..))
 where
+import Data.Data (Data)
 
  }
 %wrapper "monad"
@@ -20,6 +22,11 @@ data Token = EndOfFile |
              Tk__doccomment String |
              Tk__qq_Sandbox String
              deriving (Show)
+
+-- AlexPosn is defined by the alex wrapper, so the Data instance (required by
+-- the parser's RtkPos position type) can only be attached via standalone
+-- deriving - the same solution as the hand-written Lexer.x
+deriving instance Data AlexPosn
 
 -- A token together with the source position where it starts
 data PosToken = PosToken { ptPos :: AlexPosn, ptToken :: Token }

--- a/test/golden/sandbox/SandboxParser.y
+++ b/test/golden/sandbox/SandboxParser.y
@@ -14,17 +14,17 @@ import qualified SandboxLexer as L (Token(..), PosToken(..), AlexPosn(..), alexS
 
 rtk__eof { L.PosToken _ L.EndOfFile }
 tok_Sandbox_dummy_0 { L.PosToken _ L.Tk__tok_Sandbox_dummy_0 }
-doccomment { L.PosToken _ (L.Tk__doccomment $$) }
-qq_Sandbox { L.PosToken _ (L.Tk__qq_Sandbox $$) }
+doccomment { L.PosToken _ (L.Tk__doccomment _) }
+qq_Sandbox { L.PosToken _ (L.Tk__qq_Sandbox _) }
 
 %%
 
 Sandbox__top : Sandbox rtk__eof { $1 }
 
-Sandbox : tok_Sandbox_dummy_0 Sandbox tok_Sandbox_dummy_0 { Ctr__Sandbox__0 $2 }
+Sandbox : tok_Sandbox_dummy_0 Sandbox tok_Sandbox_dummy_0 { Ctr__Sandbox__0 (rtkPosOf $1) $2 }
 
-Sandbox : qq_Sandbox { Anti_Sandbox $1 } |
-          doccomment { Ctr__Sandbox__1 $1 }
+Sandbox : qq_Sandbox { Anti_Sandbox (tkVal_qq_Sandbox $1) } |
+          doccomment { Ctr__Sandbox__1 (rtkPosOf $1) (tkVal_doccomment $1) }
 
 
 {
@@ -40,8 +40,49 @@ showRtkToken L.Tk__tok_Sandbox_dummy_0 = "'tok_Sandbox_dummy_0'"
 showRtkToken (L.Tk__doccomment v) = "doccomment " ++ show v
 showRtkToken (L.Tk__qq_Sandbox v) = "qq_Sandbox " ++ show v
 
-data Sandbox = Ctr__Sandbox__0 Sandbox |
+-- Source position of a node: every constructor except the Anti_* splice
+-- artifacts stores the position of its alternative's first symbol in its
+-- first field. Positions are transparent for equality and ordering, so two
+-- ASTs that differ only in source positions (e.g. a quasi-quote parsed at
+-- compile time vs the same construct parsed at run time) compare equal.
+newtype RtkPos = RtkPos L.AlexPosn deriving (Show, Gen.Data, Gen.Typeable)
+instance Eq RtkPos where _ == _ = True
+instance Ord RtkPos where compare _ _ = EQ
+
+-- The position used where no source token exists: empty productions, empty
+-- lists, absent optionals and Anti_* quasi-quote splices
+rtkNoPos :: RtkPos
+rtkNoPos = RtkPos (L.AlexPn 0 0 0)
+
+class RtkPosOf a where
+    rtkPosOf :: a -> RtkPos
+instance RtkPosOf L.PosToken where
+    rtkPosOf (L.PosToken p _) = RtkPos p
+instance RtkPosOf a => RtkPosOf [a] where
+    rtkPosOf (x : _) = rtkPosOf x
+    rtkPosOf []      = rtkNoPos
+instance RtkPosOf a => RtkPosOf (Maybe a) where
+    rtkPosOf (Just x) = rtkPosOf x
+    rtkPosOf Nothing  = rtkNoPos
+-- A Char carries no position; this also covers String token payloads
+instance RtkPosOf Char where
+    rtkPosOf _ = rtkNoPos
+
+-- Recover a token's payload from the whole positioned token: %token
+-- bindings keep the L.PosToken so semantic actions can read its position
+tkVal_doccomment :: L.PosToken -> String
+tkVal_doccomment (L.PosToken _ (L.Tk__doccomment v)) = v
+tkVal_doccomment t = error ("rtk internal error: token doccomment expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_Sandbox :: L.PosToken -> String
+tkVal_qq_Sandbox (L.PosToken _ (L.Tk__qq_Sandbox v)) = v
+tkVal_qq_Sandbox t = error ("rtk internal error: token qq_Sandbox expected, got " ++ showRtkToken (L.ptToken t))
+
+data Sandbox = Ctr__Sandbox__0 RtkPos Sandbox |
                Anti_Sandbox String |
-               Ctr__Sandbox__1 String
+               Ctr__Sandbox__1 RtkPos String
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Sandbox where
+    rtkPosOf (Ctr__Sandbox__0 p _) = p
+    rtkPosOf (Anti_Sandbox _) = rtkNoPos
+    rtkPosOf (Ctr__Sandbox__1 p _) = p
 }

--- a/test/golden/sandbox/SandboxQQ.hs
+++ b/test/golden/sandbox/SandboxQQ.hs
@@ -51,6 +51,14 @@ replaceAllPatterns str = init <$> replaceAllPatterns1 (str ++ " ")
 
 qqShortcuts = M.fromList [ ("sandbox","Sandbox")]
 
+-- A quasi-quote pattern must match an AST parsed from anywhere in a source
+-- file, while the pattern itself was parsed from the quote body - so every
+-- RtkPos position field becomes a wildcard in generated patterns.
+-- (Expressions need no special case: the compile-time position they embed
+-- is equality-transparent.)
+rtkPosWildPat :: RtkPos -> Maybe (TH.Q TH.Pat)
+rtkPosWildPat _ = Just TH.wildP
+
 quoteSandboxExp :: Data.Data a => String -> (Sandbox -> a) -> String -> TH.ExpQ
 quoteSandboxExp dummy func s = do
   s1 <- either fail return (replaceAllPatterns s)
@@ -66,7 +74,7 @@ quoteSandboxPat dummy func s = do
            Left err -> fail err
            Right a -> return a
   let expr = func ast
-  dataToPatQ (const Nothing `Generics.extQ` antiSandboxPat) expr
+  dataToPatQ (const Nothing `Generics.extQ` rtkPosWildPat `Generics.extQ` antiSandboxPat) expr
 
 antiSandboxExp :: Sandbox -> Maybe (TH.Q TH.Exp )
 antiSandboxExp ( Anti_Sandbox v) = Just $ TH.varE (TH.mkName v)
@@ -83,7 +91,7 @@ antiSandboxPat _ = Nothing
 quoteSandboxType s = return TH.ListT
 quoteSandboxDecs s = return []
 
-getSandbox ( Ctr__Sandbox__0 s) = s
+getSandbox ( Ctr__Sandbox__0 _ s) = s
 
 sandbox :: QuasiQuoter
 sandbox = QuasiQuoter (quoteSandboxExp "tok_Sandbox_dummy_0" getSandbox ) (quoteSandboxPat "tok_Sandbox_dummy_0" getSandbox ) quoteSandboxType quoteSandboxDecs

--- a/test/golden/t1/T1Lexer.x
+++ b/test/golden/t1/T1Lexer.x
@@ -1,6 +1,8 @@
 {
+{-# LANGUAGE StandaloneDeriving, DeriveDataTypeable #-}
 module T1Lexer(scanTokens, alexScanTokens, Token(..), PosToken(..), AlexPosn(..))
 where
+import Data.Data (Data)
 
  }
 %wrapper "monad"
@@ -61,6 +63,11 @@ data Token = EndOfFile |
              Tk__qq_B String |
              Tk__qq_A String
              deriving (Show)
+
+-- AlexPosn is defined by the alex wrapper, so the Data instance (required by
+-- the parser's RtkPos position type) can only be attached via standalone
+-- deriving - the same solution as the hand-written Lexer.x
+deriving instance Data AlexPosn
 
 -- A token together with the source position where it starts
 data PosToken = PosToken { ptPos :: AlexPosn, ptToken :: Token }

--- a/test/golden/t1/T1Parser.y
+++ b/test/golden/t1/T1Parser.y
@@ -27,65 +27,65 @@ tok_G_dummy_9 { L.PosToken _ L.Tk__tok_G_dummy_9 }
 tok_b_1 { L.PosToken _ L.Tk__tok_b_1 }
 tok_a_0 { L.PosToken _ L.Tk__tok_a_0 }
 tok__coma__2 { L.PosToken _ L.Tk__tok__coma__2 }
-qq_G { L.PosToken _ (L.Tk__qq_G $$) }
-qq_F5 { L.PosToken _ (L.Tk__qq_F5 $$) }
-qq_F4 { L.PosToken _ (L.Tk__qq_F4 $$) }
-qq_F3 { L.PosToken _ (L.Tk__qq_F3 $$) }
-qq_F2 { L.PosToken _ (L.Tk__qq_F2 $$) }
-qq_F1 { L.PosToken _ (L.Tk__qq_F1 $$) }
-qq_E { L.PosToken _ (L.Tk__qq_E $$) }
-qq_D { L.PosToken _ (L.Tk__qq_D $$) }
-qq_C { L.PosToken _ (L.Tk__qq_C $$) }
-qq_B { L.PosToken _ (L.Tk__qq_B $$) }
-qq_A { L.PosToken _ (L.Tk__qq_A $$) }
+qq_G { L.PosToken _ (L.Tk__qq_G _) }
+qq_F5 { L.PosToken _ (L.Tk__qq_F5 _) }
+qq_F4 { L.PosToken _ (L.Tk__qq_F4 _) }
+qq_F3 { L.PosToken _ (L.Tk__qq_F3 _) }
+qq_F2 { L.PosToken _ (L.Tk__qq_F2 _) }
+qq_F1 { L.PosToken _ (L.Tk__qq_F1 _) }
+qq_E { L.PosToken _ (L.Tk__qq_E _) }
+qq_D { L.PosToken _ (L.Tk__qq_D _) }
+qq_C { L.PosToken _ (L.Tk__qq_C _) }
+qq_B { L.PosToken _ (L.Tk__qq_B _) }
+qq_A { L.PosToken _ (L.Tk__qq_A _) }
 
 %%
 
 T1__top : A rtk__eof { $1 }
 
-A : tok_A_dummy_19 A tok_A_dummy_19 { Ctr__A__0 $2 } |
-    tok_B_dummy_18 B tok_B_dummy_18 { Ctr__A__1 $2 } |
-    tok_C_dummy_17 C tok_C_dummy_17 { Ctr__A__2 (reverse $2) } |
-    tok_D_dummy_16 D tok_D_dummy_16 { Ctr__A__3 $2 } |
-    tok_E_dummy_15 E tok_E_dummy_15 { Ctr__A__4 $2 } |
-    tok_F1_dummy_14 F1 tok_F1_dummy_14 { Ctr__A__5 (reverse $2) } |
-    tok_F2_dummy_13 F2 tok_F2_dummy_13 { Ctr__A__6 (reverse $2) } |
-    tok_F3_dummy_12 F3 tok_F3_dummy_12 { Ctr__A__7 (reverse $2) } |
-    tok_F4_dummy_11 F4 tok_F4_dummy_11 { Ctr__A__8 $2 } |
-    tok_F5_dummy_10 F5 tok_F5_dummy_10 { Ctr__A__9 (reverse $2) } |
-    tok_G_dummy_9 G tok_G_dummy_9 { Ctr__A__10 $2 }
+A : tok_A_dummy_19 A tok_A_dummy_19 { Ctr__A__0 (rtkPosOf $1) $2 } |
+    tok_B_dummy_18 B tok_B_dummy_18 { Ctr__A__1 (rtkPosOf $1) $2 } |
+    tok_C_dummy_17 C tok_C_dummy_17 { Ctr__A__2 (rtkPosOf $1) (reverse $2) } |
+    tok_D_dummy_16 D tok_D_dummy_16 { Ctr__A__3 (rtkPosOf $1) $2 } |
+    tok_E_dummy_15 E tok_E_dummy_15 { Ctr__A__4 (rtkPosOf $1) $2 } |
+    tok_F1_dummy_14 F1 tok_F1_dummy_14 { Ctr__A__5 (rtkPosOf $1) (reverse $2) } |
+    tok_F2_dummy_13 F2 tok_F2_dummy_13 { Ctr__A__6 (rtkPosOf $1) (reverse $2) } |
+    tok_F3_dummy_12 F3 tok_F3_dummy_12 { Ctr__A__7 (rtkPosOf $1) (reverse $2) } |
+    tok_F4_dummy_11 F4 tok_F4_dummy_11 { Ctr__A__8 (rtkPosOf $1) $2 } |
+    tok_F5_dummy_10 F5 tok_F5_dummy_10 { Ctr__A__9 (rtkPosOf $1) (reverse $2) } |
+    tok_G_dummy_9 G tok_G_dummy_9 { Ctr__A__10 (rtkPosOf $1) $2 }
 
-ListElem_F56 : qq_F5 { Anti_A $1 } |
+ListElem_F56 : qq_F5 { Anti_A (tkVal_qq_F5 $1) } |
                A { $1 }
 
-ListElem_F35 : qq_F3 { Anti_A $1 } |
+ListElem_F35 : qq_F3 { Anti_A (tkVal_qq_F3 $1) } |
                A { $1 }
 
-ListElem_F24 : qq_F2 { Anti_A $1 } |
+ListElem_F24 : qq_F2 { Anti_A (tkVal_qq_F2 $1) } |
                A { $1 }
 
-ListElem_F13 : qq_F1 { Anti_A $1 } |
+ListElem_F13 : qq_F1 { Anti_A (tkVal_qq_F1 $1) } |
                A { $1 }
 
-ListElem_C0 : qq_C { Anti_A $1 } |
+ListElem_C0 : qq_C { Anti_A (tkVal_qq_C $1) } |
               A { $1 }
 
-A : qq_A { Anti_A $1 } |
-    tok_a_0 { Ctr__A__16 }
+A : qq_A { Anti_A (tkVal_qq_A $1) } |
+    tok_a_0 { Ctr__A__16 (rtkPosOf $1) }
 
-B : qq_B { Anti_B $1 } |
-    tok_a_0 { Ctr__B__0 } |
-    tok_b_1 { Ctr__B__1 }
+B : qq_B { Anti_B (tkVal_qq_B $1) } |
+    tok_a_0 { Ctr__B__0 (rtkPosOf $1) } |
+    tok_b_1 { Ctr__B__1 (rtkPosOf $1) }
 
 C : {- empty -} { [] } |
     C ListElem_C0 { $2 : $1 }
 
-D : qq_D { Anti_D $1 } |
-    Rule_1 C { Ctr__D__0 $1 (reverse $2) }
+D : qq_D { Anti_D (tkVal_qq_D $1) } |
+    Rule_1 C { Ctr__D__0 (rtkPosOf $1) $1 (reverse $2) }
 
-E : qq_E { Anti_E $1 } |
-    Rule_2 { Ctr__E__0 $1 } |
-    C { Ctr__E__1 (reverse $1) }
+E : qq_E { Anti_E (tkVal_qq_E $1) } |
+    Rule_2 { Ctr__E__0 (rtkPosOf $1) $1 } |
+    C { Ctr__E__1 (rtkPosOf (reverse $1)) (reverse $1) }
 
 F1 : ListElem_F13 { [$1] } |
      F1 ListElem_F13 { $2 : $1 }
@@ -99,23 +99,23 @@ F3__plus_list_ : ListElem_F35 { [$1] } |
 F3 : F3__plus_list_ { $1 } |
      {- empty -} { [] }
 
-F4 : qq_F4 { Anti_F4 $1 } |
-     { Ctr__F4__0 } |
-     A { Ctr__F4__1 $1 }
+F4 : qq_F4 { Anti_F4 (tkVal_qq_F4 $1) } |
+     { Ctr__F4__0 rtkNoPos } |
+     A { Ctr__F4__1 (rtkPosOf $1) $1 }
 
 F5 : ListElem_F56 { [$1] } |
      F5 tok__coma__2 ListElem_F56 { $3 : $1 }
 
-G : qq_G { Anti_G $1 } |
-    A Rule_7 { Ctr__G__0 $1 $2 }
+G : qq_G { Anti_G (tkVal_qq_G $1) } |
+    A Rule_7 { Ctr__G__0 (rtkPosOf $1) $1 $2 }
 
-Rule_1 : A B { Ctr__Rule_1__0 $1 $2 }
+Rule_1 : A B { Ctr__Rule_1__0 (rtkPosOf $1) $1 $2 }
 
-Rule_2 : A B { Ctr__Rule_2__0 $1 $2 }
+Rule_2 : A B { Ctr__Rule_2__0 (rtkPosOf $1) $1 $2 }
 
-Rule_7 : B C Rule_8 A { Ctr__Rule_7__0 $1 (reverse $2) $3 $4 }
+Rule_7 : B C Rule_8 A { Ctr__Rule_7__0 (rtkPosOf $1) $1 (reverse $2) $3 $4 }
 
-Rule_8 : D E { Ctr__Rule_8__0 $1 $2 }
+Rule_8 : D E { Ctr__Rule_8__0 (rtkPosOf $1) $1 $2 }
 
 
 {
@@ -153,49 +153,153 @@ showRtkToken (L.Tk__qq_C v) = "qq_C " ++ show v
 showRtkToken (L.Tk__qq_B v) = "qq_B " ++ show v
 showRtkToken (L.Tk__qq_A v) = "qq_A " ++ show v
 
-data A = Ctr__A__0 A |
-         Ctr__A__1 B |
-         Ctr__A__2 C |
-         Ctr__A__3 D |
-         Ctr__A__4 E |
-         Ctr__A__5 F1 |
-         Ctr__A__6 F2 |
-         Ctr__A__7 F3 |
-         Ctr__A__8 F4 |
-         Ctr__A__9 F5 |
-         Ctr__A__10 G |
+-- Source position of a node: every constructor except the Anti_* splice
+-- artifacts stores the position of its alternative's first symbol in its
+-- first field. Positions are transparent for equality and ordering, so two
+-- ASTs that differ only in source positions (e.g. a quasi-quote parsed at
+-- compile time vs the same construct parsed at run time) compare equal.
+newtype RtkPos = RtkPos L.AlexPosn deriving (Show, Gen.Data, Gen.Typeable)
+instance Eq RtkPos where _ == _ = True
+instance Ord RtkPos where compare _ _ = EQ
+
+-- The position used where no source token exists: empty productions, empty
+-- lists, absent optionals and Anti_* quasi-quote splices
+rtkNoPos :: RtkPos
+rtkNoPos = RtkPos (L.AlexPn 0 0 0)
+
+class RtkPosOf a where
+    rtkPosOf :: a -> RtkPos
+instance RtkPosOf L.PosToken where
+    rtkPosOf (L.PosToken p _) = RtkPos p
+instance RtkPosOf a => RtkPosOf [a] where
+    rtkPosOf (x : _) = rtkPosOf x
+    rtkPosOf []      = rtkNoPos
+instance RtkPosOf a => RtkPosOf (Maybe a) where
+    rtkPosOf (Just x) = rtkPosOf x
+    rtkPosOf Nothing  = rtkNoPos
+-- A Char carries no position; this also covers String token payloads
+instance RtkPosOf Char where
+    rtkPosOf _ = rtkNoPos
+
+-- Recover a token's payload from the whole positioned token: %token
+-- bindings keep the L.PosToken so semantic actions can read its position
+tkVal_qq_G :: L.PosToken -> String
+tkVal_qq_G (L.PosToken _ (L.Tk__qq_G v)) = v
+tkVal_qq_G t = error ("rtk internal error: token qq_G expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_F5 :: L.PosToken -> String
+tkVal_qq_F5 (L.PosToken _ (L.Tk__qq_F5 v)) = v
+tkVal_qq_F5 t = error ("rtk internal error: token qq_F5 expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_F4 :: L.PosToken -> String
+tkVal_qq_F4 (L.PosToken _ (L.Tk__qq_F4 v)) = v
+tkVal_qq_F4 t = error ("rtk internal error: token qq_F4 expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_F3 :: L.PosToken -> String
+tkVal_qq_F3 (L.PosToken _ (L.Tk__qq_F3 v)) = v
+tkVal_qq_F3 t = error ("rtk internal error: token qq_F3 expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_F2 :: L.PosToken -> String
+tkVal_qq_F2 (L.PosToken _ (L.Tk__qq_F2 v)) = v
+tkVal_qq_F2 t = error ("rtk internal error: token qq_F2 expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_F1 :: L.PosToken -> String
+tkVal_qq_F1 (L.PosToken _ (L.Tk__qq_F1 v)) = v
+tkVal_qq_F1 t = error ("rtk internal error: token qq_F1 expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_E :: L.PosToken -> String
+tkVal_qq_E (L.PosToken _ (L.Tk__qq_E v)) = v
+tkVal_qq_E t = error ("rtk internal error: token qq_E expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_D :: L.PosToken -> String
+tkVal_qq_D (L.PosToken _ (L.Tk__qq_D v)) = v
+tkVal_qq_D t = error ("rtk internal error: token qq_D expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_C :: L.PosToken -> String
+tkVal_qq_C (L.PosToken _ (L.Tk__qq_C v)) = v
+tkVal_qq_C t = error ("rtk internal error: token qq_C expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_B :: L.PosToken -> String
+tkVal_qq_B (L.PosToken _ (L.Tk__qq_B v)) = v
+tkVal_qq_B t = error ("rtk internal error: token qq_B expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_A :: L.PosToken -> String
+tkVal_qq_A (L.PosToken _ (L.Tk__qq_A v)) = v
+tkVal_qq_A t = error ("rtk internal error: token qq_A expected, got " ++ showRtkToken (L.ptToken t))
+
+data A = Ctr__A__0 RtkPos A |
+         Ctr__A__1 RtkPos B |
+         Ctr__A__2 RtkPos C |
+         Ctr__A__3 RtkPos D |
+         Ctr__A__4 RtkPos E |
+         Ctr__A__5 RtkPos F1 |
+         Ctr__A__6 RtkPos F2 |
+         Ctr__A__7 RtkPos F3 |
+         Ctr__A__8 RtkPos F4 |
+         Ctr__A__9 RtkPos F5 |
+         Ctr__A__10 RtkPos G |
          Anti_A String |
-         Ctr__A__16
+         Ctr__A__16 RtkPos
          deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf A where
+    rtkPosOf (Ctr__A__0 p _) = p
+    rtkPosOf (Ctr__A__1 p _) = p
+    rtkPosOf (Ctr__A__2 p _) = p
+    rtkPosOf (Ctr__A__3 p _) = p
+    rtkPosOf (Ctr__A__4 p _) = p
+    rtkPosOf (Ctr__A__5 p _) = p
+    rtkPosOf (Ctr__A__6 p _) = p
+    rtkPosOf (Ctr__A__7 p _) = p
+    rtkPosOf (Ctr__A__8 p _) = p
+    rtkPosOf (Ctr__A__9 p _) = p
+    rtkPosOf (Ctr__A__10 p _) = p
+    rtkPosOf (Anti_A _) = rtkNoPos
+    rtkPosOf (Ctr__A__16 p) = p
 data B = Anti_B String |
-         Ctr__B__0 |
-         Ctr__B__1
+         Ctr__B__0 RtkPos |
+         Ctr__B__1 RtkPos
          deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf B where
+    rtkPosOf (Anti_B _) = rtkNoPos
+    rtkPosOf (Ctr__B__0 p) = p
+    rtkPosOf (Ctr__B__1 p) = p
 type C = [A]
 data D = Anti_D String |
-         Ctr__D__0 Rule_1 C
+         Ctr__D__0 RtkPos Rule_1 C
          deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf D where
+    rtkPosOf (Anti_D _) = rtkNoPos
+    rtkPosOf (Ctr__D__0 p _ _) = p
 data E = Anti_E String |
-         Ctr__E__0 Rule_2 |
-         Ctr__E__1 C
+         Ctr__E__0 RtkPos Rule_2 |
+         Ctr__E__1 RtkPos C
          deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf E where
+    rtkPosOf (Anti_E _) = rtkNoPos
+    rtkPosOf (Ctr__E__0 p _) = p
+    rtkPosOf (Ctr__E__1 p _) = p
 type F1 = [A]
 type F2 = [A]
 type F3 = [A]
 data F4 = Anti_F4 String |
-          Ctr__F4__0 |
-          Ctr__F4__1 A
+          Ctr__F4__0 RtkPos |
+          Ctr__F4__1 RtkPos A
           deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf F4 where
+    rtkPosOf (Anti_F4 _) = rtkNoPos
+    rtkPosOf (Ctr__F4__0 p) = p
+    rtkPosOf (Ctr__F4__1 p _) = p
 type F5 = [A]
 data G = Anti_G String |
-         Ctr__G__0 A Rule_7
+         Ctr__G__0 RtkPos A Rule_7
          deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_1 = Ctr__Rule_1__0 A B
+instance RtkPosOf G where
+    rtkPosOf (Anti_G _) = rtkNoPos
+    rtkPosOf (Ctr__G__0 p _ _) = p
+data Rule_1 = Ctr__Rule_1__0 RtkPos A B
               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_2 = Ctr__Rule_2__0 A B
+instance RtkPosOf Rule_1 where
+    rtkPosOf (Ctr__Rule_1__0 p _ _) = p
+data Rule_2 = Ctr__Rule_2__0 RtkPos A B
               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_7 = Ctr__Rule_7__0 B C Rule_8 A
+instance RtkPosOf Rule_2 where
+    rtkPosOf (Ctr__Rule_2__0 p _ _) = p
+data Rule_7 = Ctr__Rule_7__0 RtkPos B C Rule_8 A
               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-data Rule_8 = Ctr__Rule_8__0 D E
+instance RtkPosOf Rule_7 where
+    rtkPosOf (Ctr__Rule_7__0 p _ _ _ _) = p
+data Rule_8 = Ctr__Rule_8__0 RtkPos D E
               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_8 where
+    rtkPosOf (Ctr__Rule_8__0 p _ _) = p
 }

--- a/test/golden/t1/T1QQ.hs
+++ b/test/golden/t1/T1QQ.hs
@@ -51,6 +51,14 @@ replaceAllPatterns str = init <$> replaceAllPatterns1 (str ++ " ")
 
 qqShortcuts = M.fromList [ ("a","A"),("b","B"),("c","C"),("d","D"),("e","E"),("f1","F1"),("f2","F2"),("f3","F3"),("f4","F4"),("f5","F5"),("g","G")]
 
+-- A quasi-quote pattern must match an AST parsed from anywhere in a source
+-- file, while the pattern itself was parsed from the quote body - so every
+-- RtkPos position field becomes a wildcard in generated patterns.
+-- (Expressions need no special case: the compile-time position they embed
+-- is equality-transparent.)
+rtkPosWildPat :: RtkPos -> Maybe (TH.Q TH.Pat)
+rtkPosWildPat _ = Just TH.wildP
+
 quoteT1Exp :: Data.Data a => String -> (A -> a) -> String -> TH.ExpQ
 quoteT1Exp dummy func s = do
   s1 <- either fail return (replaceAllPatterns s)
@@ -66,7 +74,7 @@ quoteT1Pat dummy func s = do
            Left err -> fail err
            Right a -> return a
   let expr = func ast
-  dataToPatQ (const Nothing `Generics.extQ` antiAPat `Generics.extQ` antiBPat `Generics.extQ` antiDPat `Generics.extQ` antiEPat `Generics.extQ` antiF4Pat `Generics.extQ` antiGPat) expr
+  dataToPatQ (const Nothing `Generics.extQ` rtkPosWildPat `Generics.extQ` antiAPat `Generics.extQ` antiBPat `Generics.extQ` antiDPat `Generics.extQ` antiEPat `Generics.extQ` antiF4Pat `Generics.extQ` antiGPat) expr
 
 antiGExp :: G -> Maybe (TH.Q TH.Exp )
 antiGExp ( Anti_G v) = Just $ TH.varE (TH.mkName v)
@@ -133,57 +141,57 @@ antiAPat _ = Nothing
 quoteT1Type s = return TH.ListT
 quoteT1Decs s = return []
 
-getA ( Ctr__A__0 s) = s
+getA ( Ctr__A__0 _ s) = s
 
 a :: QuasiQuoter
 a = QuasiQuoter (quoteT1Exp "tok_A_dummy_19" getA ) (quoteT1Pat "tok_A_dummy_19" getA ) quoteT1Type quoteT1Decs
 
-getB ( Ctr__A__1 s) = s
+getB ( Ctr__A__1 _ s) = s
 
 b :: QuasiQuoter
 b = QuasiQuoter (quoteT1Exp "tok_B_dummy_18" getB ) (quoteT1Pat "tok_B_dummy_18" getB ) quoteT1Type quoteT1Decs
 
-getC ( Ctr__A__2 s) = s
+getC ( Ctr__A__2 _ s) = s
 
 c :: QuasiQuoter
 c = QuasiQuoter (quoteT1Exp "tok_C_dummy_17" getC ) (quoteT1Pat "tok_C_dummy_17" getC ) quoteT1Type quoteT1Decs
 
-getD ( Ctr__A__3 s) = s
+getD ( Ctr__A__3 _ s) = s
 
 d :: QuasiQuoter
 d = QuasiQuoter (quoteT1Exp "tok_D_dummy_16" getD ) (quoteT1Pat "tok_D_dummy_16" getD ) quoteT1Type quoteT1Decs
 
-getE ( Ctr__A__4 s) = s
+getE ( Ctr__A__4 _ s) = s
 
 e :: QuasiQuoter
 e = QuasiQuoter (quoteT1Exp "tok_E_dummy_15" getE ) (quoteT1Pat "tok_E_dummy_15" getE ) quoteT1Type quoteT1Decs
 
-getF1 ( Ctr__A__5 s) = s
+getF1 ( Ctr__A__5 _ s) = s
 
 f1 :: QuasiQuoter
 f1 = QuasiQuoter (quoteT1Exp "tok_F1_dummy_14" getF1 ) (quoteT1Pat "tok_F1_dummy_14" getF1 ) quoteT1Type quoteT1Decs
 
-getF2 ( Ctr__A__6 s) = s
+getF2 ( Ctr__A__6 _ s) = s
 
 f2 :: QuasiQuoter
 f2 = QuasiQuoter (quoteT1Exp "tok_F2_dummy_13" getF2 ) (quoteT1Pat "tok_F2_dummy_13" getF2 ) quoteT1Type quoteT1Decs
 
-getF3 ( Ctr__A__7 s) = s
+getF3 ( Ctr__A__7 _ s) = s
 
 f3 :: QuasiQuoter
 f3 = QuasiQuoter (quoteT1Exp "tok_F3_dummy_12" getF3 ) (quoteT1Pat "tok_F3_dummy_12" getF3 ) quoteT1Type quoteT1Decs
 
-getF4 ( Ctr__A__8 s) = s
+getF4 ( Ctr__A__8 _ s) = s
 
 f4 :: QuasiQuoter
 f4 = QuasiQuoter (quoteT1Exp "tok_F4_dummy_11" getF4 ) (quoteT1Pat "tok_F4_dummy_11" getF4 ) quoteT1Type quoteT1Decs
 
-getF5 ( Ctr__A__9 s) = s
+getF5 ( Ctr__A__9 _ s) = s
 
 f5 :: QuasiQuoter
 f5 = QuasiQuoter (quoteT1Exp "tok_F5_dummy_10" getF5 ) (quoteT1Pat "tok_F5_dummy_10" getF5 ) quoteT1Type quoteT1Decs
 
-getG ( Ctr__A__10 s) = s
+getG ( Ctr__A__10 _ s) = s
 
 g :: QuasiQuoter
 g = QuasiQuoter (quoteT1Exp "tok_G_dummy_9" getG ) (quoteT1Pat "tok_G_dummy_9" getG ) quoteT1Type quoteT1Decs


### PR DESCRIPTION
Every constructor built by generated parsers - except the
quasi-quotation-only Anti_* splice constructors - now stores the position
of its alternative's first symbol (token or nonterminal, including
!-ignored tokens) in a leading RtkPos field:

- GenY defines RtkPos in every generated parser: a newtype over the
  lexer's AlexPosn whose Eq/Ord instances are transparent (== always
  holds, compare is always EQ), so ASTs differing only in positions
  compare equal; rtkNoPos is the dummy for empty productions, empty
  lists, absent optionals and Anti_* splices. A generated RtkPosOf class
  projects the position of any symbol: tokens (whole L.PosToken), each
  generated data type (first field, via a per-type instance emitted by
  GenAST), lists (source-order head) and Maybe.
- Payload %token bindings now bind the whole positioned token instead of
  a $$ projection, so token positions are reachable in semantic actions;
  generated tkVal_* extractors recover the payload at every use site.
- GenX standalone-derives Data for the alex-defined AlexPosn (the same
  solution the hand-written Lexer.x uses) so RtkPos can derive Data.
- GenQ wildcards every RtkPos field in quasi-quote patterns via one extQ
  extension on the dataToPatQ chain; expressions embed their
  compile-time positions, which the transparent Eq makes harmless. The
  Java QQ round-trip tests (compile-time patterns matching
  runtime-parsed ASTs, spliced values compared with ==) prove both
  properties end to end.
- ASTAdapter maps the rule constructors' positions into getIRulePos, so
  pipeline diagnostics under --use-generated carry structured positions.
  On a duplicate-rule fixture, rtk --use-generated now reports exactly
  what the hand-written front end reports:
    /tmp/dup-rule.pg:3:1: error: in rule 'Foo': rule 'Foo' is defined more than once (first definition at line 2, column 1)
- The hand-written parser's position for the '.' id ':' ... rule form
  moved from the identifier to the leading dot (a rule's position is
  where the rule starts), aligning it with first-symbol capture; no
  corpus grammar uses that form, and for such rules the rendered
  diagnostic position moves one token left.
- The dual-front-end AST equality test now compares positions too
  (the stripPositions weakening is gone), and a unit test pins the
  structured duplicate-rule diagnostic through the generated front end.
- Golden snapshots refreshed: every Lexer.x/Parser.y/QQ.hs changes
  uniformly. The self-hosting fixed point still holds:
  rtk --use-generated test-grammars/grammar.pg reproduces
  test/golden/grammar/ byte-for-byte. BOOTSTRAP.md drops the
  position-capture divergence.

https://claude.ai/code/session_01MSjSRFj12ZN6eYq1JJJRDf