### PR TITLE
Fix make test-p: cabal-aware compile, and a divergent subst in its driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   printed an error
 
 ### Fixed
+- `make test-p` works again: the target had a hand-rolled recipe that
+  compiled the driver with bare `ghc` outside the cabal package environment,
+  failing with `Could not find module 'Data.Generics'` in clean
+  environments. It now uses the generic `make-test-rule` like its sibling
+  targets (`cabal exec -- ghc --make -itest-out ...`); the driver binary is
+  consequently named `test-out/p-main` instead of `test-out/p-rtk`. The
+  compile failure had masked a latent bug in the driver itself:
+  `p-main.hs`'s `subst` bound `e1 = subst id e1 i` etc., self-referential
+  recursive lets that shadow the pattern variables and diverge (`<<loop>>`)
+  on the first fold expression, and it had no base case. The lets now bind
+  fresh names and a catch-all clause terminates the recursion, so the
+  driver prints the substituted AST
 - `'\f'` and `'\v'` escapes in grammar string and `[...]` regex literals now
   reach the generated lexer as bare Alex escapes; previously token
   post-processing (`unBackQuote`) stripped them to the literal letters

--- a/makefile
+++ b/makefile
@@ -141,6 +141,7 @@ $(eval $(call make-test-rule,java,Java,test-grammars/TestBasic.java))
 $(eval $(call make-test-rule,java-simple,JavaSimple,test-grammars/Simple.java))
 $(eval $(call make-test-rule,sandbox,Sandbox,test-grammars/test.sandbox))
 $(eval $(call make-test-rule,haskell,Haskell,Normalize.hs))
+$(eval $(call make-test-rule,p,P,expr.p))
 
 # Additional Java tests using the Java grammar (java.pg) - all share java-main runner
 $(eval $(call make-shared-test-rule,java-minimal,java,Java,test-grammars/java/test-minimal.java))
@@ -190,11 +191,6 @@ test-all-java: test-java test-java-simple test-java-minimal test-java-field test
 # Special cases that don't follow the pattern
 test-t1: build | test-out
 	$(RTK_EXEC) test-grammars/t1.pg test-out
-
-test-p: build test-out/PLexer.hs test-out/PParser.hs | test-out
-	$(CP) test-grammars/p-main.hs test-out
-	(cd test-out && ghc --make p-main.hs -o p-rtk)
-	test-out/p-rtk expr.p
 
 # Java quasi-quotation tests (separate from regular java-main parser driver)
 test-java-qq: build test-out/JavaLexer.hs test-out/JavaParser.hs | test-out

--- a/test-grammars/p-main.hs
+++ b/test-grammars/p-main.hs
@@ -10,12 +10,13 @@ import Text.Show.Pretty
 
 subst :: Id -> E -> Int -> E
 subst id [e|(fold $e1 $e2 (lambda ( $id1 $id2 ) $e3))|] i =
-  let e1 = subst id e1 i
-      e2 = subst id e2 i
-      e3 = subst id e3 i
-    in [e|(fold $e1 $e2 (lambda ( $id1 $id2 ) $e3))|]
+  let e1s = subst id e1 i
+      e2s = subst id e2 i
+      e3s = subst id e3 i
+    in [e|(fold $e1s $e2s (lambda ( $id1 $id2 ) $e3s))|]
+subst _ e _ = e
 
--- subst id [e|$id1|] i = if 
+-- subst id [e|$id1|] i = if
 
 evalE :: E -> Int
 evalE _ = 0


### PR DESCRIPTION
test-p was a hand-rolled special case that compiled p-main.hs with bare
ghc, outside the cabal package environment, so the packages generated
parsers need (syb for Data.Generics, array, ...) were not visible and
the target failed in clean environments. Replace the recipe with the
generic make-test-rule used by every sibling driver target, which
builds via 'cabal exec -- ghc --make -itest-out'.

The driver binary is now named test-out/p-main (generic naming) instead
of test-out/p-rtk; nothing else referenced p-rtk. The inert expr.p
argument is kept as-is (p-main.hs parses a hardcoded string and ignores
its CLI arguments).

The compile failure had masked a latent bug in the driver itself:
subst's 'let e1 = subst id e1 i' bindings shadow the pattern variables
and reference themselves, so the program died with <<loop>> as soon as
it compiled, and subst had no base case for non-fold expressions. The
lets now bind fresh names (e1s/e2s/e3s) and a catch-all clause
terminates the recursion, so the driver prints the substituted AST.

Verified: make test-p passes end to end; make test (unit 119, golden
43) stays green.

https://claude.ai/code/session_01DHiN8eDdA2KCftj4T1ZGcw