### PR TITLE
Restructure Java grammar to parse ModifierList once per declaration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -179,6 +179,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Lexer-generation errors name the lexical rule they occur in
 
 ### Changed
+- The Java grammar parses exactly ONE `ModifierList` per declaration. The
+  class/interface/enum/`@interface` rules no longer begin with their own
+  nullable list; `TypeDeclRest` (ex-`NestedTypeDeclaration`, now used at the
+  top level too) carries everything after the modifiers, and the list lives
+  on the enclosing rule: `TypeDeclaration = OptDocComment ModifierList
+  TypeDeclRest`, `FieldDeclaration = OptDocComment ModifierList
+  (MemberDeclaration | TypeDeclRest | StaticInitializer) | ';'`. The nested
+  nullable lists used to produce 14 shift/reduce conflicts (after the outer
+  list, every modifier/annotation token chose between extending it and
+  epsilon-starting the inner one) whose shift resolution parsed
+  `public class A {}` with `public` on the OUTER list and a confusing,
+  always-empty inner list; that always-empty `ModifierList` field is gone
+  from the class/interface/enum/annotation AST constructors, and the
+  generated quasi-quoter renames `nestedTypeDeclaration` to `typeDeclRest`.
+  Together with the restored dangling-else conflict (see Fixed) the
+  generated `JavaParser.y` is down to 18 shift/reduce + 0 reduce/reduce
+  conflicts (from 32 + 0), and java.pg now opens with a complete inventory
+  of all 18 - each family with its automaton items and why the shift is the
+  correct Java reading (dangling else; catch/finally attach to the nearest
+  try; member id vs empty TypeParameters; greedy CompoundName `.`;
+  bracket-list `[` shifts; `<` commits to type arguments; the QQ bootstrap
+  dummy bracket) - replacing the stale "~14"/"~13"/"32" conflict comments.
+  The commons-lang corpus success sets are unchanged (14/16 main/tests
+  files), so the parser blacklists stay as they are
 - The makefile test pipeline now runs alex with `-g` (the GHC backend), so
   generated lexers in `test-out/` compile as compact string-encoded tables
   instead of ~half-a-million-line pattern matches. GHC's compile of the
@@ -212,6 +236,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   printed an error
 
 ### Fixed
+- A brace-less nested `if` parses again: `IfStatement`'s then-branch was
+  `StatementWithoutIf`, so valid Java like `if (a) if (b) f(); else g();`
+  was rejected with "unexpected 'if'". The then-branch is a full `Statement`
+  and `StatementWithoutIf` is inlined away (`Statement` absorbs its
+  alternatives; nothing else referenced it). This re-surfaces the classic
+  dangling-else shift/reduce conflict, which happy resolves by shifting:
+  `else` binds to the NEAREST `if`, exactly the JLS 14.5 rule (verified on
+  the printed AST; regression coverage via
+  `test-grammars/java/test-nested-if.java` / `make test-java-nested-if` and
+  a quasi-quotation construction case). The exclusion never even avoided
+  that conflict - it already existed through loop bodies in then-position,
+  e.g. `if (a) while (b) if (c) f(); else g();` - it only rejected the
+  direct nested form
 - The Java grammar's last structural LALR ambiguity - deciding between a
   type and an expression after a `CompoundName` at statement start or after
   `(` - is resolved JLS-style (`happy` now reports 0 reduce/reduce

--- a/makefile
+++ b/makefile
@@ -163,6 +163,7 @@ $(eval $(call make-shared-test-rule,java-simple-assignment,java,Java,test-gramma
 $(eval $(call make-shared-test-rule,java-compound-assignment,java,Java,test-grammars/java/test-compound-assignment.java))
 $(eval $(call make-shared-test-rule,java-set-value,java,Java,test-grammars/java/test-set-value.java))
 $(eval $(call make-shared-test-rule,java-implements,java,Java,test-grammars/java/test-implements.java))
+$(eval $(call make-shared-test-rule,java-nested-if,java,Java,test-grammars/java/test-nested-if.java))
 
 # JavaDoc comment tests (blank line + {@link Class#method()} regression tests)
 $(eval $(call make-shared-test-rule,java-javadoc-blank-link,java,Java,test-grammars/java/javadoc/test-blank-then-link.java))
@@ -183,7 +184,7 @@ accept-lex-java: test-out/java-main
 	ACCEPT=1 ./test-java-lexical.sh
 
 # Run all Java tests
-test-all-java: test-java test-java-simple test-java-minimal test-java-field test-java-field-public test-java-package test-java-string test-java-complex test-java-full test-java-generics test-java-enum test-java-annotations test-java-empty-method test-java-simple-return test-java-return-field test-java-very-simple test-java-parameter-only test-java-field-this test-java-simple-assignment test-java-compound-assignment test-java-set-value test-java-implements test-java-javadoc-blank-link test-java-javadoc-minimal-hash test-java-javadoc-minimal-fail test-java-javadoc-link-tag test-java-javadoc-just-hash
+test-all-java: test-java test-java-simple test-java-minimal test-java-field test-java-field-public test-java-package test-java-string test-java-complex test-java-full test-java-generics test-java-enum test-java-annotations test-java-empty-method test-java-simple-return test-java-return-field test-java-very-simple test-java-parameter-only test-java-field-this test-java-simple-assignment test-java-compound-assignment test-java-set-value test-java-implements test-java-nested-if test-java-javadoc-blank-link test-java-javadoc-minimal-hash test-java-javadoc-minimal-fail test-java-javadoc-link-tag test-java-javadoc-just-hash
 	@echo ""
 	@echo "=== All Java tests completed successfully! ==="
 

--- a/test-grammars/java-qq-test.hs
+++ b/test-grammars/java-qq-test.hs
@@ -101,6 +101,9 @@ testConstruction = do
     let _ = [J.statement| if (x > 0) { return x; } else { return -x; } |]
     putStrLn "✅ [statement| if-else |]"
 
+    let _ = [J.statement| if (x > 0) if (y > 0) f(); else g(); |]
+    putStrLn "✅ [statement| nested if without braces (dangling else) |]"
+
     let _ = [J.statement| while (x > 0) { x = x - 1; } |]
     putStrLn "✅ [statement| while loop |]"
 

--- a/test-grammars/java.pg
+++ b/test-grammars/java.pg
@@ -1,11 +1,90 @@
 grammar 'Java';
 
+# ============================================================================
+# LALR conflict inventory (happy: 18 shift/reduce, 0 reduce/reduce)
+# ============================================================================
+# Every remaining conflict is a shift/reduce whose default resolution (shift)
+# is the correct Java reading. They fall into seven families; the items
+# identify the automaton state (happy -i state numbers move with every
+# grammar change, the items do not):
+#
+# 1. Dangling else - 1 state, 2 conflicts: 'else' and its splice token
+#    qq_OptElsePart, against reduce OptElsePart -> empty. Item:
+#        IfStatement -> 'if' '(' Expression ')' Statement . OptElsePart
+#    Shift binds the else part to the NEAREST 'if'; the reduce would close
+#    this if and hand the 'else' to an enclosing one. Shifting is the JLS
+#    14.5 rule. See IfStatement.
+#
+# 2. catch/finally attach to the nearest try - 1 state, 4 conflicts:
+#    'catch', 'finally' and their splice tokens qq_CatchList, qq_OptFinally,
+#    against reduce OptFinally -> empty. Items:
+#        TryStatement -> 'try' Statement CatchList . OptFinally
+#        CatchList -> CatchList . ('catch' '(' Parameter ')' Statement)
+#    In 'try try { } catch (E e) { } finally { }' each clause could extend
+#    the inner try (shift) or close it and attach to the outer one (reduce).
+#    Java attaches both to the nearest try.
+#
+# 3. Member id vs empty TypeParameters - 2 states (a type body after
+#    ModifierList, and the MemberDeclaration QQ entry), 1 conflict each on
+#    id, against reduce TypeParameters -> empty. Items:
+#        MemberDeclaration -> . id MemberAfterFirstId
+#        TypeParameters -> .
+#    In 'Foo bar(...)' the id either starts the non-generic alternative
+#    (shift) or follows an empty TypeParameters inside the generic one
+#    (reduce). No input is lost: id MemberAfterFirstId derives everything
+#    the empty-TypeParameters generic alternative would.
+#
+# 4. Greedy CompoundName '.' - 1 state, 1 conflict on '.', against reduce
+#    CompoundName -> id ('.' id)* . Item:
+#        ('.' id)* -> ('.' id)* . ('.' id)
+#    'a.b.c' extends the unreduced name instead of reducing 'a' early and
+#    parsing '.' as a field access; PostfixExpression '.' id still handles
+#    non-name bases ('f().x', 'this.x'), so no input is lost.
+#
+# 5. Bracket-list shifts on '[' - 5 states, 1 conflict each:
+#      - after CompoundName in an expression, at statement start, and in a
+#        cast head (reduce: the call-parens option ('(' Arglist ')')? ->
+#        empty, i.e. commit to the bare name as a complete primary). Items:
+#            PrimaryNoPostfix -> CompoundName . '[' Expression ']'
+#            Type             -> CompoundName . NonEmptyDims      (and the
+#            CastExpression heads in the cast state)
+#      - after DimExprs and after NonEmptyDims in array creation (reduce:
+#        stop the dims list). Items:
+#            DimExprs     -> DimExprs . ('[' Expression ']')
+#            NonEmptyDims -> NonEmptyDims . ('[' ']')
+#    Shifting '[' defers the type-vs-access decision by exactly one token
+#    (']' means a type's empty pair, an expression start means array
+#    access/sizing) or greedily extends the dims list; no input is lost.
+#    See the NOTEs at Dims and PrimaryNoPostfix.
+#
+# 6. '<' commits to type arguments - 3 states, 1 conflict each on '<':
+#    after CompoundName at statement start and in a cast head (reduce: bare-
+#    name primary, as in family 5), and in a pure type position (reduce:
+#    Type -> CompoundName, whose only following '<' would be
+#    'x instanceof T < y'). Standard for LALR Java parsers; see the NOTE at
+#    TypeArguments. Only the cast-head state loses real input ('(a < b)' as
+#    a parenthesized primary, see KNOWN LIMITATION at CastExpression); the
+#    other two reject only semantically invalid Java ('a < b;' as a bare
+#    statement-expression, 'x instanceof T < y').
+#
+# 7. QQ bootstrap dummy bracket - 1 state, 1 conflict. The quasi-quoter
+#    wraps a quote body in a per-rule dummy-token pair, and the whole-file
+#    entry 'Java -> DUMMY . Java DUMMY' lets a second opening DUMMY (shift)
+#    compete with deriving an empty CompilationUnit ((Package)? -> empty)
+#    right before the closing DUMMY (reduce). Only a completely empty
+#    [java| |] quote is affected (it fails to parse); any non-empty quote
+#    has a real token after the opening DUMMY.
+#
+# The cast-vs-paren decision one token AFTER ')' is conflict-free; see
+# CastExpression.
+# ============================================================================
+
 Java = CompilationUnit ;
 
 OptDocComment = (DocComment)? ;
 
 TypeDeclaration =
- OptDocComment ( ClassDeclaration | InterfaceDeclaration | EnumDeclaration | AnnotationDeclaration )  ;
+ OptDocComment ModifierList TypeDeclRest ;
 
 ImportList = (ImportStatement)*;
 CompilationUnit  =
@@ -35,9 +114,15 @@ AnnotationElement = id '=' ConditionalExpression | ConditionalExpression ;
 
 AnnotationList = Annotation* ;
 
-# NOTE: ModifierList creates shift/reduce conflicts (~14) because the parser must decide
-# when to stop adding modifiers/annotations and start parsing the Type. These conflicts
-# resolve correctly with lookahead (inherent to the grammar design).
+# Exactly ONE ModifierList is parsed per declaration, owned by the enclosing
+# declaration rule (TypeDeclaration at the top level, FieldDeclaration inside
+# a type body). The class/interface/enum/@interface rules must NOT start with
+# their own nullable ModifierList: after the enclosing list, every token that
+# can extend a ModifierList (the 10 modifier keywords, '@', and the splice
+# tokens qq_Modifier/qq_Annotation/qq_ModifierList) used to conflict between
+# extending the outer list and epsilon-starting the inner one - 14
+# shift/reduce conflicts whose shift put all modifiers on the outer list and
+# left the inner one always empty.
 ModifierList = (Modifier | Annotation)* ;
 
 ExtendsList = 'extends' CompoundName (',' CompoundName)* ;
@@ -45,19 +130,22 @@ ImplementsList = 'implements' CompoundName + ~',';
 FieldDeclarationList = FieldDeclaration *;
 
 ClassDeclaration  =
- ModifierList 'class' id TypeParameters
+ 'class' id TypeParameters
  ExtendsList?
  ImplementsList?
  '{'  FieldDeclarationList  '}'  ;
 
 InterfaceDeclaration  =
- ModifierList 'interface' id TypeParameters
+ 'interface' id TypeParameters
  ExtendsList?
  '{'  FieldDeclarationList  '}'  ;
 
-# Annotation declaration (@interface)
+# Annotation declaration (@interface). The leading '@' shifts from the same
+# state where '@' could extend the enclosing ModifierList with an Annotation;
+# the NEXT token disambiguates ('interface' here vs id for an annotation), so
+# the two uses of '@' never conflict.
 AnnotationDeclaration =
- ModifierList '@' 'interface' id
+ '@' 'interface' id
  '{' AnnotationTypeElementList '}' ;
 
 AnnotationTypeElementList = AnnotationTypeElement* ;
@@ -73,7 +161,7 @@ EnumConstant = AnnotationList id ('(' Arglist ')')? ('{' FieldDeclarationList '}
 EnumConstantList = EnumConstant (',' EnumConstant)* (',')? ;
 
 EnumDeclaration =
- ModifierList 'enum' id
+ 'enum' id
  ImplementsList?
  '{' EnumConstantList (';' FieldDeclarationList)? '}' ;
 
@@ -87,16 +175,18 @@ EnumDeclaration =
 # NOTE: DocComment comes BEFORE ModifierList to match standard Java style:
 #   /** doc */ public int field;
 # NOT: public /** doc */ int field;
-# NestedTypeDeclaration handles all nested type declarations (class, interface, enum, annotation)
-# These all share the same pattern: Javadoc? Modifiers TypeKeyword Name ...
-NestedTypeDeclaration =
+# TypeDeclRest is everything of a type declaration AFTER its modifiers: the
+# class/interface/enum/@interface keyword onwards. The ModifierList lives on
+# the enclosing rule (TypeDeclaration at the top level, FieldDeclaration for
+# nested types), see the NOTE at ModifierList.
+TypeDeclRest =
  ClassDeclaration
  | InterfaceDeclaration
  | EnumDeclaration
  | AnnotationDeclaration ;
 
 FieldDeclaration  =
- OptDocComment (ModifierList ((MemberDeclaration | NestedTypeDeclaration) | StaticInitializer))
+ OptDocComment ModifierList (MemberDeclaration | TypeDeclRest | StaticInitializer)
  |  ';'  ;
 
 # Array brackets (JLS-style split): types and declarators may only contain
@@ -166,7 +256,7 @@ StatementBlock  =  '{'  StatementList  '}'  ;
 VariableDeclaratorList = VariableDeclarator (',' VariableDeclarator)* ;
 
 # VariableDeclaration is used for:
-# 1. Local variable declarations inside method bodies (via StatementWithoutIf)
+# 1. Local variable declarations inside method bodies (via Statement)
 # 2. For loops (via ForStatement)
 # Note: Field-level variable declarations use MemberDeclaration above
 VariableDeclaration  =
@@ -200,15 +290,11 @@ OptExpression = Expression? ;
 OptId = id?;
 
 Statement =
- StatementWithoutIf
- |  IfStatement
-  ;
-
-StatementWithoutIf =
 VariableDeclaration
  |  'return'  OptExpression  ';'
  |  Expression  ';'
  |  StatementBlock
+ |  IfStatement
  |  DoStatement
  |  WhileStatement
  |  ForStatement
@@ -223,11 +309,17 @@ VariableDeclaration
 
 OptElsePart = ('else' Statement)? ;
 
-# NOTE: If-else statements create shift/reduce conflicts due to the dangling-else problem.
-# The current design with StatementWithoutIf resolves this correctly by binding else to
-# the nearest if. These conflicts (~13) are acceptable and standard in Java parsers.
+# The then-branch is a full Statement, so a nested if needs no braces:
+# 'if (a) if (b) f(); else g();' is valid Java. This is the classic
+# dangling-else shift/reduce conflict (family 1 of the inventory at the top
+# of this file); happy resolves it by shifting, i.e. 'else' binds to the
+# NEAREST 'if' - exactly the JLS 14.5 rule. (A StatementWithoutIf then-
+# branch used to exclude nested ifs from the then position: that dodged
+# nothing - the conflict already existed via loop bodies like
+# 'if (a) while (b) if (c) f(); else g();' - while rejecting the valid
+# direct form above.)
 IfStatement =
- 'if'  '(' Expression  ')' StatementWithoutIf
+ 'if'  '(' Expression  ')' Statement
    OptElsePart ;
 
 DoStatement =
@@ -349,24 +441,10 @@ Expression : MultiplicativeExpression = UnaryExpression | MultiplicativeExpressi
 # conditions (if/while/for) and argument lists there is no cast context, so
 # 'if (a < b)' and 'f(a < b)' are unaffected.
 #
-# Shift/reduce inventory after this restructure (happy: 32 s/r, 0 r/r; the
-# two reduce/reduce conflicts of the previous grammar are gone). The 8
-# java-specific conflicts beyond the long-standing ones (dangling else,
-# catch/finally repetition, ModifierList stop, compound-name '.', member
-# id-vs-TypeParameters, bootstrap dummy token) are all intended
-# shift-preferences:
-#   on '[' (5 states): after CompoundName in expression, statement-start,
-#     cast, and after DimExprs/NonEmptyDims in creation - shifting '[' just
-#     defers the type-vs-access decision to the next token (']' vs
-#     expression start) or extends the bracket list; no input is lost.
-#   on '<' (3 states): after CompoundName at statement start, in casts, and
-#     after 'instanceof' - shift prefers type arguments. Only the cast state
-#     loses input ('(a < b)' above); the other two reject only semantically
-#     invalid Java ('a < b;' as a bare statement-expression,
-#     'x instanceof T < y').
-# The cast-vs-paren decision after ')' is conflict-FREE: operand-start
-# tokens can never follow a complete parenthesized expression, so the
-# lookahead sets are disjoint.
+# The '[' and '<' shifts inside the cast head are families 5 and 6 of the
+# conflict inventory at the top of this file. The cast-vs-paren decision
+# after ')' is conflict-FREE: operand-start tokens can never follow a
+# complete parenthesized expression, so the lookahead sets are disjoint.
 Expression : CastExpression =
  '(' PrimitiveTypeKeyword Dims ')' UnaryExpression
  | '(' CompoundName NonEmptyTypeArguments Dims ')' UnaryExpressionNotPlusMinus

--- a/test-grammars/java/test-nested-if.java
+++ b/test-grammars/java/test-nested-if.java
@@ -1,0 +1,22 @@
+// Dangling else: a brace-less nested if, with else binding to the NEAREST if
+// (JLS 14.5). The then-branch of IfStatement must be a full Statement.
+class NestedIf {
+    int direct(int a, int b) {
+        if (a > 0)
+            if (b > 0)
+                return 1;
+            else
+                return 2;
+        return 3;
+    }
+
+    void throughLoop(int a, int b) {
+        // the inner if sits under a while which sits under the outer if;
+        // the else still binds to the innermost if
+        if (a > 0) while (b > 0) if (a > b) g(); else h();
+        if (a > 0) if (b > 0) g(); else h(); else g();
+    }
+
+    void g() { }
+    void h() { }
+}

--- a/test/golden/java/JavaLexer.x
+++ b/test/golden/java/JavaLexer.x
@@ -10,88 +10,87 @@ import Data.Data (Data)
 @exponentPart = ([eE]  ("+"| "-") ?  [0-9]  ([0-9_]*  [0-9]) ?)
 @floatTypeSuffix = ([fFdD])
 
-tokens :- "tok_AdditiveOp_dummy_165" { simple Tk__tok_AdditiveOp_dummy_165 }
-          "tok_Annotation_dummy_164" { simple Tk__tok_Annotation_dummy_164 }
-          "tok_AnnotationArguments_dummy_163" { simple Tk__tok_AnnotationArguments_dummy_163 }
-          "tok_AnnotationDeclaration_dummy_162" { simple Tk__tok_AnnotationDeclaration_dummy_162 }
-          "tok_AnnotationElement_dummy_161" { simple Tk__tok_AnnotationElement_dummy_161 }
-          "tok_AnnotationList_dummy_160" { simple Tk__tok_AnnotationList_dummy_160 }
-          "tok_AnnotationTypeElement_dummy_159" { simple Tk__tok_AnnotationTypeElement_dummy_159 }
-          "tok_AnnotationTypeElementList_dummy_158" { simple Tk__tok_AnnotationTypeElementList_dummy_158 }
-          "tok_Arglist_dummy_157" { simple Tk__tok_Arglist_dummy_157 }
-          "tok_AssignmentOp_dummy_156" { simple Tk__tok_AssignmentOp_dummy_156 }
-          "tok_CatchList_dummy_155" { simple Tk__tok_CatchList_dummy_155 }
-          "tok_ClassDeclaration_dummy_154" { simple Tk__tok_ClassDeclaration_dummy_154 }
-          "tok_CompilationUnit_dummy_153" { simple Tk__tok_CompilationUnit_dummy_153 }
-          "tok_CompoundName_dummy_152" { simple Tk__tok_CompoundName_dummy_152 }
-          "tok_CreationExpression_dummy_151" { simple Tk__tok_CreationExpression_dummy_151 }
-          "tok_DimExprs_dummy_150" { simple Tk__tok_DimExprs_dummy_150 }
-          "tok_Dims_dummy_149" { simple Tk__tok_Dims_dummy_149 }
-          "tok_DoStatement_dummy_148" { simple Tk__tok_DoStatement_dummy_148 }
-          "tok_DocComment_dummy_147" { simple Tk__tok_DocComment_dummy_147 }
-          "tok_EnumConstant_dummy_146" { simple Tk__tok_EnumConstant_dummy_146 }
-          "tok_EnumConstantList_dummy_145" { simple Tk__tok_EnumConstantList_dummy_145 }
-          "tok_EnumDeclaration_dummy_144" { simple Tk__tok_EnumDeclaration_dummy_144 }
-          "tok_EqualityOp_dummy_143" { simple Tk__tok_EqualityOp_dummy_143 }
-          "tok_Expression_dummy_142" { simple Tk__tok_Expression_dummy_142 }
-          "tok_ExtendsList_dummy_141" { simple Tk__tok_ExtendsList_dummy_141 }
-          "tok_FieldDeclaration_dummy_140" { simple Tk__tok_FieldDeclaration_dummy_140 }
-          "tok_FieldDeclarationList_dummy_139" { simple Tk__tok_FieldDeclarationList_dummy_139 }
-          "tok_ForStatement_dummy_138" { simple Tk__tok_ForStatement_dummy_138 }
-          "tok_IfStatement_dummy_137" { simple Tk__tok_IfStatement_dummy_137 }
-          "tok_ImplementsList_dummy_136" { simple Tk__tok_ImplementsList_dummy_136 }
-          "tok_ImportList_dummy_135" { simple Tk__tok_ImportList_dummy_135 }
-          "tok_ImportStatement_dummy_134" { simple Tk__tok_ImportStatement_dummy_134 }
-          "tok_InterfaceDeclaration_dummy_133" { simple Tk__tok_InterfaceDeclaration_dummy_133 }
-          "tok_Java_dummy_166" { simple Tk__tok_Java_dummy_166 }
-          "tok_Literal_dummy_132" { simple Tk__tok_Literal_dummy_132 }
-          "tok_MemberAfterFirstId_dummy_131" { simple Tk__tok_MemberAfterFirstId_dummy_131 }
-          "tok_MemberDeclaration_dummy_130" { simple Tk__tok_MemberDeclaration_dummy_130 }
-          "tok_MemberRest_dummy_129" { simple Tk__tok_MemberRest_dummy_129 }
-          "tok_Modifier_dummy_128" { simple Tk__tok_Modifier_dummy_128 }
-          "tok_ModifierList_dummy_127" { simple Tk__tok_ModifierList_dummy_127 }
-          "tok_MoreTypeSpecifier_dummy_126" { simple Tk__tok_MoreTypeSpecifier_dummy_126 }
-          "tok_MoreVariableDeclarators_dummy_125" { simple Tk__tok_MoreVariableDeclarators_dummy_125 }
-          "tok_MultiplicativeOp_dummy_124" { simple Tk__tok_MultiplicativeOp_dummy_124 }
-          "tok_NestedTypeDeclaration_dummy_123" { simple Tk__tok_NestedTypeDeclaration_dummy_123 }
-          "tok_NonEmptyDims_dummy_122" { simple Tk__tok_NonEmptyDims_dummy_122 }
-          "tok_NonEmptyTypeArguments_dummy_121" { simple Tk__tok_NonEmptyTypeArguments_dummy_121 }
-          "tok_OptDocComment_dummy_120" { simple Tk__tok_OptDocComment_dummy_120 }
-          "tok_OptElsePart_dummy_119" { simple Tk__tok_OptElsePart_dummy_119 }
-          "tok_OptExpression_dummy_118" { simple Tk__tok_OptExpression_dummy_118 }
-          "tok_OptFinally_dummy_117" { simple Tk__tok_OptFinally_dummy_117 }
-          "tok_OptId_dummy_116" { simple Tk__tok_OptId_dummy_116 }
-          "tok_OptVariableInitializer_dummy_115" { simple Tk__tok_OptVariableInitializer_dummy_115 }
-          "tok_Package_dummy_114" { simple Tk__tok_Package_dummy_114 }
-          "tok_Parameter_dummy_113" { simple Tk__tok_Parameter_dummy_113 }
-          "tok_ParameterList_dummy_112" { simple Tk__tok_ParameterList_dummy_112 }
-          "tok_PostfixOp_dummy_111" { simple Tk__tok_PostfixOp_dummy_111 }
-          "tok_PrefixOp_dummy_110" { simple Tk__tok_PrefixOp_dummy_110 }
-          "tok_PrimitiveTypeKeyword_dummy_109" { simple Tk__tok_PrimitiveTypeKeyword_dummy_109 }
-          "tok_RelationalOp_dummy_108" { simple Tk__tok_RelationalOp_dummy_108 }
-          "tok_ShiftOp_dummy_107" { simple Tk__tok_ShiftOp_dummy_107 }
-          "tok_Statement_dummy_106" { simple Tk__tok_Statement_dummy_106 }
-          "tok_StatementBlock_dummy_105" { simple Tk__tok_StatementBlock_dummy_105 }
-          "tok_StatementList_dummy_104" { simple Tk__tok_StatementList_dummy_104 }
-          "tok_StatementWithoutIf_dummy_103" { simple Tk__tok_StatementWithoutIf_dummy_103 }
-          "tok_StaticInitializer_dummy_102" { simple Tk__tok_StaticInitializer_dummy_102 }
-          "tok_SwitchCaseList_dummy_101" { simple Tk__tok_SwitchCaseList_dummy_101 }
-          "tok_SwitchStatement_dummy_100" { simple Tk__tok_SwitchStatement_dummy_100 }
-          "tok_TryStatement_dummy_99" { simple Tk__tok_TryStatement_dummy_99 }
-          "tok_Type_dummy_98" { simple Tk__tok_Type_dummy_98 }
-          "tok_TypeArgument_dummy_97" { simple Tk__tok_TypeArgument_dummy_97 }
-          "tok_TypeArguments_dummy_96" { simple Tk__tok_TypeArguments_dummy_96 }
-          "tok_TypeDeclaration_dummy_95" { simple Tk__tok_TypeDeclaration_dummy_95 }
-          "tok_TypeParameter_dummy_94" { simple Tk__tok_TypeParameter_dummy_94 }
-          "tok_TypeParameters_dummy_93" { simple Tk__tok_TypeParameters_dummy_93 }
-          "tok_TypeSpecifier_dummy_92" { simple Tk__tok_TypeSpecifier_dummy_92 }
-          "tok_VariableDeclaration_dummy_91" { simple Tk__tok_VariableDeclaration_dummy_91 }
-          "tok_VariableDeclarator_dummy_90" { simple Tk__tok_VariableDeclarator_dummy_90 }
-          "tok_VariableDeclaratorList_dummy_89" { simple Tk__tok_VariableDeclaratorList_dummy_89 }
-          "tok_VariableInitializer_dummy_88" { simple Tk__tok_VariableInitializer_dummy_88 }
-          "tok_VariableInitializerList_dummy_87" { simple Tk__tok_VariableInitializerList_dummy_87 }
-          "tok_WhileStatement_dummy_86" { simple Tk__tok_WhileStatement_dummy_86 }
-          "tok_WildcardType_dummy_85" { simple Tk__tok_WildcardType_dummy_85 }
+tokens :- "tok_AdditiveOp_dummy_162" { simple Tk__tok_AdditiveOp_dummy_162 }
+          "tok_Annotation_dummy_161" { simple Tk__tok_Annotation_dummy_161 }
+          "tok_AnnotationArguments_dummy_160" { simple Tk__tok_AnnotationArguments_dummy_160 }
+          "tok_AnnotationDeclaration_dummy_159" { simple Tk__tok_AnnotationDeclaration_dummy_159 }
+          "tok_AnnotationElement_dummy_158" { simple Tk__tok_AnnotationElement_dummy_158 }
+          "tok_AnnotationList_dummy_157" { simple Tk__tok_AnnotationList_dummy_157 }
+          "tok_AnnotationTypeElement_dummy_156" { simple Tk__tok_AnnotationTypeElement_dummy_156 }
+          "tok_AnnotationTypeElementList_dummy_155" { simple Tk__tok_AnnotationTypeElementList_dummy_155 }
+          "tok_Arglist_dummy_154" { simple Tk__tok_Arglist_dummy_154 }
+          "tok_AssignmentOp_dummy_153" { simple Tk__tok_AssignmentOp_dummy_153 }
+          "tok_CatchList_dummy_152" { simple Tk__tok_CatchList_dummy_152 }
+          "tok_ClassDeclaration_dummy_151" { simple Tk__tok_ClassDeclaration_dummy_151 }
+          "tok_CompilationUnit_dummy_150" { simple Tk__tok_CompilationUnit_dummy_150 }
+          "tok_CompoundName_dummy_149" { simple Tk__tok_CompoundName_dummy_149 }
+          "tok_CreationExpression_dummy_148" { simple Tk__tok_CreationExpression_dummy_148 }
+          "tok_DimExprs_dummy_147" { simple Tk__tok_DimExprs_dummy_147 }
+          "tok_Dims_dummy_146" { simple Tk__tok_Dims_dummy_146 }
+          "tok_DoStatement_dummy_145" { simple Tk__tok_DoStatement_dummy_145 }
+          "tok_DocComment_dummy_144" { simple Tk__tok_DocComment_dummy_144 }
+          "tok_EnumConstant_dummy_143" { simple Tk__tok_EnumConstant_dummy_143 }
+          "tok_EnumConstantList_dummy_142" { simple Tk__tok_EnumConstantList_dummy_142 }
+          "tok_EnumDeclaration_dummy_141" { simple Tk__tok_EnumDeclaration_dummy_141 }
+          "tok_EqualityOp_dummy_140" { simple Tk__tok_EqualityOp_dummy_140 }
+          "tok_Expression_dummy_139" { simple Tk__tok_Expression_dummy_139 }
+          "tok_ExtendsList_dummy_138" { simple Tk__tok_ExtendsList_dummy_138 }
+          "tok_FieldDeclaration_dummy_137" { simple Tk__tok_FieldDeclaration_dummy_137 }
+          "tok_FieldDeclarationList_dummy_136" { simple Tk__tok_FieldDeclarationList_dummy_136 }
+          "tok_ForStatement_dummy_135" { simple Tk__tok_ForStatement_dummy_135 }
+          "tok_IfStatement_dummy_134" { simple Tk__tok_IfStatement_dummy_134 }
+          "tok_ImplementsList_dummy_133" { simple Tk__tok_ImplementsList_dummy_133 }
+          "tok_ImportList_dummy_132" { simple Tk__tok_ImportList_dummy_132 }
+          "tok_ImportStatement_dummy_131" { simple Tk__tok_ImportStatement_dummy_131 }
+          "tok_InterfaceDeclaration_dummy_130" { simple Tk__tok_InterfaceDeclaration_dummy_130 }
+          "tok_Java_dummy_163" { simple Tk__tok_Java_dummy_163 }
+          "tok_Literal_dummy_129" { simple Tk__tok_Literal_dummy_129 }
+          "tok_MemberAfterFirstId_dummy_128" { simple Tk__tok_MemberAfterFirstId_dummy_128 }
+          "tok_MemberDeclaration_dummy_127" { simple Tk__tok_MemberDeclaration_dummy_127 }
+          "tok_MemberRest_dummy_126" { simple Tk__tok_MemberRest_dummy_126 }
+          "tok_Modifier_dummy_125" { simple Tk__tok_Modifier_dummy_125 }
+          "tok_ModifierList_dummy_124" { simple Tk__tok_ModifierList_dummy_124 }
+          "tok_MoreTypeSpecifier_dummy_123" { simple Tk__tok_MoreTypeSpecifier_dummy_123 }
+          "tok_MoreVariableDeclarators_dummy_122" { simple Tk__tok_MoreVariableDeclarators_dummy_122 }
+          "tok_MultiplicativeOp_dummy_121" { simple Tk__tok_MultiplicativeOp_dummy_121 }
+          "tok_NonEmptyDims_dummy_120" { simple Tk__tok_NonEmptyDims_dummy_120 }
+          "tok_NonEmptyTypeArguments_dummy_119" { simple Tk__tok_NonEmptyTypeArguments_dummy_119 }
+          "tok_OptDocComment_dummy_118" { simple Tk__tok_OptDocComment_dummy_118 }
+          "tok_OptElsePart_dummy_117" { simple Tk__tok_OptElsePart_dummy_117 }
+          "tok_OptExpression_dummy_116" { simple Tk__tok_OptExpression_dummy_116 }
+          "tok_OptFinally_dummy_115" { simple Tk__tok_OptFinally_dummy_115 }
+          "tok_OptId_dummy_114" { simple Tk__tok_OptId_dummy_114 }
+          "tok_OptVariableInitializer_dummy_113" { simple Tk__tok_OptVariableInitializer_dummy_113 }
+          "tok_Package_dummy_112" { simple Tk__tok_Package_dummy_112 }
+          "tok_Parameter_dummy_111" { simple Tk__tok_Parameter_dummy_111 }
+          "tok_ParameterList_dummy_110" { simple Tk__tok_ParameterList_dummy_110 }
+          "tok_PostfixOp_dummy_109" { simple Tk__tok_PostfixOp_dummy_109 }
+          "tok_PrefixOp_dummy_108" { simple Tk__tok_PrefixOp_dummy_108 }
+          "tok_PrimitiveTypeKeyword_dummy_107" { simple Tk__tok_PrimitiveTypeKeyword_dummy_107 }
+          "tok_RelationalOp_dummy_106" { simple Tk__tok_RelationalOp_dummy_106 }
+          "tok_ShiftOp_dummy_105" { simple Tk__tok_ShiftOp_dummy_105 }
+          "tok_Statement_dummy_104" { simple Tk__tok_Statement_dummy_104 }
+          "tok_StatementBlock_dummy_103" { simple Tk__tok_StatementBlock_dummy_103 }
+          "tok_StatementList_dummy_102" { simple Tk__tok_StatementList_dummy_102 }
+          "tok_StaticInitializer_dummy_101" { simple Tk__tok_StaticInitializer_dummy_101 }
+          "tok_SwitchCaseList_dummy_100" { simple Tk__tok_SwitchCaseList_dummy_100 }
+          "tok_SwitchStatement_dummy_99" { simple Tk__tok_SwitchStatement_dummy_99 }
+          "tok_TryStatement_dummy_98" { simple Tk__tok_TryStatement_dummy_98 }
+          "tok_Type_dummy_97" { simple Tk__tok_Type_dummy_97 }
+          "tok_TypeArgument_dummy_96" { simple Tk__tok_TypeArgument_dummy_96 }
+          "tok_TypeArguments_dummy_95" { simple Tk__tok_TypeArguments_dummy_95 }
+          "tok_TypeDeclRest_dummy_94" { simple Tk__tok_TypeDeclRest_dummy_94 }
+          "tok_TypeDeclaration_dummy_93" { simple Tk__tok_TypeDeclaration_dummy_93 }
+          "tok_TypeParameter_dummy_92" { simple Tk__tok_TypeParameter_dummy_92 }
+          "tok_TypeParameters_dummy_91" { simple Tk__tok_TypeParameters_dummy_91 }
+          "tok_TypeSpecifier_dummy_90" { simple Tk__tok_TypeSpecifier_dummy_90 }
+          "tok_VariableDeclaration_dummy_89" { simple Tk__tok_VariableDeclaration_dummy_89 }
+          "tok_VariableDeclarator_dummy_88" { simple Tk__tok_VariableDeclarator_dummy_88 }
+          "tok_VariableDeclaratorList_dummy_87" { simple Tk__tok_VariableDeclaratorList_dummy_87 }
+          "tok_VariableInitializer_dummy_86" { simple Tk__tok_VariableInitializer_dummy_86 }
+          "tok_VariableInitializerList_dummy_85" { simple Tk__tok_VariableInitializerList_dummy_85 }
+          "tok_WhileStatement_dummy_84" { simple Tk__tok_WhileStatement_dummy_84 }
+          "tok_WildcardType_dummy_83" { simple Tk__tok_WildcardType_dummy_83 }
           "~" { simple Tk__tok__tilde__78 }
           "}" { simple Tk__tok__symbol__14 }
           "||" { simple Tk__tok__pipe__pipe__57 }
@@ -231,7 +230,6 @@ tokens :- "tok_AdditiveOp_dummy_165" { simple Tk__tok_AdditiveOp_dummy_165 }
           ("$"  "DoStatement"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_DoStatement . ((tail . dropWhile (/= ':'))) }
           ("$"  "IfStatement"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_IfStatement . ((tail . dropWhile (/= ':'))) }
           ("$"  "OptElsePart"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_OptElsePart . ((tail . dropWhile (/= ':'))) }
-          ("$"  "StatementWithoutIf"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_StatementWithoutIf . ((tail . dropWhile (/= ':'))) }
           ("$"  "Statement"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_Statement . ((tail . dropWhile (/= ':'))) }
           ("$"  "OptId"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_OptId . ((tail . dropWhile (/= ':'))) }
           ("$"  "OptExpression"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_OptExpression . ((tail . dropWhile (/= ':'))) }
@@ -255,7 +253,7 @@ tokens :- "tok_AdditiveOp_dummy_165" { simple Tk__tok_AdditiveOp_dummy_165 }
           ("$"  "NonEmptyDims"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_NonEmptyDims . ((tail . dropWhile (/= ':'))) }
           ("$"  "Dims"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_Dims . ((tail . dropWhile (/= ':'))) }
           ("$"  "FieldDeclaration"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_FieldDeclaration . ((tail . dropWhile (/= ':'))) }
-          ("$"  "NestedTypeDeclaration"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_NestedTypeDeclaration . ((tail . dropWhile (/= ':'))) }
+          ("$"  "TypeDeclRest"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_TypeDeclRest . ((tail . dropWhile (/= ':'))) }
           ("$"  "EnumDeclaration"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_EnumDeclaration . ((tail . dropWhile (/= ':'))) }
           ("$"  "EnumConstantList"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_EnumConstantList . ((tail . dropWhile (/= ':'))) }
           ("$"  "EnumConstant"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_EnumConstant . ((tail . dropWhile (/= ':'))) }
@@ -284,88 +282,87 @@ tokens :- "tok_AdditiveOp_dummy_165" { simple Tk__tok_AdditiveOp_dummy_165 }
 
 {
 data Token = EndOfFile |
-             Tk__tok_AdditiveOp_dummy_165 |
-             Tk__tok_Annotation_dummy_164 |
-             Tk__tok_AnnotationArguments_dummy_163 |
-             Tk__tok_AnnotationDeclaration_dummy_162 |
-             Tk__tok_AnnotationElement_dummy_161 |
-             Tk__tok_AnnotationList_dummy_160 |
-             Tk__tok_AnnotationTypeElement_dummy_159 |
-             Tk__tok_AnnotationTypeElementList_dummy_158 |
-             Tk__tok_Arglist_dummy_157 |
-             Tk__tok_AssignmentOp_dummy_156 |
-             Tk__tok_CatchList_dummy_155 |
-             Tk__tok_ClassDeclaration_dummy_154 |
-             Tk__tok_CompilationUnit_dummy_153 |
-             Tk__tok_CompoundName_dummy_152 |
-             Tk__tok_CreationExpression_dummy_151 |
-             Tk__tok_DimExprs_dummy_150 |
-             Tk__tok_Dims_dummy_149 |
-             Tk__tok_DoStatement_dummy_148 |
-             Tk__tok_DocComment_dummy_147 |
-             Tk__tok_EnumConstant_dummy_146 |
-             Tk__tok_EnumConstantList_dummy_145 |
-             Tk__tok_EnumDeclaration_dummy_144 |
-             Tk__tok_EqualityOp_dummy_143 |
-             Tk__tok_Expression_dummy_142 |
-             Tk__tok_ExtendsList_dummy_141 |
-             Tk__tok_FieldDeclaration_dummy_140 |
-             Tk__tok_FieldDeclarationList_dummy_139 |
-             Tk__tok_ForStatement_dummy_138 |
-             Tk__tok_IfStatement_dummy_137 |
-             Tk__tok_ImplementsList_dummy_136 |
-             Tk__tok_ImportList_dummy_135 |
-             Tk__tok_ImportStatement_dummy_134 |
-             Tk__tok_InterfaceDeclaration_dummy_133 |
-             Tk__tok_Java_dummy_166 |
-             Tk__tok_Literal_dummy_132 |
-             Tk__tok_MemberAfterFirstId_dummy_131 |
-             Tk__tok_MemberDeclaration_dummy_130 |
-             Tk__tok_MemberRest_dummy_129 |
-             Tk__tok_Modifier_dummy_128 |
-             Tk__tok_ModifierList_dummy_127 |
-             Tk__tok_MoreTypeSpecifier_dummy_126 |
-             Tk__tok_MoreVariableDeclarators_dummy_125 |
-             Tk__tok_MultiplicativeOp_dummy_124 |
-             Tk__tok_NestedTypeDeclaration_dummy_123 |
-             Tk__tok_NonEmptyDims_dummy_122 |
-             Tk__tok_NonEmptyTypeArguments_dummy_121 |
-             Tk__tok_OptDocComment_dummy_120 |
-             Tk__tok_OptElsePart_dummy_119 |
-             Tk__tok_OptExpression_dummy_118 |
-             Tk__tok_OptFinally_dummy_117 |
-             Tk__tok_OptId_dummy_116 |
-             Tk__tok_OptVariableInitializer_dummy_115 |
-             Tk__tok_Package_dummy_114 |
-             Tk__tok_Parameter_dummy_113 |
-             Tk__tok_ParameterList_dummy_112 |
-             Tk__tok_PostfixOp_dummy_111 |
-             Tk__tok_PrefixOp_dummy_110 |
-             Tk__tok_PrimitiveTypeKeyword_dummy_109 |
-             Tk__tok_RelationalOp_dummy_108 |
-             Tk__tok_ShiftOp_dummy_107 |
-             Tk__tok_Statement_dummy_106 |
-             Tk__tok_StatementBlock_dummy_105 |
-             Tk__tok_StatementList_dummy_104 |
-             Tk__tok_StatementWithoutIf_dummy_103 |
-             Tk__tok_StaticInitializer_dummy_102 |
-             Tk__tok_SwitchCaseList_dummy_101 |
-             Tk__tok_SwitchStatement_dummy_100 |
-             Tk__tok_TryStatement_dummy_99 |
-             Tk__tok_Type_dummy_98 |
-             Tk__tok_TypeArgument_dummy_97 |
-             Tk__tok_TypeArguments_dummy_96 |
-             Tk__tok_TypeDeclaration_dummy_95 |
-             Tk__tok_TypeParameter_dummy_94 |
-             Tk__tok_TypeParameters_dummy_93 |
-             Tk__tok_TypeSpecifier_dummy_92 |
-             Tk__tok_VariableDeclaration_dummy_91 |
-             Tk__tok_VariableDeclarator_dummy_90 |
-             Tk__tok_VariableDeclaratorList_dummy_89 |
-             Tk__tok_VariableInitializer_dummy_88 |
-             Tk__tok_VariableInitializerList_dummy_87 |
-             Tk__tok_WhileStatement_dummy_86 |
-             Tk__tok_WildcardType_dummy_85 |
+             Tk__tok_AdditiveOp_dummy_162 |
+             Tk__tok_Annotation_dummy_161 |
+             Tk__tok_AnnotationArguments_dummy_160 |
+             Tk__tok_AnnotationDeclaration_dummy_159 |
+             Tk__tok_AnnotationElement_dummy_158 |
+             Tk__tok_AnnotationList_dummy_157 |
+             Tk__tok_AnnotationTypeElement_dummy_156 |
+             Tk__tok_AnnotationTypeElementList_dummy_155 |
+             Tk__tok_Arglist_dummy_154 |
+             Tk__tok_AssignmentOp_dummy_153 |
+             Tk__tok_CatchList_dummy_152 |
+             Tk__tok_ClassDeclaration_dummy_151 |
+             Tk__tok_CompilationUnit_dummy_150 |
+             Tk__tok_CompoundName_dummy_149 |
+             Tk__tok_CreationExpression_dummy_148 |
+             Tk__tok_DimExprs_dummy_147 |
+             Tk__tok_Dims_dummy_146 |
+             Tk__tok_DoStatement_dummy_145 |
+             Tk__tok_DocComment_dummy_144 |
+             Tk__tok_EnumConstant_dummy_143 |
+             Tk__tok_EnumConstantList_dummy_142 |
+             Tk__tok_EnumDeclaration_dummy_141 |
+             Tk__tok_EqualityOp_dummy_140 |
+             Tk__tok_Expression_dummy_139 |
+             Tk__tok_ExtendsList_dummy_138 |
+             Tk__tok_FieldDeclaration_dummy_137 |
+             Tk__tok_FieldDeclarationList_dummy_136 |
+             Tk__tok_ForStatement_dummy_135 |
+             Tk__tok_IfStatement_dummy_134 |
+             Tk__tok_ImplementsList_dummy_133 |
+             Tk__tok_ImportList_dummy_132 |
+             Tk__tok_ImportStatement_dummy_131 |
+             Tk__tok_InterfaceDeclaration_dummy_130 |
+             Tk__tok_Java_dummy_163 |
+             Tk__tok_Literal_dummy_129 |
+             Tk__tok_MemberAfterFirstId_dummy_128 |
+             Tk__tok_MemberDeclaration_dummy_127 |
+             Tk__tok_MemberRest_dummy_126 |
+             Tk__tok_Modifier_dummy_125 |
+             Tk__tok_ModifierList_dummy_124 |
+             Tk__tok_MoreTypeSpecifier_dummy_123 |
+             Tk__tok_MoreVariableDeclarators_dummy_122 |
+             Tk__tok_MultiplicativeOp_dummy_121 |
+             Tk__tok_NonEmptyDims_dummy_120 |
+             Tk__tok_NonEmptyTypeArguments_dummy_119 |
+             Tk__tok_OptDocComment_dummy_118 |
+             Tk__tok_OptElsePart_dummy_117 |
+             Tk__tok_OptExpression_dummy_116 |
+             Tk__tok_OptFinally_dummy_115 |
+             Tk__tok_OptId_dummy_114 |
+             Tk__tok_OptVariableInitializer_dummy_113 |
+             Tk__tok_Package_dummy_112 |
+             Tk__tok_Parameter_dummy_111 |
+             Tk__tok_ParameterList_dummy_110 |
+             Tk__tok_PostfixOp_dummy_109 |
+             Tk__tok_PrefixOp_dummy_108 |
+             Tk__tok_PrimitiveTypeKeyword_dummy_107 |
+             Tk__tok_RelationalOp_dummy_106 |
+             Tk__tok_ShiftOp_dummy_105 |
+             Tk__tok_Statement_dummy_104 |
+             Tk__tok_StatementBlock_dummy_103 |
+             Tk__tok_StatementList_dummy_102 |
+             Tk__tok_StaticInitializer_dummy_101 |
+             Tk__tok_SwitchCaseList_dummy_100 |
+             Tk__tok_SwitchStatement_dummy_99 |
+             Tk__tok_TryStatement_dummy_98 |
+             Tk__tok_Type_dummy_97 |
+             Tk__tok_TypeArgument_dummy_96 |
+             Tk__tok_TypeArguments_dummy_95 |
+             Tk__tok_TypeDeclRest_dummy_94 |
+             Tk__tok_TypeDeclaration_dummy_93 |
+             Tk__tok_TypeParameter_dummy_92 |
+             Tk__tok_TypeParameters_dummy_91 |
+             Tk__tok_TypeSpecifier_dummy_90 |
+             Tk__tok_VariableDeclaration_dummy_89 |
+             Tk__tok_VariableDeclarator_dummy_88 |
+             Tk__tok_VariableDeclaratorList_dummy_87 |
+             Tk__tok_VariableInitializer_dummy_86 |
+             Tk__tok_VariableInitializerList_dummy_85 |
+             Tk__tok_WhileStatement_dummy_84 |
+             Tk__tok_WildcardType_dummy_83 |
              Tk__tok__tilde__78 |
              Tk__tok__symbol__14 |
              Tk__tok__pipe__pipe__57 |
@@ -502,7 +499,6 @@ data Token = EndOfFile |
              Tk__qq_DoStatement String |
              Tk__qq_IfStatement String |
              Tk__qq_OptElsePart String |
-             Tk__qq_StatementWithoutIf String |
              Tk__qq_Statement String |
              Tk__qq_OptId String |
              Tk__qq_OptExpression String |
@@ -526,7 +522,7 @@ data Token = EndOfFile |
              Tk__qq_NonEmptyDims String |
              Tk__qq_Dims String |
              Tk__qq_FieldDeclaration String |
-             Tk__qq_NestedTypeDeclaration String |
+             Tk__qq_TypeDeclRest String |
              Tk__qq_EnumDeclaration String |
              Tk__qq_EnumConstantList String |
              Tk__qq_EnumConstant String |

--- a/test/golden/java/JavaParser.y
+++ b/test/golden/java/JavaParser.y
@@ -13,88 +13,87 @@ import qualified JavaLexer as L (Token(..), PosToken(..), AlexPosn(..), alexScan
 %token
 
 rtk__eof { L.PosToken _ L.EndOfFile }
-tok_AdditiveOp_dummy_165 { L.PosToken _ L.Tk__tok_AdditiveOp_dummy_165 }
-tok_Annotation_dummy_164 { L.PosToken _ L.Tk__tok_Annotation_dummy_164 }
-tok_AnnotationArguments_dummy_163 { L.PosToken _ L.Tk__tok_AnnotationArguments_dummy_163 }
-tok_AnnotationDeclaration_dummy_162 { L.PosToken _ L.Tk__tok_AnnotationDeclaration_dummy_162 }
-tok_AnnotationElement_dummy_161 { L.PosToken _ L.Tk__tok_AnnotationElement_dummy_161 }
-tok_AnnotationList_dummy_160 { L.PosToken _ L.Tk__tok_AnnotationList_dummy_160 }
-tok_AnnotationTypeElement_dummy_159 { L.PosToken _ L.Tk__tok_AnnotationTypeElement_dummy_159 }
-tok_AnnotationTypeElementList_dummy_158 { L.PosToken _ L.Tk__tok_AnnotationTypeElementList_dummy_158 }
-tok_Arglist_dummy_157 { L.PosToken _ L.Tk__tok_Arglist_dummy_157 }
-tok_AssignmentOp_dummy_156 { L.PosToken _ L.Tk__tok_AssignmentOp_dummy_156 }
-tok_CatchList_dummy_155 { L.PosToken _ L.Tk__tok_CatchList_dummy_155 }
-tok_ClassDeclaration_dummy_154 { L.PosToken _ L.Tk__tok_ClassDeclaration_dummy_154 }
-tok_CompilationUnit_dummy_153 { L.PosToken _ L.Tk__tok_CompilationUnit_dummy_153 }
-tok_CompoundName_dummy_152 { L.PosToken _ L.Tk__tok_CompoundName_dummy_152 }
-tok_CreationExpression_dummy_151 { L.PosToken _ L.Tk__tok_CreationExpression_dummy_151 }
-tok_DimExprs_dummy_150 { L.PosToken _ L.Tk__tok_DimExprs_dummy_150 }
-tok_Dims_dummy_149 { L.PosToken _ L.Tk__tok_Dims_dummy_149 }
-tok_DoStatement_dummy_148 { L.PosToken _ L.Tk__tok_DoStatement_dummy_148 }
-tok_DocComment_dummy_147 { L.PosToken _ L.Tk__tok_DocComment_dummy_147 }
-tok_EnumConstant_dummy_146 { L.PosToken _ L.Tk__tok_EnumConstant_dummy_146 }
-tok_EnumConstantList_dummy_145 { L.PosToken _ L.Tk__tok_EnumConstantList_dummy_145 }
-tok_EnumDeclaration_dummy_144 { L.PosToken _ L.Tk__tok_EnumDeclaration_dummy_144 }
-tok_EqualityOp_dummy_143 { L.PosToken _ L.Tk__tok_EqualityOp_dummy_143 }
-tok_Expression_dummy_142 { L.PosToken _ L.Tk__tok_Expression_dummy_142 }
-tok_ExtendsList_dummy_141 { L.PosToken _ L.Tk__tok_ExtendsList_dummy_141 }
-tok_FieldDeclaration_dummy_140 { L.PosToken _ L.Tk__tok_FieldDeclaration_dummy_140 }
-tok_FieldDeclarationList_dummy_139 { L.PosToken _ L.Tk__tok_FieldDeclarationList_dummy_139 }
-tok_ForStatement_dummy_138 { L.PosToken _ L.Tk__tok_ForStatement_dummy_138 }
-tok_IfStatement_dummy_137 { L.PosToken _ L.Tk__tok_IfStatement_dummy_137 }
-tok_ImplementsList_dummy_136 { L.PosToken _ L.Tk__tok_ImplementsList_dummy_136 }
-tok_ImportList_dummy_135 { L.PosToken _ L.Tk__tok_ImportList_dummy_135 }
-tok_ImportStatement_dummy_134 { L.PosToken _ L.Tk__tok_ImportStatement_dummy_134 }
-tok_InterfaceDeclaration_dummy_133 { L.PosToken _ L.Tk__tok_InterfaceDeclaration_dummy_133 }
-tok_Java_dummy_166 { L.PosToken _ L.Tk__tok_Java_dummy_166 }
-tok_Literal_dummy_132 { L.PosToken _ L.Tk__tok_Literal_dummy_132 }
-tok_MemberAfterFirstId_dummy_131 { L.PosToken _ L.Tk__tok_MemberAfterFirstId_dummy_131 }
-tok_MemberDeclaration_dummy_130 { L.PosToken _ L.Tk__tok_MemberDeclaration_dummy_130 }
-tok_MemberRest_dummy_129 { L.PosToken _ L.Tk__tok_MemberRest_dummy_129 }
-tok_Modifier_dummy_128 { L.PosToken _ L.Tk__tok_Modifier_dummy_128 }
-tok_ModifierList_dummy_127 { L.PosToken _ L.Tk__tok_ModifierList_dummy_127 }
-tok_MoreTypeSpecifier_dummy_126 { L.PosToken _ L.Tk__tok_MoreTypeSpecifier_dummy_126 }
-tok_MoreVariableDeclarators_dummy_125 { L.PosToken _ L.Tk__tok_MoreVariableDeclarators_dummy_125 }
-tok_MultiplicativeOp_dummy_124 { L.PosToken _ L.Tk__tok_MultiplicativeOp_dummy_124 }
-tok_NestedTypeDeclaration_dummy_123 { L.PosToken _ L.Tk__tok_NestedTypeDeclaration_dummy_123 }
-tok_NonEmptyDims_dummy_122 { L.PosToken _ L.Tk__tok_NonEmptyDims_dummy_122 }
-tok_NonEmptyTypeArguments_dummy_121 { L.PosToken _ L.Tk__tok_NonEmptyTypeArguments_dummy_121 }
-tok_OptDocComment_dummy_120 { L.PosToken _ L.Tk__tok_OptDocComment_dummy_120 }
-tok_OptElsePart_dummy_119 { L.PosToken _ L.Tk__tok_OptElsePart_dummy_119 }
-tok_OptExpression_dummy_118 { L.PosToken _ L.Tk__tok_OptExpression_dummy_118 }
-tok_OptFinally_dummy_117 { L.PosToken _ L.Tk__tok_OptFinally_dummy_117 }
-tok_OptId_dummy_116 { L.PosToken _ L.Tk__tok_OptId_dummy_116 }
-tok_OptVariableInitializer_dummy_115 { L.PosToken _ L.Tk__tok_OptVariableInitializer_dummy_115 }
-tok_Package_dummy_114 { L.PosToken _ L.Tk__tok_Package_dummy_114 }
-tok_Parameter_dummy_113 { L.PosToken _ L.Tk__tok_Parameter_dummy_113 }
-tok_ParameterList_dummy_112 { L.PosToken _ L.Tk__tok_ParameterList_dummy_112 }
-tok_PostfixOp_dummy_111 { L.PosToken _ L.Tk__tok_PostfixOp_dummy_111 }
-tok_PrefixOp_dummy_110 { L.PosToken _ L.Tk__tok_PrefixOp_dummy_110 }
-tok_PrimitiveTypeKeyword_dummy_109 { L.PosToken _ L.Tk__tok_PrimitiveTypeKeyword_dummy_109 }
-tok_RelationalOp_dummy_108 { L.PosToken _ L.Tk__tok_RelationalOp_dummy_108 }
-tok_ShiftOp_dummy_107 { L.PosToken _ L.Tk__tok_ShiftOp_dummy_107 }
-tok_Statement_dummy_106 { L.PosToken _ L.Tk__tok_Statement_dummy_106 }
-tok_StatementBlock_dummy_105 { L.PosToken _ L.Tk__tok_StatementBlock_dummy_105 }
-tok_StatementList_dummy_104 { L.PosToken _ L.Tk__tok_StatementList_dummy_104 }
-tok_StatementWithoutIf_dummy_103 { L.PosToken _ L.Tk__tok_StatementWithoutIf_dummy_103 }
-tok_StaticInitializer_dummy_102 { L.PosToken _ L.Tk__tok_StaticInitializer_dummy_102 }
-tok_SwitchCaseList_dummy_101 { L.PosToken _ L.Tk__tok_SwitchCaseList_dummy_101 }
-tok_SwitchStatement_dummy_100 { L.PosToken _ L.Tk__tok_SwitchStatement_dummy_100 }
-tok_TryStatement_dummy_99 { L.PosToken _ L.Tk__tok_TryStatement_dummy_99 }
-tok_Type_dummy_98 { L.PosToken _ L.Tk__tok_Type_dummy_98 }
-tok_TypeArgument_dummy_97 { L.PosToken _ L.Tk__tok_TypeArgument_dummy_97 }
-tok_TypeArguments_dummy_96 { L.PosToken _ L.Tk__tok_TypeArguments_dummy_96 }
-tok_TypeDeclaration_dummy_95 { L.PosToken _ L.Tk__tok_TypeDeclaration_dummy_95 }
-tok_TypeParameter_dummy_94 { L.PosToken _ L.Tk__tok_TypeParameter_dummy_94 }
-tok_TypeParameters_dummy_93 { L.PosToken _ L.Tk__tok_TypeParameters_dummy_93 }
-tok_TypeSpecifier_dummy_92 { L.PosToken _ L.Tk__tok_TypeSpecifier_dummy_92 }
-tok_VariableDeclaration_dummy_91 { L.PosToken _ L.Tk__tok_VariableDeclaration_dummy_91 }
-tok_VariableDeclarator_dummy_90 { L.PosToken _ L.Tk__tok_VariableDeclarator_dummy_90 }
-tok_VariableDeclaratorList_dummy_89 { L.PosToken _ L.Tk__tok_VariableDeclaratorList_dummy_89 }
-tok_VariableInitializer_dummy_88 { L.PosToken _ L.Tk__tok_VariableInitializer_dummy_88 }
-tok_VariableInitializerList_dummy_87 { L.PosToken _ L.Tk__tok_VariableInitializerList_dummy_87 }
-tok_WhileStatement_dummy_86 { L.PosToken _ L.Tk__tok_WhileStatement_dummy_86 }
-tok_WildcardType_dummy_85 { L.PosToken _ L.Tk__tok_WildcardType_dummy_85 }
+tok_AdditiveOp_dummy_162 { L.PosToken _ L.Tk__tok_AdditiveOp_dummy_162 }
+tok_Annotation_dummy_161 { L.PosToken _ L.Tk__tok_Annotation_dummy_161 }
+tok_AnnotationArguments_dummy_160 { L.PosToken _ L.Tk__tok_AnnotationArguments_dummy_160 }
+tok_AnnotationDeclaration_dummy_159 { L.PosToken _ L.Tk__tok_AnnotationDeclaration_dummy_159 }
+tok_AnnotationElement_dummy_158 { L.PosToken _ L.Tk__tok_AnnotationElement_dummy_158 }
+tok_AnnotationList_dummy_157 { L.PosToken _ L.Tk__tok_AnnotationList_dummy_157 }
+tok_AnnotationTypeElement_dummy_156 { L.PosToken _ L.Tk__tok_AnnotationTypeElement_dummy_156 }
+tok_AnnotationTypeElementList_dummy_155 { L.PosToken _ L.Tk__tok_AnnotationTypeElementList_dummy_155 }
+tok_Arglist_dummy_154 { L.PosToken _ L.Tk__tok_Arglist_dummy_154 }
+tok_AssignmentOp_dummy_153 { L.PosToken _ L.Tk__tok_AssignmentOp_dummy_153 }
+tok_CatchList_dummy_152 { L.PosToken _ L.Tk__tok_CatchList_dummy_152 }
+tok_ClassDeclaration_dummy_151 { L.PosToken _ L.Tk__tok_ClassDeclaration_dummy_151 }
+tok_CompilationUnit_dummy_150 { L.PosToken _ L.Tk__tok_CompilationUnit_dummy_150 }
+tok_CompoundName_dummy_149 { L.PosToken _ L.Tk__tok_CompoundName_dummy_149 }
+tok_CreationExpression_dummy_148 { L.PosToken _ L.Tk__tok_CreationExpression_dummy_148 }
+tok_DimExprs_dummy_147 { L.PosToken _ L.Tk__tok_DimExprs_dummy_147 }
+tok_Dims_dummy_146 { L.PosToken _ L.Tk__tok_Dims_dummy_146 }
+tok_DoStatement_dummy_145 { L.PosToken _ L.Tk__tok_DoStatement_dummy_145 }
+tok_DocComment_dummy_144 { L.PosToken _ L.Tk__tok_DocComment_dummy_144 }
+tok_EnumConstant_dummy_143 { L.PosToken _ L.Tk__tok_EnumConstant_dummy_143 }
+tok_EnumConstantList_dummy_142 { L.PosToken _ L.Tk__tok_EnumConstantList_dummy_142 }
+tok_EnumDeclaration_dummy_141 { L.PosToken _ L.Tk__tok_EnumDeclaration_dummy_141 }
+tok_EqualityOp_dummy_140 { L.PosToken _ L.Tk__tok_EqualityOp_dummy_140 }
+tok_Expression_dummy_139 { L.PosToken _ L.Tk__tok_Expression_dummy_139 }
+tok_ExtendsList_dummy_138 { L.PosToken _ L.Tk__tok_ExtendsList_dummy_138 }
+tok_FieldDeclaration_dummy_137 { L.PosToken _ L.Tk__tok_FieldDeclaration_dummy_137 }
+tok_FieldDeclarationList_dummy_136 { L.PosToken _ L.Tk__tok_FieldDeclarationList_dummy_136 }
+tok_ForStatement_dummy_135 { L.PosToken _ L.Tk__tok_ForStatement_dummy_135 }
+tok_IfStatement_dummy_134 { L.PosToken _ L.Tk__tok_IfStatement_dummy_134 }
+tok_ImplementsList_dummy_133 { L.PosToken _ L.Tk__tok_ImplementsList_dummy_133 }
+tok_ImportList_dummy_132 { L.PosToken _ L.Tk__tok_ImportList_dummy_132 }
+tok_ImportStatement_dummy_131 { L.PosToken _ L.Tk__tok_ImportStatement_dummy_131 }
+tok_InterfaceDeclaration_dummy_130 { L.PosToken _ L.Tk__tok_InterfaceDeclaration_dummy_130 }
+tok_Java_dummy_163 { L.PosToken _ L.Tk__tok_Java_dummy_163 }
+tok_Literal_dummy_129 { L.PosToken _ L.Tk__tok_Literal_dummy_129 }
+tok_MemberAfterFirstId_dummy_128 { L.PosToken _ L.Tk__tok_MemberAfterFirstId_dummy_128 }
+tok_MemberDeclaration_dummy_127 { L.PosToken _ L.Tk__tok_MemberDeclaration_dummy_127 }
+tok_MemberRest_dummy_126 { L.PosToken _ L.Tk__tok_MemberRest_dummy_126 }
+tok_Modifier_dummy_125 { L.PosToken _ L.Tk__tok_Modifier_dummy_125 }
+tok_ModifierList_dummy_124 { L.PosToken _ L.Tk__tok_ModifierList_dummy_124 }
+tok_MoreTypeSpecifier_dummy_123 { L.PosToken _ L.Tk__tok_MoreTypeSpecifier_dummy_123 }
+tok_MoreVariableDeclarators_dummy_122 { L.PosToken _ L.Tk__tok_MoreVariableDeclarators_dummy_122 }
+tok_MultiplicativeOp_dummy_121 { L.PosToken _ L.Tk__tok_MultiplicativeOp_dummy_121 }
+tok_NonEmptyDims_dummy_120 { L.PosToken _ L.Tk__tok_NonEmptyDims_dummy_120 }
+tok_NonEmptyTypeArguments_dummy_119 { L.PosToken _ L.Tk__tok_NonEmptyTypeArguments_dummy_119 }
+tok_OptDocComment_dummy_118 { L.PosToken _ L.Tk__tok_OptDocComment_dummy_118 }
+tok_OptElsePart_dummy_117 { L.PosToken _ L.Tk__tok_OptElsePart_dummy_117 }
+tok_OptExpression_dummy_116 { L.PosToken _ L.Tk__tok_OptExpression_dummy_116 }
+tok_OptFinally_dummy_115 { L.PosToken _ L.Tk__tok_OptFinally_dummy_115 }
+tok_OptId_dummy_114 { L.PosToken _ L.Tk__tok_OptId_dummy_114 }
+tok_OptVariableInitializer_dummy_113 { L.PosToken _ L.Tk__tok_OptVariableInitializer_dummy_113 }
+tok_Package_dummy_112 { L.PosToken _ L.Tk__tok_Package_dummy_112 }
+tok_Parameter_dummy_111 { L.PosToken _ L.Tk__tok_Parameter_dummy_111 }
+tok_ParameterList_dummy_110 { L.PosToken _ L.Tk__tok_ParameterList_dummy_110 }
+tok_PostfixOp_dummy_109 { L.PosToken _ L.Tk__tok_PostfixOp_dummy_109 }
+tok_PrefixOp_dummy_108 { L.PosToken _ L.Tk__tok_PrefixOp_dummy_108 }
+tok_PrimitiveTypeKeyword_dummy_107 { L.PosToken _ L.Tk__tok_PrimitiveTypeKeyword_dummy_107 }
+tok_RelationalOp_dummy_106 { L.PosToken _ L.Tk__tok_RelationalOp_dummy_106 }
+tok_ShiftOp_dummy_105 { L.PosToken _ L.Tk__tok_ShiftOp_dummy_105 }
+tok_Statement_dummy_104 { L.PosToken _ L.Tk__tok_Statement_dummy_104 }
+tok_StatementBlock_dummy_103 { L.PosToken _ L.Tk__tok_StatementBlock_dummy_103 }
+tok_StatementList_dummy_102 { L.PosToken _ L.Tk__tok_StatementList_dummy_102 }
+tok_StaticInitializer_dummy_101 { L.PosToken _ L.Tk__tok_StaticInitializer_dummy_101 }
+tok_SwitchCaseList_dummy_100 { L.PosToken _ L.Tk__tok_SwitchCaseList_dummy_100 }
+tok_SwitchStatement_dummy_99 { L.PosToken _ L.Tk__tok_SwitchStatement_dummy_99 }
+tok_TryStatement_dummy_98 { L.PosToken _ L.Tk__tok_TryStatement_dummy_98 }
+tok_Type_dummy_97 { L.PosToken _ L.Tk__tok_Type_dummy_97 }
+tok_TypeArgument_dummy_96 { L.PosToken _ L.Tk__tok_TypeArgument_dummy_96 }
+tok_TypeArguments_dummy_95 { L.PosToken _ L.Tk__tok_TypeArguments_dummy_95 }
+tok_TypeDeclRest_dummy_94 { L.PosToken _ L.Tk__tok_TypeDeclRest_dummy_94 }
+tok_TypeDeclaration_dummy_93 { L.PosToken _ L.Tk__tok_TypeDeclaration_dummy_93 }
+tok_TypeParameter_dummy_92 { L.PosToken _ L.Tk__tok_TypeParameter_dummy_92 }
+tok_TypeParameters_dummy_91 { L.PosToken _ L.Tk__tok_TypeParameters_dummy_91 }
+tok_TypeSpecifier_dummy_90 { L.PosToken _ L.Tk__tok_TypeSpecifier_dummy_90 }
+tok_VariableDeclaration_dummy_89 { L.PosToken _ L.Tk__tok_VariableDeclaration_dummy_89 }
+tok_VariableDeclarator_dummy_88 { L.PosToken _ L.Tk__tok_VariableDeclarator_dummy_88 }
+tok_VariableDeclaratorList_dummy_87 { L.PosToken _ L.Tk__tok_VariableDeclaratorList_dummy_87 }
+tok_VariableInitializer_dummy_86 { L.PosToken _ L.Tk__tok_VariableInitializer_dummy_86 }
+tok_VariableInitializerList_dummy_85 { L.PosToken _ L.Tk__tok_VariableInitializerList_dummy_85 }
+tok_WhileStatement_dummy_84 { L.PosToken _ L.Tk__tok_WhileStatement_dummy_84 }
+tok_WildcardType_dummy_83 { L.PosToken _ L.Tk__tok_WildcardType_dummy_83 }
 tok__tilde__78 { L.PosToken _ L.Tk__tok__tilde__78 }
 tok__symbol__14 { L.PosToken _ L.Tk__tok__symbol__14 }
 tok__pipe__pipe__57 { L.PosToken _ L.Tk__tok__pipe__pipe__57 }
@@ -231,7 +230,6 @@ qq_WhileStatement { L.PosToken _ (L.Tk__qq_WhileStatement _) }
 qq_DoStatement { L.PosToken _ (L.Tk__qq_DoStatement _) }
 qq_IfStatement { L.PosToken _ (L.Tk__qq_IfStatement _) }
 qq_OptElsePart { L.PosToken _ (L.Tk__qq_OptElsePart _) }
-qq_StatementWithoutIf { L.PosToken _ (L.Tk__qq_StatementWithoutIf _) }
 qq_Statement { L.PosToken _ (L.Tk__qq_Statement _) }
 qq_OptId { L.PosToken _ (L.Tk__qq_OptId _) }
 qq_OptExpression { L.PosToken _ (L.Tk__qq_OptExpression _) }
@@ -255,7 +253,7 @@ qq_MemberDeclaration { L.PosToken _ (L.Tk__qq_MemberDeclaration _) }
 qq_NonEmptyDims { L.PosToken _ (L.Tk__qq_NonEmptyDims _) }
 qq_Dims { L.PosToken _ (L.Tk__qq_Dims _) }
 qq_FieldDeclaration { L.PosToken _ (L.Tk__qq_FieldDeclaration _) }
-qq_NestedTypeDeclaration { L.PosToken _ (L.Tk__qq_NestedTypeDeclaration _) }
+qq_TypeDeclRest { L.PosToken _ (L.Tk__qq_TypeDeclRest _) }
 qq_EnumDeclaration { L.PosToken _ (L.Tk__qq_EnumDeclaration _) }
 qq_EnumConstantList { L.PosToken _ (L.Tk__qq_EnumConstantList _) }
 qq_EnumConstant { L.PosToken _ (L.Tk__qq_EnumConstant _) }
@@ -285,127 +283,126 @@ qq_Java { L.PosToken _ (L.Tk__qq_Java _) }
 
 Java__top : Java rtk__eof { $1 }
 
-Java : tok_Java_dummy_166 Java tok_Java_dummy_166 { Ctr__Java__0 (rtkPosOf $1) $2 } |
-       tok_AdditiveOp_dummy_165 AdditiveOp tok_AdditiveOp_dummy_165 { Ctr__Java__1 (rtkPosOf $1) $2 } |
-       tok_Annotation_dummy_164 Annotation tok_Annotation_dummy_164 { Ctr__Java__2 (rtkPosOf $1) $2 } |
-       tok_AnnotationArguments_dummy_163 AnnotationArguments tok_AnnotationArguments_dummy_163 { Ctr__Java__3 (rtkPosOf $1) $2 } |
-       tok_AnnotationDeclaration_dummy_162 AnnotationDeclaration tok_AnnotationDeclaration_dummy_162 { Ctr__Java__4 (rtkPosOf $1) $2 } |
-       tok_AnnotationElement_dummy_161 AnnotationElement tok_AnnotationElement_dummy_161 { Ctr__Java__5 (rtkPosOf $1) $2 } |
-       tok_AnnotationList_dummy_160 AnnotationList tok_AnnotationList_dummy_160 { Ctr__Java__6 (rtkPosOf $1) (reverse $2) } |
-       tok_AnnotationTypeElement_dummy_159 AnnotationTypeElement tok_AnnotationTypeElement_dummy_159 { Ctr__Java__7 (rtkPosOf $1) $2 } |
-       tok_AnnotationTypeElementList_dummy_158 AnnotationTypeElementList tok_AnnotationTypeElementList_dummy_158 { Ctr__Java__8 (rtkPosOf $1) (reverse $2) } |
-       tok_Arglist_dummy_157 Arglist tok_Arglist_dummy_157 { Ctr__Java__9 (rtkPosOf $1) $2 } |
-       tok_AssignmentOp_dummy_156 AssignmentOp tok_AssignmentOp_dummy_156 { Ctr__Java__10 (rtkPosOf $1) $2 } |
-       tok_CatchList_dummy_155 CatchList tok_CatchList_dummy_155 { Ctr__Java__11 (rtkPosOf $1) (reverse $2) } |
-       tok_ClassDeclaration_dummy_154 ClassDeclaration tok_ClassDeclaration_dummy_154 { Ctr__Java__12 (rtkPosOf $1) $2 } |
-       tok_CompilationUnit_dummy_153 CompilationUnit tok_CompilationUnit_dummy_153 { Ctr__Java__13 (rtkPosOf $1) $2 } |
-       tok_CompoundName_dummy_152 CompoundName tok_CompoundName_dummy_152 { Ctr__Java__14 (rtkPosOf $1) $2 } |
-       tok_CreationExpression_dummy_151 CreationExpression tok_CreationExpression_dummy_151 { Ctr__Java__15 (rtkPosOf $1) $2 } |
-       tok_DimExprs_dummy_150 DimExprs tok_DimExprs_dummy_150 { Ctr__Java__16 (rtkPosOf $1) (reverse $2) } |
-       tok_Dims_dummy_149 Dims tok_Dims_dummy_149 { Ctr__Java__17 (rtkPosOf $1) (reverse $2) } |
-       tok_DoStatement_dummy_148 DoStatement tok_DoStatement_dummy_148 { Ctr__Java__18 (rtkPosOf $1) $2 } |
-       tok_DocComment_dummy_147 DocComment tok_DocComment_dummy_147 { Ctr__Java__19 (rtkPosOf $1) $2 } |
-       tok_EnumConstant_dummy_146 EnumConstant tok_EnumConstant_dummy_146 { Ctr__Java__20 (rtkPosOf $1) $2 } |
-       tok_EnumConstantList_dummy_145 EnumConstantList tok_EnumConstantList_dummy_145 { Ctr__Java__21 (rtkPosOf $1) $2 } |
-       tok_EnumDeclaration_dummy_144 EnumDeclaration tok_EnumDeclaration_dummy_144 { Ctr__Java__22 (rtkPosOf $1) $2 } |
-       tok_EqualityOp_dummy_143 EqualityOp tok_EqualityOp_dummy_143 { Ctr__Java__23 (rtkPosOf $1) $2 } |
-       tok_Expression_dummy_142 Expression tok_Expression_dummy_142 { Ctr__Java__24 (rtkPosOf $1) $2 } |
-       tok_ExtendsList_dummy_141 ExtendsList tok_ExtendsList_dummy_141 { Ctr__Java__25 (rtkPosOf $1) $2 } |
-       tok_FieldDeclaration_dummy_140 FieldDeclaration tok_FieldDeclaration_dummy_140 { Ctr__Java__26 (rtkPosOf $1) $2 } |
-       tok_FieldDeclarationList_dummy_139 FieldDeclarationList tok_FieldDeclarationList_dummy_139 { Ctr__Java__27 (rtkPosOf $1) (reverse $2) } |
-       tok_ForStatement_dummy_138 ForStatement tok_ForStatement_dummy_138 { Ctr__Java__28 (rtkPosOf $1) $2 } |
-       tok_IfStatement_dummy_137 IfStatement tok_IfStatement_dummy_137 { Ctr__Java__29 (rtkPosOf $1) $2 } |
-       tok_ImplementsList_dummy_136 ImplementsList tok_ImplementsList_dummy_136 { Ctr__Java__30 (rtkPosOf $1) $2 } |
-       tok_ImportList_dummy_135 ImportList tok_ImportList_dummy_135 { Ctr__Java__31 (rtkPosOf $1) (reverse $2) } |
-       tok_ImportStatement_dummy_134 ImportStatement tok_ImportStatement_dummy_134 { Ctr__Java__32 (rtkPosOf $1) $2 } |
-       tok_InterfaceDeclaration_dummy_133 InterfaceDeclaration tok_InterfaceDeclaration_dummy_133 { Ctr__Java__33 (rtkPosOf $1) $2 } |
-       tok_Literal_dummy_132 Literal tok_Literal_dummy_132 { Ctr__Java__34 (rtkPosOf $1) $2 } |
-       tok_MemberAfterFirstId_dummy_131 MemberAfterFirstId tok_MemberAfterFirstId_dummy_131 { Ctr__Java__35 (rtkPosOf $1) $2 } |
-       tok_MemberDeclaration_dummy_130 MemberDeclaration tok_MemberDeclaration_dummy_130 { Ctr__Java__36 (rtkPosOf $1) $2 } |
-       tok_MemberRest_dummy_129 MemberRest tok_MemberRest_dummy_129 { Ctr__Java__37 (rtkPosOf $1) $2 } |
-       tok_Modifier_dummy_128 Modifier tok_Modifier_dummy_128 { Ctr__Java__38 (rtkPosOf $1) $2 } |
-       tok_ModifierList_dummy_127 ModifierList tok_ModifierList_dummy_127 { Ctr__Java__39 (rtkPosOf $1) (reverse $2) } |
-       tok_MoreTypeSpecifier_dummy_126 MoreTypeSpecifier tok_MoreTypeSpecifier_dummy_126 { Ctr__Java__40 (rtkPosOf $1) $2 } |
-       tok_MoreVariableDeclarators_dummy_125 MoreVariableDeclarators tok_MoreVariableDeclarators_dummy_125 { Ctr__Java__41 (rtkPosOf $1) (reverse $2) } |
-       tok_MultiplicativeOp_dummy_124 MultiplicativeOp tok_MultiplicativeOp_dummy_124 { Ctr__Java__42 (rtkPosOf $1) $2 } |
-       tok_NestedTypeDeclaration_dummy_123 NestedTypeDeclaration tok_NestedTypeDeclaration_dummy_123 { Ctr__Java__43 (rtkPosOf $1) $2 } |
-       tok_NonEmptyDims_dummy_122 NonEmptyDims tok_NonEmptyDims_dummy_122 { Ctr__Java__44 (rtkPosOf $1) (reverse $2) } |
-       tok_NonEmptyTypeArguments_dummy_121 NonEmptyTypeArguments tok_NonEmptyTypeArguments_dummy_121 { Ctr__Java__45 (rtkPosOf $1) $2 } |
-       tok_OptDocComment_dummy_120 OptDocComment tok_OptDocComment_dummy_120 { Ctr__Java__46 (rtkPosOf $1) $2 } |
-       tok_OptElsePart_dummy_119 OptElsePart tok_OptElsePart_dummy_119 { Ctr__Java__47 (rtkPosOf $1) $2 } |
-       tok_OptExpression_dummy_118 OptExpression tok_OptExpression_dummy_118 { Ctr__Java__48 (rtkPosOf $1) $2 } |
-       tok_OptFinally_dummy_117 OptFinally tok_OptFinally_dummy_117 { Ctr__Java__49 (rtkPosOf $1) $2 } |
-       tok_OptId_dummy_116 OptId tok_OptId_dummy_116 { Ctr__Java__50 (rtkPosOf $1) $2 } |
-       tok_OptVariableInitializer_dummy_115 OptVariableInitializer tok_OptVariableInitializer_dummy_115 { Ctr__Java__51 (rtkPosOf $1) $2 } |
-       tok_Package_dummy_114 Package tok_Package_dummy_114 { Ctr__Java__52 (rtkPosOf $1) $2 } |
-       tok_Parameter_dummy_113 Parameter tok_Parameter_dummy_113 { Ctr__Java__53 (rtkPosOf $1) $2 } |
-       tok_ParameterList_dummy_112 ParameterList tok_ParameterList_dummy_112 { Ctr__Java__54 (rtkPosOf $1) $2 } |
-       tok_PostfixOp_dummy_111 PostfixOp tok_PostfixOp_dummy_111 { Ctr__Java__55 (rtkPosOf $1) $2 } |
-       tok_PrefixOp_dummy_110 PrefixOp tok_PrefixOp_dummy_110 { Ctr__Java__56 (rtkPosOf $1) $2 } |
-       tok_PrimitiveTypeKeyword_dummy_109 PrimitiveTypeKeyword tok_PrimitiveTypeKeyword_dummy_109 { Ctr__Java__57 (rtkPosOf $1) $2 } |
-       tok_RelationalOp_dummy_108 RelationalOp tok_RelationalOp_dummy_108 { Ctr__Java__58 (rtkPosOf $1) $2 } |
-       tok_ShiftOp_dummy_107 ShiftOp tok_ShiftOp_dummy_107 { Ctr__Java__59 (rtkPosOf $1) $2 } |
-       tok_Statement_dummy_106 Statement tok_Statement_dummy_106 { Ctr__Java__60 (rtkPosOf $1) $2 } |
-       tok_StatementBlock_dummy_105 StatementBlock tok_StatementBlock_dummy_105 { Ctr__Java__61 (rtkPosOf $1) $2 } |
-       tok_StatementList_dummy_104 StatementList tok_StatementList_dummy_104 { Ctr__Java__62 (rtkPosOf $1) (reverse $2) } |
-       tok_StatementWithoutIf_dummy_103 StatementWithoutIf tok_StatementWithoutIf_dummy_103 { Ctr__Java__63 (rtkPosOf $1) $2 } |
-       tok_StaticInitializer_dummy_102 StaticInitializer tok_StaticInitializer_dummy_102 { Ctr__Java__64 (rtkPosOf $1) $2 } |
-       tok_SwitchCaseList_dummy_101 SwitchCaseList tok_SwitchCaseList_dummy_101 { Ctr__Java__65 (rtkPosOf $1) (reverse $2) } |
-       tok_SwitchStatement_dummy_100 SwitchStatement tok_SwitchStatement_dummy_100 { Ctr__Java__66 (rtkPosOf $1) $2 } |
-       tok_TryStatement_dummy_99 TryStatement tok_TryStatement_dummy_99 { Ctr__Java__67 (rtkPosOf $1) $2 } |
-       tok_Type_dummy_98 Type tok_Type_dummy_98 { Ctr__Java__68 (rtkPosOf $1) $2 } |
-       tok_TypeArgument_dummy_97 TypeArgument tok_TypeArgument_dummy_97 { Ctr__Java__69 (rtkPosOf $1) $2 } |
-       tok_TypeArguments_dummy_96 TypeArguments tok_TypeArguments_dummy_96 { Ctr__Java__70 (rtkPosOf $1) $2 } |
-       tok_TypeDeclaration_dummy_95 TypeDeclaration tok_TypeDeclaration_dummy_95 { Ctr__Java__71 (rtkPosOf $1) $2 } |
-       tok_TypeParameter_dummy_94 TypeParameter tok_TypeParameter_dummy_94 { Ctr__Java__72 (rtkPosOf $1) $2 } |
-       tok_TypeParameters_dummy_93 TypeParameters tok_TypeParameters_dummy_93 { Ctr__Java__73 (rtkPosOf $1) $2 } |
-       tok_TypeSpecifier_dummy_92 TypeSpecifier tok_TypeSpecifier_dummy_92 { Ctr__Java__74 (rtkPosOf $1) $2 } |
-       tok_VariableDeclaration_dummy_91 VariableDeclaration tok_VariableDeclaration_dummy_91 { Ctr__Java__75 (rtkPosOf $1) $2 } |
-       tok_VariableDeclarator_dummy_90 VariableDeclarator tok_VariableDeclarator_dummy_90 { Ctr__Java__76 (rtkPosOf $1) $2 } |
-       tok_VariableDeclaratorList_dummy_89 VariableDeclaratorList tok_VariableDeclaratorList_dummy_89 { Ctr__Java__77 (rtkPosOf $1) $2 } |
-       tok_VariableInitializer_dummy_88 VariableInitializer tok_VariableInitializer_dummy_88 { Ctr__Java__78 (rtkPosOf $1) $2 } |
-       tok_VariableInitializerList_dummy_87 VariableInitializerList tok_VariableInitializerList_dummy_87 { Ctr__Java__79 (rtkPosOf $1) $2 } |
-       tok_WhileStatement_dummy_86 WhileStatement tok_WhileStatement_dummy_86 { Ctr__Java__80 (rtkPosOf $1) $2 } |
-       tok_WildcardType_dummy_85 WildcardType tok_WildcardType_dummy_85 { Ctr__Java__81 (rtkPosOf $1) $2 }
+Java : tok_Java_dummy_163 Java tok_Java_dummy_163 { Ctr__Java__0 (rtkPosOf $1) $2 } |
+       tok_AdditiveOp_dummy_162 AdditiveOp tok_AdditiveOp_dummy_162 { Ctr__Java__1 (rtkPosOf $1) $2 } |
+       tok_Annotation_dummy_161 Annotation tok_Annotation_dummy_161 { Ctr__Java__2 (rtkPosOf $1) $2 } |
+       tok_AnnotationArguments_dummy_160 AnnotationArguments tok_AnnotationArguments_dummy_160 { Ctr__Java__3 (rtkPosOf $1) $2 } |
+       tok_AnnotationDeclaration_dummy_159 AnnotationDeclaration tok_AnnotationDeclaration_dummy_159 { Ctr__Java__4 (rtkPosOf $1) $2 } |
+       tok_AnnotationElement_dummy_158 AnnotationElement tok_AnnotationElement_dummy_158 { Ctr__Java__5 (rtkPosOf $1) $2 } |
+       tok_AnnotationList_dummy_157 AnnotationList tok_AnnotationList_dummy_157 { Ctr__Java__6 (rtkPosOf $1) (reverse $2) } |
+       tok_AnnotationTypeElement_dummy_156 AnnotationTypeElement tok_AnnotationTypeElement_dummy_156 { Ctr__Java__7 (rtkPosOf $1) $2 } |
+       tok_AnnotationTypeElementList_dummy_155 AnnotationTypeElementList tok_AnnotationTypeElementList_dummy_155 { Ctr__Java__8 (rtkPosOf $1) (reverse $2) } |
+       tok_Arglist_dummy_154 Arglist tok_Arglist_dummy_154 { Ctr__Java__9 (rtkPosOf $1) $2 } |
+       tok_AssignmentOp_dummy_153 AssignmentOp tok_AssignmentOp_dummy_153 { Ctr__Java__10 (rtkPosOf $1) $2 } |
+       tok_CatchList_dummy_152 CatchList tok_CatchList_dummy_152 { Ctr__Java__11 (rtkPosOf $1) (reverse $2) } |
+       tok_ClassDeclaration_dummy_151 ClassDeclaration tok_ClassDeclaration_dummy_151 { Ctr__Java__12 (rtkPosOf $1) $2 } |
+       tok_CompilationUnit_dummy_150 CompilationUnit tok_CompilationUnit_dummy_150 { Ctr__Java__13 (rtkPosOf $1) $2 } |
+       tok_CompoundName_dummy_149 CompoundName tok_CompoundName_dummy_149 { Ctr__Java__14 (rtkPosOf $1) $2 } |
+       tok_CreationExpression_dummy_148 CreationExpression tok_CreationExpression_dummy_148 { Ctr__Java__15 (rtkPosOf $1) $2 } |
+       tok_DimExprs_dummy_147 DimExprs tok_DimExprs_dummy_147 { Ctr__Java__16 (rtkPosOf $1) (reverse $2) } |
+       tok_Dims_dummy_146 Dims tok_Dims_dummy_146 { Ctr__Java__17 (rtkPosOf $1) (reverse $2) } |
+       tok_DoStatement_dummy_145 DoStatement tok_DoStatement_dummy_145 { Ctr__Java__18 (rtkPosOf $1) $2 } |
+       tok_DocComment_dummy_144 DocComment tok_DocComment_dummy_144 { Ctr__Java__19 (rtkPosOf $1) $2 } |
+       tok_EnumConstant_dummy_143 EnumConstant tok_EnumConstant_dummy_143 { Ctr__Java__20 (rtkPosOf $1) $2 } |
+       tok_EnumConstantList_dummy_142 EnumConstantList tok_EnumConstantList_dummy_142 { Ctr__Java__21 (rtkPosOf $1) $2 } |
+       tok_EnumDeclaration_dummy_141 EnumDeclaration tok_EnumDeclaration_dummy_141 { Ctr__Java__22 (rtkPosOf $1) $2 } |
+       tok_EqualityOp_dummy_140 EqualityOp tok_EqualityOp_dummy_140 { Ctr__Java__23 (rtkPosOf $1) $2 } |
+       tok_Expression_dummy_139 Expression tok_Expression_dummy_139 { Ctr__Java__24 (rtkPosOf $1) $2 } |
+       tok_ExtendsList_dummy_138 ExtendsList tok_ExtendsList_dummy_138 { Ctr__Java__25 (rtkPosOf $1) $2 } |
+       tok_FieldDeclaration_dummy_137 FieldDeclaration tok_FieldDeclaration_dummy_137 { Ctr__Java__26 (rtkPosOf $1) $2 } |
+       tok_FieldDeclarationList_dummy_136 FieldDeclarationList tok_FieldDeclarationList_dummy_136 { Ctr__Java__27 (rtkPosOf $1) (reverse $2) } |
+       tok_ForStatement_dummy_135 ForStatement tok_ForStatement_dummy_135 { Ctr__Java__28 (rtkPosOf $1) $2 } |
+       tok_IfStatement_dummy_134 IfStatement tok_IfStatement_dummy_134 { Ctr__Java__29 (rtkPosOf $1) $2 } |
+       tok_ImplementsList_dummy_133 ImplementsList tok_ImplementsList_dummy_133 { Ctr__Java__30 (rtkPosOf $1) $2 } |
+       tok_ImportList_dummy_132 ImportList tok_ImportList_dummy_132 { Ctr__Java__31 (rtkPosOf $1) (reverse $2) } |
+       tok_ImportStatement_dummy_131 ImportStatement tok_ImportStatement_dummy_131 { Ctr__Java__32 (rtkPosOf $1) $2 } |
+       tok_InterfaceDeclaration_dummy_130 InterfaceDeclaration tok_InterfaceDeclaration_dummy_130 { Ctr__Java__33 (rtkPosOf $1) $2 } |
+       tok_Literal_dummy_129 Literal tok_Literal_dummy_129 { Ctr__Java__34 (rtkPosOf $1) $2 } |
+       tok_MemberAfterFirstId_dummy_128 MemberAfterFirstId tok_MemberAfterFirstId_dummy_128 { Ctr__Java__35 (rtkPosOf $1) $2 } |
+       tok_MemberDeclaration_dummy_127 MemberDeclaration tok_MemberDeclaration_dummy_127 { Ctr__Java__36 (rtkPosOf $1) $2 } |
+       tok_MemberRest_dummy_126 MemberRest tok_MemberRest_dummy_126 { Ctr__Java__37 (rtkPosOf $1) $2 } |
+       tok_Modifier_dummy_125 Modifier tok_Modifier_dummy_125 { Ctr__Java__38 (rtkPosOf $1) $2 } |
+       tok_ModifierList_dummy_124 ModifierList tok_ModifierList_dummy_124 { Ctr__Java__39 (rtkPosOf $1) (reverse $2) } |
+       tok_MoreTypeSpecifier_dummy_123 MoreTypeSpecifier tok_MoreTypeSpecifier_dummy_123 { Ctr__Java__40 (rtkPosOf $1) $2 } |
+       tok_MoreVariableDeclarators_dummy_122 MoreVariableDeclarators tok_MoreVariableDeclarators_dummy_122 { Ctr__Java__41 (rtkPosOf $1) (reverse $2) } |
+       tok_MultiplicativeOp_dummy_121 MultiplicativeOp tok_MultiplicativeOp_dummy_121 { Ctr__Java__42 (rtkPosOf $1) $2 } |
+       tok_NonEmptyDims_dummy_120 NonEmptyDims tok_NonEmptyDims_dummy_120 { Ctr__Java__43 (rtkPosOf $1) (reverse $2) } |
+       tok_NonEmptyTypeArguments_dummy_119 NonEmptyTypeArguments tok_NonEmptyTypeArguments_dummy_119 { Ctr__Java__44 (rtkPosOf $1) $2 } |
+       tok_OptDocComment_dummy_118 OptDocComment tok_OptDocComment_dummy_118 { Ctr__Java__45 (rtkPosOf $1) $2 } |
+       tok_OptElsePart_dummy_117 OptElsePart tok_OptElsePart_dummy_117 { Ctr__Java__46 (rtkPosOf $1) $2 } |
+       tok_OptExpression_dummy_116 OptExpression tok_OptExpression_dummy_116 { Ctr__Java__47 (rtkPosOf $1) $2 } |
+       tok_OptFinally_dummy_115 OptFinally tok_OptFinally_dummy_115 { Ctr__Java__48 (rtkPosOf $1) $2 } |
+       tok_OptId_dummy_114 OptId tok_OptId_dummy_114 { Ctr__Java__49 (rtkPosOf $1) $2 } |
+       tok_OptVariableInitializer_dummy_113 OptVariableInitializer tok_OptVariableInitializer_dummy_113 { Ctr__Java__50 (rtkPosOf $1) $2 } |
+       tok_Package_dummy_112 Package tok_Package_dummy_112 { Ctr__Java__51 (rtkPosOf $1) $2 } |
+       tok_Parameter_dummy_111 Parameter tok_Parameter_dummy_111 { Ctr__Java__52 (rtkPosOf $1) $2 } |
+       tok_ParameterList_dummy_110 ParameterList tok_ParameterList_dummy_110 { Ctr__Java__53 (rtkPosOf $1) $2 } |
+       tok_PostfixOp_dummy_109 PostfixOp tok_PostfixOp_dummy_109 { Ctr__Java__54 (rtkPosOf $1) $2 } |
+       tok_PrefixOp_dummy_108 PrefixOp tok_PrefixOp_dummy_108 { Ctr__Java__55 (rtkPosOf $1) $2 } |
+       tok_PrimitiveTypeKeyword_dummy_107 PrimitiveTypeKeyword tok_PrimitiveTypeKeyword_dummy_107 { Ctr__Java__56 (rtkPosOf $1) $2 } |
+       tok_RelationalOp_dummy_106 RelationalOp tok_RelationalOp_dummy_106 { Ctr__Java__57 (rtkPosOf $1) $2 } |
+       tok_ShiftOp_dummy_105 ShiftOp tok_ShiftOp_dummy_105 { Ctr__Java__58 (rtkPosOf $1) $2 } |
+       tok_Statement_dummy_104 Statement tok_Statement_dummy_104 { Ctr__Java__59 (rtkPosOf $1) $2 } |
+       tok_StatementBlock_dummy_103 StatementBlock tok_StatementBlock_dummy_103 { Ctr__Java__60 (rtkPosOf $1) $2 } |
+       tok_StatementList_dummy_102 StatementList tok_StatementList_dummy_102 { Ctr__Java__61 (rtkPosOf $1) (reverse $2) } |
+       tok_StaticInitializer_dummy_101 StaticInitializer tok_StaticInitializer_dummy_101 { Ctr__Java__62 (rtkPosOf $1) $2 } |
+       tok_SwitchCaseList_dummy_100 SwitchCaseList tok_SwitchCaseList_dummy_100 { Ctr__Java__63 (rtkPosOf $1) (reverse $2) } |
+       tok_SwitchStatement_dummy_99 SwitchStatement tok_SwitchStatement_dummy_99 { Ctr__Java__64 (rtkPosOf $1) $2 } |
+       tok_TryStatement_dummy_98 TryStatement tok_TryStatement_dummy_98 { Ctr__Java__65 (rtkPosOf $1) $2 } |
+       tok_Type_dummy_97 Type tok_Type_dummy_97 { Ctr__Java__66 (rtkPosOf $1) $2 } |
+       tok_TypeArgument_dummy_96 TypeArgument tok_TypeArgument_dummy_96 { Ctr__Java__67 (rtkPosOf $1) $2 } |
+       tok_TypeArguments_dummy_95 TypeArguments tok_TypeArguments_dummy_95 { Ctr__Java__68 (rtkPosOf $1) $2 } |
+       tok_TypeDeclRest_dummy_94 TypeDeclRest tok_TypeDeclRest_dummy_94 { Ctr__Java__69 (rtkPosOf $1) $2 } |
+       tok_TypeDeclaration_dummy_93 TypeDeclaration tok_TypeDeclaration_dummy_93 { Ctr__Java__70 (rtkPosOf $1) $2 } |
+       tok_TypeParameter_dummy_92 TypeParameter tok_TypeParameter_dummy_92 { Ctr__Java__71 (rtkPosOf $1) $2 } |
+       tok_TypeParameters_dummy_91 TypeParameters tok_TypeParameters_dummy_91 { Ctr__Java__72 (rtkPosOf $1) $2 } |
+       tok_TypeSpecifier_dummy_90 TypeSpecifier tok_TypeSpecifier_dummy_90 { Ctr__Java__73 (rtkPosOf $1) $2 } |
+       tok_VariableDeclaration_dummy_89 VariableDeclaration tok_VariableDeclaration_dummy_89 { Ctr__Java__74 (rtkPosOf $1) $2 } |
+       tok_VariableDeclarator_dummy_88 VariableDeclarator tok_VariableDeclarator_dummy_88 { Ctr__Java__75 (rtkPosOf $1) $2 } |
+       tok_VariableDeclaratorList_dummy_87 VariableDeclaratorList tok_VariableDeclaratorList_dummy_87 { Ctr__Java__76 (rtkPosOf $1) $2 } |
+       tok_VariableInitializer_dummy_86 VariableInitializer tok_VariableInitializer_dummy_86 { Ctr__Java__77 (rtkPosOf $1) $2 } |
+       tok_VariableInitializerList_dummy_85 VariableInitializerList tok_VariableInitializerList_dummy_85 { Ctr__Java__78 (rtkPosOf $1) $2 } |
+       tok_WhileStatement_dummy_84 WhileStatement tok_WhileStatement_dummy_84 { Ctr__Java__79 (rtkPosOf $1) $2 } |
+       tok_WildcardType_dummy_83 WildcardType tok_WildcardType_dummy_83 { Ctr__Java__80 (rtkPosOf $1) $2 }
 
 Java : qq_Java { Anti_Java (tkVal_qq_Java $1) } |
-       CompilationUnit { Ctr__Java__82 (rtkPosOf $1) $1 }
+       CompilationUnit { Ctr__Java__81 (rtkPosOf $1) $1 }
 
 AdditiveOp : qq_AdditiveOp { Anti_AdditiveOp (tkVal_qq_AdditiveOp $1) } |
              tok__plus__72 { Ctr__AdditiveOp__0 (rtkPosOf $1) } |
              tok__minus__73 { Ctr__AdditiveOp__1 (rtkPosOf $1) }
 
-ListElem_AnnotationList10 : qq_AnnotationList { Anti_Annotation (tkVal_qq_AnnotationList $1) } |
-                            Annotation { $1 }
+ListElem_AnnotationList9 : qq_AnnotationList { Anti_Annotation (tkVal_qq_AnnotationList $1) } |
+                           Annotation { $1 }
 
 Annotation : qq_Annotation { Anti_Annotation (tkVal_qq_Annotation $1) } |
-             tok__symbol__5 CompoundName Rule_5 { Ctr__Annotation__1 (rtkPosOf $1) $2 $3 }
+             tok__symbol__5 CompoundName Rule_4 { Ctr__Annotation__1 (rtkPosOf $1) $2 $3 }
 
 AnnotationArguments : qq_AnnotationArguments { Anti_AnnotationArguments (tkVal_qq_AnnotationArguments $1) } |
-                      AnnotationElement Rule_8 { Ctr__AnnotationArguments__0 (rtkPosOf $1) $1 (reverse $2) }
+                      AnnotationElement Rule_7 { Ctr__AnnotationArguments__0 (rtkPosOf $1) $1 (reverse $2) }
 
 AnnotationDeclaration : qq_AnnotationDeclaration { Anti_AnnotationDeclaration (tkVal_qq_AnnotationDeclaration $1) } |
-                        ModifierList tok__symbol__5 tok_interface_15 id tok__symbol__13 AnnotationTypeElementList tok__symbol__14 { Ctr__AnnotationDeclaration__0 (rtkPosOf (reverse $1)) (reverse $1) (tkVal_id $4) (reverse $6) }
+                        tok__symbol__5 tok_interface_15 id tok__symbol__13 AnnotationTypeElementList tok__symbol__14 { Ctr__AnnotationDeclaration__0 (rtkPosOf $1) (tkVal_id $3) (reverse $5) }
 
 AnnotationElement : qq_AnnotationElement { Anti_AnnotationElement (tkVal_qq_AnnotationElement $1) } |
                     id tok__eql__9 ConditionalExpression { Ctr__AnnotationElement__0 (rtkPosOf $1) (tkVal_id $1) $3 } |
                     ConditionalExpression { Ctr__AnnotationElement__1 (rtkPosOf $1) $1 }
 
 AnnotationList : {- empty -} { [] } |
-                 AnnotationList ListElem_AnnotationList10 { $2 : $1 }
+                 AnnotationList ListElem_AnnotationList9 { $2 : $1 }
 
 AnnotationTypeElement : qq_AnnotationTypeElement { Anti_AnnotationTypeElement (tkVal_qq_AnnotationTypeElement $1) } |
                         FieldDeclaration { Ctr__AnnotationTypeElement__0 (rtkPosOf $1) $1 }
 
-ListElem_AnnotationTypeElementList20 : qq_AnnotationTypeElementList { Anti_AnnotationTypeElement (tkVal_qq_AnnotationTypeElementList $1) } |
+ListElem_AnnotationTypeElementList19 : qq_AnnotationTypeElementList { Anti_AnnotationTypeElement (tkVal_qq_AnnotationTypeElementList $1) } |
                                        AnnotationTypeElement { $1 }
 
 AnnotationTypeElementList : {- empty -} { [] } |
-                            AnnotationTypeElementList ListElem_AnnotationTypeElementList20 { $2 : $1 }
+                            AnnotationTypeElementList ListElem_AnnotationTypeElementList19 { $2 : $1 }
 
 Arglist : qq_Arglist { Anti_Arglist (tkVal_qq_Arglist $1) } |
           { Ctr__Arglist__0 rtkNoPos } |
-          Rule_71 { Ctr__Arglist__1 (rtkPosOf $1) $1 }
+          Rule_69 { Ctr__Arglist__1 (rtkPosOf $1) $1 }
 
 AssignmentOp : qq_AssignmentOp { Anti_AssignmentOp (tkVal_qq_AssignmentOp $1) } |
                tok__eql__9 { Ctr__AssignmentOp__0 (rtkPosOf $1) } |
@@ -422,25 +419,25 @@ AssignmentOp : qq_AssignmentOp { Anti_AssignmentOp (tkVal_qq_AssignmentOp $1) } 
                tok__symbol__symbol__symbol__eql__55 { Ctr__AssignmentOp__11 (rtkPosOf $1) }
 
 CatchList : {- empty -} { [] } |
-            CatchList ListElem_CatchList57 { $2 : $1 }
+            CatchList ListElem_CatchList55 { $2 : $1 }
 
 ClassDeclaration : qq_ClassDeclaration { Anti_ClassDeclaration (tkVal_qq_ClassDeclaration $1) } |
-                   ModifierList tok_class_12 id TypeParameters Rule_17 Rule_18 tok__symbol__13 FieldDeclarationList tok__symbol__14 { Ctr__ClassDeclaration__0 (rtkPosOf (reverse $1)) (reverse $1) (tkVal_id $3) $4 $5 $6 (reverse $8) }
+                   tok_class_12 id TypeParameters Rule_16 Rule_17 tok__symbol__13 FieldDeclarationList tok__symbol__14 { Ctr__ClassDeclaration__0 (rtkPosOf $1) (tkVal_id $2) $3 $4 $5 (reverse $7) }
 
 CompilationUnit : qq_CompilationUnit { Anti_CompilationUnit (tkVal_qq_CompilationUnit $1) } |
-                  Rule_2 ImportList Rule_3 { Ctr__CompilationUnit__0 (rtkPosOf $1) $1 (reverse $2) $3 }
+                  Rule_1 ImportList Rule_2 { Ctr__CompilationUnit__0 (rtkPosOf $1) $1 (reverse $2) $3 }
 
 CompoundName : qq_CompoundName { Anti_CompoundName (tkVal_qq_CompoundName $1) } |
-               id Rule_83 { Ctr__CompoundName__0 (rtkPosOf $1) (tkVal_id $1) (reverse $2) }
+               id Rule_81 { Ctr__CompoundName__0 (rtkPosOf $1) (tkVal_id $1) (reverse $2) }
 
 CreationExpression : qq_CreationExpression { Anti_CreationExpression (tkVal_qq_CreationExpression $1) } |
-                     tok_new_82 TypeSpecifier Rule_67 { Ctr__CreationExpression__0 (rtkPosOf $1) $2 $3 }
+                     tok_new_82 TypeSpecifier Rule_65 { Ctr__CreationExpression__0 (rtkPosOf $1) $2 $3 }
 
-DimExprs : ListElem_DimExprs70 { [$1] } |
-           DimExprs ListElem_DimExprs70 { $2 : $1 }
+DimExprs : ListElem_DimExprs68 { [$1] } |
+           DimExprs ListElem_DimExprs68 { $2 : $1 }
 
 Dims : {- empty -} { [] } |
-       Dims ListElem_Dims34 { $2 : $1 }
+       Dims ListElem_Dims32 { $2 : $1 }
 
 DoStatement : qq_DoStatement { Anti_DoStatement (tkVal_qq_DoStatement $1) } |
               tok_do_37 Statement tok_while_38 tok__lparen__6 Expression tok__rparen__7 tok__semi__1 { Ctr__DoStatement__0 (rtkPosOf $1) $2 $5 }
@@ -449,13 +446,13 @@ DocComment : qq_DocComment { Anti_DocComment (tkVal_qq_DocComment $1) } |
              doccomment { Ctr__DocComment__0 (rtkPosOf $1) (tkVal_doccomment $1) }
 
 EnumConstant : qq_EnumConstant { Anti_EnumConstant (tkVal_qq_EnumConstant $1) } |
-               AnnotationList id Rule_21 Rule_23 { Ctr__EnumConstant__0 (rtkPosOf (reverse $1)) (reverse $1) (tkVal_id $2) $3 $4 }
+               AnnotationList id Rule_20 Rule_22 { Ctr__EnumConstant__0 (rtkPosOf (reverse $1)) (reverse $1) (tkVal_id $2) $3 $4 }
 
 EnumConstantList : qq_EnumConstantList { Anti_EnumConstantList (tkVal_qq_EnumConstantList $1) } |
-                   EnumConstant Rule_25 Rule_27 { Ctr__EnumConstantList__0 (rtkPosOf $1) $1 (reverse $2) $3 }
+                   EnumConstant Rule_24 Rule_26 { Ctr__EnumConstantList__0 (rtkPosOf $1) $1 (reverse $2) $3 }
 
 EnumDeclaration : qq_EnumDeclaration { Anti_EnumDeclaration (tkVal_qq_EnumDeclaration $1) } |
-                  ModifierList tok_enum_16 id Rule_28 tok__symbol__13 EnumConstantList Rule_29 tok__symbol__14 { Ctr__EnumDeclaration__0 (rtkPosOf (reverse $1)) (reverse $1) (tkVal_id $3) $4 $6 $7 }
+                  tok_enum_16 id Rule_27 tok__symbol__13 EnumConstantList Rule_28 tok__symbol__14 { Ctr__EnumDeclaration__0 (rtkPosOf $1) (tkVal_id $2) $3 $5 $6 }
 
 EqualityOp : qq_EqualityOp { Anti_EqualityOp (tkVal_qq_EqualityOp $1) } |
              tok__eql__eql__62 { Ctr__EqualityOp__0 (rtkPosOf $1) } |
@@ -466,9 +463,9 @@ PrimaryNoPostfix : qq_Expression { Anti_Expression (tkVal_qq_Expression $1) } |
                    tok_this_80 { Ctr__Expression__1 (rtkPosOf $1) } |
                    tok__lparen__6 Expression tok__rparen__7 { Ctr__Expression__2 (rtkPosOf $1) $2 } |
                    CreationExpression { Ctr__Expression__3 (rtkPosOf $1) $1 } |
-                   CompoundName Rule_63 { Ctr__Expression__4 (rtkPosOf $1) $1 $2 } |
+                   CompoundName Rule_61 { Ctr__Expression__4 (rtkPosOf $1) $1 $2 } |
                    CompoundName tok__sq_bkt_l__17 Expression tok__sq_bkt_r__18 { Ctr__Expression__5 (rtkPosOf $1) $1 $3 } |
-                   tok_super_81 tok__dot__3 id Rule_65 { Ctr__Expression__6 (rtkPosOf $1) (tkVal_id $3) $4 }
+                   tok_super_81 tok__dot__3 id Rule_63 { Ctr__Expression__6 (rtkPosOf $1) (tkVal_id $3) $4 }
 
 PostfixExpression : PrimaryNoPostfix { Ctr__Expression__7 (rtkPosOf $1) $1 } |
                     PostfixExpression PostfixOp { Ctr__Expression__8 (rtkPosOf $1) $1 $2 } |
@@ -523,43 +520,43 @@ ConditionalOrExpression : ConditionalAndExpression { Ctr__Expression__41 (rtkPos
 ConditionalExpression : ConditionalOrExpression { Ctr__Expression__43 (rtkPosOf $1) $1 } |
                         ConditionalOrExpression tok__symbol__56 Expression tok__colon__32 ConditionalExpression { Ctr__Expression__44 (rtkPosOf $1) $1 $3 $5 }
 
-AssignmentExpression : ConditionalExpression Rule_61 { Ctr__Expression__45 (rtkPosOf $1) $1 $2 }
+AssignmentExpression : ConditionalExpression Rule_59 { Ctr__Expression__45 (rtkPosOf $1) $1 $2 }
 
 Expression : AssignmentExpression { Ctr__Expression__46 (rtkPosOf $1) $1 }
 
 ExtendsList : qq_ExtendsList { Anti_ExtendsList (tkVal_qq_ExtendsList $1) } |
-              tok_extends_10 CompoundName Rule_13 { Ctr__ExtendsList__0 (rtkPosOf $1) $2 (reverse $3) }
+              tok_extends_10 CompoundName Rule_12 { Ctr__ExtendsList__0 (rtkPosOf $1) $2 (reverse $3) }
 
 FieldDeclaration : qq_FieldDeclaration { Anti_FieldDeclaration (tkVal_qq_FieldDeclaration $1) } |
-                   OptDocComment Rule_31 { Ctr__FieldDeclaration__0 (rtkPosOf $1) $1 $2 } |
+                   OptDocComment ModifierList Rule_30 { Ctr__FieldDeclaration__0 (rtkPosOf $1) $1 (reverse $2) $3 } |
                    tok__semi__1 { Ctr__FieldDeclaration__1 (rtkPosOf $1) }
 
-ListElem_FieldDeclarationList16 : qq_FieldDeclarationList { Anti_FieldDeclaration (tkVal_qq_FieldDeclarationList $1) } |
+ListElem_FieldDeclarationList15 : qq_FieldDeclarationList { Anti_FieldDeclaration (tkVal_qq_FieldDeclarationList $1) } |
                                   FieldDeclaration { $1 }
 
 FieldDeclarationList : {- empty -} { [] } |
-                       FieldDeclarationList ListElem_FieldDeclarationList16 { $2 : $1 }
+                       FieldDeclarationList ListElem_FieldDeclarationList15 { $2 : $1 }
 
 ForStatement : qq_ForStatement { Anti_ForStatement (tkVal_qq_ForStatement $1) } |
-               tok_for_39 tok__lparen__6 Rule_55 OptExpression tok__semi__1 OptExpression tok__rparen__7 Statement { Ctr__ForStatement__0 (rtkPosOf $1) $3 $4 $6 $8 }
+               tok_for_39 tok__lparen__6 Rule_53 OptExpression tok__semi__1 OptExpression tok__rparen__7 Statement { Ctr__ForStatement__0 (rtkPosOf $1) $3 $4 $6 $8 }
 
 IfStatement : qq_IfStatement { Anti_IfStatement (tkVal_qq_IfStatement $1) } |
-              tok_if_36 tok__lparen__6 Expression tok__rparen__7 StatementWithoutIf OptElsePart { Ctr__IfStatement__0 (rtkPosOf $1) $3 $5 $6 }
+              tok_if_36 tok__lparen__6 Expression tok__rparen__7 Statement OptElsePart { Ctr__IfStatement__0 (rtkPosOf $1) $3 $5 $6 }
 
 ImplementsList : qq_ImplementsList { Anti_ImplementsList (tkVal_qq_ImplementsList $1) } |
-                 tok_implements_11 Rule_15 { Ctr__ImplementsList__0 (rtkPosOf $1) (reverse $2) }
+                 tok_implements_11 Rule_14 { Ctr__ImplementsList__0 (rtkPosOf $1) (reverse $2) }
 
 ImportList : {- empty -} { [] } |
-             ImportList ListElem_ImportList1 { $2 : $1 }
+             ImportList ListElem_ImportList0 { $2 : $1 }
 
 ImportStatement : qq_ImportStatement { Anti_ImportStatement (tkVal_qq_ImportStatement $1) } |
-                  tok_import_2 Rule_4 tok__semi__1 { Ctr__ImportStatement__0 (rtkPosOf $1) $2 }
+                  tok_import_2 Rule_3 tok__semi__1 { Ctr__ImportStatement__0 (rtkPosOf $1) $2 }
 
-ListElem_ImportList1 : qq_ImportList { Anti_ImportStatement (tkVal_qq_ImportList $1) } |
+ListElem_ImportList0 : qq_ImportList { Anti_ImportStatement (tkVal_qq_ImportList $1) } |
                        ImportStatement { $1 }
 
 InterfaceDeclaration : qq_InterfaceDeclaration { Anti_InterfaceDeclaration (tkVal_qq_InterfaceDeclaration $1) } |
-                       ModifierList tok_interface_15 id TypeParameters Rule_19 tok__symbol__13 FieldDeclarationList tok__symbol__14 { Ctr__InterfaceDeclaration__0 (rtkPosOf (reverse $1)) (reverse $1) (tkVal_id $3) $4 $5 (reverse $7) }
+                       tok_interface_15 id TypeParameters Rule_18 tok__symbol__13 FieldDeclarationList tok__symbol__14 { Ctr__InterfaceDeclaration__0 (rtkPosOf $1) (tkVal_id $2) $3 $4 (reverse $6) }
 
 Literal : qq_Literal { Anti_Literal (tkVal_qq_Literal $1) } |
           integerLiteral { Ctr__Literal__0 (rtkPosOf $1) (tkVal_integerLiteral $1) } |
@@ -571,7 +568,7 @@ Literal : qq_Literal { Anti_Literal (tkVal_qq_Literal $1) } |
           tok_null_85 { Ctr__Literal__6 (rtkPosOf $1) }
 
 MemberAfterFirstId : qq_MemberAfterFirstId { Anti_MemberAfterFirstId (tkVal_qq_MemberAfterFirstId $1) } |
-                     tok__lparen__6 Rule_37 tok__rparen__7 StatementBlock { Ctr__MemberAfterFirstId__0 (rtkPosOf $1) $2 $4 } |
+                     tok__lparen__6 Rule_35 tok__rparen__7 StatementBlock { Ctr__MemberAfterFirstId__0 (rtkPosOf $1) $2 $4 } |
                      MoreTypeSpecifier id MemberRest { Ctr__MemberAfterFirstId__1 (rtkPosOf $1) $1 (tkVal_id $2) $3 }
 
 MemberDeclaration : qq_MemberDeclaration { Anti_MemberDeclaration (tkVal_qq_MemberDeclaration $1) } |
@@ -580,7 +577,7 @@ MemberDeclaration : qq_MemberDeclaration { Anti_MemberDeclaration (tkVal_qq_Memb
                     id MemberAfterFirstId { Ctr__MemberDeclaration__2 (rtkPosOf $1) (tkVal_id $1) $2 }
 
 MemberRest : qq_MemberRest { Anti_MemberRest (tkVal_qq_MemberRest $1) } |
-             tok__lparen__6 Rule_38 tok__rparen__7 Dims Rule_39 { Ctr__MemberRest__0 (rtkPosOf $1) $2 (reverse $4) $5 } |
+             tok__lparen__6 Rule_36 tok__rparen__7 Dims Rule_37 { Ctr__MemberRest__0 (rtkPosOf $1) $2 (reverse $4) $5 } |
              Dims OptVariableInitializer MoreVariableDeclarators tok__semi__1 { Ctr__MemberRest__1 (rtkPosOf (reverse $1)) (reverse $1) $2 (reverse $3) }
 
 Modifier : qq_Modifier { Anti_Modifier (tkVal_qq_Modifier $1) } |
@@ -596,31 +593,25 @@ Modifier : qq_Modifier { Anti_Modifier (tkVal_qq_Modifier $1) } |
            tok_transient_94 { Ctr__Modifier__9 (rtkPosOf $1) }
 
 ModifierList : {- empty -} { [] } |
-               ModifierList ListElem_ModifierList12 { $2 : $1 }
+               ModifierList ListElem_ModifierList11 { $2 : $1 }
 
 MoreTypeSpecifier : qq_MoreTypeSpecifier { Anti_MoreTypeSpecifier (tkVal_qq_MoreTypeSpecifier $1) } |
                     tok__dot__3 id MoreTypeSpecifier { Ctr__MoreTypeSpecifier__0 (rtkPosOf $1) (tkVal_id $2) $3 } |
                     TypeArguments Dims { Ctr__MoreTypeSpecifier__1 (rtkPosOf $1) $1 (reverse $2) }
 
 MoreVariableDeclarators : {- empty -} { [] } |
-                          MoreVariableDeclarators ListElem_MoreVariableDeclarators43 { $2 : $1 }
+                          MoreVariableDeclarators ListElem_MoreVariableDeclarators41 { $2 : $1 }
 
 MultiplicativeOp : qq_MultiplicativeOp { Anti_MultiplicativeOp (tkVal_qq_MultiplicativeOp $1) } |
                    tok__star__4 { Ctr__MultiplicativeOp__0 (rtkPosOf $1) } |
                    tok__symbol__74 { Ctr__MultiplicativeOp__1 (rtkPosOf $1) } |
                    tok__symbol__75 { Ctr__MultiplicativeOp__2 (rtkPosOf $1) }
 
-NestedTypeDeclaration : qq_NestedTypeDeclaration { Anti_NestedTypeDeclaration (tkVal_qq_NestedTypeDeclaration $1) } |
-                        ClassDeclaration { Ctr__NestedTypeDeclaration__0 (rtkPosOf $1) $1 } |
-                        InterfaceDeclaration { Ctr__NestedTypeDeclaration__1 (rtkPosOf $1) $1 } |
-                        EnumDeclaration { Ctr__NestedTypeDeclaration__2 (rtkPosOf $1) $1 } |
-                        AnnotationDeclaration { Ctr__NestedTypeDeclaration__3 (rtkPosOf $1) $1 }
-
-NonEmptyDims : ListElem_NonEmptyDims36 { [$1] } |
-               NonEmptyDims ListElem_NonEmptyDims36 { $2 : $1 }
+NonEmptyDims : ListElem_NonEmptyDims34 { [$1] } |
+               NonEmptyDims ListElem_NonEmptyDims34 { $2 : $1 }
 
 NonEmptyTypeArguments : qq_NonEmptyTypeArguments { Anti_NonEmptyTypeArguments (tkVal_qq_NonEmptyTypeArguments $1) } |
-                        tok__symbol__64 TypeArgument Rule_74 tok__symbol__65 { Ctr__NonEmptyTypeArguments__0 (rtkPosOf $1) $2 (reverse $3) }
+                        tok__symbol__64 TypeArgument Rule_72 tok__symbol__65 { Ctr__NonEmptyTypeArguments__0 (rtkPosOf $1) $2 (reverse $3) }
 
 OptDocComment : qq_OptDocComment { Anti_OptDocComment (tkVal_qq_OptDocComment $1) } |
                 { Ctr__OptDocComment__0 rtkNoPos } |
@@ -628,7 +619,7 @@ OptDocComment : qq_OptDocComment { Anti_OptDocComment (tkVal_qq_OptDocComment $1
 
 OptElsePart : qq_OptElsePart { Anti_OptElsePart (tkVal_qq_OptElsePart $1) } |
               { Ctr__OptElsePart__0 rtkNoPos } |
-              Rule_54 { Ctr__OptElsePart__1 (rtkPosOf $1) $1 }
+              Rule_52 { Ctr__OptElsePart__1 (rtkPosOf $1) $1 }
 
 OptExpression : qq_OptExpression { Anti_OptExpression (tkVal_qq_OptExpression $1) } |
                 { Ctr__OptExpression__0 rtkNoPos } |
@@ -636,7 +627,7 @@ OptExpression : qq_OptExpression { Anti_OptExpression (tkVal_qq_OptExpression $1
 
 OptFinally : qq_OptFinally { Anti_OptFinally (tkVal_qq_OptFinally $1) } |
              { Ctr__OptFinally__0 rtkNoPos } |
-             Rule_58 { Ctr__OptFinally__1 (rtkPosOf $1) $1 }
+             Rule_56 { Ctr__OptFinally__1 (rtkPosOf $1) $1 }
 
 OptId : qq_OptId { Anti_OptId (tkVal_qq_OptId $1) } |
         { Ctr__OptId__0 rtkNoPos } |
@@ -644,7 +635,7 @@ OptId : qq_OptId { Anti_OptId (tkVal_qq_OptId $1) } |
 
 OptVariableInitializer : qq_OptVariableInitializer { Anti_OptVariableInitializer (tkVal_qq_OptVariableInitializer $1) } |
                          { Ctr__OptVariableInitializer__0 rtkNoPos } |
-                         Rule_46 { Ctr__OptVariableInitializer__1 (rtkPosOf $1) $1 }
+                         Rule_44 { Ctr__OptVariableInitializer__1 (rtkPosOf $1) $1 }
 
 Package : qq_Package { Anti_Package (tkVal_qq_Package $1) } |
           tok_package_0 CompoundName tok__semi__1 { Ctr__Package__0 (rtkPosOf $1) $2 }
@@ -653,7 +644,7 @@ Parameter : qq_Parameter { Anti_Parameter (tkVal_qq_Parameter $1) } |
             Type id Dims { Ctr__Parameter__0 (rtkPosOf $1) $1 (tkVal_id $2) (reverse $3) }
 
 ParameterList : qq_ParameterList { Anti_ParameterList (tkVal_qq_ParameterList $1) } |
-                Parameter Rule_51 { Ctr__ParameterList__0 (rtkPosOf $1) $1 (reverse $2) }
+                Parameter Rule_49 { Ctr__ParameterList__0 (rtkPosOf $1) $1 (reverse $2) }
 
 PostfixOp : qq_PostfixOp { Anti_PostfixOp (tkVal_qq_PostfixOp $1) } |
             tok__plus__plus__76 { Ctr__PostfixOp__0 (rtkPosOf $1) } |
@@ -682,218 +673,211 @@ RelationalOp : qq_RelationalOp { Anti_RelationalOp (tkVal_qq_RelationalOp $1) } 
                tok__symbol__eql__66 { Ctr__RelationalOp__2 (rtkPosOf $1) } |
                tok__symbol__eql__67 { Ctr__RelationalOp__3 (rtkPosOf $1) }
 
-Rule_0 : ClassDeclaration { Ctr__Rule_0__0 (rtkPosOf $1) $1 } |
-         InterfaceDeclaration { Ctr__Rule_0__1 (rtkPosOf $1) $1 } |
-         EnumDeclaration { Ctr__Rule_0__2 (rtkPosOf $1) $1 } |
-         AnnotationDeclaration { Ctr__Rule_0__3 (rtkPosOf $1) $1 }
+Rule_1 : { Ctr__Rule_1__0 rtkNoPos } |
+         Package { Ctr__Rule_1__1 (rtkPosOf $1) $1 }
 
-ListElem_ModifierList12 : qq_ModifierList { Anti_Rule_11 (tkVal_qq_ModifierList $1) } |
-                          Rule_11 { $1 }
+ListElem_ModifierList11 : qq_ModifierList { Anti_Rule_10 (tkVal_qq_ModifierList $1) } |
+                          Rule_10 { $1 }
 
-Rule_11 : Modifier { Ctr__Rule_11__1 (rtkPosOf $1) $1 } |
-          Annotation { Ctr__Rule_11__2 (rtkPosOf $1) $1 }
+Rule_10 : Modifier { Ctr__Rule_10__1 (rtkPosOf $1) $1 } |
+          Annotation { Ctr__Rule_10__2 (rtkPosOf $1) $1 }
 
-Rule_13 : {- empty -} { [] } |
-          Rule_13 Rule_14 { $2 : $1 }
+Rule_12 : {- empty -} { [] } |
+          Rule_12 Rule_13 { $2 : $1 }
 
-Rule_14 : tok__coma__8 CompoundName { Ctr__Rule_14__0 (rtkPosOf $1) $2 }
+Rule_13 : tok__coma__8 CompoundName { Ctr__Rule_13__0 (rtkPosOf $1) $2 }
 
-Rule_15 : CompoundName { [$1] } |
-          Rule_15 tok__coma__8 CompoundName { $3 : $1 }
+Rule_14 : CompoundName { [$1] } |
+          Rule_14 tok__coma__8 CompoundName { $3 : $1 }
+
+Rule_16 : { Ctr__Rule_16__0 rtkNoPos } |
+          ExtendsList { Ctr__Rule_16__1 (rtkPosOf $1) $1 }
 
 Rule_17 : { Ctr__Rule_17__0 rtkNoPos } |
-          ExtendsList { Ctr__Rule_17__1 (rtkPosOf $1) $1 }
+          ImplementsList { Ctr__Rule_17__1 (rtkPosOf $1) $1 }
 
 Rule_18 : { Ctr__Rule_18__0 rtkNoPos } |
-          ImplementsList { Ctr__Rule_18__1 (rtkPosOf $1) $1 }
-
-Rule_19 : { Ctr__Rule_19__0 rtkNoPos } |
-          ExtendsList { Ctr__Rule_19__1 (rtkPosOf $1) $1 }
+          ExtendsList { Ctr__Rule_18__1 (rtkPosOf $1) $1 }
 
 Rule_2 : { Ctr__Rule_2__0 rtkNoPos } |
-         Package { Ctr__Rule_2__1 (rtkPosOf $1) $1 }
+         TypeDeclaration { Ctr__Rule_2__1 (rtkPosOf $1) $1 }
 
-Rule_21 : { Ctr__Rule_21__0 rtkNoPos } |
-          Rule_22 { Ctr__Rule_21__1 (rtkPosOf $1) $1 }
+Rule_20 : { Ctr__Rule_20__0 rtkNoPos } |
+          Rule_21 { Ctr__Rule_20__1 (rtkPosOf $1) $1 }
 
-Rule_22 : tok__lparen__6 Arglist tok__rparen__7 { Ctr__Rule_22__0 (rtkPosOf $1) $2 }
+Rule_21 : tok__lparen__6 Arglist tok__rparen__7 { Ctr__Rule_21__0 (rtkPosOf $1) $2 }
 
-Rule_23 : { Ctr__Rule_23__0 rtkNoPos } |
-          Rule_24 { Ctr__Rule_23__1 (rtkPosOf $1) $1 }
+Rule_22 : { Ctr__Rule_22__0 rtkNoPos } |
+          Rule_23 { Ctr__Rule_22__1 (rtkPosOf $1) $1 }
 
-Rule_24 : tok__symbol__13 FieldDeclarationList tok__symbol__14 { Ctr__Rule_24__0 (rtkPosOf $1) (reverse $2) }
+Rule_23 : tok__symbol__13 FieldDeclarationList tok__symbol__14 { Ctr__Rule_23__0 (rtkPosOf $1) (reverse $2) }
 
-Rule_25 : {- empty -} { [] } |
-          Rule_25 Rule_26 { $2 : $1 }
+Rule_24 : {- empty -} { [] } |
+          Rule_24 Rule_25 { $2 : $1 }
 
-Rule_26 : tok__coma__8 EnumConstant { Ctr__Rule_26__0 (rtkPosOf $1) $2 }
+Rule_25 : tok__coma__8 EnumConstant { Ctr__Rule_25__0 (rtkPosOf $1) $2 }
+
+Rule_26 : { Ctr__Rule_26__0 rtkNoPos } |
+          tok__coma__8 { Ctr__Rule_26__1 (rtkPosOf $1) }
 
 Rule_27 : { Ctr__Rule_27__0 rtkNoPos } |
-          tok__coma__8 { Ctr__Rule_27__1 (rtkPosOf $1) }
+          ImplementsList { Ctr__Rule_27__1 (rtkPosOf $1) $1 }
 
 Rule_28 : { Ctr__Rule_28__0 rtkNoPos } |
-          ImplementsList { Ctr__Rule_28__1 (rtkPosOf $1) $1 }
+          Rule_29 { Ctr__Rule_28__1 (rtkPosOf $1) $1 }
 
-Rule_29 : { Ctr__Rule_29__0 rtkNoPos } |
-          Rule_30 { Ctr__Rule_29__1 (rtkPosOf $1) $1 }
+Rule_29 : tok__semi__1 FieldDeclarationList { Ctr__Rule_29__0 (rtkPosOf $1) (reverse $2) }
 
-Rule_3 : { Ctr__Rule_3__0 rtkNoPos } |
-         TypeDeclaration { Ctr__Rule_3__1 (rtkPosOf $1) $1 }
+Rule_3 : CompoundName tok__dot__3 tok__star__4 { Ctr__Rule_3__0 (rtkPosOf $1) $1 } |
+         CompoundName { Ctr__Rule_3__1 (rtkPosOf $1) $1 }
 
-Rule_30 : tok__semi__1 FieldDeclarationList { Ctr__Rule_30__0 (rtkPosOf $1) (reverse $2) }
+Rule_30 : MemberDeclaration { Ctr__Rule_30__0 (rtkPosOf $1) $1 } |
+          TypeDeclRest { Ctr__Rule_30__1 (rtkPosOf $1) $1 } |
+          StaticInitializer { Ctr__Rule_30__2 (rtkPosOf $1) $1 }
 
-Rule_31 : ModifierList Rule_32 { Ctr__Rule_31__0 (rtkPosOf (reverse $1)) (reverse $1) $2 }
+ListElem_Dims32 : qq_Dims { Anti_Rule_31 (tkVal_qq_Dims $1) } |
+                  Rule_31 { $1 }
 
-Rule_32 : MemberDeclaration { Ctr__Rule_32__0 (rtkPosOf $1) $1 } |
-          NestedTypeDeclaration { Ctr__Rule_32__1 (rtkPosOf $1) $1 } |
-          StaticInitializer { Ctr__Rule_32__2 (rtkPosOf $1) $1 }
+Rule_31 : tok__sq_bkt_l__17 tok__sq_bkt_r__18 { Ctr__Rule_31__1 (rtkPosOf $1) }
 
-ListElem_Dims34 : qq_Dims { Anti_Rule_33 (tkVal_qq_Dims $1) } |
-                  Rule_33 { $1 }
+ListElem_NonEmptyDims34 : qq_NonEmptyDims { Anti_Rule_33 (tkVal_qq_NonEmptyDims $1) } |
+                          Rule_33 { $1 }
 
 Rule_33 : tok__sq_bkt_l__17 tok__sq_bkt_r__18 { Ctr__Rule_33__1 (rtkPosOf $1) }
 
-ListElem_NonEmptyDims36 : qq_NonEmptyDims { Anti_Rule_35 (tkVal_qq_NonEmptyDims $1) } |
-                          Rule_35 { $1 }
+Rule_35 : { Ctr__Rule_35__0 rtkNoPos } |
+          ParameterList { Ctr__Rule_35__1 (rtkPosOf $1) $1 }
 
-Rule_35 : tok__sq_bkt_l__17 tok__sq_bkt_r__18 { Ctr__Rule_35__1 (rtkPosOf $1) }
+Rule_36 : { Ctr__Rule_36__0 rtkNoPos } |
+          ParameterList { Ctr__Rule_36__1 (rtkPosOf $1) $1 }
 
-Rule_37 : { Ctr__Rule_37__0 rtkNoPos } |
-          ParameterList { Ctr__Rule_37__1 (rtkPosOf $1) $1 }
+Rule_37 : StatementBlock { Ctr__Rule_37__0 (rtkPosOf $1) $1 } |
+          Rule_38 tok__semi__1 { Ctr__Rule_37__1 (rtkPosOf $1) $1 }
 
 Rule_38 : { Ctr__Rule_38__0 rtkNoPos } |
-          ParameterList { Ctr__Rule_38__1 (rtkPosOf $1) $1 }
+          Rule_39 { Ctr__Rule_38__1 (rtkPosOf $1) $1 }
 
-Rule_39 : StatementBlock { Ctr__Rule_39__0 (rtkPosOf $1) $1 } |
-          Rule_40 tok__semi__1 { Ctr__Rule_39__1 (rtkPosOf $1) $1 }
+Rule_39 : tok_default_28 Expression { Ctr__Rule_39__0 (rtkPosOf $1) $2 }
 
-Rule_4 : CompoundName tok__dot__3 tok__star__4 { Ctr__Rule_4__0 (rtkPosOf $1) $1 } |
-         CompoundName { Ctr__Rule_4__1 (rtkPosOf $1) $1 }
+Rule_4 : { Ctr__Rule_4__0 rtkNoPos } |
+         Rule_5 { Ctr__Rule_4__1 (rtkPosOf $1) $1 }
 
-Rule_40 : { Ctr__Rule_40__0 rtkNoPos } |
-          Rule_41 { Ctr__Rule_40__1 (rtkPosOf $1) $1 }
+ListElem_MoreVariableDeclarators41 : qq_MoreVariableDeclarators { Anti_Rule_40 (tkVal_qq_MoreVariableDeclarators $1) } |
+                                     Rule_40 { $1 }
 
-Rule_41 : tok_default_28 Expression { Ctr__Rule_41__0 (rtkPosOf $1) $2 }
+Rule_40 : tok__coma__8 VariableDeclarator { Ctr__Rule_40__1 (rtkPosOf $1) $2 }
 
-ListElem_MoreVariableDeclarators43 : qq_MoreVariableDeclarators { Anti_Rule_42 (tkVal_qq_MoreVariableDeclarators $1) } |
-                                     Rule_42 { $1 }
+Rule_42 : {- empty -} { [] } |
+          Rule_42 Rule_43 { $2 : $1 }
 
-Rule_42 : tok__coma__8 VariableDeclarator { Ctr__Rule_42__1 (rtkPosOf $1) $2 }
+Rule_43 : tok__coma__8 VariableDeclarator { Ctr__Rule_43__0 (rtkPosOf $1) $2 }
 
-Rule_44 : {- empty -} { [] } |
-          Rule_44 Rule_45 { $2 : $1 }
+Rule_44 : tok__eql__9 VariableInitializer { Ctr__Rule_44__0 (rtkPosOf $1) $2 }
 
-Rule_45 : tok__coma__8 VariableDeclarator { Ctr__Rule_45__0 (rtkPosOf $1) $2 }
+Rule_45 : VariableInitializer Rule_46 Rule_48 { Ctr__Rule_45__0 (rtkPosOf $1) $1 (reverse $2) $3 }
 
-Rule_46 : tok__eql__9 VariableInitializer { Ctr__Rule_46__0 (rtkPosOf $1) $2 }
+Rule_46 : {- empty -} { [] } |
+          Rule_46 Rule_47 { $2 : $1 }
 
-Rule_47 : VariableInitializer Rule_48 Rule_50 { Ctr__Rule_47__0 (rtkPosOf $1) $1 (reverse $2) $3 }
+Rule_47 : tok__coma__8 VariableInitializer { Ctr__Rule_47__0 (rtkPosOf $1) $2 }
 
-Rule_48 : {- empty -} { [] } |
-          Rule_48 Rule_49 { $2 : $1 }
+Rule_48 : { Ctr__Rule_48__0 rtkNoPos } |
+          tok__coma__8 { Ctr__Rule_48__1 (rtkPosOf $1) }
 
-Rule_49 : tok__coma__8 VariableInitializer { Ctr__Rule_49__0 (rtkPosOf $1) $2 }
+Rule_49 : {- empty -} { [] } |
+          Rule_49 Rule_50 { $2 : $1 }
 
-Rule_5 : { Ctr__Rule_5__0 rtkNoPos } |
-         Rule_6 { Ctr__Rule_5__1 (rtkPosOf $1) $1 }
+Rule_5 : tok__lparen__6 Rule_6 tok__rparen__7 { Ctr__Rule_5__0 (rtkPosOf $1) $2 }
 
-Rule_50 : { Ctr__Rule_50__0 rtkNoPos } |
-          tok__coma__8 { Ctr__Rule_50__1 (rtkPosOf $1) }
+Rule_50 : tok__coma__8 Parameter { Ctr__Rule_50__0 (rtkPosOf $1) $2 }
 
-Rule_51 : {- empty -} { [] } |
-          Rule_51 Rule_52 { $2 : $1 }
+Rule_52 : tok_else_35 Statement { Ctr__Rule_52__0 (rtkPosOf $1) $2 }
 
-Rule_52 : tok__coma__8 Parameter { Ctr__Rule_52__0 (rtkPosOf $1) $2 }
+Rule_53 : VariableDeclaration { Ctr__Rule_53__0 (rtkPosOf $1) $1 } |
+          Expression tok__semi__1 { Ctr__Rule_53__1 (rtkPosOf $1) $1 } |
+          tok__semi__1 { Ctr__Rule_53__2 (rtkPosOf $1) }
 
-Rule_54 : tok_else_35 Statement { Ctr__Rule_54__0 (rtkPosOf $1) $2 }
+ListElem_CatchList55 : qq_CatchList { Anti_Rule_54 (tkVal_qq_CatchList $1) } |
+                       Rule_54 { $1 }
 
-Rule_55 : VariableDeclaration { Ctr__Rule_55__0 (rtkPosOf $1) $1 } |
-          Expression tok__semi__1 { Ctr__Rule_55__1 (rtkPosOf $1) $1 } |
-          tok__semi__1 { Ctr__Rule_55__2 (rtkPosOf $1) }
+Rule_54 : tok_catch_40 tok__lparen__6 Parameter tok__rparen__7 Statement { Ctr__Rule_54__1 (rtkPosOf $1) $3 $5 }
 
-ListElem_CatchList57 : qq_CatchList { Anti_Rule_56 (tkVal_qq_CatchList $1) } |
-                       Rule_56 { $1 }
+Rule_56 : tok_finally_41 Statement { Ctr__Rule_56__0 (rtkPosOf $1) $2 }
 
-Rule_56 : tok_catch_40 tok__lparen__6 Parameter tok__rparen__7 Statement { Ctr__Rule_56__1 (rtkPosOf $1) $3 $5 }
+ListElem_SwitchCaseList58 : qq_SwitchCaseList { Anti_Rule_57 (tkVal_qq_SwitchCaseList $1) } |
+                            Rule_57 { $1 }
 
-Rule_58 : tok_finally_41 Statement { Ctr__Rule_58__0 (rtkPosOf $1) $2 }
+Rule_57 : tok_case_43 Expression tok__colon__32 { Ctr__Rule_57__1 (rtkPosOf $1) $2 } |
+          tok_default_28 tok__colon__32 { Ctr__Rule_57__2 (rtkPosOf $1) } |
+          Statement { Ctr__Rule_57__3 (rtkPosOf $1) $1 }
 
-ListElem_SwitchCaseList60 : qq_SwitchCaseList { Anti_Rule_59 (tkVal_qq_SwitchCaseList $1) } |
-                            Rule_59 { $1 }
+Rule_59 : { Ctr__Rule_59__0 rtkNoPos } |
+          Rule_60 { Ctr__Rule_59__1 (rtkPosOf $1) $1 }
 
-Rule_59 : tok_case_43 Expression tok__colon__32 { Ctr__Rule_59__1 (rtkPosOf $1) $2 } |
-          tok_default_28 tok__colon__32 { Ctr__Rule_59__2 (rtkPosOf $1) } |
-          Statement { Ctr__Rule_59__3 (rtkPosOf $1) $1 }
+Rule_6 : { Ctr__Rule_6__0 rtkNoPos } |
+         AnnotationArguments { Ctr__Rule_6__1 (rtkPosOf $1) $1 }
 
-Rule_6 : tok__lparen__6 Rule_7 tok__rparen__7 { Ctr__Rule_6__0 (rtkPosOf $1) $2 }
+Rule_60 : AssignmentOp AssignmentExpression { Ctr__Rule_60__0 (rtkPosOf $1) $1 $2 }
 
 Rule_61 : { Ctr__Rule_61__0 rtkNoPos } |
           Rule_62 { Ctr__Rule_61__1 (rtkPosOf $1) $1 }
 
-Rule_62 : AssignmentOp AssignmentExpression { Ctr__Rule_62__0 (rtkPosOf $1) $1 $2 }
+Rule_62 : tok__lparen__6 Arglist tok__rparen__7 { Ctr__Rule_62__0 (rtkPosOf $1) $2 }
 
 Rule_63 : { Ctr__Rule_63__0 rtkNoPos } |
           Rule_64 { Ctr__Rule_63__1 (rtkPosOf $1) $1 }
 
 Rule_64 : tok__lparen__6 Arglist tok__rparen__7 { Ctr__Rule_64__0 (rtkPosOf $1) $2 }
 
-Rule_65 : { Ctr__Rule_65__0 rtkNoPos } |
-          Rule_66 { Ctr__Rule_65__1 (rtkPosOf $1) $1 }
+Rule_65 : tok__lparen__6 Arglist tok__rparen__7 { Ctr__Rule_65__0 (rtkPosOf $1) $2 } |
+          DimExprs Rule_66 { Ctr__Rule_65__1 (rtkPosOf (reverse $1)) (reverse $1) $2 }
 
-Rule_66 : tok__lparen__6 Arglist tok__rparen__7 { Ctr__Rule_66__0 (rtkPosOf $1) $2 }
+Rule_66 : { Ctr__Rule_66__0 rtkNoPos } |
+          NonEmptyDims { Ctr__Rule_66__1 (rtkPosOf (reverse $1)) (reverse $1) }
 
-Rule_67 : tok__lparen__6 Arglist tok__rparen__7 { Ctr__Rule_67__0 (rtkPosOf $1) $2 } |
-          DimExprs Rule_68 { Ctr__Rule_67__1 (rtkPosOf (reverse $1)) (reverse $1) $2 }
+ListElem_DimExprs68 : qq_DimExprs { Anti_Rule_67 (tkVal_qq_DimExprs $1) } |
+                      Rule_67 { $1 }
 
-Rule_68 : { Ctr__Rule_68__0 rtkNoPos } |
-          NonEmptyDims { Ctr__Rule_68__1 (rtkPosOf (reverse $1)) (reverse $1) }
+Rule_67 : tok__sq_bkt_l__17 Expression tok__sq_bkt_r__18 { Ctr__Rule_67__1 (rtkPosOf $1) $2 }
 
-ListElem_DimExprs70 : qq_DimExprs { Anti_Rule_69 (tkVal_qq_DimExprs $1) } |
-                      Rule_69 { $1 }
+Rule_69 : Expression Rule_70 { Ctr__Rule_69__0 (rtkPosOf $1) $1 (reverse $2) }
 
-Rule_69 : tok__sq_bkt_l__17 Expression tok__sq_bkt_r__18 { Ctr__Rule_69__1 (rtkPosOf $1) $2 }
+Rule_7 : {- empty -} { [] } |
+         Rule_7 Rule_8 { $2 : $1 }
 
-Rule_7 : { Ctr__Rule_7__0 rtkNoPos } |
-         AnnotationArguments { Ctr__Rule_7__1 (rtkPosOf $1) $1 }
+Rule_70 : {- empty -} { [] } |
+          Rule_70 Rule_71 { $2 : $1 }
 
-Rule_71 : Expression Rule_72 { Ctr__Rule_71__0 (rtkPosOf $1) $1 (reverse $2) }
+Rule_71 : tok__coma__8 Expression { Ctr__Rule_71__0 (rtkPosOf $1) $2 }
 
 Rule_72 : {- empty -} { [] } |
           Rule_72 Rule_73 { $2 : $1 }
 
-Rule_73 : tok__coma__8 Expression { Ctr__Rule_73__0 (rtkPosOf $1) $2 }
+Rule_73 : tok__coma__8 TypeArgument { Ctr__Rule_73__0 (rtkPosOf $1) $2 }
 
-Rule_74 : {- empty -} { [] } |
-          Rule_74 Rule_75 { $2 : $1 }
+Rule_74 : tok__symbol__64 TypeParameter Rule_75 tok__symbol__65 { Ctr__Rule_74__0 (rtkPosOf $1) $2 (reverse $3) }
 
-Rule_75 : tok__coma__8 TypeArgument { Ctr__Rule_75__0 (rtkPosOf $1) $2 }
+Rule_75 : {- empty -} { [] } |
+          Rule_75 Rule_76 { $2 : $1 }
 
-Rule_76 : tok__symbol__64 TypeParameter Rule_77 tok__symbol__65 { Ctr__Rule_76__0 (rtkPosOf $1) $2 (reverse $3) }
+Rule_76 : tok__coma__8 TypeParameter { Ctr__Rule_76__0 (rtkPosOf $1) $2 }
 
-Rule_77 : {- empty -} { [] } |
-          Rule_77 Rule_78 { $2 : $1 }
+Rule_77 : { Ctr__Rule_77__0 rtkNoPos } |
+          Rule_78 { Ctr__Rule_77__1 (rtkPosOf $1) $1 }
 
-Rule_78 : tok__coma__8 TypeParameter { Ctr__Rule_78__0 (rtkPosOf $1) $2 }
+Rule_78 : tok_extends_10 Type Rule_79 { Ctr__Rule_78__0 (rtkPosOf $1) $2 (reverse $3) }
 
-Rule_79 : { Ctr__Rule_79__0 rtkNoPos } |
-          Rule_80 { Ctr__Rule_79__1 (rtkPosOf $1) $1 }
+Rule_79 : {- empty -} { [] } |
+          Rule_79 Rule_80 { $2 : $1 }
 
-Rule_8 : {- empty -} { [] } |
-         Rule_8 Rule_9 { $2 : $1 }
+Rule_8 : tok__coma__8 AnnotationElement { Ctr__Rule_8__0 (rtkPosOf $1) $2 }
 
-Rule_80 : tok_extends_10 Type Rule_81 { Ctr__Rule_80__0 (rtkPosOf $1) $2 (reverse $3) }
+Rule_80 : tok__symbol__61 Type { Ctr__Rule_80__0 (rtkPosOf $1) $2 }
 
 Rule_81 : {- empty -} { [] } |
           Rule_81 Rule_82 { $2 : $1 }
 
-Rule_82 : tok__symbol__61 Type { Ctr__Rule_82__0 (rtkPosOf $1) $2 }
-
-Rule_83 : {- empty -} { [] } |
-          Rule_83 Rule_84 { $2 : $1 }
-
-Rule_84 : tok__dot__3 id { Ctr__Rule_84__0 (rtkPosOf $1) (tkVal_id $2) }
-
-Rule_9 : tok__coma__8 AnnotationElement { Ctr__Rule_9__0 (rtkPosOf $1) $2 }
+Rule_82 : tok__dot__3 id { Ctr__Rule_82__0 (rtkPosOf $1) (tkVal_id $2) }
 
 ShiftOp : qq_ShiftOp { Anti_ShiftOp (tkVal_qq_ShiftOp $1) } |
           tok__symbol__symbol__69 { Ctr__ShiftOp__0 (rtkPosOf $1) } |
@@ -901,40 +885,37 @@ ShiftOp : qq_ShiftOp { Anti_ShiftOp (tkVal_qq_ShiftOp $1) } |
           tok__symbol__symbol__symbol__71 { Ctr__ShiftOp__2 (rtkPosOf $1) }
 
 Statement : qq_Statement { Anti_Statement (tkVal_qq_Statement $1) } |
-            StatementWithoutIf { Ctr__Statement__0 (rtkPosOf $1) $1 } |
-            IfStatement { Ctr__Statement__1 (rtkPosOf $1) $1 }
+            VariableDeclaration { Ctr__Statement__0 (rtkPosOf $1) $1 } |
+            tok_return_29 OptExpression tok__semi__1 { Ctr__Statement__1 (rtkPosOf $1) $2 } |
+            Expression tok__semi__1 { Ctr__Statement__2 (rtkPosOf $1) $1 } |
+            StatementBlock { Ctr__Statement__3 (rtkPosOf $1) $1 } |
+            IfStatement { Ctr__Statement__4 (rtkPosOf $1) $1 } |
+            DoStatement { Ctr__Statement__5 (rtkPosOf $1) $1 } |
+            WhileStatement { Ctr__Statement__6 (rtkPosOf $1) $1 } |
+            ForStatement { Ctr__Statement__7 (rtkPosOf $1) $1 } |
+            TryStatement { Ctr__Statement__8 (rtkPosOf $1) $1 } |
+            SwitchStatement { Ctr__Statement__9 (rtkPosOf $1) $1 } |
+            tok_synchronized_30 tok__lparen__6 Expression tok__rparen__7 Statement { Ctr__Statement__10 (rtkPosOf $1) $3 $5 } |
+            tok_throw_31 Expression tok__semi__1 { Ctr__Statement__11 (rtkPosOf $1) $2 } |
+            id tok__colon__32 Statement { Ctr__Statement__12 (rtkPosOf $1) (tkVal_id $1) $3 } |
+            tok_break_33 OptId tok__semi__1 { Ctr__Statement__13 (rtkPosOf $1) $2 } |
+            tok_continue_34 OptId tok__semi__1 { Ctr__Statement__14 (rtkPosOf $1) $2 } |
+            tok__semi__1 { Ctr__Statement__15 (rtkPosOf $1) }
 
-ListElem_StatementList53 : qq_StatementList { Anti_Statement (tkVal_qq_StatementList $1) } |
+ListElem_StatementList51 : qq_StatementList { Anti_Statement (tkVal_qq_StatementList $1) } |
                            Statement { $1 }
 
 StatementBlock : qq_StatementBlock { Anti_StatementBlock (tkVal_qq_StatementBlock $1) } |
                  tok__symbol__13 StatementList tok__symbol__14 { Ctr__StatementBlock__0 (rtkPosOf $1) (reverse $2) }
 
 StatementList : {- empty -} { [] } |
-                StatementList ListElem_StatementList53 { $2 : $1 }
-
-StatementWithoutIf : qq_StatementWithoutIf { Anti_StatementWithoutIf (tkVal_qq_StatementWithoutIf $1) } |
-                     VariableDeclaration { Ctr__StatementWithoutIf__0 (rtkPosOf $1) $1 } |
-                     tok_return_29 OptExpression tok__semi__1 { Ctr__StatementWithoutIf__1 (rtkPosOf $1) $2 } |
-                     Expression tok__semi__1 { Ctr__StatementWithoutIf__2 (rtkPosOf $1) $1 } |
-                     StatementBlock { Ctr__StatementWithoutIf__3 (rtkPosOf $1) $1 } |
-                     DoStatement { Ctr__StatementWithoutIf__4 (rtkPosOf $1) $1 } |
-                     WhileStatement { Ctr__StatementWithoutIf__5 (rtkPosOf $1) $1 } |
-                     ForStatement { Ctr__StatementWithoutIf__6 (rtkPosOf $1) $1 } |
-                     TryStatement { Ctr__StatementWithoutIf__7 (rtkPosOf $1) $1 } |
-                     SwitchStatement { Ctr__StatementWithoutIf__8 (rtkPosOf $1) $1 } |
-                     tok_synchronized_30 tok__lparen__6 Expression tok__rparen__7 Statement { Ctr__StatementWithoutIf__9 (rtkPosOf $1) $3 $5 } |
-                     tok_throw_31 Expression tok__semi__1 { Ctr__StatementWithoutIf__10 (rtkPosOf $1) $2 } |
-                     id tok__colon__32 Statement { Ctr__StatementWithoutIf__11 (rtkPosOf $1) (tkVal_id $1) $3 } |
-                     tok_break_33 OptId tok__semi__1 { Ctr__StatementWithoutIf__12 (rtkPosOf $1) $2 } |
-                     tok_continue_34 OptId tok__semi__1 { Ctr__StatementWithoutIf__13 (rtkPosOf $1) $2 } |
-                     tok__semi__1 { Ctr__StatementWithoutIf__14 (rtkPosOf $1) }
+                StatementList ListElem_StatementList51 { $2 : $1 }
 
 StaticInitializer : qq_StaticInitializer { Anti_StaticInitializer (tkVal_qq_StaticInitializer $1) } |
                     StatementBlock { Ctr__StaticInitializer__0 (rtkPosOf $1) $1 }
 
 SwitchCaseList : {- empty -} { [] } |
-                 SwitchCaseList ListElem_SwitchCaseList60 { $2 : $1 }
+                 SwitchCaseList ListElem_SwitchCaseList58 { $2 : $1 }
 
 SwitchStatement : qq_SwitchStatement { Anti_SwitchStatement (tkVal_qq_SwitchStatement $1) } |
                   tok_switch_44 tok__lparen__6 Expression tok__rparen__7 tok__symbol__13 SwitchCaseList tok__symbol__14 { Ctr__SwitchStatement__0 (rtkPosOf $1) $3 (reverse $6) }
@@ -956,15 +937,21 @@ TypeArguments : qq_TypeArguments { Anti_TypeArguments (tkVal_qq_TypeArguments $1
                 { Ctr__TypeArguments__0 rtkNoPos } |
                 NonEmptyTypeArguments { Ctr__TypeArguments__1 (rtkPosOf $1) $1 }
 
+TypeDeclRest : qq_TypeDeclRest { Anti_TypeDeclRest (tkVal_qq_TypeDeclRest $1) } |
+               ClassDeclaration { Ctr__TypeDeclRest__0 (rtkPosOf $1) $1 } |
+               InterfaceDeclaration { Ctr__TypeDeclRest__1 (rtkPosOf $1) $1 } |
+               EnumDeclaration { Ctr__TypeDeclRest__2 (rtkPosOf $1) $1 } |
+               AnnotationDeclaration { Ctr__TypeDeclRest__3 (rtkPosOf $1) $1 }
+
 TypeDeclaration : qq_TypeDeclaration { Anti_TypeDeclaration (tkVal_qq_TypeDeclaration $1) } |
-                  OptDocComment Rule_0 { Ctr__TypeDeclaration__0 (rtkPosOf $1) $1 $2 }
+                  OptDocComment ModifierList TypeDeclRest { Ctr__TypeDeclaration__0 (rtkPosOf $1) $1 (reverse $2) $3 }
 
 TypeParameter : qq_TypeParameter { Anti_TypeParameter (tkVal_qq_TypeParameter $1) } |
-                id Rule_79 { Ctr__TypeParameter__0 (rtkPosOf $1) (tkVal_id $1) $2 }
+                id Rule_77 { Ctr__TypeParameter__0 (rtkPosOf $1) (tkVal_id $1) $2 }
 
 TypeParameters : qq_TypeParameters { Anti_TypeParameters (tkVal_qq_TypeParameters $1) } |
                  { Ctr__TypeParameters__0 rtkNoPos } |
-                 Rule_76 { Ctr__TypeParameters__1 (rtkPosOf $1) $1 }
+                 Rule_74 { Ctr__TypeParameters__1 (rtkPosOf $1) $1 }
 
 TypeSpecifier : qq_TypeSpecifier { Anti_TypeSpecifier (tkVal_qq_TypeSpecifier $1) } |
                 tok_boolean_19 { Ctr__TypeSpecifier__0 (rtkPosOf $1) } |
@@ -985,7 +972,7 @@ VariableDeclarator : qq_VariableDeclarator { Anti_VariableDeclarator (tkVal_qq_V
                      id Dims OptVariableInitializer { Ctr__VariableDeclarator__0 (rtkPosOf $1) (tkVal_id $1) (reverse $2) $3 }
 
 VariableDeclaratorList : qq_VariableDeclaratorList { Anti_VariableDeclaratorList (tkVal_qq_VariableDeclaratorList $1) } |
-                         VariableDeclarator Rule_44 { Ctr__VariableDeclaratorList__0 (rtkPosOf $1) $1 (reverse $2) }
+                         VariableDeclarator Rule_42 { Ctr__VariableDeclaratorList__0 (rtkPosOf $1) $1 (reverse $2) }
 
 VariableInitializer : qq_VariableInitializer { Anti_VariableInitializer (tkVal_qq_VariableInitializer $1) } |
                       Expression { Ctr__VariableInitializer__0 (rtkPosOf $1) $1 } |
@@ -993,7 +980,7 @@ VariableInitializer : qq_VariableInitializer { Anti_VariableInitializer (tkVal_q
 
 VariableInitializerList : qq_VariableInitializerList { Anti_VariableInitializerList (tkVal_qq_VariableInitializerList $1) } |
                           { Ctr__VariableInitializerList__0 rtkNoPos } |
-                          Rule_47 { Ctr__VariableInitializerList__1 (rtkPosOf $1) $1 }
+                          Rule_45 { Ctr__VariableInitializerList__1 (rtkPosOf $1) $1 }
 
 WhileStatement : qq_WhileStatement { Anti_WhileStatement (tkVal_qq_WhileStatement $1) } |
                  tok_while_38 tok__lparen__6 Expression tok__rparen__7 Statement { Ctr__WhileStatement__0 (rtkPosOf $1) $3 $5 }
@@ -1013,88 +1000,87 @@ parseError (L.PosToken (L.AlexPn _ line col) tok : _) =
 -- Render a token the way it appears in the source, for error messages
 showRtkToken :: L.Token -> String
 showRtkToken L.EndOfFile = "end of input"
-showRtkToken L.Tk__tok_AdditiveOp_dummy_165 = "'tok_AdditiveOp_dummy_165'"
-showRtkToken L.Tk__tok_Annotation_dummy_164 = "'tok_Annotation_dummy_164'"
-showRtkToken L.Tk__tok_AnnotationArguments_dummy_163 = "'tok_AnnotationArguments_dummy_163'"
-showRtkToken L.Tk__tok_AnnotationDeclaration_dummy_162 = "'tok_AnnotationDeclaration_dummy_162'"
-showRtkToken L.Tk__tok_AnnotationElement_dummy_161 = "'tok_AnnotationElement_dummy_161'"
-showRtkToken L.Tk__tok_AnnotationList_dummy_160 = "'tok_AnnotationList_dummy_160'"
-showRtkToken L.Tk__tok_AnnotationTypeElement_dummy_159 = "'tok_AnnotationTypeElement_dummy_159'"
-showRtkToken L.Tk__tok_AnnotationTypeElementList_dummy_158 = "'tok_AnnotationTypeElementList_dummy_158'"
-showRtkToken L.Tk__tok_Arglist_dummy_157 = "'tok_Arglist_dummy_157'"
-showRtkToken L.Tk__tok_AssignmentOp_dummy_156 = "'tok_AssignmentOp_dummy_156'"
-showRtkToken L.Tk__tok_CatchList_dummy_155 = "'tok_CatchList_dummy_155'"
-showRtkToken L.Tk__tok_ClassDeclaration_dummy_154 = "'tok_ClassDeclaration_dummy_154'"
-showRtkToken L.Tk__tok_CompilationUnit_dummy_153 = "'tok_CompilationUnit_dummy_153'"
-showRtkToken L.Tk__tok_CompoundName_dummy_152 = "'tok_CompoundName_dummy_152'"
-showRtkToken L.Tk__tok_CreationExpression_dummy_151 = "'tok_CreationExpression_dummy_151'"
-showRtkToken L.Tk__tok_DimExprs_dummy_150 = "'tok_DimExprs_dummy_150'"
-showRtkToken L.Tk__tok_Dims_dummy_149 = "'tok_Dims_dummy_149'"
-showRtkToken L.Tk__tok_DoStatement_dummy_148 = "'tok_DoStatement_dummy_148'"
-showRtkToken L.Tk__tok_DocComment_dummy_147 = "'tok_DocComment_dummy_147'"
-showRtkToken L.Tk__tok_EnumConstant_dummy_146 = "'tok_EnumConstant_dummy_146'"
-showRtkToken L.Tk__tok_EnumConstantList_dummy_145 = "'tok_EnumConstantList_dummy_145'"
-showRtkToken L.Tk__tok_EnumDeclaration_dummy_144 = "'tok_EnumDeclaration_dummy_144'"
-showRtkToken L.Tk__tok_EqualityOp_dummy_143 = "'tok_EqualityOp_dummy_143'"
-showRtkToken L.Tk__tok_Expression_dummy_142 = "'tok_Expression_dummy_142'"
-showRtkToken L.Tk__tok_ExtendsList_dummy_141 = "'tok_ExtendsList_dummy_141'"
-showRtkToken L.Tk__tok_FieldDeclaration_dummy_140 = "'tok_FieldDeclaration_dummy_140'"
-showRtkToken L.Tk__tok_FieldDeclarationList_dummy_139 = "'tok_FieldDeclarationList_dummy_139'"
-showRtkToken L.Tk__tok_ForStatement_dummy_138 = "'tok_ForStatement_dummy_138'"
-showRtkToken L.Tk__tok_IfStatement_dummy_137 = "'tok_IfStatement_dummy_137'"
-showRtkToken L.Tk__tok_ImplementsList_dummy_136 = "'tok_ImplementsList_dummy_136'"
-showRtkToken L.Tk__tok_ImportList_dummy_135 = "'tok_ImportList_dummy_135'"
-showRtkToken L.Tk__tok_ImportStatement_dummy_134 = "'tok_ImportStatement_dummy_134'"
-showRtkToken L.Tk__tok_InterfaceDeclaration_dummy_133 = "'tok_InterfaceDeclaration_dummy_133'"
-showRtkToken L.Tk__tok_Java_dummy_166 = "'tok_Java_dummy_166'"
-showRtkToken L.Tk__tok_Literal_dummy_132 = "'tok_Literal_dummy_132'"
-showRtkToken L.Tk__tok_MemberAfterFirstId_dummy_131 = "'tok_MemberAfterFirstId_dummy_131'"
-showRtkToken L.Tk__tok_MemberDeclaration_dummy_130 = "'tok_MemberDeclaration_dummy_130'"
-showRtkToken L.Tk__tok_MemberRest_dummy_129 = "'tok_MemberRest_dummy_129'"
-showRtkToken L.Tk__tok_Modifier_dummy_128 = "'tok_Modifier_dummy_128'"
-showRtkToken L.Tk__tok_ModifierList_dummy_127 = "'tok_ModifierList_dummy_127'"
-showRtkToken L.Tk__tok_MoreTypeSpecifier_dummy_126 = "'tok_MoreTypeSpecifier_dummy_126'"
-showRtkToken L.Tk__tok_MoreVariableDeclarators_dummy_125 = "'tok_MoreVariableDeclarators_dummy_125'"
-showRtkToken L.Tk__tok_MultiplicativeOp_dummy_124 = "'tok_MultiplicativeOp_dummy_124'"
-showRtkToken L.Tk__tok_NestedTypeDeclaration_dummy_123 = "'tok_NestedTypeDeclaration_dummy_123'"
-showRtkToken L.Tk__tok_NonEmptyDims_dummy_122 = "'tok_NonEmptyDims_dummy_122'"
-showRtkToken L.Tk__tok_NonEmptyTypeArguments_dummy_121 = "'tok_NonEmptyTypeArguments_dummy_121'"
-showRtkToken L.Tk__tok_OptDocComment_dummy_120 = "'tok_OptDocComment_dummy_120'"
-showRtkToken L.Tk__tok_OptElsePart_dummy_119 = "'tok_OptElsePart_dummy_119'"
-showRtkToken L.Tk__tok_OptExpression_dummy_118 = "'tok_OptExpression_dummy_118'"
-showRtkToken L.Tk__tok_OptFinally_dummy_117 = "'tok_OptFinally_dummy_117'"
-showRtkToken L.Tk__tok_OptId_dummy_116 = "'tok_OptId_dummy_116'"
-showRtkToken L.Tk__tok_OptVariableInitializer_dummy_115 = "'tok_OptVariableInitializer_dummy_115'"
-showRtkToken L.Tk__tok_Package_dummy_114 = "'tok_Package_dummy_114'"
-showRtkToken L.Tk__tok_Parameter_dummy_113 = "'tok_Parameter_dummy_113'"
-showRtkToken L.Tk__tok_ParameterList_dummy_112 = "'tok_ParameterList_dummy_112'"
-showRtkToken L.Tk__tok_PostfixOp_dummy_111 = "'tok_PostfixOp_dummy_111'"
-showRtkToken L.Tk__tok_PrefixOp_dummy_110 = "'tok_PrefixOp_dummy_110'"
-showRtkToken L.Tk__tok_PrimitiveTypeKeyword_dummy_109 = "'tok_PrimitiveTypeKeyword_dummy_109'"
-showRtkToken L.Tk__tok_RelationalOp_dummy_108 = "'tok_RelationalOp_dummy_108'"
-showRtkToken L.Tk__tok_ShiftOp_dummy_107 = "'tok_ShiftOp_dummy_107'"
-showRtkToken L.Tk__tok_Statement_dummy_106 = "'tok_Statement_dummy_106'"
-showRtkToken L.Tk__tok_StatementBlock_dummy_105 = "'tok_StatementBlock_dummy_105'"
-showRtkToken L.Tk__tok_StatementList_dummy_104 = "'tok_StatementList_dummy_104'"
-showRtkToken L.Tk__tok_StatementWithoutIf_dummy_103 = "'tok_StatementWithoutIf_dummy_103'"
-showRtkToken L.Tk__tok_StaticInitializer_dummy_102 = "'tok_StaticInitializer_dummy_102'"
-showRtkToken L.Tk__tok_SwitchCaseList_dummy_101 = "'tok_SwitchCaseList_dummy_101'"
-showRtkToken L.Tk__tok_SwitchStatement_dummy_100 = "'tok_SwitchStatement_dummy_100'"
-showRtkToken L.Tk__tok_TryStatement_dummy_99 = "'tok_TryStatement_dummy_99'"
-showRtkToken L.Tk__tok_Type_dummy_98 = "'tok_Type_dummy_98'"
-showRtkToken L.Tk__tok_TypeArgument_dummy_97 = "'tok_TypeArgument_dummy_97'"
-showRtkToken L.Tk__tok_TypeArguments_dummy_96 = "'tok_TypeArguments_dummy_96'"
-showRtkToken L.Tk__tok_TypeDeclaration_dummy_95 = "'tok_TypeDeclaration_dummy_95'"
-showRtkToken L.Tk__tok_TypeParameter_dummy_94 = "'tok_TypeParameter_dummy_94'"
-showRtkToken L.Tk__tok_TypeParameters_dummy_93 = "'tok_TypeParameters_dummy_93'"
-showRtkToken L.Tk__tok_TypeSpecifier_dummy_92 = "'tok_TypeSpecifier_dummy_92'"
-showRtkToken L.Tk__tok_VariableDeclaration_dummy_91 = "'tok_VariableDeclaration_dummy_91'"
-showRtkToken L.Tk__tok_VariableDeclarator_dummy_90 = "'tok_VariableDeclarator_dummy_90'"
-showRtkToken L.Tk__tok_VariableDeclaratorList_dummy_89 = "'tok_VariableDeclaratorList_dummy_89'"
-showRtkToken L.Tk__tok_VariableInitializer_dummy_88 = "'tok_VariableInitializer_dummy_88'"
-showRtkToken L.Tk__tok_VariableInitializerList_dummy_87 = "'tok_VariableInitializerList_dummy_87'"
-showRtkToken L.Tk__tok_WhileStatement_dummy_86 = "'tok_WhileStatement_dummy_86'"
-showRtkToken L.Tk__tok_WildcardType_dummy_85 = "'tok_WildcardType_dummy_85'"
+showRtkToken L.Tk__tok_AdditiveOp_dummy_162 = "'tok_AdditiveOp_dummy_162'"
+showRtkToken L.Tk__tok_Annotation_dummy_161 = "'tok_Annotation_dummy_161'"
+showRtkToken L.Tk__tok_AnnotationArguments_dummy_160 = "'tok_AnnotationArguments_dummy_160'"
+showRtkToken L.Tk__tok_AnnotationDeclaration_dummy_159 = "'tok_AnnotationDeclaration_dummy_159'"
+showRtkToken L.Tk__tok_AnnotationElement_dummy_158 = "'tok_AnnotationElement_dummy_158'"
+showRtkToken L.Tk__tok_AnnotationList_dummy_157 = "'tok_AnnotationList_dummy_157'"
+showRtkToken L.Tk__tok_AnnotationTypeElement_dummy_156 = "'tok_AnnotationTypeElement_dummy_156'"
+showRtkToken L.Tk__tok_AnnotationTypeElementList_dummy_155 = "'tok_AnnotationTypeElementList_dummy_155'"
+showRtkToken L.Tk__tok_Arglist_dummy_154 = "'tok_Arglist_dummy_154'"
+showRtkToken L.Tk__tok_AssignmentOp_dummy_153 = "'tok_AssignmentOp_dummy_153'"
+showRtkToken L.Tk__tok_CatchList_dummy_152 = "'tok_CatchList_dummy_152'"
+showRtkToken L.Tk__tok_ClassDeclaration_dummy_151 = "'tok_ClassDeclaration_dummy_151'"
+showRtkToken L.Tk__tok_CompilationUnit_dummy_150 = "'tok_CompilationUnit_dummy_150'"
+showRtkToken L.Tk__tok_CompoundName_dummy_149 = "'tok_CompoundName_dummy_149'"
+showRtkToken L.Tk__tok_CreationExpression_dummy_148 = "'tok_CreationExpression_dummy_148'"
+showRtkToken L.Tk__tok_DimExprs_dummy_147 = "'tok_DimExprs_dummy_147'"
+showRtkToken L.Tk__tok_Dims_dummy_146 = "'tok_Dims_dummy_146'"
+showRtkToken L.Tk__tok_DoStatement_dummy_145 = "'tok_DoStatement_dummy_145'"
+showRtkToken L.Tk__tok_DocComment_dummy_144 = "'tok_DocComment_dummy_144'"
+showRtkToken L.Tk__tok_EnumConstant_dummy_143 = "'tok_EnumConstant_dummy_143'"
+showRtkToken L.Tk__tok_EnumConstantList_dummy_142 = "'tok_EnumConstantList_dummy_142'"
+showRtkToken L.Tk__tok_EnumDeclaration_dummy_141 = "'tok_EnumDeclaration_dummy_141'"
+showRtkToken L.Tk__tok_EqualityOp_dummy_140 = "'tok_EqualityOp_dummy_140'"
+showRtkToken L.Tk__tok_Expression_dummy_139 = "'tok_Expression_dummy_139'"
+showRtkToken L.Tk__tok_ExtendsList_dummy_138 = "'tok_ExtendsList_dummy_138'"
+showRtkToken L.Tk__tok_FieldDeclaration_dummy_137 = "'tok_FieldDeclaration_dummy_137'"
+showRtkToken L.Tk__tok_FieldDeclarationList_dummy_136 = "'tok_FieldDeclarationList_dummy_136'"
+showRtkToken L.Tk__tok_ForStatement_dummy_135 = "'tok_ForStatement_dummy_135'"
+showRtkToken L.Tk__tok_IfStatement_dummy_134 = "'tok_IfStatement_dummy_134'"
+showRtkToken L.Tk__tok_ImplementsList_dummy_133 = "'tok_ImplementsList_dummy_133'"
+showRtkToken L.Tk__tok_ImportList_dummy_132 = "'tok_ImportList_dummy_132'"
+showRtkToken L.Tk__tok_ImportStatement_dummy_131 = "'tok_ImportStatement_dummy_131'"
+showRtkToken L.Tk__tok_InterfaceDeclaration_dummy_130 = "'tok_InterfaceDeclaration_dummy_130'"
+showRtkToken L.Tk__tok_Java_dummy_163 = "'tok_Java_dummy_163'"
+showRtkToken L.Tk__tok_Literal_dummy_129 = "'tok_Literal_dummy_129'"
+showRtkToken L.Tk__tok_MemberAfterFirstId_dummy_128 = "'tok_MemberAfterFirstId_dummy_128'"
+showRtkToken L.Tk__tok_MemberDeclaration_dummy_127 = "'tok_MemberDeclaration_dummy_127'"
+showRtkToken L.Tk__tok_MemberRest_dummy_126 = "'tok_MemberRest_dummy_126'"
+showRtkToken L.Tk__tok_Modifier_dummy_125 = "'tok_Modifier_dummy_125'"
+showRtkToken L.Tk__tok_ModifierList_dummy_124 = "'tok_ModifierList_dummy_124'"
+showRtkToken L.Tk__tok_MoreTypeSpecifier_dummy_123 = "'tok_MoreTypeSpecifier_dummy_123'"
+showRtkToken L.Tk__tok_MoreVariableDeclarators_dummy_122 = "'tok_MoreVariableDeclarators_dummy_122'"
+showRtkToken L.Tk__tok_MultiplicativeOp_dummy_121 = "'tok_MultiplicativeOp_dummy_121'"
+showRtkToken L.Tk__tok_NonEmptyDims_dummy_120 = "'tok_NonEmptyDims_dummy_120'"
+showRtkToken L.Tk__tok_NonEmptyTypeArguments_dummy_119 = "'tok_NonEmptyTypeArguments_dummy_119'"
+showRtkToken L.Tk__tok_OptDocComment_dummy_118 = "'tok_OptDocComment_dummy_118'"
+showRtkToken L.Tk__tok_OptElsePart_dummy_117 = "'tok_OptElsePart_dummy_117'"
+showRtkToken L.Tk__tok_OptExpression_dummy_116 = "'tok_OptExpression_dummy_116'"
+showRtkToken L.Tk__tok_OptFinally_dummy_115 = "'tok_OptFinally_dummy_115'"
+showRtkToken L.Tk__tok_OptId_dummy_114 = "'tok_OptId_dummy_114'"
+showRtkToken L.Tk__tok_OptVariableInitializer_dummy_113 = "'tok_OptVariableInitializer_dummy_113'"
+showRtkToken L.Tk__tok_Package_dummy_112 = "'tok_Package_dummy_112'"
+showRtkToken L.Tk__tok_Parameter_dummy_111 = "'tok_Parameter_dummy_111'"
+showRtkToken L.Tk__tok_ParameterList_dummy_110 = "'tok_ParameterList_dummy_110'"
+showRtkToken L.Tk__tok_PostfixOp_dummy_109 = "'tok_PostfixOp_dummy_109'"
+showRtkToken L.Tk__tok_PrefixOp_dummy_108 = "'tok_PrefixOp_dummy_108'"
+showRtkToken L.Tk__tok_PrimitiveTypeKeyword_dummy_107 = "'tok_PrimitiveTypeKeyword_dummy_107'"
+showRtkToken L.Tk__tok_RelationalOp_dummy_106 = "'tok_RelationalOp_dummy_106'"
+showRtkToken L.Tk__tok_ShiftOp_dummy_105 = "'tok_ShiftOp_dummy_105'"
+showRtkToken L.Tk__tok_Statement_dummy_104 = "'tok_Statement_dummy_104'"
+showRtkToken L.Tk__tok_StatementBlock_dummy_103 = "'tok_StatementBlock_dummy_103'"
+showRtkToken L.Tk__tok_StatementList_dummy_102 = "'tok_StatementList_dummy_102'"
+showRtkToken L.Tk__tok_StaticInitializer_dummy_101 = "'tok_StaticInitializer_dummy_101'"
+showRtkToken L.Tk__tok_SwitchCaseList_dummy_100 = "'tok_SwitchCaseList_dummy_100'"
+showRtkToken L.Tk__tok_SwitchStatement_dummy_99 = "'tok_SwitchStatement_dummy_99'"
+showRtkToken L.Tk__tok_TryStatement_dummy_98 = "'tok_TryStatement_dummy_98'"
+showRtkToken L.Tk__tok_Type_dummy_97 = "'tok_Type_dummy_97'"
+showRtkToken L.Tk__tok_TypeArgument_dummy_96 = "'tok_TypeArgument_dummy_96'"
+showRtkToken L.Tk__tok_TypeArguments_dummy_95 = "'tok_TypeArguments_dummy_95'"
+showRtkToken L.Tk__tok_TypeDeclRest_dummy_94 = "'tok_TypeDeclRest_dummy_94'"
+showRtkToken L.Tk__tok_TypeDeclaration_dummy_93 = "'tok_TypeDeclaration_dummy_93'"
+showRtkToken L.Tk__tok_TypeParameter_dummy_92 = "'tok_TypeParameter_dummy_92'"
+showRtkToken L.Tk__tok_TypeParameters_dummy_91 = "'tok_TypeParameters_dummy_91'"
+showRtkToken L.Tk__tok_TypeSpecifier_dummy_90 = "'tok_TypeSpecifier_dummy_90'"
+showRtkToken L.Tk__tok_VariableDeclaration_dummy_89 = "'tok_VariableDeclaration_dummy_89'"
+showRtkToken L.Tk__tok_VariableDeclarator_dummy_88 = "'tok_VariableDeclarator_dummy_88'"
+showRtkToken L.Tk__tok_VariableDeclaratorList_dummy_87 = "'tok_VariableDeclaratorList_dummy_87'"
+showRtkToken L.Tk__tok_VariableInitializer_dummy_86 = "'tok_VariableInitializer_dummy_86'"
+showRtkToken L.Tk__tok_VariableInitializerList_dummy_85 = "'tok_VariableInitializerList_dummy_85'"
+showRtkToken L.Tk__tok_WhileStatement_dummy_84 = "'tok_WhileStatement_dummy_84'"
+showRtkToken L.Tk__tok_WildcardType_dummy_83 = "'tok_WildcardType_dummy_83'"
 showRtkToken L.Tk__tok__tilde__78 = "'~'"
 showRtkToken L.Tk__tok__symbol__14 = "'}'"
 showRtkToken L.Tk__tok__pipe__pipe__57 = "'||'"
@@ -1231,7 +1217,6 @@ showRtkToken (L.Tk__qq_WhileStatement v) = "qq_WhileStatement " ++ show v
 showRtkToken (L.Tk__qq_DoStatement v) = "qq_DoStatement " ++ show v
 showRtkToken (L.Tk__qq_IfStatement v) = "qq_IfStatement " ++ show v
 showRtkToken (L.Tk__qq_OptElsePart v) = "qq_OptElsePart " ++ show v
-showRtkToken (L.Tk__qq_StatementWithoutIf v) = "qq_StatementWithoutIf " ++ show v
 showRtkToken (L.Tk__qq_Statement v) = "qq_Statement " ++ show v
 showRtkToken (L.Tk__qq_OptId v) = "qq_OptId " ++ show v
 showRtkToken (L.Tk__qq_OptExpression v) = "qq_OptExpression " ++ show v
@@ -1255,7 +1240,7 @@ showRtkToken (L.Tk__qq_MemberDeclaration v) = "qq_MemberDeclaration " ++ show v
 showRtkToken (L.Tk__qq_NonEmptyDims v) = "qq_NonEmptyDims " ++ show v
 showRtkToken (L.Tk__qq_Dims v) = "qq_Dims " ++ show v
 showRtkToken (L.Tk__qq_FieldDeclaration v) = "qq_FieldDeclaration " ++ show v
-showRtkToken (L.Tk__qq_NestedTypeDeclaration v) = "qq_NestedTypeDeclaration " ++ show v
+showRtkToken (L.Tk__qq_TypeDeclRest v) = "qq_TypeDeclRest " ++ show v
 showRtkToken (L.Tk__qq_EnumDeclaration v) = "qq_EnumDeclaration " ++ show v
 showRtkToken (L.Tk__qq_EnumConstantList v) = "qq_EnumConstantList " ++ show v
 showRtkToken (L.Tk__qq_EnumConstant v) = "qq_EnumConstant " ++ show v
@@ -1434,9 +1419,6 @@ tkVal_qq_IfStatement t = error ("rtk internal error: token qq_IfStatement expect
 tkVal_qq_OptElsePart :: L.PosToken -> String
 tkVal_qq_OptElsePart (L.PosToken _ (L.Tk__qq_OptElsePart v)) = v
 tkVal_qq_OptElsePart t = error ("rtk internal error: token qq_OptElsePart expected, got " ++ showRtkToken (L.ptToken t))
-tkVal_qq_StatementWithoutIf :: L.PosToken -> String
-tkVal_qq_StatementWithoutIf (L.PosToken _ (L.Tk__qq_StatementWithoutIf v)) = v
-tkVal_qq_StatementWithoutIf t = error ("rtk internal error: token qq_StatementWithoutIf expected, got " ++ showRtkToken (L.ptToken t))
 tkVal_qq_Statement :: L.PosToken -> String
 tkVal_qq_Statement (L.PosToken _ (L.Tk__qq_Statement v)) = v
 tkVal_qq_Statement t = error ("rtk internal error: token qq_Statement expected, got " ++ showRtkToken (L.ptToken t))
@@ -1506,9 +1488,9 @@ tkVal_qq_Dims t = error ("rtk internal error: token qq_Dims expected, got " ++ s
 tkVal_qq_FieldDeclaration :: L.PosToken -> String
 tkVal_qq_FieldDeclaration (L.PosToken _ (L.Tk__qq_FieldDeclaration v)) = v
 tkVal_qq_FieldDeclaration t = error ("rtk internal error: token qq_FieldDeclaration expected, got " ++ showRtkToken (L.ptToken t))
-tkVal_qq_NestedTypeDeclaration :: L.PosToken -> String
-tkVal_qq_NestedTypeDeclaration (L.PosToken _ (L.Tk__qq_NestedTypeDeclaration v)) = v
-tkVal_qq_NestedTypeDeclaration t = error ("rtk internal error: token qq_NestedTypeDeclaration expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_TypeDeclRest :: L.PosToken -> String
+tkVal_qq_TypeDeclRest (L.PosToken _ (L.Tk__qq_TypeDeclRest v)) = v
+tkVal_qq_TypeDeclRest t = error ("rtk internal error: token qq_TypeDeclRest expected, got " ++ showRtkToken (L.ptToken t))
 tkVal_qq_EnumDeclaration :: L.PosToken -> String
 tkVal_qq_EnumDeclaration (L.PosToken _ (L.Tk__qq_EnumDeclaration v)) = v
 tkVal_qq_EnumDeclaration t = error ("rtk internal error: token qq_EnumDeclaration expected, got " ++ showRtkToken (L.ptToken t))
@@ -1625,47 +1607,46 @@ data Java = Ctr__Java__0 RtkPos Java |
             Ctr__Java__40 RtkPos MoreTypeSpecifier |
             Ctr__Java__41 RtkPos MoreVariableDeclarators |
             Ctr__Java__42 RtkPos MultiplicativeOp |
-            Ctr__Java__43 RtkPos NestedTypeDeclaration |
-            Ctr__Java__44 RtkPos NonEmptyDims |
-            Ctr__Java__45 RtkPos NonEmptyTypeArguments |
-            Ctr__Java__46 RtkPos OptDocComment |
-            Ctr__Java__47 RtkPos OptElsePart |
-            Ctr__Java__48 RtkPos OptExpression |
-            Ctr__Java__49 RtkPos OptFinally |
-            Ctr__Java__50 RtkPos OptId |
-            Ctr__Java__51 RtkPos OptVariableInitializer |
-            Ctr__Java__52 RtkPos Package |
-            Ctr__Java__53 RtkPos Parameter |
-            Ctr__Java__54 RtkPos ParameterList |
-            Ctr__Java__55 RtkPos PostfixOp |
-            Ctr__Java__56 RtkPos PrefixOp |
-            Ctr__Java__57 RtkPos PrimitiveTypeKeyword |
-            Ctr__Java__58 RtkPos RelationalOp |
-            Ctr__Java__59 RtkPos ShiftOp |
-            Ctr__Java__60 RtkPos Statement |
-            Ctr__Java__61 RtkPos StatementBlock |
-            Ctr__Java__62 RtkPos StatementList |
-            Ctr__Java__63 RtkPos StatementWithoutIf |
-            Ctr__Java__64 RtkPos StaticInitializer |
-            Ctr__Java__65 RtkPos SwitchCaseList |
-            Ctr__Java__66 RtkPos SwitchStatement |
-            Ctr__Java__67 RtkPos TryStatement |
-            Ctr__Java__68 RtkPos Type |
-            Ctr__Java__69 RtkPos TypeArgument |
-            Ctr__Java__70 RtkPos TypeArguments |
-            Ctr__Java__71 RtkPos TypeDeclaration |
-            Ctr__Java__72 RtkPos TypeParameter |
-            Ctr__Java__73 RtkPos TypeParameters |
-            Ctr__Java__74 RtkPos TypeSpecifier |
-            Ctr__Java__75 RtkPos VariableDeclaration |
-            Ctr__Java__76 RtkPos VariableDeclarator |
-            Ctr__Java__77 RtkPos VariableDeclaratorList |
-            Ctr__Java__78 RtkPos VariableInitializer |
-            Ctr__Java__79 RtkPos VariableInitializerList |
-            Ctr__Java__80 RtkPos WhileStatement |
-            Ctr__Java__81 RtkPos WildcardType |
+            Ctr__Java__43 RtkPos NonEmptyDims |
+            Ctr__Java__44 RtkPos NonEmptyTypeArguments |
+            Ctr__Java__45 RtkPos OptDocComment |
+            Ctr__Java__46 RtkPos OptElsePart |
+            Ctr__Java__47 RtkPos OptExpression |
+            Ctr__Java__48 RtkPos OptFinally |
+            Ctr__Java__49 RtkPos OptId |
+            Ctr__Java__50 RtkPos OptVariableInitializer |
+            Ctr__Java__51 RtkPos Package |
+            Ctr__Java__52 RtkPos Parameter |
+            Ctr__Java__53 RtkPos ParameterList |
+            Ctr__Java__54 RtkPos PostfixOp |
+            Ctr__Java__55 RtkPos PrefixOp |
+            Ctr__Java__56 RtkPos PrimitiveTypeKeyword |
+            Ctr__Java__57 RtkPos RelationalOp |
+            Ctr__Java__58 RtkPos ShiftOp |
+            Ctr__Java__59 RtkPos Statement |
+            Ctr__Java__60 RtkPos StatementBlock |
+            Ctr__Java__61 RtkPos StatementList |
+            Ctr__Java__62 RtkPos StaticInitializer |
+            Ctr__Java__63 RtkPos SwitchCaseList |
+            Ctr__Java__64 RtkPos SwitchStatement |
+            Ctr__Java__65 RtkPos TryStatement |
+            Ctr__Java__66 RtkPos Type |
+            Ctr__Java__67 RtkPos TypeArgument |
+            Ctr__Java__68 RtkPos TypeArguments |
+            Ctr__Java__69 RtkPos TypeDeclRest |
+            Ctr__Java__70 RtkPos TypeDeclaration |
+            Ctr__Java__71 RtkPos TypeParameter |
+            Ctr__Java__72 RtkPos TypeParameters |
+            Ctr__Java__73 RtkPos TypeSpecifier |
+            Ctr__Java__74 RtkPos VariableDeclaration |
+            Ctr__Java__75 RtkPos VariableDeclarator |
+            Ctr__Java__76 RtkPos VariableDeclaratorList |
+            Ctr__Java__77 RtkPos VariableInitializer |
+            Ctr__Java__78 RtkPos VariableInitializerList |
+            Ctr__Java__79 RtkPos WhileStatement |
+            Ctr__Java__80 RtkPos WildcardType |
             Anti_Java String |
-            Ctr__Java__82 RtkPos CompilationUnit
+            Ctr__Java__81 RtkPos CompilationUnit
             deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Java where
     rtkPosOf (Ctr__Java__0 p _) = p
@@ -1749,9 +1730,8 @@ instance RtkPosOf Java where
     rtkPosOf (Ctr__Java__78 p _) = p
     rtkPosOf (Ctr__Java__79 p _) = p
     rtkPosOf (Ctr__Java__80 p _) = p
-    rtkPosOf (Ctr__Java__81 p _) = p
     rtkPosOf (Anti_Java _) = rtkNoPos
-    rtkPosOf (Ctr__Java__82 p _) = p
+    rtkPosOf (Ctr__Java__81 p _) = p
 data AdditiveOp = Anti_AdditiveOp String |
                   Ctr__AdditiveOp__0 RtkPos |
                   Ctr__AdditiveOp__1 RtkPos
@@ -1761,23 +1741,23 @@ instance RtkPosOf AdditiveOp where
     rtkPosOf (Ctr__AdditiveOp__0 p) = p
     rtkPosOf (Ctr__AdditiveOp__1 p) = p
 data Annotation = Anti_Annotation String |
-                  Ctr__Annotation__1 RtkPos CompoundName Rule_5
+                  Ctr__Annotation__1 RtkPos CompoundName Rule_4
                   deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Annotation where
     rtkPosOf (Anti_Annotation _) = rtkNoPos
     rtkPosOf (Ctr__Annotation__1 p _ _) = p
 data AnnotationArguments = Anti_AnnotationArguments String |
-                           Ctr__AnnotationArguments__0 RtkPos AnnotationElement Rule_8
+                           Ctr__AnnotationArguments__0 RtkPos AnnotationElement Rule_7
                            deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf AnnotationArguments where
     rtkPosOf (Anti_AnnotationArguments _) = rtkNoPos
     rtkPosOf (Ctr__AnnotationArguments__0 p _ _) = p
 data AnnotationDeclaration = Anti_AnnotationDeclaration String |
-                             Ctr__AnnotationDeclaration__0 RtkPos ModifierList String AnnotationTypeElementList
+                             Ctr__AnnotationDeclaration__0 RtkPos String AnnotationTypeElementList
                              deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf AnnotationDeclaration where
     rtkPosOf (Anti_AnnotationDeclaration _) = rtkNoPos
-    rtkPosOf (Ctr__AnnotationDeclaration__0 p _ _ _) = p
+    rtkPosOf (Ctr__AnnotationDeclaration__0 p _ _) = p
 data AnnotationElement = Anti_AnnotationElement String |
                          Ctr__AnnotationElement__0 RtkPos String Expression |
                          Ctr__AnnotationElement__1 RtkPos Expression
@@ -1796,7 +1776,7 @@ instance RtkPosOf AnnotationTypeElement where
 type AnnotationTypeElementList = [AnnotationTypeElement]
 data Arglist = Anti_Arglist String |
                Ctr__Arglist__0 RtkPos |
-               Ctr__Arglist__1 RtkPos Rule_71
+               Ctr__Arglist__1 RtkPos Rule_69
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Arglist where
     rtkPosOf (Anti_Arglist _) = rtkNoPos
@@ -1830,33 +1810,33 @@ instance RtkPosOf AssignmentOp where
     rtkPosOf (Ctr__AssignmentOp__9 p) = p
     rtkPosOf (Ctr__AssignmentOp__10 p) = p
     rtkPosOf (Ctr__AssignmentOp__11 p) = p
-type CatchList = [Rule_56]
+type CatchList = [Rule_54]
 data ClassDeclaration = Anti_ClassDeclaration String |
-                        Ctr__ClassDeclaration__0 RtkPos ModifierList String TypeParameters Rule_17 Rule_18 FieldDeclarationList
+                        Ctr__ClassDeclaration__0 RtkPos String TypeParameters Rule_16 Rule_17 FieldDeclarationList
                         deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf ClassDeclaration where
     rtkPosOf (Anti_ClassDeclaration _) = rtkNoPos
-    rtkPosOf (Ctr__ClassDeclaration__0 p _ _ _ _ _ _) = p
+    rtkPosOf (Ctr__ClassDeclaration__0 p _ _ _ _ _) = p
 data CompilationUnit = Anti_CompilationUnit String |
-                       Ctr__CompilationUnit__0 RtkPos Rule_2 ImportList Rule_3
+                       Ctr__CompilationUnit__0 RtkPos Rule_1 ImportList Rule_2
                        deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf CompilationUnit where
     rtkPosOf (Anti_CompilationUnit _) = rtkNoPos
     rtkPosOf (Ctr__CompilationUnit__0 p _ _ _) = p
 data CompoundName = Anti_CompoundName String |
-                    Ctr__CompoundName__0 RtkPos String Rule_83
+                    Ctr__CompoundName__0 RtkPos String Rule_81
                     deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf CompoundName where
     rtkPosOf (Anti_CompoundName _) = rtkNoPos
     rtkPosOf (Ctr__CompoundName__0 p _ _) = p
 data CreationExpression = Anti_CreationExpression String |
-                          Ctr__CreationExpression__0 RtkPos TypeSpecifier Rule_67
+                          Ctr__CreationExpression__0 RtkPos TypeSpecifier Rule_65
                           deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf CreationExpression where
     rtkPosOf (Anti_CreationExpression _) = rtkNoPos
     rtkPosOf (Ctr__CreationExpression__0 p _ _) = p
-type DimExprs = [Rule_69]
-type Dims = [Rule_33]
+type DimExprs = [Rule_67]
+type Dims = [Rule_31]
 data DoStatement = Anti_DoStatement String |
                    Ctr__DoStatement__0 RtkPos Statement Expression
                    deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
@@ -1870,23 +1850,23 @@ instance RtkPosOf DocComment where
     rtkPosOf (Anti_DocComment _) = rtkNoPos
     rtkPosOf (Ctr__DocComment__0 p _) = p
 data EnumConstant = Anti_EnumConstant String |
-                    Ctr__EnumConstant__0 RtkPos AnnotationList String Rule_21 Rule_23
+                    Ctr__EnumConstant__0 RtkPos AnnotationList String Rule_20 Rule_22
                     deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf EnumConstant where
     rtkPosOf (Anti_EnumConstant _) = rtkNoPos
     rtkPosOf (Ctr__EnumConstant__0 p _ _ _ _) = p
 data EnumConstantList = Anti_EnumConstantList String |
-                        Ctr__EnumConstantList__0 RtkPos EnumConstant Rule_25 Rule_27
+                        Ctr__EnumConstantList__0 RtkPos EnumConstant Rule_24 Rule_26
                         deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf EnumConstantList where
     rtkPosOf (Anti_EnumConstantList _) = rtkNoPos
     rtkPosOf (Ctr__EnumConstantList__0 p _ _ _) = p
 data EnumDeclaration = Anti_EnumDeclaration String |
-                       Ctr__EnumDeclaration__0 RtkPos ModifierList String Rule_28 EnumConstantList Rule_29
+                       Ctr__EnumDeclaration__0 RtkPos String Rule_27 EnumConstantList Rule_28
                        deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf EnumDeclaration where
     rtkPosOf (Anti_EnumDeclaration _) = rtkNoPos
-    rtkPosOf (Ctr__EnumDeclaration__0 p _ _ _ _ _) = p
+    rtkPosOf (Ctr__EnumDeclaration__0 p _ _ _ _) = p
 data EqualityOp = Anti_EqualityOp String |
                   Ctr__EqualityOp__0 RtkPos |
                   Ctr__EqualityOp__1 RtkPos
@@ -1900,9 +1880,9 @@ data Expression = Anti_Expression String |
                   Ctr__Expression__1 RtkPos |
                   Ctr__Expression__2 RtkPos Expression |
                   Ctr__Expression__3 RtkPos CreationExpression |
-                  Ctr__Expression__4 RtkPos CompoundName Rule_63 |
+                  Ctr__Expression__4 RtkPos CompoundName Rule_61 |
                   Ctr__Expression__5 RtkPos CompoundName Expression |
-                  Ctr__Expression__6 RtkPos String Rule_65 |
+                  Ctr__Expression__6 RtkPos String Rule_63 |
                   Ctr__Expression__7 RtkPos Expression |
                   Ctr__Expression__8 RtkPos Expression PostfixOp |
                   Ctr__Expression__9 RtkPos Expression String |
@@ -1941,7 +1921,7 @@ data Expression = Anti_Expression String |
                   Ctr__Expression__42 RtkPos Expression Expression |
                   Ctr__Expression__43 RtkPos Expression |
                   Ctr__Expression__44 RtkPos Expression Expression Expression |
-                  Ctr__Expression__45 RtkPos Expression Rule_61 |
+                  Ctr__Expression__45 RtkPos Expression Rule_59 |
                   Ctr__Expression__46 RtkPos Expression
                   deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Expression where
@@ -1994,51 +1974,51 @@ instance RtkPosOf Expression where
     rtkPosOf (Ctr__Expression__45 p _ _) = p
     rtkPosOf (Ctr__Expression__46 p _) = p
 data ExtendsList = Anti_ExtendsList String |
-                   Ctr__ExtendsList__0 RtkPos CompoundName Rule_13
+                   Ctr__ExtendsList__0 RtkPos CompoundName Rule_12
                    deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf ExtendsList where
     rtkPosOf (Anti_ExtendsList _) = rtkNoPos
     rtkPosOf (Ctr__ExtendsList__0 p _ _) = p
 data FieldDeclaration = Anti_FieldDeclaration String |
-                        Ctr__FieldDeclaration__0 RtkPos OptDocComment Rule_31 |
+                        Ctr__FieldDeclaration__0 RtkPos OptDocComment ModifierList Rule_30 |
                         Ctr__FieldDeclaration__1 RtkPos
                         deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf FieldDeclaration where
     rtkPosOf (Anti_FieldDeclaration _) = rtkNoPos
-    rtkPosOf (Ctr__FieldDeclaration__0 p _ _) = p
+    rtkPosOf (Ctr__FieldDeclaration__0 p _ _ _) = p
     rtkPosOf (Ctr__FieldDeclaration__1 p) = p
 type FieldDeclarationList = [FieldDeclaration]
 data ForStatement = Anti_ForStatement String |
-                    Ctr__ForStatement__0 RtkPos Rule_55 OptExpression OptExpression Statement
+                    Ctr__ForStatement__0 RtkPos Rule_53 OptExpression OptExpression Statement
                     deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf ForStatement where
     rtkPosOf (Anti_ForStatement _) = rtkNoPos
     rtkPosOf (Ctr__ForStatement__0 p _ _ _ _) = p
 data IfStatement = Anti_IfStatement String |
-                   Ctr__IfStatement__0 RtkPos Expression StatementWithoutIf OptElsePart
+                   Ctr__IfStatement__0 RtkPos Expression Statement OptElsePart
                    deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf IfStatement where
     rtkPosOf (Anti_IfStatement _) = rtkNoPos
     rtkPosOf (Ctr__IfStatement__0 p _ _ _) = p
 data ImplementsList = Anti_ImplementsList String |
-                      Ctr__ImplementsList__0 RtkPos Rule_15
+                      Ctr__ImplementsList__0 RtkPos Rule_14
                       deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf ImplementsList where
     rtkPosOf (Anti_ImplementsList _) = rtkNoPos
     rtkPosOf (Ctr__ImplementsList__0 p _) = p
 type ImportList = [ImportStatement]
 data ImportStatement = Anti_ImportStatement String |
-                       Ctr__ImportStatement__0 RtkPos Rule_4
+                       Ctr__ImportStatement__0 RtkPos Rule_3
                        deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf ImportStatement where
     rtkPosOf (Anti_ImportStatement _) = rtkNoPos
     rtkPosOf (Ctr__ImportStatement__0 p _) = p
 data InterfaceDeclaration = Anti_InterfaceDeclaration String |
-                            Ctr__InterfaceDeclaration__0 RtkPos ModifierList String TypeParameters Rule_19 FieldDeclarationList
+                            Ctr__InterfaceDeclaration__0 RtkPos String TypeParameters Rule_18 FieldDeclarationList
                             deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf InterfaceDeclaration where
     rtkPosOf (Anti_InterfaceDeclaration _) = rtkNoPos
-    rtkPosOf (Ctr__InterfaceDeclaration__0 p _ _ _ _ _) = p
+    rtkPosOf (Ctr__InterfaceDeclaration__0 p _ _ _ _) = p
 data Literal = Anti_Literal String |
                Ctr__Literal__0 RtkPos String |
                Ctr__Literal__1 RtkPos String |
@@ -2058,7 +2038,7 @@ instance RtkPosOf Literal where
     rtkPosOf (Ctr__Literal__5 p _) = p
     rtkPosOf (Ctr__Literal__6 p) = p
 data MemberAfterFirstId = Anti_MemberAfterFirstId String |
-                          Ctr__MemberAfterFirstId__0 RtkPos Rule_37 StatementBlock |
+                          Ctr__MemberAfterFirstId__0 RtkPos Rule_35 StatementBlock |
                           Ctr__MemberAfterFirstId__1 RtkPos MoreTypeSpecifier String MemberRest
                           deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf MemberAfterFirstId where
@@ -2076,7 +2056,7 @@ instance RtkPosOf MemberDeclaration where
     rtkPosOf (Ctr__MemberDeclaration__1 p _ _ _ _ _) = p
     rtkPosOf (Ctr__MemberDeclaration__2 p _ _) = p
 data MemberRest = Anti_MemberRest String |
-                  Ctr__MemberRest__0 RtkPos Rule_38 Dims Rule_39 |
+                  Ctr__MemberRest__0 RtkPos Rule_36 Dims Rule_37 |
                   Ctr__MemberRest__1 RtkPos Dims OptVariableInitializer MoreVariableDeclarators
                   deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf MemberRest where
@@ -2107,7 +2087,7 @@ instance RtkPosOf Modifier where
     rtkPosOf (Ctr__Modifier__7 p) = p
     rtkPosOf (Ctr__Modifier__8 p) = p
     rtkPosOf (Ctr__Modifier__9 p) = p
-type ModifierList = [Rule_11]
+type ModifierList = [Rule_10]
 data MoreTypeSpecifier = Anti_MoreTypeSpecifier String |
                          Ctr__MoreTypeSpecifier__0 RtkPos String MoreTypeSpecifier |
                          Ctr__MoreTypeSpecifier__1 RtkPos TypeArguments Dims
@@ -2116,7 +2096,7 @@ instance RtkPosOf MoreTypeSpecifier where
     rtkPosOf (Anti_MoreTypeSpecifier _) = rtkNoPos
     rtkPosOf (Ctr__MoreTypeSpecifier__0 p _ _) = p
     rtkPosOf (Ctr__MoreTypeSpecifier__1 p _ _) = p
-type MoreVariableDeclarators = [Rule_42]
+type MoreVariableDeclarators = [Rule_40]
 data MultiplicativeOp = Anti_MultiplicativeOp String |
                         Ctr__MultiplicativeOp__0 RtkPos |
                         Ctr__MultiplicativeOp__1 RtkPos |
@@ -2127,21 +2107,9 @@ instance RtkPosOf MultiplicativeOp where
     rtkPosOf (Ctr__MultiplicativeOp__0 p) = p
     rtkPosOf (Ctr__MultiplicativeOp__1 p) = p
     rtkPosOf (Ctr__MultiplicativeOp__2 p) = p
-data NestedTypeDeclaration = Anti_NestedTypeDeclaration String |
-                             Ctr__NestedTypeDeclaration__0 RtkPos ClassDeclaration |
-                             Ctr__NestedTypeDeclaration__1 RtkPos InterfaceDeclaration |
-                             Ctr__NestedTypeDeclaration__2 RtkPos EnumDeclaration |
-                             Ctr__NestedTypeDeclaration__3 RtkPos AnnotationDeclaration
-                             deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-instance RtkPosOf NestedTypeDeclaration where
-    rtkPosOf (Anti_NestedTypeDeclaration _) = rtkNoPos
-    rtkPosOf (Ctr__NestedTypeDeclaration__0 p _) = p
-    rtkPosOf (Ctr__NestedTypeDeclaration__1 p _) = p
-    rtkPosOf (Ctr__NestedTypeDeclaration__2 p _) = p
-    rtkPosOf (Ctr__NestedTypeDeclaration__3 p _) = p
-type NonEmptyDims = [Rule_35]
+type NonEmptyDims = [Rule_33]
 data NonEmptyTypeArguments = Anti_NonEmptyTypeArguments String |
-                             Ctr__NonEmptyTypeArguments__0 RtkPos TypeArgument Rule_74
+                             Ctr__NonEmptyTypeArguments__0 RtkPos TypeArgument Rule_72
                              deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf NonEmptyTypeArguments where
     rtkPosOf (Anti_NonEmptyTypeArguments _) = rtkNoPos
@@ -2156,7 +2124,7 @@ instance RtkPosOf OptDocComment where
     rtkPosOf (Ctr__OptDocComment__1 p _) = p
 data OptElsePart = Anti_OptElsePart String |
                    Ctr__OptElsePart__0 RtkPos |
-                   Ctr__OptElsePart__1 RtkPos Rule_54
+                   Ctr__OptElsePart__1 RtkPos Rule_52
                    deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf OptElsePart where
     rtkPosOf (Anti_OptElsePart _) = rtkNoPos
@@ -2172,7 +2140,7 @@ instance RtkPosOf OptExpression where
     rtkPosOf (Ctr__OptExpression__1 p _) = p
 data OptFinally = Anti_OptFinally String |
                   Ctr__OptFinally__0 RtkPos |
-                  Ctr__OptFinally__1 RtkPos Rule_58
+                  Ctr__OptFinally__1 RtkPos Rule_56
                   deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf OptFinally where
     rtkPosOf (Anti_OptFinally _) = rtkNoPos
@@ -2188,7 +2156,7 @@ instance RtkPosOf OptId where
     rtkPosOf (Ctr__OptId__1 p _) = p
 data OptVariableInitializer = Anti_OptVariableInitializer String |
                               Ctr__OptVariableInitializer__0 RtkPos |
-                              Ctr__OptVariableInitializer__1 RtkPos Rule_46
+                              Ctr__OptVariableInitializer__1 RtkPos Rule_44
                               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf OptVariableInitializer where
     rtkPosOf (Anti_OptVariableInitializer _) = rtkNoPos
@@ -2207,7 +2175,7 @@ instance RtkPosOf Parameter where
     rtkPosOf (Anti_Parameter _) = rtkNoPos
     rtkPosOf (Ctr__Parameter__0 p _ _ _) = p
 data ParameterList = Anti_ParameterList String |
-                     Ctr__ParameterList__0 RtkPos Parameter Rule_51
+                     Ctr__ParameterList__0 RtkPos Parameter Rule_49
                      deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf ParameterList where
     rtkPosOf (Anti_ParameterList _) = rtkNoPos
@@ -2266,252 +2234,254 @@ instance RtkPosOf RelationalOp where
     rtkPosOf (Ctr__RelationalOp__1 p) = p
     rtkPosOf (Ctr__RelationalOp__2 p) = p
     rtkPosOf (Ctr__RelationalOp__3 p) = p
-data Rule_0 = Ctr__Rule_0__0 RtkPos ClassDeclaration |
-              Ctr__Rule_0__1 RtkPos InterfaceDeclaration |
-              Ctr__Rule_0__2 RtkPos EnumDeclaration |
-              Ctr__Rule_0__3 RtkPos AnnotationDeclaration
+data Rule_1 = Ctr__Rule_1__0 RtkPos |
+              Ctr__Rule_1__1 RtkPos Package
               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-instance RtkPosOf Rule_0 where
-    rtkPosOf (Ctr__Rule_0__0 p _) = p
-    rtkPosOf (Ctr__Rule_0__1 p _) = p
-    rtkPosOf (Ctr__Rule_0__2 p _) = p
-    rtkPosOf (Ctr__Rule_0__3 p _) = p
-data Rule_11 = Anti_Rule_11 String |
-               Ctr__Rule_11__1 RtkPos Modifier |
-               Ctr__Rule_11__2 RtkPos Annotation
+instance RtkPosOf Rule_1 where
+    rtkPosOf (Ctr__Rule_1__0 p) = p
+    rtkPosOf (Ctr__Rule_1__1 p _) = p
+data Rule_10 = Anti_Rule_10 String |
+               Ctr__Rule_10__1 RtkPos Modifier |
+               Ctr__Rule_10__2 RtkPos Annotation
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-instance RtkPosOf Rule_11 where
-    rtkPosOf (Anti_Rule_11 _) = rtkNoPos
-    rtkPosOf (Ctr__Rule_11__1 p _) = p
-    rtkPosOf (Ctr__Rule_11__2 p _) = p
-type Rule_13 = [Rule_14]
-data Rule_14 = Ctr__Rule_14__0 RtkPos CompoundName
+instance RtkPosOf Rule_10 where
+    rtkPosOf (Anti_Rule_10 _) = rtkNoPos
+    rtkPosOf (Ctr__Rule_10__1 p _) = p
+    rtkPosOf (Ctr__Rule_10__2 p _) = p
+type Rule_12 = [Rule_13]
+data Rule_13 = Ctr__Rule_13__0 RtkPos CompoundName
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-instance RtkPosOf Rule_14 where
-    rtkPosOf (Ctr__Rule_14__0 p _) = p
-type Rule_15 = [CompoundName]
+instance RtkPosOf Rule_13 where
+    rtkPosOf (Ctr__Rule_13__0 p _) = p
+type Rule_14 = [CompoundName]
+data Rule_16 = Ctr__Rule_16__0 RtkPos |
+               Ctr__Rule_16__1 RtkPos ExtendsList
+               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_16 where
+    rtkPosOf (Ctr__Rule_16__0 p) = p
+    rtkPosOf (Ctr__Rule_16__1 p _) = p
 data Rule_17 = Ctr__Rule_17__0 RtkPos |
-               Ctr__Rule_17__1 RtkPos ExtendsList
+               Ctr__Rule_17__1 RtkPos ImplementsList
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_17 where
     rtkPosOf (Ctr__Rule_17__0 p) = p
     rtkPosOf (Ctr__Rule_17__1 p _) = p
 data Rule_18 = Ctr__Rule_18__0 RtkPos |
-               Ctr__Rule_18__1 RtkPos ImplementsList
+               Ctr__Rule_18__1 RtkPos ExtendsList
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_18 where
     rtkPosOf (Ctr__Rule_18__0 p) = p
     rtkPosOf (Ctr__Rule_18__1 p _) = p
-data Rule_19 = Ctr__Rule_19__0 RtkPos |
-               Ctr__Rule_19__1 RtkPos ExtendsList
-               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-instance RtkPosOf Rule_19 where
-    rtkPosOf (Ctr__Rule_19__0 p) = p
-    rtkPosOf (Ctr__Rule_19__1 p _) = p
 data Rule_2 = Ctr__Rule_2__0 RtkPos |
-              Ctr__Rule_2__1 RtkPos Package
+              Ctr__Rule_2__1 RtkPos TypeDeclaration
               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_2 where
     rtkPosOf (Ctr__Rule_2__0 p) = p
     rtkPosOf (Ctr__Rule_2__1 p _) = p
-data Rule_21 = Ctr__Rule_21__0 RtkPos |
-               Ctr__Rule_21__1 RtkPos Rule_22
+data Rule_20 = Ctr__Rule_20__0 RtkPos |
+               Ctr__Rule_20__1 RtkPos Rule_21
+               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_20 where
+    rtkPosOf (Ctr__Rule_20__0 p) = p
+    rtkPosOf (Ctr__Rule_20__1 p _) = p
+data Rule_21 = Ctr__Rule_21__0 RtkPos Arglist
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_21 where
-    rtkPosOf (Ctr__Rule_21__0 p) = p
-    rtkPosOf (Ctr__Rule_21__1 p _) = p
-data Rule_22 = Ctr__Rule_22__0 RtkPos Arglist
+    rtkPosOf (Ctr__Rule_21__0 p _) = p
+data Rule_22 = Ctr__Rule_22__0 RtkPos |
+               Ctr__Rule_22__1 RtkPos Rule_23
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_22 where
-    rtkPosOf (Ctr__Rule_22__0 p _) = p
-data Rule_23 = Ctr__Rule_23__0 RtkPos |
-               Ctr__Rule_23__1 RtkPos Rule_24
+    rtkPosOf (Ctr__Rule_22__0 p) = p
+    rtkPosOf (Ctr__Rule_22__1 p _) = p
+data Rule_23 = Ctr__Rule_23__0 RtkPos FieldDeclarationList
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_23 where
-    rtkPosOf (Ctr__Rule_23__0 p) = p
-    rtkPosOf (Ctr__Rule_23__1 p _) = p
-data Rule_24 = Ctr__Rule_24__0 RtkPos FieldDeclarationList
+    rtkPosOf (Ctr__Rule_23__0 p _) = p
+type Rule_24 = [Rule_25]
+data Rule_25 = Ctr__Rule_25__0 RtkPos EnumConstant
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-instance RtkPosOf Rule_24 where
-    rtkPosOf (Ctr__Rule_24__0 p _) = p
-type Rule_25 = [Rule_26]
-data Rule_26 = Ctr__Rule_26__0 RtkPos EnumConstant
+instance RtkPosOf Rule_25 where
+    rtkPosOf (Ctr__Rule_25__0 p _) = p
+data Rule_26 = Ctr__Rule_26__0 RtkPos |
+               Ctr__Rule_26__1 RtkPos
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_26 where
-    rtkPosOf (Ctr__Rule_26__0 p _) = p
+    rtkPosOf (Ctr__Rule_26__0 p) = p
+    rtkPosOf (Ctr__Rule_26__1 p) = p
 data Rule_27 = Ctr__Rule_27__0 RtkPos |
-               Ctr__Rule_27__1 RtkPos
+               Ctr__Rule_27__1 RtkPos ImplementsList
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_27 where
     rtkPosOf (Ctr__Rule_27__0 p) = p
-    rtkPosOf (Ctr__Rule_27__1 p) = p
+    rtkPosOf (Ctr__Rule_27__1 p _) = p
 data Rule_28 = Ctr__Rule_28__0 RtkPos |
-               Ctr__Rule_28__1 RtkPos ImplementsList
+               Ctr__Rule_28__1 RtkPos Rule_29
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_28 where
     rtkPosOf (Ctr__Rule_28__0 p) = p
     rtkPosOf (Ctr__Rule_28__1 p _) = p
-data Rule_29 = Ctr__Rule_29__0 RtkPos |
-               Ctr__Rule_29__1 RtkPos Rule_30
+data Rule_29 = Ctr__Rule_29__0 RtkPos FieldDeclarationList
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_29 where
-    rtkPosOf (Ctr__Rule_29__0 p) = p
-    rtkPosOf (Ctr__Rule_29__1 p _) = p
-data Rule_3 = Ctr__Rule_3__0 RtkPos |
-              Ctr__Rule_3__1 RtkPos TypeDeclaration
+    rtkPosOf (Ctr__Rule_29__0 p _) = p
+data Rule_3 = Ctr__Rule_3__0 RtkPos CompoundName |
+              Ctr__Rule_3__1 RtkPos CompoundName
               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_3 where
-    rtkPosOf (Ctr__Rule_3__0 p) = p
+    rtkPosOf (Ctr__Rule_3__0 p _) = p
     rtkPosOf (Ctr__Rule_3__1 p _) = p
-data Rule_30 = Ctr__Rule_30__0 RtkPos FieldDeclarationList
+data Rule_30 = Ctr__Rule_30__0 RtkPos MemberDeclaration |
+               Ctr__Rule_30__1 RtkPos TypeDeclRest |
+               Ctr__Rule_30__2 RtkPos StaticInitializer
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_30 where
     rtkPosOf (Ctr__Rule_30__0 p _) = p
-data Rule_31 = Ctr__Rule_31__0 RtkPos ModifierList Rule_32
+    rtkPosOf (Ctr__Rule_30__1 p _) = p
+    rtkPosOf (Ctr__Rule_30__2 p _) = p
+data Rule_31 = Anti_Rule_31 String |
+               Ctr__Rule_31__1 RtkPos
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_31 where
-    rtkPosOf (Ctr__Rule_31__0 p _ _) = p
-data Rule_32 = Ctr__Rule_32__0 RtkPos MemberDeclaration |
-               Ctr__Rule_32__1 RtkPos NestedTypeDeclaration |
-               Ctr__Rule_32__2 RtkPos StaticInitializer
-               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-instance RtkPosOf Rule_32 where
-    rtkPosOf (Ctr__Rule_32__0 p _) = p
-    rtkPosOf (Ctr__Rule_32__1 p _) = p
-    rtkPosOf (Ctr__Rule_32__2 p _) = p
+    rtkPosOf (Anti_Rule_31 _) = rtkNoPos
+    rtkPosOf (Ctr__Rule_31__1 p) = p
 data Rule_33 = Anti_Rule_33 String |
                Ctr__Rule_33__1 RtkPos
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_33 where
     rtkPosOf (Anti_Rule_33 _) = rtkNoPos
     rtkPosOf (Ctr__Rule_33__1 p) = p
-data Rule_35 = Anti_Rule_35 String |
-               Ctr__Rule_35__1 RtkPos
+data Rule_35 = Ctr__Rule_35__0 RtkPos |
+               Ctr__Rule_35__1 RtkPos ParameterList
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_35 where
-    rtkPosOf (Anti_Rule_35 _) = rtkNoPos
-    rtkPosOf (Ctr__Rule_35__1 p) = p
-data Rule_37 = Ctr__Rule_37__0 RtkPos |
-               Ctr__Rule_37__1 RtkPos ParameterList
+    rtkPosOf (Ctr__Rule_35__0 p) = p
+    rtkPosOf (Ctr__Rule_35__1 p _) = p
+data Rule_36 = Ctr__Rule_36__0 RtkPos |
+               Ctr__Rule_36__1 RtkPos ParameterList
+               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_36 where
+    rtkPosOf (Ctr__Rule_36__0 p) = p
+    rtkPosOf (Ctr__Rule_36__1 p _) = p
+data Rule_37 = Ctr__Rule_37__0 RtkPos StatementBlock |
+               Ctr__Rule_37__1 RtkPos Rule_38
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_37 where
-    rtkPosOf (Ctr__Rule_37__0 p) = p
+    rtkPosOf (Ctr__Rule_37__0 p _) = p
     rtkPosOf (Ctr__Rule_37__1 p _) = p
 data Rule_38 = Ctr__Rule_38__0 RtkPos |
-               Ctr__Rule_38__1 RtkPos ParameterList
+               Ctr__Rule_38__1 RtkPos Rule_39
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_38 where
     rtkPosOf (Ctr__Rule_38__0 p) = p
     rtkPosOf (Ctr__Rule_38__1 p _) = p
-data Rule_39 = Ctr__Rule_39__0 RtkPos StatementBlock |
-               Ctr__Rule_39__1 RtkPos Rule_40
+data Rule_39 = Ctr__Rule_39__0 RtkPos Expression
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_39 where
     rtkPosOf (Ctr__Rule_39__0 p _) = p
-    rtkPosOf (Ctr__Rule_39__1 p _) = p
-data Rule_4 = Ctr__Rule_4__0 RtkPos CompoundName |
-              Ctr__Rule_4__1 RtkPos CompoundName
+data Rule_4 = Ctr__Rule_4__0 RtkPos |
+              Ctr__Rule_4__1 RtkPos Rule_5
               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_4 where
-    rtkPosOf (Ctr__Rule_4__0 p _) = p
+    rtkPosOf (Ctr__Rule_4__0 p) = p
     rtkPosOf (Ctr__Rule_4__1 p _) = p
-data Rule_40 = Ctr__Rule_40__0 RtkPos |
-               Ctr__Rule_40__1 RtkPos Rule_41
+data Rule_40 = Anti_Rule_40 String |
+               Ctr__Rule_40__1 RtkPos VariableDeclarator
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_40 where
-    rtkPosOf (Ctr__Rule_40__0 p) = p
+    rtkPosOf (Anti_Rule_40 _) = rtkNoPos
     rtkPosOf (Ctr__Rule_40__1 p _) = p
-data Rule_41 = Ctr__Rule_41__0 RtkPos Expression
+type Rule_42 = [Rule_43]
+data Rule_43 = Ctr__Rule_43__0 RtkPos VariableDeclarator
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-instance RtkPosOf Rule_41 where
-    rtkPosOf (Ctr__Rule_41__0 p _) = p
-data Rule_42 = Anti_Rule_42 String |
-               Ctr__Rule_42__1 RtkPos VariableDeclarator
+instance RtkPosOf Rule_43 where
+    rtkPosOf (Ctr__Rule_43__0 p _) = p
+data Rule_44 = Ctr__Rule_44__0 RtkPos VariableInitializer
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-instance RtkPosOf Rule_42 where
-    rtkPosOf (Anti_Rule_42 _) = rtkNoPos
-    rtkPosOf (Ctr__Rule_42__1 p _) = p
-type Rule_44 = [Rule_45]
-data Rule_45 = Ctr__Rule_45__0 RtkPos VariableDeclarator
+instance RtkPosOf Rule_44 where
+    rtkPosOf (Ctr__Rule_44__0 p _) = p
+data Rule_45 = Ctr__Rule_45__0 RtkPos VariableInitializer Rule_46 Rule_48
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_45 where
-    rtkPosOf (Ctr__Rule_45__0 p _) = p
-data Rule_46 = Ctr__Rule_46__0 RtkPos VariableInitializer
-               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-instance RtkPosOf Rule_46 where
-    rtkPosOf (Ctr__Rule_46__0 p _) = p
-data Rule_47 = Ctr__Rule_47__0 RtkPos VariableInitializer Rule_48 Rule_50
+    rtkPosOf (Ctr__Rule_45__0 p _ _ _) = p
+type Rule_46 = [Rule_47]
+data Rule_47 = Ctr__Rule_47__0 RtkPos VariableInitializer
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_47 where
-    rtkPosOf (Ctr__Rule_47__0 p _ _ _) = p
-type Rule_48 = [Rule_49]
-data Rule_49 = Ctr__Rule_49__0 RtkPos VariableInitializer
+    rtkPosOf (Ctr__Rule_47__0 p _) = p
+data Rule_48 = Ctr__Rule_48__0 RtkPos |
+               Ctr__Rule_48__1 RtkPos
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-instance RtkPosOf Rule_49 where
-    rtkPosOf (Ctr__Rule_49__0 p _) = p
-data Rule_5 = Ctr__Rule_5__0 RtkPos |
-              Ctr__Rule_5__1 RtkPos Rule_6
+instance RtkPosOf Rule_48 where
+    rtkPosOf (Ctr__Rule_48__0 p) = p
+    rtkPosOf (Ctr__Rule_48__1 p) = p
+type Rule_49 = [Rule_50]
+data Rule_5 = Ctr__Rule_5__0 RtkPos Rule_6
               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_5 where
-    rtkPosOf (Ctr__Rule_5__0 p) = p
-    rtkPosOf (Ctr__Rule_5__1 p _) = p
-data Rule_50 = Ctr__Rule_50__0 RtkPos |
-               Ctr__Rule_50__1 RtkPos
+    rtkPosOf (Ctr__Rule_5__0 p _) = p
+data Rule_50 = Ctr__Rule_50__0 RtkPos Parameter
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_50 where
-    rtkPosOf (Ctr__Rule_50__0 p) = p
-    rtkPosOf (Ctr__Rule_50__1 p) = p
-type Rule_51 = [Rule_52]
-data Rule_52 = Ctr__Rule_52__0 RtkPos Parameter
+    rtkPosOf (Ctr__Rule_50__0 p _) = p
+data Rule_52 = Ctr__Rule_52__0 RtkPos Statement
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_52 where
     rtkPosOf (Ctr__Rule_52__0 p _) = p
-data Rule_54 = Ctr__Rule_54__0 RtkPos Statement
+data Rule_53 = Ctr__Rule_53__0 RtkPos VariableDeclaration |
+               Ctr__Rule_53__1 RtkPos Expression |
+               Ctr__Rule_53__2 RtkPos
+               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_53 where
+    rtkPosOf (Ctr__Rule_53__0 p _) = p
+    rtkPosOf (Ctr__Rule_53__1 p _) = p
+    rtkPosOf (Ctr__Rule_53__2 p) = p
+data Rule_54 = Anti_Rule_54 String |
+               Ctr__Rule_54__1 RtkPos Parameter Statement
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_54 where
-    rtkPosOf (Ctr__Rule_54__0 p _) = p
-data Rule_55 = Ctr__Rule_55__0 RtkPos VariableDeclaration |
-               Ctr__Rule_55__1 RtkPos Expression |
-               Ctr__Rule_55__2 RtkPos
-               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-instance RtkPosOf Rule_55 where
-    rtkPosOf (Ctr__Rule_55__0 p _) = p
-    rtkPosOf (Ctr__Rule_55__1 p _) = p
-    rtkPosOf (Ctr__Rule_55__2 p) = p
-data Rule_56 = Anti_Rule_56 String |
-               Ctr__Rule_56__1 RtkPos Parameter Statement
+    rtkPosOf (Anti_Rule_54 _) = rtkNoPos
+    rtkPosOf (Ctr__Rule_54__1 p _ _) = p
+data Rule_56 = Ctr__Rule_56__0 RtkPos Statement
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_56 where
-    rtkPosOf (Anti_Rule_56 _) = rtkNoPos
-    rtkPosOf (Ctr__Rule_56__1 p _ _) = p
-data Rule_58 = Ctr__Rule_58__0 RtkPos Statement
+    rtkPosOf (Ctr__Rule_56__0 p _) = p
+data Rule_57 = Anti_Rule_57 String |
+               Ctr__Rule_57__1 RtkPos Expression |
+               Ctr__Rule_57__2 RtkPos |
+               Ctr__Rule_57__3 RtkPos Statement
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-instance RtkPosOf Rule_58 where
-    rtkPosOf (Ctr__Rule_58__0 p _) = p
-data Rule_59 = Anti_Rule_59 String |
-               Ctr__Rule_59__1 RtkPos Expression |
-               Ctr__Rule_59__2 RtkPos |
-               Ctr__Rule_59__3 RtkPos Statement
+instance RtkPosOf Rule_57 where
+    rtkPosOf (Anti_Rule_57 _) = rtkNoPos
+    rtkPosOf (Ctr__Rule_57__1 p _) = p
+    rtkPosOf (Ctr__Rule_57__2 p) = p
+    rtkPosOf (Ctr__Rule_57__3 p _) = p
+data Rule_59 = Ctr__Rule_59__0 RtkPos |
+               Ctr__Rule_59__1 RtkPos Rule_60
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_59 where
-    rtkPosOf (Anti_Rule_59 _) = rtkNoPos
+    rtkPosOf (Ctr__Rule_59__0 p) = p
     rtkPosOf (Ctr__Rule_59__1 p _) = p
-    rtkPosOf (Ctr__Rule_59__2 p) = p
-    rtkPosOf (Ctr__Rule_59__3 p _) = p
-data Rule_6 = Ctr__Rule_6__0 RtkPos Rule_7
+data Rule_6 = Ctr__Rule_6__0 RtkPos |
+              Ctr__Rule_6__1 RtkPos AnnotationArguments
               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_6 where
-    rtkPosOf (Ctr__Rule_6__0 p _) = p
+    rtkPosOf (Ctr__Rule_6__0 p) = p
+    rtkPosOf (Ctr__Rule_6__1 p _) = p
+data Rule_60 = Ctr__Rule_60__0 RtkPos AssignmentOp Expression
+               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_60 where
+    rtkPosOf (Ctr__Rule_60__0 p _ _) = p
 data Rule_61 = Ctr__Rule_61__0 RtkPos |
                Ctr__Rule_61__1 RtkPos Rule_62
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_61 where
     rtkPosOf (Ctr__Rule_61__0 p) = p
     rtkPosOf (Ctr__Rule_61__1 p _) = p
-data Rule_62 = Ctr__Rule_62__0 RtkPos AssignmentOp Expression
+data Rule_62 = Ctr__Rule_62__0 RtkPos Arglist
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_62 where
-    rtkPosOf (Ctr__Rule_62__0 p _ _) = p
+    rtkPosOf (Ctr__Rule_62__0 p _) = p
 data Rule_63 = Ctr__Rule_63__0 RtkPos |
                Ctr__Rule_63__1 RtkPos Rule_64
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
@@ -2522,88 +2492,72 @@ data Rule_64 = Ctr__Rule_64__0 RtkPos Arglist
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_64 where
     rtkPosOf (Ctr__Rule_64__0 p _) = p
-data Rule_65 = Ctr__Rule_65__0 RtkPos |
-               Ctr__Rule_65__1 RtkPos Rule_66
+data Rule_65 = Ctr__Rule_65__0 RtkPos Arglist |
+               Ctr__Rule_65__1 RtkPos DimExprs Rule_66
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_65 where
-    rtkPosOf (Ctr__Rule_65__0 p) = p
-    rtkPosOf (Ctr__Rule_65__1 p _) = p
-data Rule_66 = Ctr__Rule_66__0 RtkPos Arglist
+    rtkPosOf (Ctr__Rule_65__0 p _) = p
+    rtkPosOf (Ctr__Rule_65__1 p _ _) = p
+data Rule_66 = Ctr__Rule_66__0 RtkPos |
+               Ctr__Rule_66__1 RtkPos NonEmptyDims
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_66 where
-    rtkPosOf (Ctr__Rule_66__0 p _) = p
-data Rule_67 = Ctr__Rule_67__0 RtkPos Arglist |
-               Ctr__Rule_67__1 RtkPos DimExprs Rule_68
+    rtkPosOf (Ctr__Rule_66__0 p) = p
+    rtkPosOf (Ctr__Rule_66__1 p _) = p
+data Rule_67 = Anti_Rule_67 String |
+               Ctr__Rule_67__1 RtkPos Expression
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_67 where
-    rtkPosOf (Ctr__Rule_67__0 p _) = p
-    rtkPosOf (Ctr__Rule_67__1 p _ _) = p
-data Rule_68 = Ctr__Rule_68__0 RtkPos |
-               Ctr__Rule_68__1 RtkPos NonEmptyDims
-               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-instance RtkPosOf Rule_68 where
-    rtkPosOf (Ctr__Rule_68__0 p) = p
-    rtkPosOf (Ctr__Rule_68__1 p _) = p
-data Rule_69 = Anti_Rule_69 String |
-               Ctr__Rule_69__1 RtkPos Expression
+    rtkPosOf (Anti_Rule_67 _) = rtkNoPos
+    rtkPosOf (Ctr__Rule_67__1 p _) = p
+data Rule_69 = Ctr__Rule_69__0 RtkPos Expression Rule_70
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_69 where
-    rtkPosOf (Anti_Rule_69 _) = rtkNoPos
-    rtkPosOf (Ctr__Rule_69__1 p _) = p
-data Rule_7 = Ctr__Rule_7__0 RtkPos |
-              Ctr__Rule_7__1 RtkPos AnnotationArguments
-              deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-instance RtkPosOf Rule_7 where
-    rtkPosOf (Ctr__Rule_7__0 p) = p
-    rtkPosOf (Ctr__Rule_7__1 p _) = p
-data Rule_71 = Ctr__Rule_71__0 RtkPos Expression Rule_72
+    rtkPosOf (Ctr__Rule_69__0 p _ _) = p
+type Rule_7 = [Rule_8]
+type Rule_70 = [Rule_71]
+data Rule_71 = Ctr__Rule_71__0 RtkPos Expression
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_71 where
-    rtkPosOf (Ctr__Rule_71__0 p _ _) = p
+    rtkPosOf (Ctr__Rule_71__0 p _) = p
 type Rule_72 = [Rule_73]
-data Rule_73 = Ctr__Rule_73__0 RtkPos Expression
+data Rule_73 = Ctr__Rule_73__0 RtkPos TypeArgument
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_73 where
     rtkPosOf (Ctr__Rule_73__0 p _) = p
-type Rule_74 = [Rule_75]
-data Rule_75 = Ctr__Rule_75__0 RtkPos TypeArgument
+data Rule_74 = Ctr__Rule_74__0 RtkPos TypeParameter Rule_75
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-instance RtkPosOf Rule_75 where
-    rtkPosOf (Ctr__Rule_75__0 p _) = p
-data Rule_76 = Ctr__Rule_76__0 RtkPos TypeParameter Rule_77
+instance RtkPosOf Rule_74 where
+    rtkPosOf (Ctr__Rule_74__0 p _ _) = p
+type Rule_75 = [Rule_76]
+data Rule_76 = Ctr__Rule_76__0 RtkPos TypeParameter
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_76 where
-    rtkPosOf (Ctr__Rule_76__0 p _ _) = p
-type Rule_77 = [Rule_78]
-data Rule_78 = Ctr__Rule_78__0 RtkPos TypeParameter
+    rtkPosOf (Ctr__Rule_76__0 p _) = p
+data Rule_77 = Ctr__Rule_77__0 RtkPos |
+               Ctr__Rule_77__1 RtkPos Rule_78
+               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_77 where
+    rtkPosOf (Ctr__Rule_77__0 p) = p
+    rtkPosOf (Ctr__Rule_77__1 p _) = p
+data Rule_78 = Ctr__Rule_78__0 RtkPos Type Rule_79
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_78 where
-    rtkPosOf (Ctr__Rule_78__0 p _) = p
-data Rule_79 = Ctr__Rule_79__0 RtkPos |
-               Ctr__Rule_79__1 RtkPos Rule_80
-               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-instance RtkPosOf Rule_79 where
-    rtkPosOf (Ctr__Rule_79__0 p) = p
-    rtkPosOf (Ctr__Rule_79__1 p _) = p
-type Rule_8 = [Rule_9]
-data Rule_80 = Ctr__Rule_80__0 RtkPos Type Rule_81
+    rtkPosOf (Ctr__Rule_78__0 p _ _) = p
+type Rule_79 = [Rule_80]
+data Rule_8 = Ctr__Rule_8__0 RtkPos AnnotationElement
+              deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_8 where
+    rtkPosOf (Ctr__Rule_8__0 p _) = p
+data Rule_80 = Ctr__Rule_80__0 RtkPos Type
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_80 where
-    rtkPosOf (Ctr__Rule_80__0 p _ _) = p
+    rtkPosOf (Ctr__Rule_80__0 p _) = p
 type Rule_81 = [Rule_82]
-data Rule_82 = Ctr__Rule_82__0 RtkPos Type
+data Rule_82 = Ctr__Rule_82__0 RtkPos String
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_82 where
     rtkPosOf (Ctr__Rule_82__0 p _) = p
-type Rule_83 = [Rule_84]
-data Rule_84 = Ctr__Rule_84__0 RtkPos String
-               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-instance RtkPosOf Rule_84 where
-    rtkPosOf (Ctr__Rule_84__0 p _) = p
-data Rule_9 = Ctr__Rule_9__0 RtkPos AnnotationElement
-              deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-instance RtkPosOf Rule_9 where
-    rtkPosOf (Ctr__Rule_9__0 p _) = p
 data ShiftOp = Anti_ShiftOp String |
                Ctr__ShiftOp__0 RtkPos |
                Ctr__ShiftOp__1 RtkPos |
@@ -2615,13 +2569,41 @@ instance RtkPosOf ShiftOp where
     rtkPosOf (Ctr__ShiftOp__1 p) = p
     rtkPosOf (Ctr__ShiftOp__2 p) = p
 data Statement = Anti_Statement String |
-                 Ctr__Statement__0 RtkPos StatementWithoutIf |
-                 Ctr__Statement__1 RtkPos IfStatement
+                 Ctr__Statement__0 RtkPos VariableDeclaration |
+                 Ctr__Statement__1 RtkPos OptExpression |
+                 Ctr__Statement__2 RtkPos Expression |
+                 Ctr__Statement__3 RtkPos StatementBlock |
+                 Ctr__Statement__4 RtkPos IfStatement |
+                 Ctr__Statement__5 RtkPos DoStatement |
+                 Ctr__Statement__6 RtkPos WhileStatement |
+                 Ctr__Statement__7 RtkPos ForStatement |
+                 Ctr__Statement__8 RtkPos TryStatement |
+                 Ctr__Statement__9 RtkPos SwitchStatement |
+                 Ctr__Statement__10 RtkPos Expression Statement |
+                 Ctr__Statement__11 RtkPos Expression |
+                 Ctr__Statement__12 RtkPos String Statement |
+                 Ctr__Statement__13 RtkPos OptId |
+                 Ctr__Statement__14 RtkPos OptId |
+                 Ctr__Statement__15 RtkPos
                  deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Statement where
     rtkPosOf (Anti_Statement _) = rtkNoPos
     rtkPosOf (Ctr__Statement__0 p _) = p
     rtkPosOf (Ctr__Statement__1 p _) = p
+    rtkPosOf (Ctr__Statement__2 p _) = p
+    rtkPosOf (Ctr__Statement__3 p _) = p
+    rtkPosOf (Ctr__Statement__4 p _) = p
+    rtkPosOf (Ctr__Statement__5 p _) = p
+    rtkPosOf (Ctr__Statement__6 p _) = p
+    rtkPosOf (Ctr__Statement__7 p _) = p
+    rtkPosOf (Ctr__Statement__8 p _) = p
+    rtkPosOf (Ctr__Statement__9 p _) = p
+    rtkPosOf (Ctr__Statement__10 p _ _) = p
+    rtkPosOf (Ctr__Statement__11 p _) = p
+    rtkPosOf (Ctr__Statement__12 p _ _) = p
+    rtkPosOf (Ctr__Statement__13 p _) = p
+    rtkPosOf (Ctr__Statement__14 p _) = p
+    rtkPosOf (Ctr__Statement__15 p) = p
 data StatementBlock = Anti_StatementBlock String |
                       Ctr__StatementBlock__0 RtkPos StatementList
                       deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
@@ -2629,47 +2611,13 @@ instance RtkPosOf StatementBlock where
     rtkPosOf (Anti_StatementBlock _) = rtkNoPos
     rtkPosOf (Ctr__StatementBlock__0 p _) = p
 type StatementList = [Statement]
-data StatementWithoutIf = Anti_StatementWithoutIf String |
-                          Ctr__StatementWithoutIf__0 RtkPos VariableDeclaration |
-                          Ctr__StatementWithoutIf__1 RtkPos OptExpression |
-                          Ctr__StatementWithoutIf__2 RtkPos Expression |
-                          Ctr__StatementWithoutIf__3 RtkPos StatementBlock |
-                          Ctr__StatementWithoutIf__4 RtkPos DoStatement |
-                          Ctr__StatementWithoutIf__5 RtkPos WhileStatement |
-                          Ctr__StatementWithoutIf__6 RtkPos ForStatement |
-                          Ctr__StatementWithoutIf__7 RtkPos TryStatement |
-                          Ctr__StatementWithoutIf__8 RtkPos SwitchStatement |
-                          Ctr__StatementWithoutIf__9 RtkPos Expression Statement |
-                          Ctr__StatementWithoutIf__10 RtkPos Expression |
-                          Ctr__StatementWithoutIf__11 RtkPos String Statement |
-                          Ctr__StatementWithoutIf__12 RtkPos OptId |
-                          Ctr__StatementWithoutIf__13 RtkPos OptId |
-                          Ctr__StatementWithoutIf__14 RtkPos
-                          deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-instance RtkPosOf StatementWithoutIf where
-    rtkPosOf (Anti_StatementWithoutIf _) = rtkNoPos
-    rtkPosOf (Ctr__StatementWithoutIf__0 p _) = p
-    rtkPosOf (Ctr__StatementWithoutIf__1 p _) = p
-    rtkPosOf (Ctr__StatementWithoutIf__2 p _) = p
-    rtkPosOf (Ctr__StatementWithoutIf__3 p _) = p
-    rtkPosOf (Ctr__StatementWithoutIf__4 p _) = p
-    rtkPosOf (Ctr__StatementWithoutIf__5 p _) = p
-    rtkPosOf (Ctr__StatementWithoutIf__6 p _) = p
-    rtkPosOf (Ctr__StatementWithoutIf__7 p _) = p
-    rtkPosOf (Ctr__StatementWithoutIf__8 p _) = p
-    rtkPosOf (Ctr__StatementWithoutIf__9 p _ _) = p
-    rtkPosOf (Ctr__StatementWithoutIf__10 p _) = p
-    rtkPosOf (Ctr__StatementWithoutIf__11 p _ _) = p
-    rtkPosOf (Ctr__StatementWithoutIf__12 p _) = p
-    rtkPosOf (Ctr__StatementWithoutIf__13 p _) = p
-    rtkPosOf (Ctr__StatementWithoutIf__14 p) = p
 data StaticInitializer = Anti_StaticInitializer String |
                          Ctr__StaticInitializer__0 RtkPos StatementBlock
                          deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf StaticInitializer where
     rtkPosOf (Anti_StaticInitializer _) = rtkNoPos
     rtkPosOf (Ctr__StaticInitializer__0 p _) = p
-type SwitchCaseList = [Rule_59]
+type SwitchCaseList = [Rule_57]
 data SwitchStatement = Anti_SwitchStatement String |
                        Ctr__SwitchStatement__0 RtkPos Expression SwitchCaseList
                        deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
@@ -2710,21 +2658,33 @@ instance RtkPosOf TypeArguments where
     rtkPosOf (Anti_TypeArguments _) = rtkNoPos
     rtkPosOf (Ctr__TypeArguments__0 p) = p
     rtkPosOf (Ctr__TypeArguments__1 p _) = p
+data TypeDeclRest = Anti_TypeDeclRest String |
+                    Ctr__TypeDeclRest__0 RtkPos ClassDeclaration |
+                    Ctr__TypeDeclRest__1 RtkPos InterfaceDeclaration |
+                    Ctr__TypeDeclRest__2 RtkPos EnumDeclaration |
+                    Ctr__TypeDeclRest__3 RtkPos AnnotationDeclaration
+                    deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf TypeDeclRest where
+    rtkPosOf (Anti_TypeDeclRest _) = rtkNoPos
+    rtkPosOf (Ctr__TypeDeclRest__0 p _) = p
+    rtkPosOf (Ctr__TypeDeclRest__1 p _) = p
+    rtkPosOf (Ctr__TypeDeclRest__2 p _) = p
+    rtkPosOf (Ctr__TypeDeclRest__3 p _) = p
 data TypeDeclaration = Anti_TypeDeclaration String |
-                       Ctr__TypeDeclaration__0 RtkPos OptDocComment Rule_0
+                       Ctr__TypeDeclaration__0 RtkPos OptDocComment ModifierList TypeDeclRest
                        deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf TypeDeclaration where
     rtkPosOf (Anti_TypeDeclaration _) = rtkNoPos
-    rtkPosOf (Ctr__TypeDeclaration__0 p _ _) = p
+    rtkPosOf (Ctr__TypeDeclaration__0 p _ _ _) = p
 data TypeParameter = Anti_TypeParameter String |
-                     Ctr__TypeParameter__0 RtkPos String Rule_79
+                     Ctr__TypeParameter__0 RtkPos String Rule_77
                      deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf TypeParameter where
     rtkPosOf (Anti_TypeParameter _) = rtkNoPos
     rtkPosOf (Ctr__TypeParameter__0 p _ _) = p
 data TypeParameters = Anti_TypeParameters String |
                       Ctr__TypeParameters__0 RtkPos |
-                      Ctr__TypeParameters__1 RtkPos Rule_76
+                      Ctr__TypeParameters__1 RtkPos Rule_74
                       deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf TypeParameters where
     rtkPosOf (Anti_TypeParameters _) = rtkNoPos
@@ -2767,7 +2727,7 @@ instance RtkPosOf VariableDeclarator where
     rtkPosOf (Anti_VariableDeclarator _) = rtkNoPos
     rtkPosOf (Ctr__VariableDeclarator__0 p _ _ _) = p
 data VariableDeclaratorList = Anti_VariableDeclaratorList String |
-                              Ctr__VariableDeclaratorList__0 RtkPos VariableDeclarator Rule_44
+                              Ctr__VariableDeclaratorList__0 RtkPos VariableDeclarator Rule_42
                               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf VariableDeclaratorList where
     rtkPosOf (Anti_VariableDeclaratorList _) = rtkNoPos
@@ -2782,7 +2742,7 @@ instance RtkPosOf VariableInitializer where
     rtkPosOf (Ctr__VariableInitializer__1 p _) = p
 data VariableInitializerList = Anti_VariableInitializerList String |
                                Ctr__VariableInitializerList__0 RtkPos |
-                               Ctr__VariableInitializerList__1 RtkPos Rule_47
+                               Ctr__VariableInitializerList__1 RtkPos Rule_45
                                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf VariableInitializerList where
     rtkPosOf (Anti_VariableInitializerList _) = rtkNoPos

--- a/test/golden/java/JavaQQ.hs
+++ b/test/golden/java/JavaQQ.hs
@@ -63,7 +63,7 @@ rtkRenderError err =
                 _ -> err
         _ -> err
 
-qqShortcuts = M.fromList [ ("java","Java"),("additiveOp","AdditiveOp"),("annotation","Annotation"),("annotationArguments","AnnotationArguments"),("annotationDeclaration","AnnotationDeclaration"),("annotationElement","AnnotationElement"),("annotationList","AnnotationList"),("annotationTypeElement","AnnotationTypeElement"),("annotationTypeElementList","AnnotationTypeElementList"),("arglist","Arglist"),("assignmentOp","AssignmentOp"),("catchList","CatchList"),("classDeclaration","ClassDeclaration"),("compilationUnit","CompilationUnit"),("compoundName","CompoundName"),("creationExpression","CreationExpression"),("dimExprs","DimExprs"),("dims","Dims"),("doStatement","DoStatement"),("docComment","DocComment"),("enumConstant","EnumConstant"),("enumConstantList","EnumConstantList"),("enumDeclaration","EnumDeclaration"),("equalityOp","EqualityOp"),("expression","Expression"),("extendsList","ExtendsList"),("fieldDeclaration","FieldDeclaration"),("fieldDeclarationList","FieldDeclarationList"),("forStatement","ForStatement"),("ifStatement","IfStatement"),("implementsList","ImplementsList"),("importList","ImportList"),("importStatement","ImportStatement"),("interfaceDeclaration","InterfaceDeclaration"),("literal","Literal"),("memberAfterFirstId","MemberAfterFirstId"),("memberDeclaration","MemberDeclaration"),("memberRest","MemberRest"),("modifier","Modifier"),("modifierList","ModifierList"),("moreTypeSpecifier","MoreTypeSpecifier"),("moreVariableDeclarators","MoreVariableDeclarators"),("multiplicativeOp","MultiplicativeOp"),("nestedTypeDeclaration","NestedTypeDeclaration"),("nonEmptyDims","NonEmptyDims"),("nonEmptyTypeArguments","NonEmptyTypeArguments"),("optDocComment","OptDocComment"),("optElsePart","OptElsePart"),("optExpression","OptExpression"),("optFinally","OptFinally"),("optId","OptId"),("optVariableInitializer","OptVariableInitializer"),("package","Package"),("parameter","Parameter"),("parameterList","ParameterList"),("postfixOp","PostfixOp"),("prefixOp","PrefixOp"),("primitiveTypeKeyword","PrimitiveTypeKeyword"),("relationalOp","RelationalOp"),("shiftOp","ShiftOp"),("statement","Statement"),("statementBlock","StatementBlock"),("statementList","StatementList"),("statementWithoutIf","StatementWithoutIf"),("staticInitializer","StaticInitializer"),("switchCaseList","SwitchCaseList"),("switchStatement","SwitchStatement"),("tryStatement","TryStatement"),("type","Type"),("typeArgument","TypeArgument"),("typeArguments","TypeArguments"),("typeDeclaration","TypeDeclaration"),("typeParameter","TypeParameter"),("typeParameters","TypeParameters"),("typeSpecifier","TypeSpecifier"),("variableDeclaration","VariableDeclaration"),("variableDeclarator","VariableDeclarator"),("variableDeclaratorList","VariableDeclaratorList"),("variableInitializer","VariableInitializer"),("variableInitializerList","VariableInitializerList"),("whileStatement","WhileStatement"),("wildcardType","WildcardType")]
+qqShortcuts = M.fromList [ ("java","Java"),("additiveOp","AdditiveOp"),("annotation","Annotation"),("annotationArguments","AnnotationArguments"),("annotationDeclaration","AnnotationDeclaration"),("annotationElement","AnnotationElement"),("annotationList","AnnotationList"),("annotationTypeElement","AnnotationTypeElement"),("annotationTypeElementList","AnnotationTypeElementList"),("arglist","Arglist"),("assignmentOp","AssignmentOp"),("catchList","CatchList"),("classDeclaration","ClassDeclaration"),("compilationUnit","CompilationUnit"),("compoundName","CompoundName"),("creationExpression","CreationExpression"),("dimExprs","DimExprs"),("dims","Dims"),("doStatement","DoStatement"),("docComment","DocComment"),("enumConstant","EnumConstant"),("enumConstantList","EnumConstantList"),("enumDeclaration","EnumDeclaration"),("equalityOp","EqualityOp"),("expression","Expression"),("extendsList","ExtendsList"),("fieldDeclaration","FieldDeclaration"),("fieldDeclarationList","FieldDeclarationList"),("forStatement","ForStatement"),("ifStatement","IfStatement"),("implementsList","ImplementsList"),("importList","ImportList"),("importStatement","ImportStatement"),("interfaceDeclaration","InterfaceDeclaration"),("literal","Literal"),("memberAfterFirstId","MemberAfterFirstId"),("memberDeclaration","MemberDeclaration"),("memberRest","MemberRest"),("modifier","Modifier"),("modifierList","ModifierList"),("moreTypeSpecifier","MoreTypeSpecifier"),("moreVariableDeclarators","MoreVariableDeclarators"),("multiplicativeOp","MultiplicativeOp"),("nonEmptyDims","NonEmptyDims"),("nonEmptyTypeArguments","NonEmptyTypeArguments"),("optDocComment","OptDocComment"),("optElsePart","OptElsePart"),("optExpression","OptExpression"),("optFinally","OptFinally"),("optId","OptId"),("optVariableInitializer","OptVariableInitializer"),("package","Package"),("parameter","Parameter"),("parameterList","ParameterList"),("postfixOp","PostfixOp"),("prefixOp","PrefixOp"),("primitiveTypeKeyword","PrimitiveTypeKeyword"),("relationalOp","RelationalOp"),("shiftOp","ShiftOp"),("statement","Statement"),("statementBlock","StatementBlock"),("statementList","StatementList"),("staticInitializer","StaticInitializer"),("switchCaseList","SwitchCaseList"),("switchStatement","SwitchStatement"),("tryStatement","TryStatement"),("type","Type"),("typeArgument","TypeArgument"),("typeArguments","TypeArguments"),("typeDeclRest","TypeDeclRest"),("typeDeclaration","TypeDeclaration"),("typeParameter","TypeParameter"),("typeParameters","TypeParameters"),("typeSpecifier","TypeSpecifier"),("variableDeclaration","VariableDeclaration"),("variableDeclarator","VariableDeclarator"),("variableDeclaratorList","VariableDeclaratorList"),("variableInitializer","VariableInitializer"),("variableInitializerList","VariableInitializerList"),("whileStatement","WhileStatement"),("wildcardType","WildcardType")]
 
 -- A quasi-quote pattern must match an AST parsed from anywhere in a source
 -- file, while the pattern itself was parsed from the quote body - so every
@@ -80,7 +80,7 @@ quoteJavaExp dummy func s = do
            Left err -> fail (rtkRenderError err)
            Right a -> return a
   let expr = func ast
-  dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_11Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiNestedTypeDeclarationExp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiRule_35Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_42Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiStatementWithoutIfExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_56Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_59Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_69Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) expr
+  dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_40Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_54Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_67Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) expr
 quoteJavaPat :: Data.Data a => String -> (Java -> a) -> String -> TH.PatQ
 quoteJavaPat dummy func s = do
   s1 <- either fail return (replaceAllPatterns s)
@@ -88,7 +88,7 @@ quoteJavaPat dummy func s = do
            Left err -> fail (rtkRenderError err)
            Right a -> return a
   let expr = func ast
-  dataToPatQ (const Nothing `Generics.extQ` rtkPosWildPat `Generics.extQ` antiJavaPat `Generics.extQ` antiOptDocCommentPat `Generics.extQ` antiTypeDeclarationPat `Generics.extQ` antiImportStatementPat `Generics.extQ` antiCompilationUnitPat `Generics.extQ` antiPackagePat `Generics.extQ` antiDocCommentPat `Generics.extQ` antiAnnotationPat `Generics.extQ` antiAnnotationArgumentsPat `Generics.extQ` antiAnnotationElementPat `Generics.extQ` antiRule_11Pat `Generics.extQ` antiExtendsListPat `Generics.extQ` antiImplementsListPat `Generics.extQ` antiFieldDeclarationPat `Generics.extQ` antiClassDeclarationPat `Generics.extQ` antiInterfaceDeclarationPat `Generics.extQ` antiAnnotationDeclarationPat `Generics.extQ` antiAnnotationTypeElementPat `Generics.extQ` antiEnumConstantPat `Generics.extQ` antiEnumConstantListPat `Generics.extQ` antiEnumDeclarationPat `Generics.extQ` antiNestedTypeDeclarationPat `Generics.extQ` antiRule_33Pat `Generics.extQ` antiRule_35Pat `Generics.extQ` antiMemberDeclarationPat `Generics.extQ` antiPrimitiveTypeKeywordPat `Generics.extQ` antiMemberAfterFirstIdPat `Generics.extQ` antiMoreTypeSpecifierPat `Generics.extQ` antiMemberRestPat `Generics.extQ` antiRule_42Pat `Generics.extQ` antiStatementBlockPat `Generics.extQ` antiVariableDeclaratorListPat `Generics.extQ` antiVariableDeclarationPat `Generics.extQ` antiOptVariableInitializerPat `Generics.extQ` antiVariableDeclaratorPat `Generics.extQ` antiVariableInitializerListPat `Generics.extQ` antiVariableInitializerPat `Generics.extQ` antiStaticInitializerPat `Generics.extQ` antiParameterListPat `Generics.extQ` antiParameterPat `Generics.extQ` antiStatementPat `Generics.extQ` antiOptExpressionPat `Generics.extQ` antiOptIdPat `Generics.extQ` antiStatementWithoutIfPat `Generics.extQ` antiOptElsePartPat `Generics.extQ` antiIfStatementPat `Generics.extQ` antiDoStatementPat `Generics.extQ` antiWhileStatementPat `Generics.extQ` antiForStatementPat `Generics.extQ` antiRule_56Pat `Generics.extQ` antiOptFinallyPat `Generics.extQ` antiTryStatementPat `Generics.extQ` antiRule_59Pat `Generics.extQ` antiSwitchStatementPat `Generics.extQ` antiExpressionPat `Generics.extQ` antiAssignmentOpPat `Generics.extQ` antiEqualityOpPat `Generics.extQ` antiRelationalOpPat `Generics.extQ` antiShiftOpPat `Generics.extQ` antiAdditiveOpPat `Generics.extQ` antiMultiplicativeOpPat `Generics.extQ` antiPrefixOpPat `Generics.extQ` antiPostfixOpPat `Generics.extQ` antiCreationExpressionPat `Generics.extQ` antiRule_69Pat `Generics.extQ` antiLiteralPat `Generics.extQ` antiArglistPat `Generics.extQ` antiTypeArgumentsPat `Generics.extQ` antiNonEmptyTypeArgumentsPat `Generics.extQ` antiTypeArgumentPat `Generics.extQ` antiWildcardTypePat `Generics.extQ` antiTypeParametersPat `Generics.extQ` antiTypeParameterPat `Generics.extQ` antiTypePat `Generics.extQ` antiTypeSpecifierPat `Generics.extQ` antiModifierPat `Generics.extQ` antiCompoundNamePat) expr
+  dataToPatQ (const Nothing `Generics.extQ` rtkPosWildPat `Generics.extQ` antiJavaPat `Generics.extQ` antiOptDocCommentPat `Generics.extQ` antiTypeDeclarationPat `Generics.extQ` antiImportStatementPat `Generics.extQ` antiCompilationUnitPat `Generics.extQ` antiPackagePat `Generics.extQ` antiDocCommentPat `Generics.extQ` antiAnnotationPat `Generics.extQ` antiAnnotationArgumentsPat `Generics.extQ` antiAnnotationElementPat `Generics.extQ` antiRule_10Pat `Generics.extQ` antiExtendsListPat `Generics.extQ` antiImplementsListPat `Generics.extQ` antiFieldDeclarationPat `Generics.extQ` antiClassDeclarationPat `Generics.extQ` antiInterfaceDeclarationPat `Generics.extQ` antiAnnotationDeclarationPat `Generics.extQ` antiAnnotationTypeElementPat `Generics.extQ` antiEnumConstantPat `Generics.extQ` antiEnumConstantListPat `Generics.extQ` antiEnumDeclarationPat `Generics.extQ` antiTypeDeclRestPat `Generics.extQ` antiRule_31Pat `Generics.extQ` antiRule_33Pat `Generics.extQ` antiMemberDeclarationPat `Generics.extQ` antiPrimitiveTypeKeywordPat `Generics.extQ` antiMemberAfterFirstIdPat `Generics.extQ` antiMoreTypeSpecifierPat `Generics.extQ` antiMemberRestPat `Generics.extQ` antiRule_40Pat `Generics.extQ` antiStatementBlockPat `Generics.extQ` antiVariableDeclaratorListPat `Generics.extQ` antiVariableDeclarationPat `Generics.extQ` antiOptVariableInitializerPat `Generics.extQ` antiVariableDeclaratorPat `Generics.extQ` antiVariableInitializerListPat `Generics.extQ` antiVariableInitializerPat `Generics.extQ` antiStaticInitializerPat `Generics.extQ` antiParameterListPat `Generics.extQ` antiParameterPat `Generics.extQ` antiStatementPat `Generics.extQ` antiOptExpressionPat `Generics.extQ` antiOptIdPat `Generics.extQ` antiOptElsePartPat `Generics.extQ` antiIfStatementPat `Generics.extQ` antiDoStatementPat `Generics.extQ` antiWhileStatementPat `Generics.extQ` antiForStatementPat `Generics.extQ` antiRule_54Pat `Generics.extQ` antiOptFinallyPat `Generics.extQ` antiTryStatementPat `Generics.extQ` antiRule_57Pat `Generics.extQ` antiSwitchStatementPat `Generics.extQ` antiExpressionPat `Generics.extQ` antiAssignmentOpPat `Generics.extQ` antiEqualityOpPat `Generics.extQ` antiRelationalOpPat `Generics.extQ` antiShiftOpPat `Generics.extQ` antiAdditiveOpPat `Generics.extQ` antiMultiplicativeOpPat `Generics.extQ` antiPrefixOpPat `Generics.extQ` antiPostfixOpPat `Generics.extQ` antiCreationExpressionPat `Generics.extQ` antiRule_67Pat `Generics.extQ` antiLiteralPat `Generics.extQ` antiArglistPat `Generics.extQ` antiTypeArgumentsPat `Generics.extQ` antiNonEmptyTypeArgumentsPat `Generics.extQ` antiTypeArgumentPat `Generics.extQ` antiWildcardTypePat `Generics.extQ` antiTypeParametersPat `Generics.extQ` antiTypeParameterPat `Generics.extQ` antiTypePat `Generics.extQ` antiTypeSpecifierPat `Generics.extQ` antiModifierPat `Generics.extQ` antiCompoundNamePat) expr
 
 antiCompoundNameExp :: CompoundName -> Maybe (TH.Q TH.Exp )
 antiCompoundNameExp ( Anti_CompoundName v) = Just $ TH.varE (TH.mkName v)
@@ -150,12 +150,12 @@ antiLiteralExp ( Anti_Literal v) = Just $ TH.varE (TH.mkName v)
 antiLiteralExp _ = Nothing
 
 
-antiRule_69Exp :: [ Rule_69 ] -> Maybe (TH.Q TH.Exp)
-antiRule_69Exp ((Anti_Rule_69 v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_11Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiNestedTypeDeclarationExp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiRule_35Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_42Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiStatementWithoutIfExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_56Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_59Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_69Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
+antiRule_67Exp :: [ Rule_67 ] -> Maybe (TH.Q TH.Exp)
+antiRule_67Exp ((Anti_Rule_67 v):rest) =
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_40Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_54Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_67Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
-antiRule_69Exp _ = Nothing
+antiRule_67Exp _ = Nothing
 
 
 antiCreationExpressionExp :: CreationExpression -> Maybe (TH.Q TH.Exp )
@@ -213,12 +213,12 @@ antiSwitchStatementExp ( Anti_SwitchStatement v) = Just $ TH.varE (TH.mkName v)
 antiSwitchStatementExp _ = Nothing
 
 
-antiRule_59Exp :: [ Rule_59 ] -> Maybe (TH.Q TH.Exp)
-antiRule_59Exp ((Anti_Rule_59 v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_11Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiNestedTypeDeclarationExp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiRule_35Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_42Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiStatementWithoutIfExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_56Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_59Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_69Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
+antiRule_57Exp :: [ Rule_57 ] -> Maybe (TH.Q TH.Exp)
+antiRule_57Exp ((Anti_Rule_57 v):rest) =
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_40Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_54Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_67Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
-antiRule_59Exp _ = Nothing
+antiRule_57Exp _ = Nothing
 
 
 antiTryStatementExp :: TryStatement -> Maybe (TH.Q TH.Exp )
@@ -231,12 +231,12 @@ antiOptFinallyExp ( Anti_OptFinally v) = Just $ TH.varE (TH.mkName v)
 antiOptFinallyExp _ = Nothing
 
 
-antiRule_56Exp :: [ Rule_56 ] -> Maybe (TH.Q TH.Exp)
-antiRule_56Exp ((Anti_Rule_56 v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_11Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiNestedTypeDeclarationExp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiRule_35Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_42Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiStatementWithoutIfExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_56Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_59Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_69Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
+antiRule_54Exp :: [ Rule_54 ] -> Maybe (TH.Q TH.Exp)
+antiRule_54Exp ((Anti_Rule_54 v):rest) =
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_40Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_54Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_67Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
-antiRule_56Exp _ = Nothing
+antiRule_54Exp _ = Nothing
 
 
 antiForStatementExp :: ForStatement -> Maybe (TH.Q TH.Exp )
@@ -264,11 +264,6 @@ antiOptElsePartExp ( Anti_OptElsePart v) = Just $ TH.varE (TH.mkName v)
 antiOptElsePartExp _ = Nothing
 
 
-antiStatementWithoutIfExp :: StatementWithoutIf -> Maybe (TH.Q TH.Exp )
-antiStatementWithoutIfExp ( Anti_StatementWithoutIf v) = Just $ TH.varE (TH.mkName v)
-antiStatementWithoutIfExp _ = Nothing
-
-
 antiOptIdExp :: OptId -> Maybe (TH.Q TH.Exp )
 antiOptIdExp ( Anti_OptId v) = Just $ TH.varE (TH.mkName v)
 antiOptIdExp _ = Nothing
@@ -281,7 +276,7 @@ antiOptExpressionExp _ = Nothing
 
 antiStatementExp :: [ Statement ] -> Maybe (TH.Q TH.Exp)
 antiStatementExp ((Anti_Statement v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_11Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiNestedTypeDeclarationExp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiRule_35Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_42Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiStatementWithoutIfExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_56Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_59Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_69Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_40Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_54Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_67Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
 antiStatementExp _ = Nothing
@@ -337,12 +332,12 @@ antiStatementBlockExp ( Anti_StatementBlock v) = Just $ TH.varE (TH.mkName v)
 antiStatementBlockExp _ = Nothing
 
 
-antiRule_42Exp :: [ Rule_42 ] -> Maybe (TH.Q TH.Exp)
-antiRule_42Exp ((Anti_Rule_42 v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_11Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiNestedTypeDeclarationExp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiRule_35Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_42Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiStatementWithoutIfExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_56Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_59Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_69Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
+antiRule_40Exp :: [ Rule_40 ] -> Maybe (TH.Q TH.Exp)
+antiRule_40Exp ((Anti_Rule_40 v):rest) =
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_40Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_54Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_67Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
-antiRule_42Exp _ = Nothing
+antiRule_40Exp _ = Nothing
 
 
 antiMemberRestExp :: MemberRest -> Maybe (TH.Q TH.Exp )
@@ -370,25 +365,25 @@ antiMemberDeclarationExp ( Anti_MemberDeclaration v) = Just $ TH.varE (TH.mkName
 antiMemberDeclarationExp _ = Nothing
 
 
-antiRule_35Exp :: [ Rule_35 ] -> Maybe (TH.Q TH.Exp)
-antiRule_35Exp ((Anti_Rule_35 v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_11Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiNestedTypeDeclarationExp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiRule_35Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_42Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiStatementWithoutIfExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_56Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_59Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_69Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
-     lvar = TH.varE $ TH.mkName v
-   in Just [| $lvar ++ $restExp |]
-antiRule_35Exp _ = Nothing
-
-
 antiRule_33Exp :: [ Rule_33 ] -> Maybe (TH.Q TH.Exp)
 antiRule_33Exp ((Anti_Rule_33 v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_11Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiNestedTypeDeclarationExp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiRule_35Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_42Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiStatementWithoutIfExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_56Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_59Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_69Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_40Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_54Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_67Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
 antiRule_33Exp _ = Nothing
 
 
-antiNestedTypeDeclarationExp :: NestedTypeDeclaration -> Maybe (TH.Q TH.Exp )
-antiNestedTypeDeclarationExp ( Anti_NestedTypeDeclaration v) = Just $ TH.varE (TH.mkName v)
-antiNestedTypeDeclarationExp _ = Nothing
+antiRule_31Exp :: [ Rule_31 ] -> Maybe (TH.Q TH.Exp)
+antiRule_31Exp ((Anti_Rule_31 v):rest) =
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_40Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_54Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_67Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
+     lvar = TH.varE $ TH.mkName v
+   in Just [| $lvar ++ $restExp |]
+antiRule_31Exp _ = Nothing
+
+
+antiTypeDeclRestExp :: TypeDeclRest -> Maybe (TH.Q TH.Exp )
+antiTypeDeclRestExp ( Anti_TypeDeclRest v) = Just $ TH.varE (TH.mkName v)
+antiTypeDeclRestExp _ = Nothing
 
 
 antiEnumDeclarationExp :: EnumDeclaration -> Maybe (TH.Q TH.Exp )
@@ -408,7 +403,7 @@ antiEnumConstantExp _ = Nothing
 
 antiAnnotationTypeElementExp :: [ AnnotationTypeElement ] -> Maybe (TH.Q TH.Exp)
 antiAnnotationTypeElementExp ((Anti_AnnotationTypeElement v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_11Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiNestedTypeDeclarationExp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiRule_35Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_42Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiStatementWithoutIfExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_56Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_59Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_69Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_40Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_54Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_67Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
 antiAnnotationTypeElementExp _ = Nothing
@@ -431,7 +426,7 @@ antiClassDeclarationExp _ = Nothing
 
 antiFieldDeclarationExp :: [ FieldDeclaration ] -> Maybe (TH.Q TH.Exp)
 antiFieldDeclarationExp ((Anti_FieldDeclaration v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_11Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiNestedTypeDeclarationExp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiRule_35Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_42Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiStatementWithoutIfExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_56Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_59Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_69Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_40Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_54Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_67Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
 antiFieldDeclarationExp _ = Nothing
@@ -447,12 +442,12 @@ antiExtendsListExp ( Anti_ExtendsList v) = Just $ TH.varE (TH.mkName v)
 antiExtendsListExp _ = Nothing
 
 
-antiRule_11Exp :: [ Rule_11 ] -> Maybe (TH.Q TH.Exp)
-antiRule_11Exp ((Anti_Rule_11 v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_11Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiNestedTypeDeclarationExp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiRule_35Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_42Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiStatementWithoutIfExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_56Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_59Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_69Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
+antiRule_10Exp :: [ Rule_10 ] -> Maybe (TH.Q TH.Exp)
+antiRule_10Exp ((Anti_Rule_10 v):rest) =
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_40Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_54Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_67Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
-antiRule_11Exp _ = Nothing
+antiRule_10Exp _ = Nothing
 
 
 antiAnnotationElementExp :: AnnotationElement -> Maybe (TH.Q TH.Exp )
@@ -487,7 +482,7 @@ antiCompilationUnitExp _ = Nothing
 
 antiImportStatementExp :: [ ImportStatement ] -> Maybe (TH.Q TH.Exp)
 antiImportStatementExp ((Anti_ImportStatement v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_11Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiNestedTypeDeclarationExp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiRule_35Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_42Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiStatementWithoutIfExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_56Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_59Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_69Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_40Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_54Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_67Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
 antiImportStatementExp _ = Nothing
@@ -569,9 +564,9 @@ antiLiteralPat ( Anti_Literal v) = Just $ TH.varP (TH.mkName v)
 antiLiteralPat _ = Nothing
 
 
-antiRule_69Pat :: [ Rule_69 ] -> Maybe (TH.Q TH.Pat)
-antiRule_69Pat [Anti_Rule_69 v] = Just $ TH.varP (TH.mkName v)
-antiRule_69Pat _ = Nothing
+antiRule_67Pat :: [ Rule_67 ] -> Maybe (TH.Q TH.Pat)
+antiRule_67Pat [Anti_Rule_67 v] = Just $ TH.varP (TH.mkName v)
+antiRule_67Pat _ = Nothing
 
 
 antiCreationExpressionPat :: CreationExpression -> Maybe (TH.Q TH.Pat )
@@ -629,9 +624,9 @@ antiSwitchStatementPat ( Anti_SwitchStatement v) = Just $ TH.varP (TH.mkName v)
 antiSwitchStatementPat _ = Nothing
 
 
-antiRule_59Pat :: [ Rule_59 ] -> Maybe (TH.Q TH.Pat)
-antiRule_59Pat [Anti_Rule_59 v] = Just $ TH.varP (TH.mkName v)
-antiRule_59Pat _ = Nothing
+antiRule_57Pat :: [ Rule_57 ] -> Maybe (TH.Q TH.Pat)
+antiRule_57Pat [Anti_Rule_57 v] = Just $ TH.varP (TH.mkName v)
+antiRule_57Pat _ = Nothing
 
 
 antiTryStatementPat :: TryStatement -> Maybe (TH.Q TH.Pat )
@@ -644,9 +639,9 @@ antiOptFinallyPat ( Anti_OptFinally v) = Just $ TH.varP (TH.mkName v)
 antiOptFinallyPat _ = Nothing
 
 
-antiRule_56Pat :: [ Rule_56 ] -> Maybe (TH.Q TH.Pat)
-antiRule_56Pat [Anti_Rule_56 v] = Just $ TH.varP (TH.mkName v)
-antiRule_56Pat _ = Nothing
+antiRule_54Pat :: [ Rule_54 ] -> Maybe (TH.Q TH.Pat)
+antiRule_54Pat [Anti_Rule_54 v] = Just $ TH.varP (TH.mkName v)
+antiRule_54Pat _ = Nothing
 
 
 antiForStatementPat :: ForStatement -> Maybe (TH.Q TH.Pat )
@@ -672,11 +667,6 @@ antiIfStatementPat _ = Nothing
 antiOptElsePartPat :: OptElsePart -> Maybe (TH.Q TH.Pat )
 antiOptElsePartPat ( Anti_OptElsePart v) = Just $ TH.varP (TH.mkName v)
 antiOptElsePartPat _ = Nothing
-
-
-antiStatementWithoutIfPat :: StatementWithoutIf -> Maybe (TH.Q TH.Pat )
-antiStatementWithoutIfPat ( Anti_StatementWithoutIf v) = Just $ TH.varP (TH.mkName v)
-antiStatementWithoutIfPat _ = Nothing
 
 
 antiOptIdPat :: OptId -> Maybe (TH.Q TH.Pat )
@@ -744,9 +734,9 @@ antiStatementBlockPat ( Anti_StatementBlock v) = Just $ TH.varP (TH.mkName v)
 antiStatementBlockPat _ = Nothing
 
 
-antiRule_42Pat :: [ Rule_42 ] -> Maybe (TH.Q TH.Pat)
-antiRule_42Pat [Anti_Rule_42 v] = Just $ TH.varP (TH.mkName v)
-antiRule_42Pat _ = Nothing
+antiRule_40Pat :: [ Rule_40 ] -> Maybe (TH.Q TH.Pat)
+antiRule_40Pat [Anti_Rule_40 v] = Just $ TH.varP (TH.mkName v)
+antiRule_40Pat _ = Nothing
 
 
 antiMemberRestPat :: MemberRest -> Maybe (TH.Q TH.Pat )
@@ -774,19 +764,19 @@ antiMemberDeclarationPat ( Anti_MemberDeclaration v) = Just $ TH.varP (TH.mkName
 antiMemberDeclarationPat _ = Nothing
 
 
-antiRule_35Pat :: [ Rule_35 ] -> Maybe (TH.Q TH.Pat)
-antiRule_35Pat [Anti_Rule_35 v] = Just $ TH.varP (TH.mkName v)
-antiRule_35Pat _ = Nothing
-
-
 antiRule_33Pat :: [ Rule_33 ] -> Maybe (TH.Q TH.Pat)
 antiRule_33Pat [Anti_Rule_33 v] = Just $ TH.varP (TH.mkName v)
 antiRule_33Pat _ = Nothing
 
 
-antiNestedTypeDeclarationPat :: NestedTypeDeclaration -> Maybe (TH.Q TH.Pat )
-antiNestedTypeDeclarationPat ( Anti_NestedTypeDeclaration v) = Just $ TH.varP (TH.mkName v)
-antiNestedTypeDeclarationPat _ = Nothing
+antiRule_31Pat :: [ Rule_31 ] -> Maybe (TH.Q TH.Pat)
+antiRule_31Pat [Anti_Rule_31 v] = Just $ TH.varP (TH.mkName v)
+antiRule_31Pat _ = Nothing
+
+
+antiTypeDeclRestPat :: TypeDeclRest -> Maybe (TH.Q TH.Pat )
+antiTypeDeclRestPat ( Anti_TypeDeclRest v) = Just $ TH.varP (TH.mkName v)
+antiTypeDeclRestPat _ = Nothing
 
 
 antiEnumDeclarationPat :: EnumDeclaration -> Maybe (TH.Q TH.Pat )
@@ -839,9 +829,9 @@ antiExtendsListPat ( Anti_ExtendsList v) = Just $ TH.varP (TH.mkName v)
 antiExtendsListPat _ = Nothing
 
 
-antiRule_11Pat :: [ Rule_11 ] -> Maybe (TH.Q TH.Pat)
-antiRule_11Pat [Anti_Rule_11 v] = Just $ TH.varP (TH.mkName v)
-antiRule_11Pat _ = Nothing
+antiRule_10Pat :: [ Rule_10 ] -> Maybe (TH.Q TH.Pat)
+antiRule_10Pat [Anti_Rule_10 v] = Just $ TH.varP (TH.mkName v)
+antiRule_10Pat _ = Nothing
 
 
 antiAnnotationElementPat :: AnnotationElement -> Maybe (TH.Q TH.Pat )
@@ -901,410 +891,405 @@ quoteJavaDecs s = return []
 getJava ( Ctr__Java__0 _ s) = s
 
 java :: QuasiQuoter
-java = QuasiQuoter (quoteJavaExp "tok_Java_dummy_166" getJava ) (quoteJavaPat "tok_Java_dummy_166" getJava ) quoteJavaType quoteJavaDecs
+java = QuasiQuoter (quoteJavaExp "tok_Java_dummy_163" getJava ) (quoteJavaPat "tok_Java_dummy_163" getJava ) quoteJavaType quoteJavaDecs
 
 getAdditiveOp ( Ctr__Java__1 _ s) = s
 
 additiveOp :: QuasiQuoter
-additiveOp = QuasiQuoter (quoteJavaExp "tok_AdditiveOp_dummy_165" getAdditiveOp ) (quoteJavaPat "tok_AdditiveOp_dummy_165" getAdditiveOp ) quoteJavaType quoteJavaDecs
+additiveOp = QuasiQuoter (quoteJavaExp "tok_AdditiveOp_dummy_162" getAdditiveOp ) (quoteJavaPat "tok_AdditiveOp_dummy_162" getAdditiveOp ) quoteJavaType quoteJavaDecs
 
 getAnnotation ( Ctr__Java__2 _ s) = s
 
 annotation :: QuasiQuoter
-annotation = QuasiQuoter (quoteJavaExp "tok_Annotation_dummy_164" getAnnotation ) (quoteJavaPat "tok_Annotation_dummy_164" getAnnotation ) quoteJavaType quoteJavaDecs
+annotation = QuasiQuoter (quoteJavaExp "tok_Annotation_dummy_161" getAnnotation ) (quoteJavaPat "tok_Annotation_dummy_161" getAnnotation ) quoteJavaType quoteJavaDecs
 
 getAnnotationArguments ( Ctr__Java__3 _ s) = s
 
 annotationArguments :: QuasiQuoter
-annotationArguments = QuasiQuoter (quoteJavaExp "tok_AnnotationArguments_dummy_163" getAnnotationArguments ) (quoteJavaPat "tok_AnnotationArguments_dummy_163" getAnnotationArguments ) quoteJavaType quoteJavaDecs
+annotationArguments = QuasiQuoter (quoteJavaExp "tok_AnnotationArguments_dummy_160" getAnnotationArguments ) (quoteJavaPat "tok_AnnotationArguments_dummy_160" getAnnotationArguments ) quoteJavaType quoteJavaDecs
 
 getAnnotationDeclaration ( Ctr__Java__4 _ s) = s
 
 annotationDeclaration :: QuasiQuoter
-annotationDeclaration = QuasiQuoter (quoteJavaExp "tok_AnnotationDeclaration_dummy_162" getAnnotationDeclaration ) (quoteJavaPat "tok_AnnotationDeclaration_dummy_162" getAnnotationDeclaration ) quoteJavaType quoteJavaDecs
+annotationDeclaration = QuasiQuoter (quoteJavaExp "tok_AnnotationDeclaration_dummy_159" getAnnotationDeclaration ) (quoteJavaPat "tok_AnnotationDeclaration_dummy_159" getAnnotationDeclaration ) quoteJavaType quoteJavaDecs
 
 getAnnotationElement ( Ctr__Java__5 _ s) = s
 
 annotationElement :: QuasiQuoter
-annotationElement = QuasiQuoter (quoteJavaExp "tok_AnnotationElement_dummy_161" getAnnotationElement ) (quoteJavaPat "tok_AnnotationElement_dummy_161" getAnnotationElement ) quoteJavaType quoteJavaDecs
+annotationElement = QuasiQuoter (quoteJavaExp "tok_AnnotationElement_dummy_158" getAnnotationElement ) (quoteJavaPat "tok_AnnotationElement_dummy_158" getAnnotationElement ) quoteJavaType quoteJavaDecs
 
 getAnnotationList ( Ctr__Java__6 _ s) = s
 
 annotationList :: QuasiQuoter
-annotationList = QuasiQuoter (quoteJavaExp "tok_AnnotationList_dummy_160" getAnnotationList ) (quoteJavaPat "tok_AnnotationList_dummy_160" getAnnotationList ) quoteJavaType quoteJavaDecs
+annotationList = QuasiQuoter (quoteJavaExp "tok_AnnotationList_dummy_157" getAnnotationList ) (quoteJavaPat "tok_AnnotationList_dummy_157" getAnnotationList ) quoteJavaType quoteJavaDecs
 
 getAnnotationTypeElement ( Ctr__Java__7 _ s) = s
 
 annotationTypeElement :: QuasiQuoter
-annotationTypeElement = QuasiQuoter (quoteJavaExp "tok_AnnotationTypeElement_dummy_159" getAnnotationTypeElement ) (quoteJavaPat "tok_AnnotationTypeElement_dummy_159" getAnnotationTypeElement ) quoteJavaType quoteJavaDecs
+annotationTypeElement = QuasiQuoter (quoteJavaExp "tok_AnnotationTypeElement_dummy_156" getAnnotationTypeElement ) (quoteJavaPat "tok_AnnotationTypeElement_dummy_156" getAnnotationTypeElement ) quoteJavaType quoteJavaDecs
 
 getAnnotationTypeElementList ( Ctr__Java__8 _ s) = s
 
 annotationTypeElementList :: QuasiQuoter
-annotationTypeElementList = QuasiQuoter (quoteJavaExp "tok_AnnotationTypeElementList_dummy_158" getAnnotationTypeElementList ) (quoteJavaPat "tok_AnnotationTypeElementList_dummy_158" getAnnotationTypeElementList ) quoteJavaType quoteJavaDecs
+annotationTypeElementList = QuasiQuoter (quoteJavaExp "tok_AnnotationTypeElementList_dummy_155" getAnnotationTypeElementList ) (quoteJavaPat "tok_AnnotationTypeElementList_dummy_155" getAnnotationTypeElementList ) quoteJavaType quoteJavaDecs
 
 getArglist ( Ctr__Java__9 _ s) = s
 
 arglist :: QuasiQuoter
-arglist = QuasiQuoter (quoteJavaExp "tok_Arglist_dummy_157" getArglist ) (quoteJavaPat "tok_Arglist_dummy_157" getArglist ) quoteJavaType quoteJavaDecs
+arglist = QuasiQuoter (quoteJavaExp "tok_Arglist_dummy_154" getArglist ) (quoteJavaPat "tok_Arglist_dummy_154" getArglist ) quoteJavaType quoteJavaDecs
 
 getAssignmentOp ( Ctr__Java__10 _ s) = s
 
 assignmentOp :: QuasiQuoter
-assignmentOp = QuasiQuoter (quoteJavaExp "tok_AssignmentOp_dummy_156" getAssignmentOp ) (quoteJavaPat "tok_AssignmentOp_dummy_156" getAssignmentOp ) quoteJavaType quoteJavaDecs
+assignmentOp = QuasiQuoter (quoteJavaExp "tok_AssignmentOp_dummy_153" getAssignmentOp ) (quoteJavaPat "tok_AssignmentOp_dummy_153" getAssignmentOp ) quoteJavaType quoteJavaDecs
 
 getCatchList ( Ctr__Java__11 _ s) = s
 
 catchList :: QuasiQuoter
-catchList = QuasiQuoter (quoteJavaExp "tok_CatchList_dummy_155" getCatchList ) (quoteJavaPat "tok_CatchList_dummy_155" getCatchList ) quoteJavaType quoteJavaDecs
+catchList = QuasiQuoter (quoteJavaExp "tok_CatchList_dummy_152" getCatchList ) (quoteJavaPat "tok_CatchList_dummy_152" getCatchList ) quoteJavaType quoteJavaDecs
 
 getClassDeclaration ( Ctr__Java__12 _ s) = s
 
 classDeclaration :: QuasiQuoter
-classDeclaration = QuasiQuoter (quoteJavaExp "tok_ClassDeclaration_dummy_154" getClassDeclaration ) (quoteJavaPat "tok_ClassDeclaration_dummy_154" getClassDeclaration ) quoteJavaType quoteJavaDecs
+classDeclaration = QuasiQuoter (quoteJavaExp "tok_ClassDeclaration_dummy_151" getClassDeclaration ) (quoteJavaPat "tok_ClassDeclaration_dummy_151" getClassDeclaration ) quoteJavaType quoteJavaDecs
 
 getCompilationUnit ( Ctr__Java__13 _ s) = s
 
 compilationUnit :: QuasiQuoter
-compilationUnit = QuasiQuoter (quoteJavaExp "tok_CompilationUnit_dummy_153" getCompilationUnit ) (quoteJavaPat "tok_CompilationUnit_dummy_153" getCompilationUnit ) quoteJavaType quoteJavaDecs
+compilationUnit = QuasiQuoter (quoteJavaExp "tok_CompilationUnit_dummy_150" getCompilationUnit ) (quoteJavaPat "tok_CompilationUnit_dummy_150" getCompilationUnit ) quoteJavaType quoteJavaDecs
 
 getCompoundName ( Ctr__Java__14 _ s) = s
 
 compoundName :: QuasiQuoter
-compoundName = QuasiQuoter (quoteJavaExp "tok_CompoundName_dummy_152" getCompoundName ) (quoteJavaPat "tok_CompoundName_dummy_152" getCompoundName ) quoteJavaType quoteJavaDecs
+compoundName = QuasiQuoter (quoteJavaExp "tok_CompoundName_dummy_149" getCompoundName ) (quoteJavaPat "tok_CompoundName_dummy_149" getCompoundName ) quoteJavaType quoteJavaDecs
 
 getCreationExpression ( Ctr__Java__15 _ s) = s
 
 creationExpression :: QuasiQuoter
-creationExpression = QuasiQuoter (quoteJavaExp "tok_CreationExpression_dummy_151" getCreationExpression ) (quoteJavaPat "tok_CreationExpression_dummy_151" getCreationExpression ) quoteJavaType quoteJavaDecs
+creationExpression = QuasiQuoter (quoteJavaExp "tok_CreationExpression_dummy_148" getCreationExpression ) (quoteJavaPat "tok_CreationExpression_dummy_148" getCreationExpression ) quoteJavaType quoteJavaDecs
 
 getDimExprs ( Ctr__Java__16 _ s) = s
 
 dimExprs :: QuasiQuoter
-dimExprs = QuasiQuoter (quoteJavaExp "tok_DimExprs_dummy_150" getDimExprs ) (quoteJavaPat "tok_DimExprs_dummy_150" getDimExprs ) quoteJavaType quoteJavaDecs
+dimExprs = QuasiQuoter (quoteJavaExp "tok_DimExprs_dummy_147" getDimExprs ) (quoteJavaPat "tok_DimExprs_dummy_147" getDimExprs ) quoteJavaType quoteJavaDecs
 
 getDims ( Ctr__Java__17 _ s) = s
 
 dims :: QuasiQuoter
-dims = QuasiQuoter (quoteJavaExp "tok_Dims_dummy_149" getDims ) (quoteJavaPat "tok_Dims_dummy_149" getDims ) quoteJavaType quoteJavaDecs
+dims = QuasiQuoter (quoteJavaExp "tok_Dims_dummy_146" getDims ) (quoteJavaPat "tok_Dims_dummy_146" getDims ) quoteJavaType quoteJavaDecs
 
 getDoStatement ( Ctr__Java__18 _ s) = s
 
 doStatement :: QuasiQuoter
-doStatement = QuasiQuoter (quoteJavaExp "tok_DoStatement_dummy_148" getDoStatement ) (quoteJavaPat "tok_DoStatement_dummy_148" getDoStatement ) quoteJavaType quoteJavaDecs
+doStatement = QuasiQuoter (quoteJavaExp "tok_DoStatement_dummy_145" getDoStatement ) (quoteJavaPat "tok_DoStatement_dummy_145" getDoStatement ) quoteJavaType quoteJavaDecs
 
 getDocComment ( Ctr__Java__19 _ s) = s
 
 docComment :: QuasiQuoter
-docComment = QuasiQuoter (quoteJavaExp "tok_DocComment_dummy_147" getDocComment ) (quoteJavaPat "tok_DocComment_dummy_147" getDocComment ) quoteJavaType quoteJavaDecs
+docComment = QuasiQuoter (quoteJavaExp "tok_DocComment_dummy_144" getDocComment ) (quoteJavaPat "tok_DocComment_dummy_144" getDocComment ) quoteJavaType quoteJavaDecs
 
 getEnumConstant ( Ctr__Java__20 _ s) = s
 
 enumConstant :: QuasiQuoter
-enumConstant = QuasiQuoter (quoteJavaExp "tok_EnumConstant_dummy_146" getEnumConstant ) (quoteJavaPat "tok_EnumConstant_dummy_146" getEnumConstant ) quoteJavaType quoteJavaDecs
+enumConstant = QuasiQuoter (quoteJavaExp "tok_EnumConstant_dummy_143" getEnumConstant ) (quoteJavaPat "tok_EnumConstant_dummy_143" getEnumConstant ) quoteJavaType quoteJavaDecs
 
 getEnumConstantList ( Ctr__Java__21 _ s) = s
 
 enumConstantList :: QuasiQuoter
-enumConstantList = QuasiQuoter (quoteJavaExp "tok_EnumConstantList_dummy_145" getEnumConstantList ) (quoteJavaPat "tok_EnumConstantList_dummy_145" getEnumConstantList ) quoteJavaType quoteJavaDecs
+enumConstantList = QuasiQuoter (quoteJavaExp "tok_EnumConstantList_dummy_142" getEnumConstantList ) (quoteJavaPat "tok_EnumConstantList_dummy_142" getEnumConstantList ) quoteJavaType quoteJavaDecs
 
 getEnumDeclaration ( Ctr__Java__22 _ s) = s
 
 enumDeclaration :: QuasiQuoter
-enumDeclaration = QuasiQuoter (quoteJavaExp "tok_EnumDeclaration_dummy_144" getEnumDeclaration ) (quoteJavaPat "tok_EnumDeclaration_dummy_144" getEnumDeclaration ) quoteJavaType quoteJavaDecs
+enumDeclaration = QuasiQuoter (quoteJavaExp "tok_EnumDeclaration_dummy_141" getEnumDeclaration ) (quoteJavaPat "tok_EnumDeclaration_dummy_141" getEnumDeclaration ) quoteJavaType quoteJavaDecs
 
 getEqualityOp ( Ctr__Java__23 _ s) = s
 
 equalityOp :: QuasiQuoter
-equalityOp = QuasiQuoter (quoteJavaExp "tok_EqualityOp_dummy_143" getEqualityOp ) (quoteJavaPat "tok_EqualityOp_dummy_143" getEqualityOp ) quoteJavaType quoteJavaDecs
+equalityOp = QuasiQuoter (quoteJavaExp "tok_EqualityOp_dummy_140" getEqualityOp ) (quoteJavaPat "tok_EqualityOp_dummy_140" getEqualityOp ) quoteJavaType quoteJavaDecs
 
 getExpression ( Ctr__Java__24 _ s) = s
 
 expression :: QuasiQuoter
-expression = QuasiQuoter (quoteJavaExp "tok_Expression_dummy_142" getExpression ) (quoteJavaPat "tok_Expression_dummy_142" getExpression ) quoteJavaType quoteJavaDecs
+expression = QuasiQuoter (quoteJavaExp "tok_Expression_dummy_139" getExpression ) (quoteJavaPat "tok_Expression_dummy_139" getExpression ) quoteJavaType quoteJavaDecs
 
 getExtendsList ( Ctr__Java__25 _ s) = s
 
 extendsList :: QuasiQuoter
-extendsList = QuasiQuoter (quoteJavaExp "tok_ExtendsList_dummy_141" getExtendsList ) (quoteJavaPat "tok_ExtendsList_dummy_141" getExtendsList ) quoteJavaType quoteJavaDecs
+extendsList = QuasiQuoter (quoteJavaExp "tok_ExtendsList_dummy_138" getExtendsList ) (quoteJavaPat "tok_ExtendsList_dummy_138" getExtendsList ) quoteJavaType quoteJavaDecs
 
 getFieldDeclaration ( Ctr__Java__26 _ s) = s
 
 fieldDeclaration :: QuasiQuoter
-fieldDeclaration = QuasiQuoter (quoteJavaExp "tok_FieldDeclaration_dummy_140" getFieldDeclaration ) (quoteJavaPat "tok_FieldDeclaration_dummy_140" getFieldDeclaration ) quoteJavaType quoteJavaDecs
+fieldDeclaration = QuasiQuoter (quoteJavaExp "tok_FieldDeclaration_dummy_137" getFieldDeclaration ) (quoteJavaPat "tok_FieldDeclaration_dummy_137" getFieldDeclaration ) quoteJavaType quoteJavaDecs
 
 getFieldDeclarationList ( Ctr__Java__27 _ s) = s
 
 fieldDeclarationList :: QuasiQuoter
-fieldDeclarationList = QuasiQuoter (quoteJavaExp "tok_FieldDeclarationList_dummy_139" getFieldDeclarationList ) (quoteJavaPat "tok_FieldDeclarationList_dummy_139" getFieldDeclarationList ) quoteJavaType quoteJavaDecs
+fieldDeclarationList = QuasiQuoter (quoteJavaExp "tok_FieldDeclarationList_dummy_136" getFieldDeclarationList ) (quoteJavaPat "tok_FieldDeclarationList_dummy_136" getFieldDeclarationList ) quoteJavaType quoteJavaDecs
 
 getForStatement ( Ctr__Java__28 _ s) = s
 
 forStatement :: QuasiQuoter
-forStatement = QuasiQuoter (quoteJavaExp "tok_ForStatement_dummy_138" getForStatement ) (quoteJavaPat "tok_ForStatement_dummy_138" getForStatement ) quoteJavaType quoteJavaDecs
+forStatement = QuasiQuoter (quoteJavaExp "tok_ForStatement_dummy_135" getForStatement ) (quoteJavaPat "tok_ForStatement_dummy_135" getForStatement ) quoteJavaType quoteJavaDecs
 
 getIfStatement ( Ctr__Java__29 _ s) = s
 
 ifStatement :: QuasiQuoter
-ifStatement = QuasiQuoter (quoteJavaExp "tok_IfStatement_dummy_137" getIfStatement ) (quoteJavaPat "tok_IfStatement_dummy_137" getIfStatement ) quoteJavaType quoteJavaDecs
+ifStatement = QuasiQuoter (quoteJavaExp "tok_IfStatement_dummy_134" getIfStatement ) (quoteJavaPat "tok_IfStatement_dummy_134" getIfStatement ) quoteJavaType quoteJavaDecs
 
 getImplementsList ( Ctr__Java__30 _ s) = s
 
 implementsList :: QuasiQuoter
-implementsList = QuasiQuoter (quoteJavaExp "tok_ImplementsList_dummy_136" getImplementsList ) (quoteJavaPat "tok_ImplementsList_dummy_136" getImplementsList ) quoteJavaType quoteJavaDecs
+implementsList = QuasiQuoter (quoteJavaExp "tok_ImplementsList_dummy_133" getImplementsList ) (quoteJavaPat "tok_ImplementsList_dummy_133" getImplementsList ) quoteJavaType quoteJavaDecs
 
 getImportList ( Ctr__Java__31 _ s) = s
 
 importList :: QuasiQuoter
-importList = QuasiQuoter (quoteJavaExp "tok_ImportList_dummy_135" getImportList ) (quoteJavaPat "tok_ImportList_dummy_135" getImportList ) quoteJavaType quoteJavaDecs
+importList = QuasiQuoter (quoteJavaExp "tok_ImportList_dummy_132" getImportList ) (quoteJavaPat "tok_ImportList_dummy_132" getImportList ) quoteJavaType quoteJavaDecs
 
 getImportStatement ( Ctr__Java__32 _ s) = s
 
 importStatement :: QuasiQuoter
-importStatement = QuasiQuoter (quoteJavaExp "tok_ImportStatement_dummy_134" getImportStatement ) (quoteJavaPat "tok_ImportStatement_dummy_134" getImportStatement ) quoteJavaType quoteJavaDecs
+importStatement = QuasiQuoter (quoteJavaExp "tok_ImportStatement_dummy_131" getImportStatement ) (quoteJavaPat "tok_ImportStatement_dummy_131" getImportStatement ) quoteJavaType quoteJavaDecs
 
 getInterfaceDeclaration ( Ctr__Java__33 _ s) = s
 
 interfaceDeclaration :: QuasiQuoter
-interfaceDeclaration = QuasiQuoter (quoteJavaExp "tok_InterfaceDeclaration_dummy_133" getInterfaceDeclaration ) (quoteJavaPat "tok_InterfaceDeclaration_dummy_133" getInterfaceDeclaration ) quoteJavaType quoteJavaDecs
+interfaceDeclaration = QuasiQuoter (quoteJavaExp "tok_InterfaceDeclaration_dummy_130" getInterfaceDeclaration ) (quoteJavaPat "tok_InterfaceDeclaration_dummy_130" getInterfaceDeclaration ) quoteJavaType quoteJavaDecs
 
 getLiteral ( Ctr__Java__34 _ s) = s
 
 literal :: QuasiQuoter
-literal = QuasiQuoter (quoteJavaExp "tok_Literal_dummy_132" getLiteral ) (quoteJavaPat "tok_Literal_dummy_132" getLiteral ) quoteJavaType quoteJavaDecs
+literal = QuasiQuoter (quoteJavaExp "tok_Literal_dummy_129" getLiteral ) (quoteJavaPat "tok_Literal_dummy_129" getLiteral ) quoteJavaType quoteJavaDecs
 
 getMemberAfterFirstId ( Ctr__Java__35 _ s) = s
 
 memberAfterFirstId :: QuasiQuoter
-memberAfterFirstId = QuasiQuoter (quoteJavaExp "tok_MemberAfterFirstId_dummy_131" getMemberAfterFirstId ) (quoteJavaPat "tok_MemberAfterFirstId_dummy_131" getMemberAfterFirstId ) quoteJavaType quoteJavaDecs
+memberAfterFirstId = QuasiQuoter (quoteJavaExp "tok_MemberAfterFirstId_dummy_128" getMemberAfterFirstId ) (quoteJavaPat "tok_MemberAfterFirstId_dummy_128" getMemberAfterFirstId ) quoteJavaType quoteJavaDecs
 
 getMemberDeclaration ( Ctr__Java__36 _ s) = s
 
 memberDeclaration :: QuasiQuoter
-memberDeclaration = QuasiQuoter (quoteJavaExp "tok_MemberDeclaration_dummy_130" getMemberDeclaration ) (quoteJavaPat "tok_MemberDeclaration_dummy_130" getMemberDeclaration ) quoteJavaType quoteJavaDecs
+memberDeclaration = QuasiQuoter (quoteJavaExp "tok_MemberDeclaration_dummy_127" getMemberDeclaration ) (quoteJavaPat "tok_MemberDeclaration_dummy_127" getMemberDeclaration ) quoteJavaType quoteJavaDecs
 
 getMemberRest ( Ctr__Java__37 _ s) = s
 
 memberRest :: QuasiQuoter
-memberRest = QuasiQuoter (quoteJavaExp "tok_MemberRest_dummy_129" getMemberRest ) (quoteJavaPat "tok_MemberRest_dummy_129" getMemberRest ) quoteJavaType quoteJavaDecs
+memberRest = QuasiQuoter (quoteJavaExp "tok_MemberRest_dummy_126" getMemberRest ) (quoteJavaPat "tok_MemberRest_dummy_126" getMemberRest ) quoteJavaType quoteJavaDecs
 
 getModifier ( Ctr__Java__38 _ s) = s
 
 modifier :: QuasiQuoter
-modifier = QuasiQuoter (quoteJavaExp "tok_Modifier_dummy_128" getModifier ) (quoteJavaPat "tok_Modifier_dummy_128" getModifier ) quoteJavaType quoteJavaDecs
+modifier = QuasiQuoter (quoteJavaExp "tok_Modifier_dummy_125" getModifier ) (quoteJavaPat "tok_Modifier_dummy_125" getModifier ) quoteJavaType quoteJavaDecs
 
 getModifierList ( Ctr__Java__39 _ s) = s
 
 modifierList :: QuasiQuoter
-modifierList = QuasiQuoter (quoteJavaExp "tok_ModifierList_dummy_127" getModifierList ) (quoteJavaPat "tok_ModifierList_dummy_127" getModifierList ) quoteJavaType quoteJavaDecs
+modifierList = QuasiQuoter (quoteJavaExp "tok_ModifierList_dummy_124" getModifierList ) (quoteJavaPat "tok_ModifierList_dummy_124" getModifierList ) quoteJavaType quoteJavaDecs
 
 getMoreTypeSpecifier ( Ctr__Java__40 _ s) = s
 
 moreTypeSpecifier :: QuasiQuoter
-moreTypeSpecifier = QuasiQuoter (quoteJavaExp "tok_MoreTypeSpecifier_dummy_126" getMoreTypeSpecifier ) (quoteJavaPat "tok_MoreTypeSpecifier_dummy_126" getMoreTypeSpecifier ) quoteJavaType quoteJavaDecs
+moreTypeSpecifier = QuasiQuoter (quoteJavaExp "tok_MoreTypeSpecifier_dummy_123" getMoreTypeSpecifier ) (quoteJavaPat "tok_MoreTypeSpecifier_dummy_123" getMoreTypeSpecifier ) quoteJavaType quoteJavaDecs
 
 getMoreVariableDeclarators ( Ctr__Java__41 _ s) = s
 
 moreVariableDeclarators :: QuasiQuoter
-moreVariableDeclarators = QuasiQuoter (quoteJavaExp "tok_MoreVariableDeclarators_dummy_125" getMoreVariableDeclarators ) (quoteJavaPat "tok_MoreVariableDeclarators_dummy_125" getMoreVariableDeclarators ) quoteJavaType quoteJavaDecs
+moreVariableDeclarators = QuasiQuoter (quoteJavaExp "tok_MoreVariableDeclarators_dummy_122" getMoreVariableDeclarators ) (quoteJavaPat "tok_MoreVariableDeclarators_dummy_122" getMoreVariableDeclarators ) quoteJavaType quoteJavaDecs
 
 getMultiplicativeOp ( Ctr__Java__42 _ s) = s
 
 multiplicativeOp :: QuasiQuoter
-multiplicativeOp = QuasiQuoter (quoteJavaExp "tok_MultiplicativeOp_dummy_124" getMultiplicativeOp ) (quoteJavaPat "tok_MultiplicativeOp_dummy_124" getMultiplicativeOp ) quoteJavaType quoteJavaDecs
+multiplicativeOp = QuasiQuoter (quoteJavaExp "tok_MultiplicativeOp_dummy_121" getMultiplicativeOp ) (quoteJavaPat "tok_MultiplicativeOp_dummy_121" getMultiplicativeOp ) quoteJavaType quoteJavaDecs
 
-getNestedTypeDeclaration ( Ctr__Java__43 _ s) = s
-
-nestedTypeDeclaration :: QuasiQuoter
-nestedTypeDeclaration = QuasiQuoter (quoteJavaExp "tok_NestedTypeDeclaration_dummy_123" getNestedTypeDeclaration ) (quoteJavaPat "tok_NestedTypeDeclaration_dummy_123" getNestedTypeDeclaration ) quoteJavaType quoteJavaDecs
-
-getNonEmptyDims ( Ctr__Java__44 _ s) = s
+getNonEmptyDims ( Ctr__Java__43 _ s) = s
 
 nonEmptyDims :: QuasiQuoter
-nonEmptyDims = QuasiQuoter (quoteJavaExp "tok_NonEmptyDims_dummy_122" getNonEmptyDims ) (quoteJavaPat "tok_NonEmptyDims_dummy_122" getNonEmptyDims ) quoteJavaType quoteJavaDecs
+nonEmptyDims = QuasiQuoter (quoteJavaExp "tok_NonEmptyDims_dummy_120" getNonEmptyDims ) (quoteJavaPat "tok_NonEmptyDims_dummy_120" getNonEmptyDims ) quoteJavaType quoteJavaDecs
 
-getNonEmptyTypeArguments ( Ctr__Java__45 _ s) = s
+getNonEmptyTypeArguments ( Ctr__Java__44 _ s) = s
 
 nonEmptyTypeArguments :: QuasiQuoter
-nonEmptyTypeArguments = QuasiQuoter (quoteJavaExp "tok_NonEmptyTypeArguments_dummy_121" getNonEmptyTypeArguments ) (quoteJavaPat "tok_NonEmptyTypeArguments_dummy_121" getNonEmptyTypeArguments ) quoteJavaType quoteJavaDecs
+nonEmptyTypeArguments = QuasiQuoter (quoteJavaExp "tok_NonEmptyTypeArguments_dummy_119" getNonEmptyTypeArguments ) (quoteJavaPat "tok_NonEmptyTypeArguments_dummy_119" getNonEmptyTypeArguments ) quoteJavaType quoteJavaDecs
 
-getOptDocComment ( Ctr__Java__46 _ s) = s
+getOptDocComment ( Ctr__Java__45 _ s) = s
 
 optDocComment :: QuasiQuoter
-optDocComment = QuasiQuoter (quoteJavaExp "tok_OptDocComment_dummy_120" getOptDocComment ) (quoteJavaPat "tok_OptDocComment_dummy_120" getOptDocComment ) quoteJavaType quoteJavaDecs
+optDocComment = QuasiQuoter (quoteJavaExp "tok_OptDocComment_dummy_118" getOptDocComment ) (quoteJavaPat "tok_OptDocComment_dummy_118" getOptDocComment ) quoteJavaType quoteJavaDecs
 
-getOptElsePart ( Ctr__Java__47 _ s) = s
+getOptElsePart ( Ctr__Java__46 _ s) = s
 
 optElsePart :: QuasiQuoter
-optElsePart = QuasiQuoter (quoteJavaExp "tok_OptElsePart_dummy_119" getOptElsePart ) (quoteJavaPat "tok_OptElsePart_dummy_119" getOptElsePart ) quoteJavaType quoteJavaDecs
+optElsePart = QuasiQuoter (quoteJavaExp "tok_OptElsePart_dummy_117" getOptElsePart ) (quoteJavaPat "tok_OptElsePart_dummy_117" getOptElsePart ) quoteJavaType quoteJavaDecs
 
-getOptExpression ( Ctr__Java__48 _ s) = s
+getOptExpression ( Ctr__Java__47 _ s) = s
 
 optExpression :: QuasiQuoter
-optExpression = QuasiQuoter (quoteJavaExp "tok_OptExpression_dummy_118" getOptExpression ) (quoteJavaPat "tok_OptExpression_dummy_118" getOptExpression ) quoteJavaType quoteJavaDecs
+optExpression = QuasiQuoter (quoteJavaExp "tok_OptExpression_dummy_116" getOptExpression ) (quoteJavaPat "tok_OptExpression_dummy_116" getOptExpression ) quoteJavaType quoteJavaDecs
 
-getOptFinally ( Ctr__Java__49 _ s) = s
+getOptFinally ( Ctr__Java__48 _ s) = s
 
 optFinally :: QuasiQuoter
-optFinally = QuasiQuoter (quoteJavaExp "tok_OptFinally_dummy_117" getOptFinally ) (quoteJavaPat "tok_OptFinally_dummy_117" getOptFinally ) quoteJavaType quoteJavaDecs
+optFinally = QuasiQuoter (quoteJavaExp "tok_OptFinally_dummy_115" getOptFinally ) (quoteJavaPat "tok_OptFinally_dummy_115" getOptFinally ) quoteJavaType quoteJavaDecs
 
-getOptId ( Ctr__Java__50 _ s) = s
+getOptId ( Ctr__Java__49 _ s) = s
 
 optId :: QuasiQuoter
-optId = QuasiQuoter (quoteJavaExp "tok_OptId_dummy_116" getOptId ) (quoteJavaPat "tok_OptId_dummy_116" getOptId ) quoteJavaType quoteJavaDecs
+optId = QuasiQuoter (quoteJavaExp "tok_OptId_dummy_114" getOptId ) (quoteJavaPat "tok_OptId_dummy_114" getOptId ) quoteJavaType quoteJavaDecs
 
-getOptVariableInitializer ( Ctr__Java__51 _ s) = s
+getOptVariableInitializer ( Ctr__Java__50 _ s) = s
 
 optVariableInitializer :: QuasiQuoter
-optVariableInitializer = QuasiQuoter (quoteJavaExp "tok_OptVariableInitializer_dummy_115" getOptVariableInitializer ) (quoteJavaPat "tok_OptVariableInitializer_dummy_115" getOptVariableInitializer ) quoteJavaType quoteJavaDecs
+optVariableInitializer = QuasiQuoter (quoteJavaExp "tok_OptVariableInitializer_dummy_113" getOptVariableInitializer ) (quoteJavaPat "tok_OptVariableInitializer_dummy_113" getOptVariableInitializer ) quoteJavaType quoteJavaDecs
 
-getPackage ( Ctr__Java__52 _ s) = s
+getPackage ( Ctr__Java__51 _ s) = s
 
 package :: QuasiQuoter
-package = QuasiQuoter (quoteJavaExp "tok_Package_dummy_114" getPackage ) (quoteJavaPat "tok_Package_dummy_114" getPackage ) quoteJavaType quoteJavaDecs
+package = QuasiQuoter (quoteJavaExp "tok_Package_dummy_112" getPackage ) (quoteJavaPat "tok_Package_dummy_112" getPackage ) quoteJavaType quoteJavaDecs
 
-getParameter ( Ctr__Java__53 _ s) = s
+getParameter ( Ctr__Java__52 _ s) = s
 
 parameter :: QuasiQuoter
-parameter = QuasiQuoter (quoteJavaExp "tok_Parameter_dummy_113" getParameter ) (quoteJavaPat "tok_Parameter_dummy_113" getParameter ) quoteJavaType quoteJavaDecs
+parameter = QuasiQuoter (quoteJavaExp "tok_Parameter_dummy_111" getParameter ) (quoteJavaPat "tok_Parameter_dummy_111" getParameter ) quoteJavaType quoteJavaDecs
 
-getParameterList ( Ctr__Java__54 _ s) = s
+getParameterList ( Ctr__Java__53 _ s) = s
 
 parameterList :: QuasiQuoter
-parameterList = QuasiQuoter (quoteJavaExp "tok_ParameterList_dummy_112" getParameterList ) (quoteJavaPat "tok_ParameterList_dummy_112" getParameterList ) quoteJavaType quoteJavaDecs
+parameterList = QuasiQuoter (quoteJavaExp "tok_ParameterList_dummy_110" getParameterList ) (quoteJavaPat "tok_ParameterList_dummy_110" getParameterList ) quoteJavaType quoteJavaDecs
 
-getPostfixOp ( Ctr__Java__55 _ s) = s
+getPostfixOp ( Ctr__Java__54 _ s) = s
 
 postfixOp :: QuasiQuoter
-postfixOp = QuasiQuoter (quoteJavaExp "tok_PostfixOp_dummy_111" getPostfixOp ) (quoteJavaPat "tok_PostfixOp_dummy_111" getPostfixOp ) quoteJavaType quoteJavaDecs
+postfixOp = QuasiQuoter (quoteJavaExp "tok_PostfixOp_dummy_109" getPostfixOp ) (quoteJavaPat "tok_PostfixOp_dummy_109" getPostfixOp ) quoteJavaType quoteJavaDecs
 
-getPrefixOp ( Ctr__Java__56 _ s) = s
+getPrefixOp ( Ctr__Java__55 _ s) = s
 
 prefixOp :: QuasiQuoter
-prefixOp = QuasiQuoter (quoteJavaExp "tok_PrefixOp_dummy_110" getPrefixOp ) (quoteJavaPat "tok_PrefixOp_dummy_110" getPrefixOp ) quoteJavaType quoteJavaDecs
+prefixOp = QuasiQuoter (quoteJavaExp "tok_PrefixOp_dummy_108" getPrefixOp ) (quoteJavaPat "tok_PrefixOp_dummy_108" getPrefixOp ) quoteJavaType quoteJavaDecs
 
-getPrimitiveTypeKeyword ( Ctr__Java__57 _ s) = s
+getPrimitiveTypeKeyword ( Ctr__Java__56 _ s) = s
 
 primitiveTypeKeyword :: QuasiQuoter
-primitiveTypeKeyword = QuasiQuoter (quoteJavaExp "tok_PrimitiveTypeKeyword_dummy_109" getPrimitiveTypeKeyword ) (quoteJavaPat "tok_PrimitiveTypeKeyword_dummy_109" getPrimitiveTypeKeyword ) quoteJavaType quoteJavaDecs
+primitiveTypeKeyword = QuasiQuoter (quoteJavaExp "tok_PrimitiveTypeKeyword_dummy_107" getPrimitiveTypeKeyword ) (quoteJavaPat "tok_PrimitiveTypeKeyword_dummy_107" getPrimitiveTypeKeyword ) quoteJavaType quoteJavaDecs
 
-getRelationalOp ( Ctr__Java__58 _ s) = s
+getRelationalOp ( Ctr__Java__57 _ s) = s
 
 relationalOp :: QuasiQuoter
-relationalOp = QuasiQuoter (quoteJavaExp "tok_RelationalOp_dummy_108" getRelationalOp ) (quoteJavaPat "tok_RelationalOp_dummy_108" getRelationalOp ) quoteJavaType quoteJavaDecs
+relationalOp = QuasiQuoter (quoteJavaExp "tok_RelationalOp_dummy_106" getRelationalOp ) (quoteJavaPat "tok_RelationalOp_dummy_106" getRelationalOp ) quoteJavaType quoteJavaDecs
 
-getShiftOp ( Ctr__Java__59 _ s) = s
+getShiftOp ( Ctr__Java__58 _ s) = s
 
 shiftOp :: QuasiQuoter
-shiftOp = QuasiQuoter (quoteJavaExp "tok_ShiftOp_dummy_107" getShiftOp ) (quoteJavaPat "tok_ShiftOp_dummy_107" getShiftOp ) quoteJavaType quoteJavaDecs
+shiftOp = QuasiQuoter (quoteJavaExp "tok_ShiftOp_dummy_105" getShiftOp ) (quoteJavaPat "tok_ShiftOp_dummy_105" getShiftOp ) quoteJavaType quoteJavaDecs
 
-getStatement ( Ctr__Java__60 _ s) = s
+getStatement ( Ctr__Java__59 _ s) = s
 
 statement :: QuasiQuoter
-statement = QuasiQuoter (quoteJavaExp "tok_Statement_dummy_106" getStatement ) (quoteJavaPat "tok_Statement_dummy_106" getStatement ) quoteJavaType quoteJavaDecs
+statement = QuasiQuoter (quoteJavaExp "tok_Statement_dummy_104" getStatement ) (quoteJavaPat "tok_Statement_dummy_104" getStatement ) quoteJavaType quoteJavaDecs
 
-getStatementBlock ( Ctr__Java__61 _ s) = s
+getStatementBlock ( Ctr__Java__60 _ s) = s
 
 statementBlock :: QuasiQuoter
-statementBlock = QuasiQuoter (quoteJavaExp "tok_StatementBlock_dummy_105" getStatementBlock ) (quoteJavaPat "tok_StatementBlock_dummy_105" getStatementBlock ) quoteJavaType quoteJavaDecs
+statementBlock = QuasiQuoter (quoteJavaExp "tok_StatementBlock_dummy_103" getStatementBlock ) (quoteJavaPat "tok_StatementBlock_dummy_103" getStatementBlock ) quoteJavaType quoteJavaDecs
 
-getStatementList ( Ctr__Java__62 _ s) = s
+getStatementList ( Ctr__Java__61 _ s) = s
 
 statementList :: QuasiQuoter
-statementList = QuasiQuoter (quoteJavaExp "tok_StatementList_dummy_104" getStatementList ) (quoteJavaPat "tok_StatementList_dummy_104" getStatementList ) quoteJavaType quoteJavaDecs
+statementList = QuasiQuoter (quoteJavaExp "tok_StatementList_dummy_102" getStatementList ) (quoteJavaPat "tok_StatementList_dummy_102" getStatementList ) quoteJavaType quoteJavaDecs
 
-getStatementWithoutIf ( Ctr__Java__63 _ s) = s
-
-statementWithoutIf :: QuasiQuoter
-statementWithoutIf = QuasiQuoter (quoteJavaExp "tok_StatementWithoutIf_dummy_103" getStatementWithoutIf ) (quoteJavaPat "tok_StatementWithoutIf_dummy_103" getStatementWithoutIf ) quoteJavaType quoteJavaDecs
-
-getStaticInitializer ( Ctr__Java__64 _ s) = s
+getStaticInitializer ( Ctr__Java__62 _ s) = s
 
 staticInitializer :: QuasiQuoter
-staticInitializer = QuasiQuoter (quoteJavaExp "tok_StaticInitializer_dummy_102" getStaticInitializer ) (quoteJavaPat "tok_StaticInitializer_dummy_102" getStaticInitializer ) quoteJavaType quoteJavaDecs
+staticInitializer = QuasiQuoter (quoteJavaExp "tok_StaticInitializer_dummy_101" getStaticInitializer ) (quoteJavaPat "tok_StaticInitializer_dummy_101" getStaticInitializer ) quoteJavaType quoteJavaDecs
 
-getSwitchCaseList ( Ctr__Java__65 _ s) = s
+getSwitchCaseList ( Ctr__Java__63 _ s) = s
 
 switchCaseList :: QuasiQuoter
-switchCaseList = QuasiQuoter (quoteJavaExp "tok_SwitchCaseList_dummy_101" getSwitchCaseList ) (quoteJavaPat "tok_SwitchCaseList_dummy_101" getSwitchCaseList ) quoteJavaType quoteJavaDecs
+switchCaseList = QuasiQuoter (quoteJavaExp "tok_SwitchCaseList_dummy_100" getSwitchCaseList ) (quoteJavaPat "tok_SwitchCaseList_dummy_100" getSwitchCaseList ) quoteJavaType quoteJavaDecs
 
-getSwitchStatement ( Ctr__Java__66 _ s) = s
+getSwitchStatement ( Ctr__Java__64 _ s) = s
 
 switchStatement :: QuasiQuoter
-switchStatement = QuasiQuoter (quoteJavaExp "tok_SwitchStatement_dummy_100" getSwitchStatement ) (quoteJavaPat "tok_SwitchStatement_dummy_100" getSwitchStatement ) quoteJavaType quoteJavaDecs
+switchStatement = QuasiQuoter (quoteJavaExp "tok_SwitchStatement_dummy_99" getSwitchStatement ) (quoteJavaPat "tok_SwitchStatement_dummy_99" getSwitchStatement ) quoteJavaType quoteJavaDecs
 
-getTryStatement ( Ctr__Java__67 _ s) = s
+getTryStatement ( Ctr__Java__65 _ s) = s
 
 tryStatement :: QuasiQuoter
-tryStatement = QuasiQuoter (quoteJavaExp "tok_TryStatement_dummy_99" getTryStatement ) (quoteJavaPat "tok_TryStatement_dummy_99" getTryStatement ) quoteJavaType quoteJavaDecs
+tryStatement = QuasiQuoter (quoteJavaExp "tok_TryStatement_dummy_98" getTryStatement ) (quoteJavaPat "tok_TryStatement_dummy_98" getTryStatement ) quoteJavaType quoteJavaDecs
 
-getType ( Ctr__Java__68 _ s) = s
+getType ( Ctr__Java__66 _ s) = s
 
 __type :: QuasiQuoter
-__type = QuasiQuoter (quoteJavaExp "tok_Type_dummy_98" getType ) (quoteJavaPat "tok_Type_dummy_98" getType ) quoteJavaType quoteJavaDecs
+__type = QuasiQuoter (quoteJavaExp "tok_Type_dummy_97" getType ) (quoteJavaPat "tok_Type_dummy_97" getType ) quoteJavaType quoteJavaDecs
 
-getTypeArgument ( Ctr__Java__69 _ s) = s
+getTypeArgument ( Ctr__Java__67 _ s) = s
 
 typeArgument :: QuasiQuoter
-typeArgument = QuasiQuoter (quoteJavaExp "tok_TypeArgument_dummy_97" getTypeArgument ) (quoteJavaPat "tok_TypeArgument_dummy_97" getTypeArgument ) quoteJavaType quoteJavaDecs
+typeArgument = QuasiQuoter (quoteJavaExp "tok_TypeArgument_dummy_96" getTypeArgument ) (quoteJavaPat "tok_TypeArgument_dummy_96" getTypeArgument ) quoteJavaType quoteJavaDecs
 
-getTypeArguments ( Ctr__Java__70 _ s) = s
+getTypeArguments ( Ctr__Java__68 _ s) = s
 
 typeArguments :: QuasiQuoter
-typeArguments = QuasiQuoter (quoteJavaExp "tok_TypeArguments_dummy_96" getTypeArguments ) (quoteJavaPat "tok_TypeArguments_dummy_96" getTypeArguments ) quoteJavaType quoteJavaDecs
+typeArguments = QuasiQuoter (quoteJavaExp "tok_TypeArguments_dummy_95" getTypeArguments ) (quoteJavaPat "tok_TypeArguments_dummy_95" getTypeArguments ) quoteJavaType quoteJavaDecs
 
-getTypeDeclaration ( Ctr__Java__71 _ s) = s
+getTypeDeclRest ( Ctr__Java__69 _ s) = s
+
+typeDeclRest :: QuasiQuoter
+typeDeclRest = QuasiQuoter (quoteJavaExp "tok_TypeDeclRest_dummy_94" getTypeDeclRest ) (quoteJavaPat "tok_TypeDeclRest_dummy_94" getTypeDeclRest ) quoteJavaType quoteJavaDecs
+
+getTypeDeclaration ( Ctr__Java__70 _ s) = s
 
 typeDeclaration :: QuasiQuoter
-typeDeclaration = QuasiQuoter (quoteJavaExp "tok_TypeDeclaration_dummy_95" getTypeDeclaration ) (quoteJavaPat "tok_TypeDeclaration_dummy_95" getTypeDeclaration ) quoteJavaType quoteJavaDecs
+typeDeclaration = QuasiQuoter (quoteJavaExp "tok_TypeDeclaration_dummy_93" getTypeDeclaration ) (quoteJavaPat "tok_TypeDeclaration_dummy_93" getTypeDeclaration ) quoteJavaType quoteJavaDecs
 
-getTypeParameter ( Ctr__Java__72 _ s) = s
+getTypeParameter ( Ctr__Java__71 _ s) = s
 
 typeParameter :: QuasiQuoter
-typeParameter = QuasiQuoter (quoteJavaExp "tok_TypeParameter_dummy_94" getTypeParameter ) (quoteJavaPat "tok_TypeParameter_dummy_94" getTypeParameter ) quoteJavaType quoteJavaDecs
+typeParameter = QuasiQuoter (quoteJavaExp "tok_TypeParameter_dummy_92" getTypeParameter ) (quoteJavaPat "tok_TypeParameter_dummy_92" getTypeParameter ) quoteJavaType quoteJavaDecs
 
-getTypeParameters ( Ctr__Java__73 _ s) = s
+getTypeParameters ( Ctr__Java__72 _ s) = s
 
 typeParameters :: QuasiQuoter
-typeParameters = QuasiQuoter (quoteJavaExp "tok_TypeParameters_dummy_93" getTypeParameters ) (quoteJavaPat "tok_TypeParameters_dummy_93" getTypeParameters ) quoteJavaType quoteJavaDecs
+typeParameters = QuasiQuoter (quoteJavaExp "tok_TypeParameters_dummy_91" getTypeParameters ) (quoteJavaPat "tok_TypeParameters_dummy_91" getTypeParameters ) quoteJavaType quoteJavaDecs
 
-getTypeSpecifier ( Ctr__Java__74 _ s) = s
+getTypeSpecifier ( Ctr__Java__73 _ s) = s
 
 typeSpecifier :: QuasiQuoter
-typeSpecifier = QuasiQuoter (quoteJavaExp "tok_TypeSpecifier_dummy_92" getTypeSpecifier ) (quoteJavaPat "tok_TypeSpecifier_dummy_92" getTypeSpecifier ) quoteJavaType quoteJavaDecs
+typeSpecifier = QuasiQuoter (quoteJavaExp "tok_TypeSpecifier_dummy_90" getTypeSpecifier ) (quoteJavaPat "tok_TypeSpecifier_dummy_90" getTypeSpecifier ) quoteJavaType quoteJavaDecs
 
-getVariableDeclaration ( Ctr__Java__75 _ s) = s
+getVariableDeclaration ( Ctr__Java__74 _ s) = s
 
 variableDeclaration :: QuasiQuoter
-variableDeclaration = QuasiQuoter (quoteJavaExp "tok_VariableDeclaration_dummy_91" getVariableDeclaration ) (quoteJavaPat "tok_VariableDeclaration_dummy_91" getVariableDeclaration ) quoteJavaType quoteJavaDecs
+variableDeclaration = QuasiQuoter (quoteJavaExp "tok_VariableDeclaration_dummy_89" getVariableDeclaration ) (quoteJavaPat "tok_VariableDeclaration_dummy_89" getVariableDeclaration ) quoteJavaType quoteJavaDecs
 
-getVariableDeclarator ( Ctr__Java__76 _ s) = s
+getVariableDeclarator ( Ctr__Java__75 _ s) = s
 
 variableDeclarator :: QuasiQuoter
-variableDeclarator = QuasiQuoter (quoteJavaExp "tok_VariableDeclarator_dummy_90" getVariableDeclarator ) (quoteJavaPat "tok_VariableDeclarator_dummy_90" getVariableDeclarator ) quoteJavaType quoteJavaDecs
+variableDeclarator = QuasiQuoter (quoteJavaExp "tok_VariableDeclarator_dummy_88" getVariableDeclarator ) (quoteJavaPat "tok_VariableDeclarator_dummy_88" getVariableDeclarator ) quoteJavaType quoteJavaDecs
 
-getVariableDeclaratorList ( Ctr__Java__77 _ s) = s
+getVariableDeclaratorList ( Ctr__Java__76 _ s) = s
 
 variableDeclaratorList :: QuasiQuoter
-variableDeclaratorList = QuasiQuoter (quoteJavaExp "tok_VariableDeclaratorList_dummy_89" getVariableDeclaratorList ) (quoteJavaPat "tok_VariableDeclaratorList_dummy_89" getVariableDeclaratorList ) quoteJavaType quoteJavaDecs
+variableDeclaratorList = QuasiQuoter (quoteJavaExp "tok_VariableDeclaratorList_dummy_87" getVariableDeclaratorList ) (quoteJavaPat "tok_VariableDeclaratorList_dummy_87" getVariableDeclaratorList ) quoteJavaType quoteJavaDecs
 
-getVariableInitializer ( Ctr__Java__78 _ s) = s
+getVariableInitializer ( Ctr__Java__77 _ s) = s
 
 variableInitializer :: QuasiQuoter
-variableInitializer = QuasiQuoter (quoteJavaExp "tok_VariableInitializer_dummy_88" getVariableInitializer ) (quoteJavaPat "tok_VariableInitializer_dummy_88" getVariableInitializer ) quoteJavaType quoteJavaDecs
+variableInitializer = QuasiQuoter (quoteJavaExp "tok_VariableInitializer_dummy_86" getVariableInitializer ) (quoteJavaPat "tok_VariableInitializer_dummy_86" getVariableInitializer ) quoteJavaType quoteJavaDecs
 
-getVariableInitializerList ( Ctr__Java__79 _ s) = s
+getVariableInitializerList ( Ctr__Java__78 _ s) = s
 
 variableInitializerList :: QuasiQuoter
-variableInitializerList = QuasiQuoter (quoteJavaExp "tok_VariableInitializerList_dummy_87" getVariableInitializerList ) (quoteJavaPat "tok_VariableInitializerList_dummy_87" getVariableInitializerList ) quoteJavaType quoteJavaDecs
+variableInitializerList = QuasiQuoter (quoteJavaExp "tok_VariableInitializerList_dummy_85" getVariableInitializerList ) (quoteJavaPat "tok_VariableInitializerList_dummy_85" getVariableInitializerList ) quoteJavaType quoteJavaDecs
 
-getWhileStatement ( Ctr__Java__80 _ s) = s
+getWhileStatement ( Ctr__Java__79 _ s) = s
 
 whileStatement :: QuasiQuoter
-whileStatement = QuasiQuoter (quoteJavaExp "tok_WhileStatement_dummy_86" getWhileStatement ) (quoteJavaPat "tok_WhileStatement_dummy_86" getWhileStatement ) quoteJavaType quoteJavaDecs
+whileStatement = QuasiQuoter (quoteJavaExp "tok_WhileStatement_dummy_84" getWhileStatement ) (quoteJavaPat "tok_WhileStatement_dummy_84" getWhileStatement ) quoteJavaType quoteJavaDecs
 
-getWildcardType ( Ctr__Java__81 _ s) = s
+getWildcardType ( Ctr__Java__80 _ s) = s
 
 wildcardType :: QuasiQuoter
-wildcardType = QuasiQuoter (quoteJavaExp "tok_WildcardType_dummy_85" getWildcardType ) (quoteJavaPat "tok_WildcardType_dummy_85" getWildcardType ) quoteJavaType quoteJavaDecs
+wildcardType = QuasiQuoter (quoteJavaExp "tok_WildcardType_dummy_83" getWildcardType ) (quoteJavaPat "tok_WildcardType_dummy_83" getWildcardType ) quoteJavaType quoteJavaDecs
 


### PR DESCRIPTION
## Summary

Refactors the Java grammar to enforce a single `ModifierList` per declaration, eliminating redundant modifier parsing and resolving shift/reduce conflicts. The grammar now parses modifiers at the top level and passes them down through a unified `TypeDeclRest` rule, simplifying the structure and improving clarity.

## Key Changes

- **Grammar restructuring**: Moved `ModifierList` parsing to the outermost declaration rules (`TypeDeclaration`, `FieldDeclaration`, etc.) instead of having each class/interface/enum/`@interface` rule begin with its own nullable modifier list
- **Unified TypeDeclRest**: Introduced `TypeDeclRest` (replacing the previous `NestedTypeDeclaration` pattern) to handle everything after modifiers, used consistently at both top-level and nested declaration sites
- **Conflict resolution**: Documented all 18 remaining shift/reduce conflicts in the grammar with detailed explanations of why the default shift resolution is correct for Java semantics:
  - Dangling else binding to nearest `if` (JLS 14.5)
  - catch/finally attachment to nearest try
  - Member id vs empty TypeParameters disambiguation
  - Greedy CompoundName extension
  - Bracket-list shifts in various contexts
  - Array dimension parsing
- **Generated artifacts**: Regenerated `JavaLexer.x`, `JavaParser.y`, and `JavaQQ.hs` to reflect the new grammar structure
- **Test coverage**: Added `test-nested-if.java` to verify correct dangling-else parsing; updated quasi-quotation tests to include nested-if cases

## Implementation Details

The refactoring maintains full backward compatibility in parsing behavior while improving grammar clarity. All 18 shift/reduce conflicts are intentional and documented—their default shift resolution correctly implements Java Language Specification semantics. The grammar now has a cleaner separation of concerns: modifiers are parsed once at the declaration level, then the rest of the declaration structure is handled uniformly through `TypeDeclRest`.

https://claude.ai/code/session_019ekwjA89LLrJi2D4NUg9Az