### PR TITLE
CI: Add toolchain caching and refine test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,12 @@ on:
     branches: [ main, master, develop ]
   workflow_dispatch:
 
+# Cancel superseded runs on the same ref, but never on master: every master
+# push must produce a complete CI record.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
 jobs:
   build-and-test:
     name: Build, Lint, and Test
@@ -17,6 +23,16 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: 'recursive'
+
+    # Everything under runner.temp/ghcup is determined by the two pinned
+    # versions below, so cache it across runs: on a hit the Setup Haskell
+    # step finds the toolchain already installed and drops from ~90s to
+    # seconds. Bump the -v suffix to force a fresh install.
+    - name: Cache GHC/Cabal toolchain
+      uses: actions/cache@v4
+      with:
+        path: ${{ runner.temp }}/ghcup
+        key: ghcup-9.6.4-3.10.2.0-v1
 
     - name: Setup Haskell
       uses: haskell-actions/setup@v2
@@ -102,7 +118,7 @@ jobs:
         export PATH="$HOME/.cabal/bin:$PATH"
         # Build with -Werror to treat all warnings as errors
         # This will fail the build if there are any unused imports or other warnings
-        cabal build --ghc-options="-Werror" --enable-tests --enable-benchmarks -j
+        cabal build --ghc-options="-Werror" --enable-tests -j
 
     - name: Run all tests
       run: |
@@ -141,8 +157,10 @@ jobs:
         run_test "Java QQ Tests" "make test-java-qq"
         run_test "Apache Commons Lexical Tests" "make test-lex-commons-lang-all"
         run_test "Apache Commons Parser Tests" "make test-parse-commons-lang-all"
-        run_test "Debug Options Test" "make test-debug"
-        run_test "Comprehensive Debug Test" "make test-debug-all"
+        # test-debug and test-debug-all exercise the same debug flags but
+        # only print their output; test-debug-options is the automated suite
+        # that asserts on it, so it is the only one CI runs (the other two
+        # targets remain in the makefile for local use).
         run_test "Automated Debug Options" "make test-debug-options"
 
     - name: Print test results summary
@@ -203,7 +221,7 @@ jobs:
         fi
 
     - name: Upload test artifacts
-      if: always()
+      if: failure()
       uses: actions/upload-artifact@v4
       with:
         name: test-output


### PR DESCRIPTION
## Summary
Optimize CI performance by caching the GHC/Cabal toolchain across runs, and refine the test suite to remove redundant debug output tests while keeping the automated assertions.

## Key Changes

- **Toolchain Caching**: Added `actions/cache@v4` step to cache `${{ runner.temp }}/ghcup` (GHC 9.6.4 and Cabal 3.10.2.0), reducing Setup Haskell step from ~90s to seconds on cache hits
- **Concurrency Control**: Added workflow concurrency settings to cancel superseded runs on the same ref, except on master branch (to preserve complete CI records for every master push)
- **Test Suite Refinement**: Removed `test-debug` and `test-debug-all` from CI (they only print output without assertions); kept `test-debug-options` as the automated suite that validates debug flags
- **Build Optimization**: Removed `--enable-benchmarks` flag from cabal build command (no benchmark stanzas exist in rtk.cabal)
- **Artifact Upload**: Changed artifact upload condition from `always()` to `failure()` to only capture test output when tests fail, reducing storage usage

## Implementation Details

The GHC/Cabal toolchain cache key is pinned to specific versions (`ghcup-9.6.4-3.10.2.0-v1`), allowing cache invalidation by bumping the `-v` suffix when toolchain versions change.

The debug test consolidation follows the project's principle of keeping manual debugging targets in the makefile while running only the automated assertion suite in CI.

## Verification

- Baseline (before): master run 27365613686, source-changing commit — **5m03s**, Setup Haskell ~92s reinstall every run.
- Cold-cache run after the change: green in 5m02s; post-job step saved the `ghcup-9.6.4-3.10.2.0-v1` cache in ~6s.
- Warm-cache run 27369306557: green in **2m52s** with cache restore 10s + **Setup Haskell 8s**, full test-out regeneration (the source-touching test profile), all 8 summary-table suites passing, artifact upload skipped. The build step was fully cached in that run; a commit that also recompiles the library adds its incremental build on top, so expect ~3m15–3m40s for a typical source-touching push.

https://claude.ai/code/session_01B4kCHHTz2HMqBCcCSTPAVY