### PR TITLE
Add import-static and throws clauses to the Java grammar (Phase 4a)

### DIFF
--- a/test-grammars/java.pg
+++ b/test-grammars/java.pg
@@ -96,8 +96,22 @@ Package  =
  'package' CompoundName  ';'  ;
 
 ImportStatement  =
- 'import'  (  ( CompoundName  '.'  '*' )
- | CompoundName  )  ';'  ;
+ 'import'  ('static')?  ImportName  ';'  ;
+
+# Import names have their own LEFT-recursive spelling instead of reusing
+# CompoundName: the on-demand form would need CompoundName reduced on
+# lookahead '.' (to then shift '.' '*'), but that reduce loses to the greedy
+# name-extension shift (family 4), which made the star branch unreachable
+# ('import a.b.*;' never parsed). Left recursion keeps both '.'
+# continuations in one item set, so the token AFTER each '.' (id vs '*')
+# picks the branch - no early commitment, no conflict.
+ImportName =
+ ImportHead
+ | ImportHead '.' '*' ;
+
+ImportHead =
+ id
+ | ImportHead '.' id ;
 
 DocComment = doccomment;
 
@@ -219,7 +233,7 @@ PrimitiveTypeKeyword =
 
 # After first id (without TypeParameters or primitive type), branch on next token:
 MemberAfterFirstId =
- '(' ParameterList? ')' StatementBlock                          # Constructor: id '(' ...
+ '(' ParameterList? ')' ThrowsClause? StatementBlock            # Constructor: id '(' ...
  | MoreTypeSpecifier id MemberRest ;                            # Reference type: id ... id MemberRest
 
 # MoreTypeSpecifier handles the rest of a type after the first id
@@ -228,6 +242,13 @@ MoreTypeSpecifier =
  '.' id MoreTypeSpecifier                                       # Qualified name
  | TypeArguments Dims ;                                          # Generics + array brackets
 
+# Throws clause for methods and constructors (JLS 8.4.6): 'throws' is a fresh
+# keyword in follow position, so the optional clause never conflicts with the
+# tokens that end a method header ('{', ';', 'default'). Exception types are
+# CompoundNames: a generic class may not subclass Throwable, so type
+# arguments cannot occur here.
+ThrowsClause = 'throws' CompoundName (',' CompoundName)* ;
+
 # MemberRest branches on what follows "Type id":
 # - '(' indicates a method declaration
 # - '[' or '=' or ',' or ';' indicates a variable declaration
@@ -235,7 +256,7 @@ MoreTypeSpecifier =
 # (int value() default 5;). Accepting it on ordinary methods too is
 # parser-level tolerance; rejecting it there is a semantic check (javac's job).
 MemberRest =
- '(' ParameterList? ')' Dims ( StatementBlock | ('default' Expression)? ';' )
+ '(' ParameterList? ')' Dims ThrowsClause? ( StatementBlock | ('default' Expression)? ';' )
  | Dims OptVariableInitializer MoreVariableDeclarators ';' ;
 
 MoreVariableDeclarators = (',' VariableDeclarator)* ;

--- a/test-grammars/java/lexical/char-literals.tokens
+++ b/test-grammars/java/lexical/char-literals.tokens
@@ -1,70 +1,70 @@
-Tk__tok_class_12
+Tk__tok_class_13
 Tk__id "CharLiterals"
-Tk__tok__symbol__13
-Tk__tok_char_21
+Tk__tok__symbol__14
+Tk__tok_char_22
 Tk__id "simple"
-Tk__tok__eql__9
+Tk__tok__eql__10
 Tk__char "'a'"
 Tk__tok__semi__1
-Tk__tok_char_21
+Tk__tok_char_22
 Tk__id "digit"
-Tk__tok__eql__9
+Tk__tok__eql__10
 Tk__char "'7'"
 Tk__tok__semi__1
-Tk__tok_char_21
+Tk__tok_char_22
 Tk__id "space"
-Tk__tok__eql__9
+Tk__tok__eql__10
 Tk__char "' '"
 Tk__tok__semi__1
-Tk__tok_char_21
+Tk__tok_char_22
 Tk__id "newline"
-Tk__tok__eql__9
+Tk__tok__eql__10
 Tk__char "'\\n'"
 Tk__tok__semi__1
-Tk__tok_char_21
+Tk__tok_char_22
 Tk__id "tab"
-Tk__tok__eql__9
+Tk__tok__eql__10
 Tk__char "'\\t'"
 Tk__tok__semi__1
-Tk__tok_char_21
+Tk__tok_char_22
 Tk__id "backslash"
-Tk__tok__eql__9
+Tk__tok__eql__10
 Tk__char "'\\\\'"
 Tk__tok__semi__1
-Tk__tok_char_21
+Tk__tok_char_22
 Tk__id "quote"
-Tk__tok__eql__9
+Tk__tok__eql__10
 Tk__char "'\\''"
 Tk__tok__semi__1
-Tk__tok_char_21
+Tk__tok_char_22
 Tk__id "doubleQuote"
-Tk__tok__eql__9
+Tk__tok__eql__10
 Tk__char "'\"'"
 Tk__tok__semi__1
-Tk__tok_char_21
+Tk__tok_char_22
 Tk__id "nul"
-Tk__tok__eql__9
+Tk__tok__eql__10
 Tk__char "'\\0'"
 Tk__tok__semi__1
-Tk__tok_char_21
+Tk__tok_char_22
 Tk__id "octal2"
-Tk__tok__eql__9
+Tk__tok__eql__10
 Tk__char "'\\12'"
 Tk__tok__semi__1
-Tk__tok_char_21
+Tk__tok_char_22
 Tk__id "octal3"
-Tk__tok__eql__9
+Tk__tok__eql__10
 Tk__char "'\\101'"
 Tk__tok__semi__1
-Tk__tok_char_21
+Tk__tok_char_22
 Tk__id "octalMax"
-Tk__tok__eql__9
+Tk__tok__eql__10
 Tk__char "'\\377'"
 Tk__tok__semi__1
-Tk__tok_char_21
+Tk__tok_char_22
 Tk__id "unicode"
-Tk__tok__eql__9
+Tk__tok__eql__10
 Tk__char "'\\u0041'"
 Tk__tok__semi__1
-Tk__tok__symbol__14
+Tk__tok__symbol__15
 EndOfFile

--- a/test-grammars/java/lexical/comments.tokens
+++ b/test-grammars/java/lexical/comments.tokens
@@ -1,11 +1,11 @@
 Tk__doccomment "/** A doc comment with {@link Foo#bar()}.\n *\n * @param none\n */"
-Tk__tok_class_12
+Tk__tok_class_13
 Tk__id "Comments"
-Tk__tok__symbol__13
-Tk__tok_int_23
+Tk__tok__symbol__14
+Tk__tok_int_24
 Tk__id "x"
-Tk__tok__eql__9
+Tk__tok__eql__10
 Tk__integerLiteral "1"
 Tk__tok__semi__1
-Tk__tok__symbol__14
+Tk__tok__symbol__15
 EndOfFile

--- a/test-grammars/java/lexical/float-literals.tokens
+++ b/test-grammars/java/lexical/float-literals.tokens
@@ -1,85 +1,85 @@
-Tk__tok_class_12
+Tk__tok_class_13
 Tk__id "FloatLiterals"
-Tk__tok__symbol__13
-Tk__tok_double_26
+Tk__tok__symbol__14
+Tk__tok_double_27
 Tk__id "plain"
-Tk__tok__eql__9
+Tk__tok__eql__10
 Tk__floatLiteral "1.5"
 Tk__tok__semi__1
-Tk__tok_double_26
+Tk__tok_double_27
 Tk__id "leadingDot"
-Tk__tok__eql__9
+Tk__tok__eql__10
 Tk__floatLiteral ".5"
 Tk__tok__semi__1
-Tk__tok_double_26
+Tk__tok_double_27
 Tk__id "trailingDot"
-Tk__tok__eql__9
+Tk__tok__eql__10
 Tk__floatLiteral "1."
 Tk__tok__semi__1
-Tk__tok_float_24
+Tk__tok_float_25
 Tk__id "suffixF"
-Tk__tok__eql__9
+Tk__tok__eql__10
 Tk__floatLiteral "1.5f"
 Tk__tok__semi__1
-Tk__tok_float_24
+Tk__tok_float_25
 Tk__id "suffixFUpper"
-Tk__tok__eql__9
+Tk__tok__eql__10
 Tk__floatLiteral "1.5F"
 Tk__tok__semi__1
-Tk__tok_double_26
+Tk__tok_double_27
 Tk__id "suffixD"
-Tk__tok__eql__9
+Tk__tok__eql__10
 Tk__floatLiteral "1.5d"
 Tk__tok__semi__1
-Tk__tok_double_26
+Tk__tok_double_27
 Tk__id "suffixDUpper"
-Tk__tok__eql__9
+Tk__tok__eql__10
 Tk__floatLiteral "1.5D"
 Tk__tok__semi__1
-Tk__tok_double_26
+Tk__tok_double_27
 Tk__id "expLower"
-Tk__tok__eql__9
+Tk__tok__eql__10
 Tk__floatLiteral "1.5e10"
 Tk__tok__semi__1
-Tk__tok_double_26
+Tk__tok_double_27
 Tk__id "expUpper"
-Tk__tok__eql__9
+Tk__tok__eql__10
 Tk__floatLiteral "1.5E10"
 Tk__tok__semi__1
-Tk__tok_double_26
+Tk__tok_double_27
 Tk__id "expPlus"
-Tk__tok__eql__9
+Tk__tok__eql__10
 Tk__floatLiteral "1.5e+10"
 Tk__tok__semi__1
-Tk__tok_double_26
+Tk__tok_double_27
 Tk__id "expMinus"
-Tk__tok__eql__9
+Tk__tok__eql__10
 Tk__floatLiteral "1.5e-10"
 Tk__tok__semi__1
-Tk__tok_double_26
+Tk__tok_double_27
 Tk__id "intExp"
-Tk__tok__eql__9
+Tk__tok__eql__10
 Tk__floatLiteral "1e5"
 Tk__tok__semi__1
-Tk__tok_double_26
+Tk__tok_double_27
 Tk__id "intExpSuffix"
-Tk__tok__eql__9
+Tk__tok__eql__10
 Tk__floatLiteral "2E5d"
 Tk__tok__semi__1
-Tk__tok_float_24
+Tk__tok_float_25
 Tk__id "intSuffix"
-Tk__tok__eql__9
+Tk__tok__eql__10
 Tk__floatLiteral "10f"
 Tk__tok__semi__1
-Tk__tok_double_26
+Tk__tok_double_27
 Tk__id "intSuffixUpper"
-Tk__tok__eql__9
+Tk__tok__eql__10
 Tk__floatLiteral "10D"
 Tk__tok__semi__1
-Tk__tok_double_26
+Tk__tok_double_27
 Tk__id "underscore"
-Tk__tok__eql__9
+Tk__tok__eql__10
 Tk__floatLiteral "1_000.000_1"
 Tk__tok__semi__1
-Tk__tok__symbol__14
+Tk__tok__symbol__15
 EndOfFile

--- a/test-grammars/java/lexical/int-literals.tokens
+++ b/test-grammars/java/lexical/int-literals.tokens
@@ -1,75 +1,75 @@
-Tk__tok_class_12
+Tk__tok_class_13
 Tk__id "IntLiterals"
-Tk__tok__symbol__13
-Tk__tok_int_23
+Tk__tok__symbol__14
+Tk__tok_int_24
 Tk__id "dec"
-Tk__tok__eql__9
+Tk__tok__eql__10
 Tk__integerLiteral "42"
 Tk__tok__semi__1
-Tk__tok_int_23
+Tk__tok_int_24
 Tk__id "zero"
-Tk__tok__eql__9
+Tk__tok__eql__10
 Tk__integerLiteral "0"
 Tk__tok__semi__1
-Tk__tok_int_23
+Tk__tok_int_24
 Tk__id "oct"
-Tk__tok__eql__9
+Tk__tok__eql__10
 Tk__integerLiteral "0777"
 Tk__tok__semi__1
-Tk__tok_int_23
+Tk__tok_int_24
 Tk__id "hexLower"
-Tk__tok__eql__9
+Tk__tok__eql__10
 Tk__integerLiteral "0xCafeBabe"
 Tk__tok__semi__1
-Tk__tok_int_23
+Tk__tok_int_24
 Tk__id "hexUpper"
-Tk__tok__eql__9
+Tk__tok__eql__10
 Tk__integerLiteral "0X1F"
 Tk__tok__semi__1
-Tk__tok_int_23
+Tk__tok_int_24
 Tk__id "bin"
-Tk__tok__eql__9
+Tk__tok__eql__10
 Tk__integerLiteral "0b1010"
 Tk__tok__semi__1
-Tk__tok_int_23
+Tk__tok_int_24
 Tk__id "binUpper"
-Tk__tok__eql__9
+Tk__tok__eql__10
 Tk__integerLiteral "0B1"
 Tk__tok__semi__1
-Tk__tok_long_25
+Tk__tok_long_26
 Tk__id "longLower"
-Tk__tok__eql__9
+Tk__tok__eql__10
 Tk__integerLiteral "42l"
 Tk__tok__semi__1
-Tk__tok_long_25
+Tk__tok_long_26
 Tk__id "longUpper"
-Tk__tok__eql__9
+Tk__tok__eql__10
 Tk__integerLiteral "42L"
 Tk__tok__semi__1
-Tk__tok_long_25
+Tk__tok_long_26
 Tk__id "hexLong"
-Tk__tok__eql__9
+Tk__tok__eql__10
 Tk__integerLiteral "0xFFL"
 Tk__tok__semi__1
-Tk__tok_int_23
+Tk__tok_int_24
 Tk__id "underscore"
-Tk__tok__eql__9
+Tk__tok__eql__10
 Tk__integerLiteral "1_000_000"
 Tk__tok__semi__1
-Tk__tok_int_23
+Tk__tok_int_24
 Tk__id "underscoreHex"
-Tk__tok__eql__9
+Tk__tok__eql__10
 Tk__integerLiteral "0xFF_EC_DE_5E"
 Tk__tok__semi__1
-Tk__tok_int_23
+Tk__tok_int_24
 Tk__id "underscoreBin"
-Tk__tok__eql__9
+Tk__tok__eql__10
 Tk__integerLiteral "0b1010_1010"
 Tk__tok__semi__1
-Tk__tok_long_25
+Tk__tok_long_26
 Tk__id "underscoreLong"
-Tk__tok__eql__9
+Tk__tok__eql__10
 Tk__integerLiteral "9_999_999_999L"
 Tk__tok__semi__1
-Tk__tok__symbol__14
+Tk__tok__symbol__15
 EndOfFile

--- a/test-grammars/java/lexical/operators.tokens
+++ b/test-grammars/java/lexical/operators.tokens
@@ -1,142 +1,142 @@
-Tk__tok_class_12
+Tk__tok_class_13
 Tk__id "Operators"
-Tk__tok__symbol__13
-Tk__tok_void_27
+Tk__tok__symbol__14
+Tk__tok_void_28
 Tk__id "m"
-Tk__tok__lparen__6
-Tk__tok__rparen__7
-Tk__tok__symbol__13
-Tk__tok_int_23
+Tk__tok__lparen__7
+Tk__tok__rparen__8
+Tk__tok__symbol__14
+Tk__tok_int_24
 Tk__id "a"
-Tk__tok__eql__9
+Tk__tok__eql__10
 Tk__integerLiteral "1"
-Tk__tok__plus__72
+Tk__tok__plus__74
 Tk__integerLiteral "2"
-Tk__tok__minus__73
+Tk__tok__minus__75
 Tk__integerLiteral "3"
-Tk__tok__star__4
+Tk__tok__star__5
 Tk__integerLiteral "4"
-Tk__tok__symbol__74
+Tk__tok__symbol__76
 Tk__integerLiteral "5"
-Tk__tok__symbol__75
+Tk__tok__symbol__77
 Tk__integerLiteral "6"
 Tk__tok__semi__1
 Tk__id "a"
-Tk__tok__plus__eql__45
+Tk__tok__plus__eql__47
 Tk__integerLiteral "1"
 Tk__tok__semi__1
 Tk__id "a"
-Tk__tok__minus__eql__46
+Tk__tok__minus__eql__48
 Tk__integerLiteral "1"
 Tk__tok__semi__1
 Tk__id "a"
-Tk__tok__star__eql__47
+Tk__tok__star__eql__49
 Tk__integerLiteral "2"
-Tk__tok__semi__1
-Tk__id "a"
-Tk__tok__symbol__eql__48
-Tk__integerLiteral "2"
-Tk__tok__semi__1
-Tk__id "a"
-Tk__tok__symbol__eql__52
-Tk__integerLiteral "2"
-Tk__tok__semi__1
-Tk__id "a"
-Tk__tok__symbol__symbol__eql__53
-Tk__integerLiteral "1"
-Tk__tok__semi__1
-Tk__id "a"
-Tk__tok__symbol__symbol__eql__54
-Tk__integerLiteral "1"
-Tk__tok__semi__1
-Tk__id "a"
-Tk__tok__symbol__symbol__symbol__eql__55
-Tk__integerLiteral "1"
 Tk__tok__semi__1
 Tk__id "a"
 Tk__tok__symbol__eql__50
-Tk__integerLiteral "1"
-Tk__tok__semi__1
-Tk__id "a"
-Tk__tok__pipe__eql__49
-Tk__integerLiteral "1"
-Tk__tok__semi__1
-Tk__id "a"
-Tk__tok__symbol__eql__51
-Tk__integerLiteral "1"
-Tk__tok__semi__1
-Tk__tok_int_23
-Tk__id "b"
-Tk__tok__eql__9
-Tk__id "a"
-Tk__tok__symbol__symbol__70
-Tk__integerLiteral "1"
-Tk__tok__pipe__59
-Tk__id "a"
-Tk__tok__symbol__symbol__69
 Tk__integerLiteral "2"
-Tk__tok__symbol__61
+Tk__tok__semi__1
 Tk__id "a"
-Tk__tok__symbol__symbol__symbol__71
+Tk__tok__symbol__eql__54
+Tk__integerLiteral "2"
+Tk__tok__semi__1
+Tk__id "a"
+Tk__tok__symbol__symbol__eql__55
+Tk__integerLiteral "1"
+Tk__tok__semi__1
+Tk__id "a"
+Tk__tok__symbol__symbol__eql__56
+Tk__integerLiteral "1"
+Tk__tok__semi__1
+Tk__id "a"
+Tk__tok__symbol__symbol__symbol__eql__57
+Tk__integerLiteral "1"
+Tk__tok__semi__1
+Tk__id "a"
+Tk__tok__symbol__eql__52
+Tk__integerLiteral "1"
+Tk__tok__semi__1
+Tk__id "a"
+Tk__tok__pipe__eql__51
+Tk__integerLiteral "1"
+Tk__tok__semi__1
+Tk__id "a"
+Tk__tok__symbol__eql__53
+Tk__integerLiteral "1"
+Tk__tok__semi__1
+Tk__tok_int_24
+Tk__id "b"
+Tk__tok__eql__10
+Tk__id "a"
+Tk__tok__symbol__symbol__72
+Tk__integerLiteral "1"
+Tk__tok__pipe__61
+Tk__id "a"
+Tk__tok__symbol__symbol__71
+Tk__integerLiteral "2"
+Tk__tok__symbol__63
+Tk__id "a"
+Tk__tok__symbol__symbol__symbol__73
 Tk__integerLiteral "3"
-Tk__tok__symbol__60
-Tk__tok__tilde__78
+Tk__tok__symbol__62
+Tk__tok__tilde__80
 Tk__id "a"
 Tk__tok__semi__1
-Tk__tok_boolean_19
+Tk__tok_boolean_20
 Tk__id "c"
-Tk__tok__eql__9
+Tk__tok__eql__10
 Tk__id "a"
-Tk__tok__symbol__64
+Tk__tok__symbol__66
 Tk__id "b"
-Tk__tok__pipe__pipe__57
+Tk__tok__pipe__pipe__59
 Tk__id "a"
-Tk__tok__symbol__65
+Tk__tok__symbol__67
 Tk__id "b"
-Tk__tok__symbol__symbol__58
+Tk__tok__symbol__symbol__60
 Tk__id "a"
-Tk__tok__symbol__eql__66
+Tk__tok__symbol__eql__68
 Tk__id "b"
-Tk__tok__pipe__59
+Tk__tok__pipe__61
 Tk__id "a"
-Tk__tok__symbol__eql__67
+Tk__tok__symbol__eql__69
 Tk__id "b"
-Tk__tok__symbol__61
+Tk__tok__symbol__63
 Tk__id "a"
-Tk__tok__eql__eql__62
+Tk__tok__eql__eql__64
 Tk__id "b"
-Tk__tok__symbol__60
+Tk__tok__symbol__62
 Tk__id "a"
-Tk__tok__exclamation__eql__63
+Tk__tok__exclamation__eql__65
 Tk__id "b"
 Tk__tok__semi__1
-Tk__tok_boolean_19
+Tk__tok_boolean_20
 Tk__id "d"
-Tk__tok__eql__9
-Tk__tok__exclamation__79
+Tk__tok__eql__10
+Tk__tok__exclamation__81
 Tk__id "c"
 Tk__tok__semi__1
 Tk__id "a"
-Tk__tok__plus__plus__76
+Tk__tok__plus__plus__78
 Tk__tok__semi__1
 Tk__id "a"
-Tk__tok__minus__minus__77
+Tk__tok__minus__minus__79
 Tk__tok__semi__1
-Tk__tok__plus__plus__76
+Tk__tok__plus__plus__78
 Tk__id "a"
 Tk__tok__semi__1
-Tk__tok__minus__minus__77
+Tk__tok__minus__minus__79
 Tk__id "a"
 Tk__tok__semi__1
-Tk__tok_int_23
+Tk__tok_int_24
 Tk__id "e"
-Tk__tok__eql__9
+Tk__tok__eql__10
 Tk__id "c"
-Tk__tok__symbol__56
+Tk__tok__symbol__58
 Tk__id "a"
-Tk__tok__colon__32
+Tk__tok__colon__34
 Tk__id "b"
 Tk__tok__semi__1
-Tk__tok__symbol__14
-Tk__tok__symbol__14
+Tk__tok__symbol__15
+Tk__tok__symbol__15
 EndOfFile

--- a/test-grammars/java/lexical/string-literals.tokens
+++ b/test-grammars/java/lexical/string-literals.tokens
@@ -1,35 +1,35 @@
-Tk__tok_class_12
+Tk__tok_class_13
 Tk__id "StringLiterals"
-Tk__tok__symbol__13
+Tk__tok__symbol__14
 Tk__id "String"
 Tk__id "empty"
-Tk__tok__eql__9
+Tk__tok__eql__10
 Tk__string "\"\""
 Tk__tok__semi__1
 Tk__id "String"
 Tk__id "simple"
-Tk__tok__eql__9
+Tk__tok__eql__10
 Tk__string "\"hello\""
 Tk__tok__semi__1
 Tk__id "String"
 Tk__id "escapes"
-Tk__tok__eql__9
+Tk__tok__eql__10
 Tk__string "\"tab\\there\\nnewline\""
 Tk__tok__semi__1
 Tk__id "String"
 Tk__id "quote"
-Tk__tok__eql__9
+Tk__tok__eql__10
 Tk__string "\"she said \\\"hi\\\"\""
 Tk__tok__semi__1
 Tk__id "String"
 Tk__id "backslash"
-Tk__tok__eql__9
+Tk__tok__eql__10
 Tk__string "\"back\\\\slash\""
 Tk__tok__semi__1
 Tk__id "String"
 Tk__id "unicode"
-Tk__tok__eql__9
+Tk__tok__eql__10
 Tk__string "\"\\u0041BC\""
 Tk__tok__semi__1
-Tk__tok__symbol__14
+Tk__tok__symbol__15
 EndOfFile

--- a/test-suites/commons-lang-parser-blacklist-tests.txt
+++ b/test-suites/commons-lang-parser-blacklist-tests.txt
@@ -1,14 +1,13 @@
 # Blacklist for full parsing tests (test sources)
-# These files use Java 8+ features not yet supported by the grammar:
-# - Lambda expressions (->)
-# - Method references (::)
-# - Anonymous inner classes
-# - Enhanced for-each with colon
+# These files use features not yet supported by the grammar, chiefly:
+# - 'final' (and annotations) on method parameters
+# - generic method calls / nested generics in expressions
+# - class literals (Foo.class), lambda expressions (->), method
+#   references (::), anonymous inner classes, enhanced for (:)
 #
-# Total: 251 files blacklisted, 16 files passing
+# Total: 238 files blacklisted, 29 files passing
 # As grammar support is added, remove files from this list
 
-org/apache/commons/lang3/AbstractLangTest.java
 org/apache/commons/lang3/AnnotationUtilsTest.java
 org/apache/commons/lang3/AppendableJoinerTest.java
 org/apache/commons/lang3/ArchUtilsTest.java
@@ -40,7 +39,6 @@ org/apache/commons/lang3/EnumUtilsTest.java
 org/apache/commons/lang3/FunctionsTest.java
 org/apache/commons/lang3/HashSetvBitSetTest.java
 org/apache/commons/lang3/IntegerRangeTest.java
-org/apache/commons/lang3/JavaVersionTest.java
 org/apache/commons/lang3/LangAssertions.java
 org/apache/commons/lang3/LocaleUtilsTest.java
 org/apache/commons/lang3/LongRangeTest.java
@@ -57,12 +55,8 @@ org/apache/commons/lang3/StreamsTest.java
 org/apache/commons/lang3/StringEscapeUtilsTest.java
 org/apache/commons/lang3/StringUtilsAbbreviateTest.java
 org/apache/commons/lang3/StringUtilsContainsTest.java
-org/apache/commons/lang3/StringUtilsEmptyBlankTest.java
 org/apache/commons/lang3/StringUtilsEqualsIndexOfTest.java
 org/apache/commons/lang3/StringUtilsIsMixedCaseTest.java
-org/apache/commons/lang3/StringUtilsIsTest.java
-org/apache/commons/lang3/StringUtilsStartsEndsWithTest.java
-org/apache/commons/lang3/StringUtilsSubstringTest.java
 org/apache/commons/lang3/StringUtilsTest.java
 org/apache/commons/lang3/StringUtilsTrimStripTest.java
 org/apache/commons/lang3/StringUtilsValueOfTest.java
@@ -81,7 +75,6 @@ org/apache/commons/lang3/builder/EqualsBuilderReflectJreImplementationTest.java
 org/apache/commons/lang3/builder/EqualsBuilderTest.java
 org/apache/commons/lang3/builder/HashCodeBuilderAndEqualsBuilderTest.java
 org/apache/commons/lang3/builder/HashCodeBuilderTest.java
-org/apache/commons/lang3/builder/IDKeyTest.java
 org/apache/commons/lang3/builder/JsonToStringStyleTest.java
 org/apache/commons/lang3/builder/MultiLineToStringStyleTest.java
 org/apache/commons/lang3/builder/MultilineRecursiveToStringStyleTest.java
@@ -96,8 +89,6 @@ org/apache/commons/lang3/builder/ReflectionToStringBuilderExcludeTest.java
 org/apache/commons/lang3/builder/ReflectionToStringBuilderExcludeWithAnnotationTest.java
 org/apache/commons/lang3/builder/ReflectionToStringBuilderIncludeTest.java
 org/apache/commons/lang3/builder/ReflectionToStringBuilderMutateInspectConcurrencyTest.java
-org/apache/commons/lang3/builder/ReflectionToStringBuilderSummaryTest.java
-org/apache/commons/lang3/builder/ReflectionToStringBuilderTest.java
 org/apache/commons/lang3/builder/ShortPrefixToStringStyleTest.java
 org/apache/commons/lang3/builder/SimpleToStringStyleTest.java
 org/apache/commons/lang3/builder/StandardToStringStyleTest.java
@@ -170,7 +161,6 @@ org/apache/commons/lang3/function/MethodInvokersBiFunctionTest.java
 org/apache/commons/lang3/function/MethodInvokersFailableBiConsumerTest.java
 org/apache/commons/lang3/function/MethodInvokersFailableBiFunctionTest.java
 org/apache/commons/lang3/function/MethodInvokersFailableFunctionTest.java
-org/apache/commons/lang3/function/MethodInvokersFailableSupplierTest.java
 org/apache/commons/lang3/function/MethodInvokersFunctionTest.java
 org/apache/commons/lang3/function/MethodInvokersSupplierTest.java
 org/apache/commons/lang3/function/Objects.java
@@ -229,7 +219,6 @@ org/apache/commons/lang3/text/translate/NumericEntityUnescaperTest.java
 org/apache/commons/lang3/text/translate/OctalUnescaperTest.java
 org/apache/commons/lang3/text/translate/UnicodeEscaperTest.java
 org/apache/commons/lang3/text/translate/UnicodeUnescaperTest.java
-org/apache/commons/lang3/text/translate/UnicodeUnpairedSurrogateRemoverTest.java
 org/apache/commons/lang3/time/CalendarUtilsTest.java
 org/apache/commons/lang3/time/DateFormatUtilsTest.java
 org/apache/commons/lang3/time/DateUtilsFragmentTest.java
@@ -245,11 +234,9 @@ org/apache/commons/lang3/time/FastDateParser_MoreOrLessTest.java
 org/apache/commons/lang3/time/FastDateParser_TimeZoneStrategyTest.java
 org/apache/commons/lang3/time/FastDatePrinterTest.java
 org/apache/commons/lang3/time/FastDatePrinterTimeZonesTest.java
-org/apache/commons/lang3/time/FastTimeZoneTest.java
 org/apache/commons/lang3/time/GmtTimeZoneTest.java
 org/apache/commons/lang3/time/Java15BugFastDateParserTest.java
 org/apache/commons/lang3/time/StopWatchTest.java
-org/apache/commons/lang3/time/TimeZonesTest.java
 org/apache/commons/lang3/time/WeekYearTest.java
 org/apache/commons/lang3/tuple/ImmutablePairTest.java
 org/apache/commons/lang3/tuple/ImmutableTripleTest.java

--- a/test-suites/commons-lang-parser-blacklist.txt
+++ b/test-suites/commons-lang-parser-blacklist.txt
@@ -1,11 +1,11 @@
 # Blacklist for full parsing tests (main sources)
-# These files use Java 8+ features not yet supported by the grammar:
-# - Lambda expressions (->)
-# - Method references (::)
-# - Anonymous inner classes
-# - Enhanced for-each with colon
+# These files use features not yet supported by the grammar, chiefly:
+# - 'final' (and annotations) on method parameters
+# - generic method calls / nested generics in expressions
+# - class literals (Foo.class), lambda expressions (->), method
+#   references (::), anonymous inner classes, enhanced for (:)
 #
-# Total: 245 files blacklisted, 14 files passing
+# Total: 232 files blacklisted, 27 files passing
 # As grammar support is added, remove files from this list
 
 org/apache/commons/lang3/AnnotationUtils.java
@@ -84,7 +84,6 @@ org/apache/commons/lang3/concurrent/BackgroundInitializer.java
 org/apache/commons/lang3/concurrent/BasicThreadFactory.java
 org/apache/commons/lang3/concurrent/CallableBackgroundInitializer.java
 org/apache/commons/lang3/concurrent/CircuitBreakingException.java
-org/apache/commons/lang3/concurrent/Computable.java
 org/apache/commons/lang3/concurrent/ConcurrentException.java
 org/apache/commons/lang3/concurrent/ConcurrentInitializer.java
 org/apache/commons/lang3/concurrent/ConcurrentRuntimeException.java
@@ -125,34 +124,25 @@ org/apache/commons/lang3/function/Failable.java
 org/apache/commons/lang3/function/FailableBiConsumer.java
 org/apache/commons/lang3/function/FailableBiFunction.java
 org/apache/commons/lang3/function/FailableBiPredicate.java
-org/apache/commons/lang3/function/FailableBooleanSupplier.java
 org/apache/commons/lang3/function/FailableByteConsumer.java
-org/apache/commons/lang3/function/FailableByteSupplier.java
-org/apache/commons/lang3/function/FailableCallable.java
 org/apache/commons/lang3/function/FailableConsumer.java
-org/apache/commons/lang3/function/FailableDoubleBinaryOperator.java
 org/apache/commons/lang3/function/FailableDoubleConsumer.java
 org/apache/commons/lang3/function/FailableDoubleFunction.java
 org/apache/commons/lang3/function/FailableDoublePredicate.java
-org/apache/commons/lang3/function/FailableDoubleSupplier.java
 org/apache/commons/lang3/function/FailableDoubleToIntFunction.java
 org/apache/commons/lang3/function/FailableDoubleToLongFunction.java
 org/apache/commons/lang3/function/FailableDoubleUnaryOperator.java
 org/apache/commons/lang3/function/FailableFunction.java
-org/apache/commons/lang3/function/FailableIntBinaryOperator.java
 org/apache/commons/lang3/function/FailableIntConsumer.java
 org/apache/commons/lang3/function/FailableIntFunction.java
 org/apache/commons/lang3/function/FailableIntPredicate.java
-org/apache/commons/lang3/function/FailableIntSupplier.java
 org/apache/commons/lang3/function/FailableIntToDoubleFunction.java
 org/apache/commons/lang3/function/FailableIntToFloatFunction.java
 org/apache/commons/lang3/function/FailableIntToLongFunction.java
 org/apache/commons/lang3/function/FailableIntUnaryOperator.java
-org/apache/commons/lang3/function/FailableLongBinaryOperator.java
 org/apache/commons/lang3/function/FailableLongConsumer.java
 org/apache/commons/lang3/function/FailableLongFunction.java
 org/apache/commons/lang3/function/FailableLongPredicate.java
-org/apache/commons/lang3/function/FailableLongSupplier.java
 org/apache/commons/lang3/function/FailableLongToDoubleFunction.java
 org/apache/commons/lang3/function/FailableLongToIntFunction.java
 org/apache/commons/lang3/function/FailableLongUnaryOperator.java
@@ -160,8 +150,6 @@ org/apache/commons/lang3/function/FailableObjDoubleConsumer.java
 org/apache/commons/lang3/function/FailableObjIntConsumer.java
 org/apache/commons/lang3/function/FailableObjLongConsumer.java
 org/apache/commons/lang3/function/FailablePredicate.java
-org/apache/commons/lang3/function/FailableRunnable.java
-org/apache/commons/lang3/function/FailableShortSupplier.java
 org/apache/commons/lang3/function/FailableSupplier.java
 org/apache/commons/lang3/function/FailableToBooleanFunction.java
 org/apache/commons/lang3/function/FailableToDoubleBiFunction.java
@@ -231,7 +219,6 @@ org/apache/commons/lang3/text/translate/package-info.java
 org/apache/commons/lang3/time/AbstractFormatCache.java
 org/apache/commons/lang3/time/CalendarUtils.java
 org/apache/commons/lang3/time/DateFormatUtils.java
-org/apache/commons/lang3/time/DateParser.java
 org/apache/commons/lang3/time/DateUtils.java
 org/apache/commons/lang3/time/DurationFormatUtils.java
 org/apache/commons/lang3/time/DurationUtils.java

--- a/test/golden/java/JavaLexer.x
+++ b/test/golden/java/JavaLexer.x
@@ -10,182 +10,186 @@ import Data.Data (Data)
 @exponentPart = ([eE]  ("+"| "-") ?  [0-9]  ([0-9_]*  [0-9]) ?)
 @floatTypeSuffix = ([fFdD])
 
-tokens :- "tok_AdditiveOp_dummy_162" { simple Tk__tok_AdditiveOp_dummy_162 }
-          "tok_Annotation_dummy_161" { simple Tk__tok_Annotation_dummy_161 }
-          "tok_AnnotationArguments_dummy_160" { simple Tk__tok_AnnotationArguments_dummy_160 }
-          "tok_AnnotationDeclaration_dummy_159" { simple Tk__tok_AnnotationDeclaration_dummy_159 }
-          "tok_AnnotationElement_dummy_158" { simple Tk__tok_AnnotationElement_dummy_158 }
-          "tok_AnnotationList_dummy_157" { simple Tk__tok_AnnotationList_dummy_157 }
-          "tok_AnnotationTypeElement_dummy_156" { simple Tk__tok_AnnotationTypeElement_dummy_156 }
-          "tok_AnnotationTypeElementList_dummy_155" { simple Tk__tok_AnnotationTypeElementList_dummy_155 }
-          "tok_Arglist_dummy_154" { simple Tk__tok_Arglist_dummy_154 }
-          "tok_AssignmentOp_dummy_153" { simple Tk__tok_AssignmentOp_dummy_153 }
-          "tok_CatchList_dummy_152" { simple Tk__tok_CatchList_dummy_152 }
-          "tok_ClassDeclaration_dummy_151" { simple Tk__tok_ClassDeclaration_dummy_151 }
-          "tok_CompilationUnit_dummy_150" { simple Tk__tok_CompilationUnit_dummy_150 }
-          "tok_CompoundName_dummy_149" { simple Tk__tok_CompoundName_dummy_149 }
-          "tok_CreationExpression_dummy_148" { simple Tk__tok_CreationExpression_dummy_148 }
-          "tok_DimExprs_dummy_147" { simple Tk__tok_DimExprs_dummy_147 }
-          "tok_Dims_dummy_146" { simple Tk__tok_Dims_dummy_146 }
-          "tok_DoStatement_dummy_145" { simple Tk__tok_DoStatement_dummy_145 }
-          "tok_DocComment_dummy_144" { simple Tk__tok_DocComment_dummy_144 }
-          "tok_EnumConstant_dummy_143" { simple Tk__tok_EnumConstant_dummy_143 }
-          "tok_EnumConstantList_dummy_142" { simple Tk__tok_EnumConstantList_dummy_142 }
-          "tok_EnumDeclaration_dummy_141" { simple Tk__tok_EnumDeclaration_dummy_141 }
-          "tok_EqualityOp_dummy_140" { simple Tk__tok_EqualityOp_dummy_140 }
-          "tok_Expression_dummy_139" { simple Tk__tok_Expression_dummy_139 }
-          "tok_ExtendsList_dummy_138" { simple Tk__tok_ExtendsList_dummy_138 }
-          "tok_FieldDeclaration_dummy_137" { simple Tk__tok_FieldDeclaration_dummy_137 }
-          "tok_FieldDeclarationList_dummy_136" { simple Tk__tok_FieldDeclarationList_dummy_136 }
-          "tok_ForStatement_dummy_135" { simple Tk__tok_ForStatement_dummy_135 }
-          "tok_IfStatement_dummy_134" { simple Tk__tok_IfStatement_dummy_134 }
-          "tok_ImplementsList_dummy_133" { simple Tk__tok_ImplementsList_dummy_133 }
-          "tok_ImportList_dummy_132" { simple Tk__tok_ImportList_dummy_132 }
-          "tok_ImportStatement_dummy_131" { simple Tk__tok_ImportStatement_dummy_131 }
-          "tok_InterfaceDeclaration_dummy_130" { simple Tk__tok_InterfaceDeclaration_dummy_130 }
-          "tok_Java_dummy_163" { simple Tk__tok_Java_dummy_163 }
-          "tok_Literal_dummy_129" { simple Tk__tok_Literal_dummy_129 }
-          "tok_MemberAfterFirstId_dummy_128" { simple Tk__tok_MemberAfterFirstId_dummy_128 }
-          "tok_MemberDeclaration_dummy_127" { simple Tk__tok_MemberDeclaration_dummy_127 }
-          "tok_MemberRest_dummy_126" { simple Tk__tok_MemberRest_dummy_126 }
-          "tok_Modifier_dummy_125" { simple Tk__tok_Modifier_dummy_125 }
-          "tok_ModifierList_dummy_124" { simple Tk__tok_ModifierList_dummy_124 }
-          "tok_MoreTypeSpecifier_dummy_123" { simple Tk__tok_MoreTypeSpecifier_dummy_123 }
-          "tok_MoreVariableDeclarators_dummy_122" { simple Tk__tok_MoreVariableDeclarators_dummy_122 }
-          "tok_MultiplicativeOp_dummy_121" { simple Tk__tok_MultiplicativeOp_dummy_121 }
-          "tok_NonEmptyDims_dummy_120" { simple Tk__tok_NonEmptyDims_dummy_120 }
-          "tok_NonEmptyTypeArguments_dummy_119" { simple Tk__tok_NonEmptyTypeArguments_dummy_119 }
-          "tok_OptDocComment_dummy_118" { simple Tk__tok_OptDocComment_dummy_118 }
-          "tok_OptElsePart_dummy_117" { simple Tk__tok_OptElsePart_dummy_117 }
-          "tok_OptExpression_dummy_116" { simple Tk__tok_OptExpression_dummy_116 }
-          "tok_OptFinally_dummy_115" { simple Tk__tok_OptFinally_dummy_115 }
-          "tok_OptId_dummy_114" { simple Tk__tok_OptId_dummy_114 }
-          "tok_OptVariableInitializer_dummy_113" { simple Tk__tok_OptVariableInitializer_dummy_113 }
-          "tok_Package_dummy_112" { simple Tk__tok_Package_dummy_112 }
-          "tok_Parameter_dummy_111" { simple Tk__tok_Parameter_dummy_111 }
-          "tok_ParameterList_dummy_110" { simple Tk__tok_ParameterList_dummy_110 }
-          "tok_PostfixOp_dummy_109" { simple Tk__tok_PostfixOp_dummy_109 }
-          "tok_PrefixOp_dummy_108" { simple Tk__tok_PrefixOp_dummy_108 }
-          "tok_PrimitiveTypeKeyword_dummy_107" { simple Tk__tok_PrimitiveTypeKeyword_dummy_107 }
-          "tok_RelationalOp_dummy_106" { simple Tk__tok_RelationalOp_dummy_106 }
-          "tok_ShiftOp_dummy_105" { simple Tk__tok_ShiftOp_dummy_105 }
-          "tok_Statement_dummy_104" { simple Tk__tok_Statement_dummy_104 }
-          "tok_StatementBlock_dummy_103" { simple Tk__tok_StatementBlock_dummy_103 }
-          "tok_StatementList_dummy_102" { simple Tk__tok_StatementList_dummy_102 }
-          "tok_StaticInitializer_dummy_101" { simple Tk__tok_StaticInitializer_dummy_101 }
-          "tok_SwitchCaseList_dummy_100" { simple Tk__tok_SwitchCaseList_dummy_100 }
-          "tok_SwitchStatement_dummy_99" { simple Tk__tok_SwitchStatement_dummy_99 }
-          "tok_TryStatement_dummy_98" { simple Tk__tok_TryStatement_dummy_98 }
-          "tok_Type_dummy_97" { simple Tk__tok_Type_dummy_97 }
-          "tok_TypeArgument_dummy_96" { simple Tk__tok_TypeArgument_dummy_96 }
-          "tok_TypeArguments_dummy_95" { simple Tk__tok_TypeArguments_dummy_95 }
-          "tok_TypeDeclRest_dummy_94" { simple Tk__tok_TypeDeclRest_dummy_94 }
-          "tok_TypeDeclaration_dummy_93" { simple Tk__tok_TypeDeclaration_dummy_93 }
-          "tok_TypeParameter_dummy_92" { simple Tk__tok_TypeParameter_dummy_92 }
-          "tok_TypeParameters_dummy_91" { simple Tk__tok_TypeParameters_dummy_91 }
-          "tok_TypeSpecifier_dummy_90" { simple Tk__tok_TypeSpecifier_dummy_90 }
-          "tok_VariableDeclaration_dummy_89" { simple Tk__tok_VariableDeclaration_dummy_89 }
-          "tok_VariableDeclarator_dummy_88" { simple Tk__tok_VariableDeclarator_dummy_88 }
-          "tok_VariableDeclaratorList_dummy_87" { simple Tk__tok_VariableDeclaratorList_dummy_87 }
-          "tok_VariableInitializer_dummy_86" { simple Tk__tok_VariableInitializer_dummy_86 }
-          "tok_VariableInitializerList_dummy_85" { simple Tk__tok_VariableInitializerList_dummy_85 }
-          "tok_WhileStatement_dummy_84" { simple Tk__tok_WhileStatement_dummy_84 }
-          "tok_WildcardType_dummy_83" { simple Tk__tok_WildcardType_dummy_83 }
-          "~" { simple Tk__tok__tilde__78 }
-          "}" { simple Tk__tok__symbol__14 }
-          "||" { simple Tk__tok__pipe__pipe__57 }
-          "|=" { simple Tk__tok__pipe__eql__49 }
-          "|" { simple Tk__tok__pipe__59 }
-          "{" { simple Tk__tok__symbol__13 }
-          "while" { simple Tk__tok_while_38 }
-          "void" { simple Tk__tok_void_27 }
-          "try" { simple Tk__tok_try_42 }
-          "true" { simple Tk__tok_true_83 }
-          "transient" { simple Tk__tok_transient_94 }
-          "throw" { simple Tk__tok_throw_31 }
-          "threadsafe" { simple Tk__tok_threadsafe_93 }
-          "this" { simple Tk__tok_this_80 }
-          "synchronized" { simple Tk__tok_synchronized_30 }
-          "switch" { simple Tk__tok_switch_44 }
-          "super" { simple Tk__tok_super_81 }
-          "static" { simple Tk__tok_static_89 }
-          "short" { simple Tk__tok_short_22 }
-          "return" { simple Tk__tok_return_29 }
-          "public" { simple Tk__tok_public_86 }
-          "protected" { simple Tk__tok_protected_88 }
-          "private" { simple Tk__tok_private_87 }
+tokens :- "tok_AdditiveOp_dummy_169" { simple Tk__tok_AdditiveOp_dummy_169 }
+          "tok_Annotation_dummy_168" { simple Tk__tok_Annotation_dummy_168 }
+          "tok_AnnotationArguments_dummy_167" { simple Tk__tok_AnnotationArguments_dummy_167 }
+          "tok_AnnotationDeclaration_dummy_166" { simple Tk__tok_AnnotationDeclaration_dummy_166 }
+          "tok_AnnotationElement_dummy_165" { simple Tk__tok_AnnotationElement_dummy_165 }
+          "tok_AnnotationList_dummy_164" { simple Tk__tok_AnnotationList_dummy_164 }
+          "tok_AnnotationTypeElement_dummy_163" { simple Tk__tok_AnnotationTypeElement_dummy_163 }
+          "tok_AnnotationTypeElementList_dummy_162" { simple Tk__tok_AnnotationTypeElementList_dummy_162 }
+          "tok_Arglist_dummy_161" { simple Tk__tok_Arglist_dummy_161 }
+          "tok_AssignmentOp_dummy_160" { simple Tk__tok_AssignmentOp_dummy_160 }
+          "tok_CatchList_dummy_159" { simple Tk__tok_CatchList_dummy_159 }
+          "tok_ClassDeclaration_dummy_158" { simple Tk__tok_ClassDeclaration_dummy_158 }
+          "tok_CompilationUnit_dummy_157" { simple Tk__tok_CompilationUnit_dummy_157 }
+          "tok_CompoundName_dummy_156" { simple Tk__tok_CompoundName_dummy_156 }
+          "tok_CreationExpression_dummy_155" { simple Tk__tok_CreationExpression_dummy_155 }
+          "tok_DimExprs_dummy_154" { simple Tk__tok_DimExprs_dummy_154 }
+          "tok_Dims_dummy_153" { simple Tk__tok_Dims_dummy_153 }
+          "tok_DoStatement_dummy_152" { simple Tk__tok_DoStatement_dummy_152 }
+          "tok_DocComment_dummy_151" { simple Tk__tok_DocComment_dummy_151 }
+          "tok_EnumConstant_dummy_150" { simple Tk__tok_EnumConstant_dummy_150 }
+          "tok_EnumConstantList_dummy_149" { simple Tk__tok_EnumConstantList_dummy_149 }
+          "tok_EnumDeclaration_dummy_148" { simple Tk__tok_EnumDeclaration_dummy_148 }
+          "tok_EqualityOp_dummy_147" { simple Tk__tok_EqualityOp_dummy_147 }
+          "tok_Expression_dummy_146" { simple Tk__tok_Expression_dummy_146 }
+          "tok_ExtendsList_dummy_145" { simple Tk__tok_ExtendsList_dummy_145 }
+          "tok_FieldDeclaration_dummy_144" { simple Tk__tok_FieldDeclaration_dummy_144 }
+          "tok_FieldDeclarationList_dummy_143" { simple Tk__tok_FieldDeclarationList_dummy_143 }
+          "tok_ForStatement_dummy_142" { simple Tk__tok_ForStatement_dummy_142 }
+          "tok_IfStatement_dummy_141" { simple Tk__tok_IfStatement_dummy_141 }
+          "tok_ImplementsList_dummy_140" { simple Tk__tok_ImplementsList_dummy_140 }
+          "tok_ImportHead_dummy_139" { simple Tk__tok_ImportHead_dummy_139 }
+          "tok_ImportList_dummy_138" { simple Tk__tok_ImportList_dummy_138 }
+          "tok_ImportName_dummy_137" { simple Tk__tok_ImportName_dummy_137 }
+          "tok_ImportStatement_dummy_136" { simple Tk__tok_ImportStatement_dummy_136 }
+          "tok_InterfaceDeclaration_dummy_135" { simple Tk__tok_InterfaceDeclaration_dummy_135 }
+          "tok_Java_dummy_170" { simple Tk__tok_Java_dummy_170 }
+          "tok_Literal_dummy_134" { simple Tk__tok_Literal_dummy_134 }
+          "tok_MemberAfterFirstId_dummy_133" { simple Tk__tok_MemberAfterFirstId_dummy_133 }
+          "tok_MemberDeclaration_dummy_132" { simple Tk__tok_MemberDeclaration_dummy_132 }
+          "tok_MemberRest_dummy_131" { simple Tk__tok_MemberRest_dummy_131 }
+          "tok_Modifier_dummy_130" { simple Tk__tok_Modifier_dummy_130 }
+          "tok_ModifierList_dummy_129" { simple Tk__tok_ModifierList_dummy_129 }
+          "tok_MoreTypeSpecifier_dummy_128" { simple Tk__tok_MoreTypeSpecifier_dummy_128 }
+          "tok_MoreVariableDeclarators_dummy_127" { simple Tk__tok_MoreVariableDeclarators_dummy_127 }
+          "tok_MultiplicativeOp_dummy_126" { simple Tk__tok_MultiplicativeOp_dummy_126 }
+          "tok_NonEmptyDims_dummy_125" { simple Tk__tok_NonEmptyDims_dummy_125 }
+          "tok_NonEmptyTypeArguments_dummy_124" { simple Tk__tok_NonEmptyTypeArguments_dummy_124 }
+          "tok_OptDocComment_dummy_123" { simple Tk__tok_OptDocComment_dummy_123 }
+          "tok_OptElsePart_dummy_122" { simple Tk__tok_OptElsePart_dummy_122 }
+          "tok_OptExpression_dummy_121" { simple Tk__tok_OptExpression_dummy_121 }
+          "tok_OptFinally_dummy_120" { simple Tk__tok_OptFinally_dummy_120 }
+          "tok_OptId_dummy_119" { simple Tk__tok_OptId_dummy_119 }
+          "tok_OptVariableInitializer_dummy_118" { simple Tk__tok_OptVariableInitializer_dummy_118 }
+          "tok_Package_dummy_117" { simple Tk__tok_Package_dummy_117 }
+          "tok_Parameter_dummy_116" { simple Tk__tok_Parameter_dummy_116 }
+          "tok_ParameterList_dummy_115" { simple Tk__tok_ParameterList_dummy_115 }
+          "tok_PostfixOp_dummy_114" { simple Tk__tok_PostfixOp_dummy_114 }
+          "tok_PrefixOp_dummy_113" { simple Tk__tok_PrefixOp_dummy_113 }
+          "tok_PrimitiveTypeKeyword_dummy_112" { simple Tk__tok_PrimitiveTypeKeyword_dummy_112 }
+          "tok_RelationalOp_dummy_111" { simple Tk__tok_RelationalOp_dummy_111 }
+          "tok_ShiftOp_dummy_110" { simple Tk__tok_ShiftOp_dummy_110 }
+          "tok_Statement_dummy_109" { simple Tk__tok_Statement_dummy_109 }
+          "tok_StatementBlock_dummy_108" { simple Tk__tok_StatementBlock_dummy_108 }
+          "tok_StatementList_dummy_107" { simple Tk__tok_StatementList_dummy_107 }
+          "tok_StaticInitializer_dummy_106" { simple Tk__tok_StaticInitializer_dummy_106 }
+          "tok_SwitchCaseList_dummy_105" { simple Tk__tok_SwitchCaseList_dummy_105 }
+          "tok_SwitchStatement_dummy_104" { simple Tk__tok_SwitchStatement_dummy_104 }
+          "tok_ThrowsClause_dummy_103" { simple Tk__tok_ThrowsClause_dummy_103 }
+          "tok_TryStatement_dummy_102" { simple Tk__tok_TryStatement_dummy_102 }
+          "tok_Type_dummy_101" { simple Tk__tok_Type_dummy_101 }
+          "tok_TypeArgument_dummy_100" { simple Tk__tok_TypeArgument_dummy_100 }
+          "tok_TypeArguments_dummy_99" { simple Tk__tok_TypeArguments_dummy_99 }
+          "tok_TypeDeclRest_dummy_98" { simple Tk__tok_TypeDeclRest_dummy_98 }
+          "tok_TypeDeclaration_dummy_97" { simple Tk__tok_TypeDeclaration_dummy_97 }
+          "tok_TypeParameter_dummy_96" { simple Tk__tok_TypeParameter_dummy_96 }
+          "tok_TypeParameters_dummy_95" { simple Tk__tok_TypeParameters_dummy_95 }
+          "tok_TypeSpecifier_dummy_94" { simple Tk__tok_TypeSpecifier_dummy_94 }
+          "tok_VariableDeclaration_dummy_93" { simple Tk__tok_VariableDeclaration_dummy_93 }
+          "tok_VariableDeclarator_dummy_92" { simple Tk__tok_VariableDeclarator_dummy_92 }
+          "tok_VariableDeclaratorList_dummy_91" { simple Tk__tok_VariableDeclaratorList_dummy_91 }
+          "tok_VariableInitializer_dummy_90" { simple Tk__tok_VariableInitializer_dummy_90 }
+          "tok_VariableInitializerList_dummy_89" { simple Tk__tok_VariableInitializerList_dummy_89 }
+          "tok_WhileStatement_dummy_88" { simple Tk__tok_WhileStatement_dummy_88 }
+          "tok_WildcardType_dummy_87" { simple Tk__tok_WildcardType_dummy_87 }
+          "~" { simple Tk__tok__tilde__80 }
+          "}" { simple Tk__tok__symbol__15 }
+          "||" { simple Tk__tok__pipe__pipe__59 }
+          "|=" { simple Tk__tok__pipe__eql__51 }
+          "|" { simple Tk__tok__pipe__61 }
+          "{" { simple Tk__tok__symbol__14 }
+          "while" { simple Tk__tok_while_40 }
+          "void" { simple Tk__tok_void_28 }
+          "try" { simple Tk__tok_try_44 }
+          "true" { simple Tk__tok_true_85 }
+          "transient" { simple Tk__tok_transient_95 }
+          "throws" { simple Tk__tok_throws_29 }
+          "throw" { simple Tk__tok_throw_33 }
+          "threadsafe" { simple Tk__tok_threadsafe_94 }
+          "this" { simple Tk__tok_this_82 }
+          "synchronized" { simple Tk__tok_synchronized_32 }
+          "switch" { simple Tk__tok_switch_46 }
+          "super" { simple Tk__tok_super_83 }
+          "static" { simple Tk__tok_static_3 }
+          "short" { simple Tk__tok_short_23 }
+          "return" { simple Tk__tok_return_31 }
+          "public" { simple Tk__tok_public_88 }
+          "protected" { simple Tk__tok_protected_90 }
+          "private" { simple Tk__tok_private_89 }
           "package" { simple Tk__tok_package_0 }
-          "null" { simple Tk__tok_null_85 }
-          "new" { simple Tk__tok_new_82 }
-          "native" { simple Tk__tok_native_91 }
-          "long" { simple Tk__tok_long_25 }
-          "interface" { simple Tk__tok_interface_15 }
-          "int" { simple Tk__tok_int_23 }
-          "instanceof" { simple Tk__tok_instanceof_68 }
+          "null" { simple Tk__tok_null_87 }
+          "new" { simple Tk__tok_new_84 }
+          "native" { simple Tk__tok_native_92 }
+          "long" { simple Tk__tok_long_26 }
+          "interface" { simple Tk__tok_interface_16 }
+          "int" { simple Tk__tok_int_24 }
+          "instanceof" { simple Tk__tok_instanceof_70 }
           "import" { simple Tk__tok_import_2 }
-          "implements" { simple Tk__tok_implements_11 }
-          "if" { simple Tk__tok_if_36 }
-          "for" { simple Tk__tok_for_39 }
-          "float" { simple Tk__tok_float_24 }
-          "finally" { simple Tk__tok_finally_41 }
-          "final" { simple Tk__tok_final_90 }
-          "false" { simple Tk__tok_false_84 }
-          "extends" { simple Tk__tok_extends_10 }
-          "enum" { simple Tk__tok_enum_16 }
-          "else" { simple Tk__tok_else_35 }
-          "double" { simple Tk__tok_double_26 }
-          "do" { simple Tk__tok_do_37 }
-          "default" { simple Tk__tok_default_28 }
-          "continue" { simple Tk__tok_continue_34 }
-          "class" { simple Tk__tok_class_12 }
-          "char" { simple Tk__tok_char_21 }
-          "catch" { simple Tk__tok_catch_40 }
-          "case" { simple Tk__tok_case_43 }
-          "byte" { simple Tk__tok_byte_20 }
-          "break" { simple Tk__tok_break_33 }
-          "boolean" { simple Tk__tok_boolean_19 }
-          "abstract" { simple Tk__tok_abstract_92 }
-          "^=" { simple Tk__tok__symbol__eql__51 }
-          "^" { simple Tk__tok__symbol__60 }
-          "]" { simple Tk__tok__sq_bkt_r__18 }
-          "[" { simple Tk__tok__sq_bkt_l__17 }
-          "@" { simple Tk__tok__symbol__5 }
-          "?" { simple Tk__tok__symbol__56 }
-          ">>>=" { simple Tk__tok__symbol__symbol__symbol__eql__55 }
-          ">>>" { simple Tk__tok__symbol__symbol__symbol__71 }
-          ">>=" { simple Tk__tok__symbol__symbol__eql__54 }
-          ">>" { simple Tk__tok__symbol__symbol__69 }
-          ">=" { simple Tk__tok__symbol__eql__67 }
-          ">" { simple Tk__tok__symbol__65 }
-          "==" { simple Tk__tok__eql__eql__62 }
-          "=" { simple Tk__tok__eql__9 }
-          "<=" { simple Tk__tok__symbol__eql__66 }
-          "<<=" { simple Tk__tok__symbol__symbol__eql__53 }
-          "<<" { simple Tk__tok__symbol__symbol__70 }
-          "<" { simple Tk__tok__symbol__64 }
+          "implements" { simple Tk__tok_implements_12 }
+          "if" { simple Tk__tok_if_38 }
+          "for" { simple Tk__tok_for_41 }
+          "float" { simple Tk__tok_float_25 }
+          "finally" { simple Tk__tok_finally_43 }
+          "final" { simple Tk__tok_final_91 }
+          "false" { simple Tk__tok_false_86 }
+          "extends" { simple Tk__tok_extends_11 }
+          "enum" { simple Tk__tok_enum_17 }
+          "else" { simple Tk__tok_else_37 }
+          "double" { simple Tk__tok_double_27 }
+          "do" { simple Tk__tok_do_39 }
+          "default" { simple Tk__tok_default_30 }
+          "continue" { simple Tk__tok_continue_36 }
+          "class" { simple Tk__tok_class_13 }
+          "char" { simple Tk__tok_char_22 }
+          "catch" { simple Tk__tok_catch_42 }
+          "case" { simple Tk__tok_case_45 }
+          "byte" { simple Tk__tok_byte_21 }
+          "break" { simple Tk__tok_break_35 }
+          "boolean" { simple Tk__tok_boolean_20 }
+          "abstract" { simple Tk__tok_abstract_93 }
+          "^=" { simple Tk__tok__symbol__eql__53 }
+          "^" { simple Tk__tok__symbol__62 }
+          "]" { simple Tk__tok__sq_bkt_r__19 }
+          "[" { simple Tk__tok__sq_bkt_l__18 }
+          "@" { simple Tk__tok__symbol__6 }
+          "?" { simple Tk__tok__symbol__58 }
+          ">>>=" { simple Tk__tok__symbol__symbol__symbol__eql__57 }
+          ">>>" { simple Tk__tok__symbol__symbol__symbol__73 }
+          ">>=" { simple Tk__tok__symbol__symbol__eql__56 }
+          ">>" { simple Tk__tok__symbol__symbol__71 }
+          ">=" { simple Tk__tok__symbol__eql__69 }
+          ">" { simple Tk__tok__symbol__67 }
+          "==" { simple Tk__tok__eql__eql__64 }
+          "=" { simple Tk__tok__eql__10 }
+          "<=" { simple Tk__tok__symbol__eql__68 }
+          "<<=" { simple Tk__tok__symbol__symbol__eql__55 }
+          "<<" { simple Tk__tok__symbol__symbol__72 }
+          "<" { simple Tk__tok__symbol__66 }
           ";" { simple Tk__tok__semi__1 }
-          ":" { simple Tk__tok__colon__32 }
-          "/=" { simple Tk__tok__symbol__eql__48 }
-          "/" { simple Tk__tok__symbol__74 }
-          "." { simple Tk__tok__dot__3 }
-          "-=" { simple Tk__tok__minus__eql__46 }
-          "--" { simple Tk__tok__minus__minus__77 }
-          "-" { simple Tk__tok__minus__73 }
-          "," { simple Tk__tok__coma__8 }
-          "+=" { simple Tk__tok__plus__eql__45 }
-          "++" { simple Tk__tok__plus__plus__76 }
-          "+" { simple Tk__tok__plus__72 }
-          "*=" { simple Tk__tok__star__eql__47 }
-          "*" { simple Tk__tok__star__4 }
-          ")" { simple Tk__tok__rparen__7 }
-          "(" { simple Tk__tok__lparen__6 }
-          "&=" { simple Tk__tok__symbol__eql__50 }
-          "&&" { simple Tk__tok__symbol__symbol__58 }
-          "&" { simple Tk__tok__symbol__61 }
-          "%=" { simple Tk__tok__symbol__eql__52 }
-          "%" { simple Tk__tok__symbol__75 }
-          "!=" { simple Tk__tok__exclamation__eql__63 }
-          "!" { simple Tk__tok__exclamation__79 }
+          ":" { simple Tk__tok__colon__34 }
+          "/=" { simple Tk__tok__symbol__eql__50 }
+          "/" { simple Tk__tok__symbol__76 }
+          "." { simple Tk__tok__dot__4 }
+          "-=" { simple Tk__tok__minus__eql__48 }
+          "--" { simple Tk__tok__minus__minus__79 }
+          "-" { simple Tk__tok__minus__75 }
+          "," { simple Tk__tok__coma__9 }
+          "+=" { simple Tk__tok__plus__eql__47 }
+          "++" { simple Tk__tok__plus__plus__78 }
+          "+" { simple Tk__tok__plus__74 }
+          "*=" { simple Tk__tok__star__eql__49 }
+          "*" { simple Tk__tok__star__5 }
+          ")" { simple Tk__tok__rparen__8 }
+          "(" { simple Tk__tok__lparen__7 }
+          "&=" { simple Tk__tok__symbol__eql__52 }
+          "&&" { simple Tk__tok__symbol__symbol__60 }
+          "&" { simple Tk__tok__symbol__63 }
+          "%=" { simple Tk__tok__symbol__eql__54 }
+          "%" { simple Tk__tok__symbol__77 }
+          "!=" { simple Tk__tok__exclamation__eql__65 }
+          "!" { simple Tk__tok__exclamation__81 }
           ("/*"  ([^\*\n]| [\n])  ([\n]| [^\*\n]| [\*]  [^\/\n]| [\*]  [\n])*  "*/") ;
           ("//"  [^\n]*  \n) ;
           ([\ \t\n\r]+) ;
@@ -246,6 +250,7 @@ tokens :- "tok_AdditiveOp_dummy_162" { simple Tk__tok_AdditiveOp_dummy_162 }
           ("$"  "StatementBlock"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_StatementBlock . ((tail . dropWhile (/= ':'))) }
           ("$"  "MoreVariableDeclarators"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_MoreVariableDeclarators . ((tail . dropWhile (/= ':'))) }
           ("$"  "MemberRest"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_MemberRest . ((tail . dropWhile (/= ':'))) }
+          ("$"  "ThrowsClause"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_ThrowsClause . ((tail . dropWhile (/= ':'))) }
           ("$"  "MoreTypeSpecifier"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_MoreTypeSpecifier . ((tail . dropWhile (/= ':'))) }
           ("$"  "MemberAfterFirstId"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_MemberAfterFirstId . ((tail . dropWhile (/= ':'))) }
           ("$"  "PrimitiveTypeKeyword"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_PrimitiveTypeKeyword . ((tail . dropWhile (/= ':'))) }
@@ -271,6 +276,8 @@ tokens :- "tok_AdditiveOp_dummy_162" { simple Tk__tok_AdditiveOp_dummy_162 }
           ("$"  "AnnotationArguments"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_AnnotationArguments . ((tail . dropWhile (/= ':'))) }
           ("$"  "Annotation"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_Annotation . ((tail . dropWhile (/= ':'))) }
           ("$"  "DocComment"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_DocComment . ((tail . dropWhile (/= ':'))) }
+          ("$"  "ImportHead"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_ImportHead . ((tail . dropWhile (/= ':'))) }
+          ("$"  "ImportName"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_ImportName . ((tail . dropWhile (/= ':'))) }
           ("$"  "ImportStatement"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_ImportStatement . ((tail . dropWhile (/= ':'))) }
           ("$"  "Package"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_Package . ((tail . dropWhile (/= ':'))) }
           ("$"  "CompilationUnit"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_CompilationUnit . ((tail . dropWhile (/= ':'))) }
@@ -282,182 +289,186 @@ tokens :- "tok_AdditiveOp_dummy_162" { simple Tk__tok_AdditiveOp_dummy_162 }
 
 {
 data Token = EndOfFile |
-             Tk__tok_AdditiveOp_dummy_162 |
-             Tk__tok_Annotation_dummy_161 |
-             Tk__tok_AnnotationArguments_dummy_160 |
-             Tk__tok_AnnotationDeclaration_dummy_159 |
-             Tk__tok_AnnotationElement_dummy_158 |
-             Tk__tok_AnnotationList_dummy_157 |
-             Tk__tok_AnnotationTypeElement_dummy_156 |
-             Tk__tok_AnnotationTypeElementList_dummy_155 |
-             Tk__tok_Arglist_dummy_154 |
-             Tk__tok_AssignmentOp_dummy_153 |
-             Tk__tok_CatchList_dummy_152 |
-             Tk__tok_ClassDeclaration_dummy_151 |
-             Tk__tok_CompilationUnit_dummy_150 |
-             Tk__tok_CompoundName_dummy_149 |
-             Tk__tok_CreationExpression_dummy_148 |
-             Tk__tok_DimExprs_dummy_147 |
-             Tk__tok_Dims_dummy_146 |
-             Tk__tok_DoStatement_dummy_145 |
-             Tk__tok_DocComment_dummy_144 |
-             Tk__tok_EnumConstant_dummy_143 |
-             Tk__tok_EnumConstantList_dummy_142 |
-             Tk__tok_EnumDeclaration_dummy_141 |
-             Tk__tok_EqualityOp_dummy_140 |
-             Tk__tok_Expression_dummy_139 |
-             Tk__tok_ExtendsList_dummy_138 |
-             Tk__tok_FieldDeclaration_dummy_137 |
-             Tk__tok_FieldDeclarationList_dummy_136 |
-             Tk__tok_ForStatement_dummy_135 |
-             Tk__tok_IfStatement_dummy_134 |
-             Tk__tok_ImplementsList_dummy_133 |
-             Tk__tok_ImportList_dummy_132 |
-             Tk__tok_ImportStatement_dummy_131 |
-             Tk__tok_InterfaceDeclaration_dummy_130 |
-             Tk__tok_Java_dummy_163 |
-             Tk__tok_Literal_dummy_129 |
-             Tk__tok_MemberAfterFirstId_dummy_128 |
-             Tk__tok_MemberDeclaration_dummy_127 |
-             Tk__tok_MemberRest_dummy_126 |
-             Tk__tok_Modifier_dummy_125 |
-             Tk__tok_ModifierList_dummy_124 |
-             Tk__tok_MoreTypeSpecifier_dummy_123 |
-             Tk__tok_MoreVariableDeclarators_dummy_122 |
-             Tk__tok_MultiplicativeOp_dummy_121 |
-             Tk__tok_NonEmptyDims_dummy_120 |
-             Tk__tok_NonEmptyTypeArguments_dummy_119 |
-             Tk__tok_OptDocComment_dummy_118 |
-             Tk__tok_OptElsePart_dummy_117 |
-             Tk__tok_OptExpression_dummy_116 |
-             Tk__tok_OptFinally_dummy_115 |
-             Tk__tok_OptId_dummy_114 |
-             Tk__tok_OptVariableInitializer_dummy_113 |
-             Tk__tok_Package_dummy_112 |
-             Tk__tok_Parameter_dummy_111 |
-             Tk__tok_ParameterList_dummy_110 |
-             Tk__tok_PostfixOp_dummy_109 |
-             Tk__tok_PrefixOp_dummy_108 |
-             Tk__tok_PrimitiveTypeKeyword_dummy_107 |
-             Tk__tok_RelationalOp_dummy_106 |
-             Tk__tok_ShiftOp_dummy_105 |
-             Tk__tok_Statement_dummy_104 |
-             Tk__tok_StatementBlock_dummy_103 |
-             Tk__tok_StatementList_dummy_102 |
-             Tk__tok_StaticInitializer_dummy_101 |
-             Tk__tok_SwitchCaseList_dummy_100 |
-             Tk__tok_SwitchStatement_dummy_99 |
-             Tk__tok_TryStatement_dummy_98 |
-             Tk__tok_Type_dummy_97 |
-             Tk__tok_TypeArgument_dummy_96 |
-             Tk__tok_TypeArguments_dummy_95 |
-             Tk__tok_TypeDeclRest_dummy_94 |
-             Tk__tok_TypeDeclaration_dummy_93 |
-             Tk__tok_TypeParameter_dummy_92 |
-             Tk__tok_TypeParameters_dummy_91 |
-             Tk__tok_TypeSpecifier_dummy_90 |
-             Tk__tok_VariableDeclaration_dummy_89 |
-             Tk__tok_VariableDeclarator_dummy_88 |
-             Tk__tok_VariableDeclaratorList_dummy_87 |
-             Tk__tok_VariableInitializer_dummy_86 |
-             Tk__tok_VariableInitializerList_dummy_85 |
-             Tk__tok_WhileStatement_dummy_84 |
-             Tk__tok_WildcardType_dummy_83 |
-             Tk__tok__tilde__78 |
+             Tk__tok_AdditiveOp_dummy_169 |
+             Tk__tok_Annotation_dummy_168 |
+             Tk__tok_AnnotationArguments_dummy_167 |
+             Tk__tok_AnnotationDeclaration_dummy_166 |
+             Tk__tok_AnnotationElement_dummy_165 |
+             Tk__tok_AnnotationList_dummy_164 |
+             Tk__tok_AnnotationTypeElement_dummy_163 |
+             Tk__tok_AnnotationTypeElementList_dummy_162 |
+             Tk__tok_Arglist_dummy_161 |
+             Tk__tok_AssignmentOp_dummy_160 |
+             Tk__tok_CatchList_dummy_159 |
+             Tk__tok_ClassDeclaration_dummy_158 |
+             Tk__tok_CompilationUnit_dummy_157 |
+             Tk__tok_CompoundName_dummy_156 |
+             Tk__tok_CreationExpression_dummy_155 |
+             Tk__tok_DimExprs_dummy_154 |
+             Tk__tok_Dims_dummy_153 |
+             Tk__tok_DoStatement_dummy_152 |
+             Tk__tok_DocComment_dummy_151 |
+             Tk__tok_EnumConstant_dummy_150 |
+             Tk__tok_EnumConstantList_dummy_149 |
+             Tk__tok_EnumDeclaration_dummy_148 |
+             Tk__tok_EqualityOp_dummy_147 |
+             Tk__tok_Expression_dummy_146 |
+             Tk__tok_ExtendsList_dummy_145 |
+             Tk__tok_FieldDeclaration_dummy_144 |
+             Tk__tok_FieldDeclarationList_dummy_143 |
+             Tk__tok_ForStatement_dummy_142 |
+             Tk__tok_IfStatement_dummy_141 |
+             Tk__tok_ImplementsList_dummy_140 |
+             Tk__tok_ImportHead_dummy_139 |
+             Tk__tok_ImportList_dummy_138 |
+             Tk__tok_ImportName_dummy_137 |
+             Tk__tok_ImportStatement_dummy_136 |
+             Tk__tok_InterfaceDeclaration_dummy_135 |
+             Tk__tok_Java_dummy_170 |
+             Tk__tok_Literal_dummy_134 |
+             Tk__tok_MemberAfterFirstId_dummy_133 |
+             Tk__tok_MemberDeclaration_dummy_132 |
+             Tk__tok_MemberRest_dummy_131 |
+             Tk__tok_Modifier_dummy_130 |
+             Tk__tok_ModifierList_dummy_129 |
+             Tk__tok_MoreTypeSpecifier_dummy_128 |
+             Tk__tok_MoreVariableDeclarators_dummy_127 |
+             Tk__tok_MultiplicativeOp_dummy_126 |
+             Tk__tok_NonEmptyDims_dummy_125 |
+             Tk__tok_NonEmptyTypeArguments_dummy_124 |
+             Tk__tok_OptDocComment_dummy_123 |
+             Tk__tok_OptElsePart_dummy_122 |
+             Tk__tok_OptExpression_dummy_121 |
+             Tk__tok_OptFinally_dummy_120 |
+             Tk__tok_OptId_dummy_119 |
+             Tk__tok_OptVariableInitializer_dummy_118 |
+             Tk__tok_Package_dummy_117 |
+             Tk__tok_Parameter_dummy_116 |
+             Tk__tok_ParameterList_dummy_115 |
+             Tk__tok_PostfixOp_dummy_114 |
+             Tk__tok_PrefixOp_dummy_113 |
+             Tk__tok_PrimitiveTypeKeyword_dummy_112 |
+             Tk__tok_RelationalOp_dummy_111 |
+             Tk__tok_ShiftOp_dummy_110 |
+             Tk__tok_Statement_dummy_109 |
+             Tk__tok_StatementBlock_dummy_108 |
+             Tk__tok_StatementList_dummy_107 |
+             Tk__tok_StaticInitializer_dummy_106 |
+             Tk__tok_SwitchCaseList_dummy_105 |
+             Tk__tok_SwitchStatement_dummy_104 |
+             Tk__tok_ThrowsClause_dummy_103 |
+             Tk__tok_TryStatement_dummy_102 |
+             Tk__tok_Type_dummy_101 |
+             Tk__tok_TypeArgument_dummy_100 |
+             Tk__tok_TypeArguments_dummy_99 |
+             Tk__tok_TypeDeclRest_dummy_98 |
+             Tk__tok_TypeDeclaration_dummy_97 |
+             Tk__tok_TypeParameter_dummy_96 |
+             Tk__tok_TypeParameters_dummy_95 |
+             Tk__tok_TypeSpecifier_dummy_94 |
+             Tk__tok_VariableDeclaration_dummy_93 |
+             Tk__tok_VariableDeclarator_dummy_92 |
+             Tk__tok_VariableDeclaratorList_dummy_91 |
+             Tk__tok_VariableInitializer_dummy_90 |
+             Tk__tok_VariableInitializerList_dummy_89 |
+             Tk__tok_WhileStatement_dummy_88 |
+             Tk__tok_WildcardType_dummy_87 |
+             Tk__tok__tilde__80 |
+             Tk__tok__symbol__15 |
+             Tk__tok__pipe__pipe__59 |
+             Tk__tok__pipe__eql__51 |
+             Tk__tok__pipe__61 |
              Tk__tok__symbol__14 |
-             Tk__tok__pipe__pipe__57 |
-             Tk__tok__pipe__eql__49 |
-             Tk__tok__pipe__59 |
-             Tk__tok__symbol__13 |
-             Tk__tok_while_38 |
-             Tk__tok_void_27 |
-             Tk__tok_try_42 |
-             Tk__tok_true_83 |
-             Tk__tok_transient_94 |
-             Tk__tok_throw_31 |
-             Tk__tok_threadsafe_93 |
-             Tk__tok_this_80 |
-             Tk__tok_synchronized_30 |
-             Tk__tok_switch_44 |
-             Tk__tok_super_81 |
-             Tk__tok_static_89 |
-             Tk__tok_short_22 |
-             Tk__tok_return_29 |
-             Tk__tok_public_86 |
-             Tk__tok_protected_88 |
-             Tk__tok_private_87 |
+             Tk__tok_while_40 |
+             Tk__tok_void_28 |
+             Tk__tok_try_44 |
+             Tk__tok_true_85 |
+             Tk__tok_transient_95 |
+             Tk__tok_throws_29 |
+             Tk__tok_throw_33 |
+             Tk__tok_threadsafe_94 |
+             Tk__tok_this_82 |
+             Tk__tok_synchronized_32 |
+             Tk__tok_switch_46 |
+             Tk__tok_super_83 |
+             Tk__tok_static_3 |
+             Tk__tok_short_23 |
+             Tk__tok_return_31 |
+             Tk__tok_public_88 |
+             Tk__tok_protected_90 |
+             Tk__tok_private_89 |
              Tk__tok_package_0 |
-             Tk__tok_null_85 |
-             Tk__tok_new_82 |
-             Tk__tok_native_91 |
-             Tk__tok_long_25 |
-             Tk__tok_interface_15 |
-             Tk__tok_int_23 |
-             Tk__tok_instanceof_68 |
+             Tk__tok_null_87 |
+             Tk__tok_new_84 |
+             Tk__tok_native_92 |
+             Tk__tok_long_26 |
+             Tk__tok_interface_16 |
+             Tk__tok_int_24 |
+             Tk__tok_instanceof_70 |
              Tk__tok_import_2 |
-             Tk__tok_implements_11 |
-             Tk__tok_if_36 |
-             Tk__tok_for_39 |
-             Tk__tok_float_24 |
-             Tk__tok_finally_41 |
-             Tk__tok_final_90 |
-             Tk__tok_false_84 |
-             Tk__tok_extends_10 |
-             Tk__tok_enum_16 |
-             Tk__tok_else_35 |
-             Tk__tok_double_26 |
-             Tk__tok_do_37 |
-             Tk__tok_default_28 |
-             Tk__tok_continue_34 |
-             Tk__tok_class_12 |
-             Tk__tok_char_21 |
-             Tk__tok_catch_40 |
-             Tk__tok_case_43 |
-             Tk__tok_byte_20 |
-             Tk__tok_break_33 |
-             Tk__tok_boolean_19 |
-             Tk__tok_abstract_92 |
-             Tk__tok__symbol__eql__51 |
-             Tk__tok__symbol__60 |
-             Tk__tok__sq_bkt_r__18 |
-             Tk__tok__sq_bkt_l__17 |
-             Tk__tok__symbol__5 |
-             Tk__tok__symbol__56 |
-             Tk__tok__symbol__symbol__symbol__eql__55 |
-             Tk__tok__symbol__symbol__symbol__71 |
-             Tk__tok__symbol__symbol__eql__54 |
-             Tk__tok__symbol__symbol__69 |
-             Tk__tok__symbol__eql__67 |
-             Tk__tok__symbol__65 |
-             Tk__tok__eql__eql__62 |
-             Tk__tok__eql__9 |
-             Tk__tok__symbol__eql__66 |
-             Tk__tok__symbol__symbol__eql__53 |
-             Tk__tok__symbol__symbol__70 |
-             Tk__tok__symbol__64 |
+             Tk__tok_implements_12 |
+             Tk__tok_if_38 |
+             Tk__tok_for_41 |
+             Tk__tok_float_25 |
+             Tk__tok_finally_43 |
+             Tk__tok_final_91 |
+             Tk__tok_false_86 |
+             Tk__tok_extends_11 |
+             Tk__tok_enum_17 |
+             Tk__tok_else_37 |
+             Tk__tok_double_27 |
+             Tk__tok_do_39 |
+             Tk__tok_default_30 |
+             Tk__tok_continue_36 |
+             Tk__tok_class_13 |
+             Tk__tok_char_22 |
+             Tk__tok_catch_42 |
+             Tk__tok_case_45 |
+             Tk__tok_byte_21 |
+             Tk__tok_break_35 |
+             Tk__tok_boolean_20 |
+             Tk__tok_abstract_93 |
+             Tk__tok__symbol__eql__53 |
+             Tk__tok__symbol__62 |
+             Tk__tok__sq_bkt_r__19 |
+             Tk__tok__sq_bkt_l__18 |
+             Tk__tok__symbol__6 |
+             Tk__tok__symbol__58 |
+             Tk__tok__symbol__symbol__symbol__eql__57 |
+             Tk__tok__symbol__symbol__symbol__73 |
+             Tk__tok__symbol__symbol__eql__56 |
+             Tk__tok__symbol__symbol__71 |
+             Tk__tok__symbol__eql__69 |
+             Tk__tok__symbol__67 |
+             Tk__tok__eql__eql__64 |
+             Tk__tok__eql__10 |
+             Tk__tok__symbol__eql__68 |
+             Tk__tok__symbol__symbol__eql__55 |
+             Tk__tok__symbol__symbol__72 |
+             Tk__tok__symbol__66 |
              Tk__tok__semi__1 |
-             Tk__tok__colon__32 |
-             Tk__tok__symbol__eql__48 |
-             Tk__tok__symbol__74 |
-             Tk__tok__dot__3 |
-             Tk__tok__minus__eql__46 |
-             Tk__tok__minus__minus__77 |
-             Tk__tok__minus__73 |
-             Tk__tok__coma__8 |
-             Tk__tok__plus__eql__45 |
-             Tk__tok__plus__plus__76 |
-             Tk__tok__plus__72 |
-             Tk__tok__star__eql__47 |
-             Tk__tok__star__4 |
-             Tk__tok__rparen__7 |
-             Tk__tok__lparen__6 |
+             Tk__tok__colon__34 |
              Tk__tok__symbol__eql__50 |
-             Tk__tok__symbol__symbol__58 |
-             Tk__tok__symbol__61 |
+             Tk__tok__symbol__76 |
+             Tk__tok__dot__4 |
+             Tk__tok__minus__eql__48 |
+             Tk__tok__minus__minus__79 |
+             Tk__tok__minus__75 |
+             Tk__tok__coma__9 |
+             Tk__tok__plus__eql__47 |
+             Tk__tok__plus__plus__78 |
+             Tk__tok__plus__74 |
+             Tk__tok__star__eql__49 |
+             Tk__tok__star__5 |
+             Tk__tok__rparen__8 |
+             Tk__tok__lparen__7 |
              Tk__tok__symbol__eql__52 |
-             Tk__tok__symbol__75 |
-             Tk__tok__exclamation__eql__63 |
-             Tk__tok__exclamation__79 |
+             Tk__tok__symbol__symbol__60 |
+             Tk__tok__symbol__63 |
+             Tk__tok__symbol__eql__54 |
+             Tk__tok__symbol__77 |
+             Tk__tok__exclamation__eql__65 |
+             Tk__tok__exclamation__81 |
              Tk__doccomment String |
              Tk__id String |
              Tk__string String |
@@ -515,6 +526,7 @@ data Token = EndOfFile |
              Tk__qq_StatementBlock String |
              Tk__qq_MoreVariableDeclarators String |
              Tk__qq_MemberRest String |
+             Tk__qq_ThrowsClause String |
              Tk__qq_MoreTypeSpecifier String |
              Tk__qq_MemberAfterFirstId String |
              Tk__qq_PrimitiveTypeKeyword String |
@@ -540,6 +552,8 @@ data Token = EndOfFile |
              Tk__qq_AnnotationArguments String |
              Tk__qq_Annotation String |
              Tk__qq_DocComment String |
+             Tk__qq_ImportHead String |
+             Tk__qq_ImportName String |
              Tk__qq_ImportStatement String |
              Tk__qq_Package String |
              Tk__qq_CompilationUnit String |

--- a/test/golden/java/JavaParser.y
+++ b/test/golden/java/JavaParser.y
@@ -13,182 +13,186 @@ import qualified JavaLexer as L (Token(..), PosToken(..), AlexPosn(..), alexScan
 %token
 
 rtk__eof { L.PosToken _ L.EndOfFile }
-tok_AdditiveOp_dummy_162 { L.PosToken _ L.Tk__tok_AdditiveOp_dummy_162 }
-tok_Annotation_dummy_161 { L.PosToken _ L.Tk__tok_Annotation_dummy_161 }
-tok_AnnotationArguments_dummy_160 { L.PosToken _ L.Tk__tok_AnnotationArguments_dummy_160 }
-tok_AnnotationDeclaration_dummy_159 { L.PosToken _ L.Tk__tok_AnnotationDeclaration_dummy_159 }
-tok_AnnotationElement_dummy_158 { L.PosToken _ L.Tk__tok_AnnotationElement_dummy_158 }
-tok_AnnotationList_dummy_157 { L.PosToken _ L.Tk__tok_AnnotationList_dummy_157 }
-tok_AnnotationTypeElement_dummy_156 { L.PosToken _ L.Tk__tok_AnnotationTypeElement_dummy_156 }
-tok_AnnotationTypeElementList_dummy_155 { L.PosToken _ L.Tk__tok_AnnotationTypeElementList_dummy_155 }
-tok_Arglist_dummy_154 { L.PosToken _ L.Tk__tok_Arglist_dummy_154 }
-tok_AssignmentOp_dummy_153 { L.PosToken _ L.Tk__tok_AssignmentOp_dummy_153 }
-tok_CatchList_dummy_152 { L.PosToken _ L.Tk__tok_CatchList_dummy_152 }
-tok_ClassDeclaration_dummy_151 { L.PosToken _ L.Tk__tok_ClassDeclaration_dummy_151 }
-tok_CompilationUnit_dummy_150 { L.PosToken _ L.Tk__tok_CompilationUnit_dummy_150 }
-tok_CompoundName_dummy_149 { L.PosToken _ L.Tk__tok_CompoundName_dummy_149 }
-tok_CreationExpression_dummy_148 { L.PosToken _ L.Tk__tok_CreationExpression_dummy_148 }
-tok_DimExprs_dummy_147 { L.PosToken _ L.Tk__tok_DimExprs_dummy_147 }
-tok_Dims_dummy_146 { L.PosToken _ L.Tk__tok_Dims_dummy_146 }
-tok_DoStatement_dummy_145 { L.PosToken _ L.Tk__tok_DoStatement_dummy_145 }
-tok_DocComment_dummy_144 { L.PosToken _ L.Tk__tok_DocComment_dummy_144 }
-tok_EnumConstant_dummy_143 { L.PosToken _ L.Tk__tok_EnumConstant_dummy_143 }
-tok_EnumConstantList_dummy_142 { L.PosToken _ L.Tk__tok_EnumConstantList_dummy_142 }
-tok_EnumDeclaration_dummy_141 { L.PosToken _ L.Tk__tok_EnumDeclaration_dummy_141 }
-tok_EqualityOp_dummy_140 { L.PosToken _ L.Tk__tok_EqualityOp_dummy_140 }
-tok_Expression_dummy_139 { L.PosToken _ L.Tk__tok_Expression_dummy_139 }
-tok_ExtendsList_dummy_138 { L.PosToken _ L.Tk__tok_ExtendsList_dummy_138 }
-tok_FieldDeclaration_dummy_137 { L.PosToken _ L.Tk__tok_FieldDeclaration_dummy_137 }
-tok_FieldDeclarationList_dummy_136 { L.PosToken _ L.Tk__tok_FieldDeclarationList_dummy_136 }
-tok_ForStatement_dummy_135 { L.PosToken _ L.Tk__tok_ForStatement_dummy_135 }
-tok_IfStatement_dummy_134 { L.PosToken _ L.Tk__tok_IfStatement_dummy_134 }
-tok_ImplementsList_dummy_133 { L.PosToken _ L.Tk__tok_ImplementsList_dummy_133 }
-tok_ImportList_dummy_132 { L.PosToken _ L.Tk__tok_ImportList_dummy_132 }
-tok_ImportStatement_dummy_131 { L.PosToken _ L.Tk__tok_ImportStatement_dummy_131 }
-tok_InterfaceDeclaration_dummy_130 { L.PosToken _ L.Tk__tok_InterfaceDeclaration_dummy_130 }
-tok_Java_dummy_163 { L.PosToken _ L.Tk__tok_Java_dummy_163 }
-tok_Literal_dummy_129 { L.PosToken _ L.Tk__tok_Literal_dummy_129 }
-tok_MemberAfterFirstId_dummy_128 { L.PosToken _ L.Tk__tok_MemberAfterFirstId_dummy_128 }
-tok_MemberDeclaration_dummy_127 { L.PosToken _ L.Tk__tok_MemberDeclaration_dummy_127 }
-tok_MemberRest_dummy_126 { L.PosToken _ L.Tk__tok_MemberRest_dummy_126 }
-tok_Modifier_dummy_125 { L.PosToken _ L.Tk__tok_Modifier_dummy_125 }
-tok_ModifierList_dummy_124 { L.PosToken _ L.Tk__tok_ModifierList_dummy_124 }
-tok_MoreTypeSpecifier_dummy_123 { L.PosToken _ L.Tk__tok_MoreTypeSpecifier_dummy_123 }
-tok_MoreVariableDeclarators_dummy_122 { L.PosToken _ L.Tk__tok_MoreVariableDeclarators_dummy_122 }
-tok_MultiplicativeOp_dummy_121 { L.PosToken _ L.Tk__tok_MultiplicativeOp_dummy_121 }
-tok_NonEmptyDims_dummy_120 { L.PosToken _ L.Tk__tok_NonEmptyDims_dummy_120 }
-tok_NonEmptyTypeArguments_dummy_119 { L.PosToken _ L.Tk__tok_NonEmptyTypeArguments_dummy_119 }
-tok_OptDocComment_dummy_118 { L.PosToken _ L.Tk__tok_OptDocComment_dummy_118 }
-tok_OptElsePart_dummy_117 { L.PosToken _ L.Tk__tok_OptElsePart_dummy_117 }
-tok_OptExpression_dummy_116 { L.PosToken _ L.Tk__tok_OptExpression_dummy_116 }
-tok_OptFinally_dummy_115 { L.PosToken _ L.Tk__tok_OptFinally_dummy_115 }
-tok_OptId_dummy_114 { L.PosToken _ L.Tk__tok_OptId_dummy_114 }
-tok_OptVariableInitializer_dummy_113 { L.PosToken _ L.Tk__tok_OptVariableInitializer_dummy_113 }
-tok_Package_dummy_112 { L.PosToken _ L.Tk__tok_Package_dummy_112 }
-tok_Parameter_dummy_111 { L.PosToken _ L.Tk__tok_Parameter_dummy_111 }
-tok_ParameterList_dummy_110 { L.PosToken _ L.Tk__tok_ParameterList_dummy_110 }
-tok_PostfixOp_dummy_109 { L.PosToken _ L.Tk__tok_PostfixOp_dummy_109 }
-tok_PrefixOp_dummy_108 { L.PosToken _ L.Tk__tok_PrefixOp_dummy_108 }
-tok_PrimitiveTypeKeyword_dummy_107 { L.PosToken _ L.Tk__tok_PrimitiveTypeKeyword_dummy_107 }
-tok_RelationalOp_dummy_106 { L.PosToken _ L.Tk__tok_RelationalOp_dummy_106 }
-tok_ShiftOp_dummy_105 { L.PosToken _ L.Tk__tok_ShiftOp_dummy_105 }
-tok_Statement_dummy_104 { L.PosToken _ L.Tk__tok_Statement_dummy_104 }
-tok_StatementBlock_dummy_103 { L.PosToken _ L.Tk__tok_StatementBlock_dummy_103 }
-tok_StatementList_dummy_102 { L.PosToken _ L.Tk__tok_StatementList_dummy_102 }
-tok_StaticInitializer_dummy_101 { L.PosToken _ L.Tk__tok_StaticInitializer_dummy_101 }
-tok_SwitchCaseList_dummy_100 { L.PosToken _ L.Tk__tok_SwitchCaseList_dummy_100 }
-tok_SwitchStatement_dummy_99 { L.PosToken _ L.Tk__tok_SwitchStatement_dummy_99 }
-tok_TryStatement_dummy_98 { L.PosToken _ L.Tk__tok_TryStatement_dummy_98 }
-tok_Type_dummy_97 { L.PosToken _ L.Tk__tok_Type_dummy_97 }
-tok_TypeArgument_dummy_96 { L.PosToken _ L.Tk__tok_TypeArgument_dummy_96 }
-tok_TypeArguments_dummy_95 { L.PosToken _ L.Tk__tok_TypeArguments_dummy_95 }
-tok_TypeDeclRest_dummy_94 { L.PosToken _ L.Tk__tok_TypeDeclRest_dummy_94 }
-tok_TypeDeclaration_dummy_93 { L.PosToken _ L.Tk__tok_TypeDeclaration_dummy_93 }
-tok_TypeParameter_dummy_92 { L.PosToken _ L.Tk__tok_TypeParameter_dummy_92 }
-tok_TypeParameters_dummy_91 { L.PosToken _ L.Tk__tok_TypeParameters_dummy_91 }
-tok_TypeSpecifier_dummy_90 { L.PosToken _ L.Tk__tok_TypeSpecifier_dummy_90 }
-tok_VariableDeclaration_dummy_89 { L.PosToken _ L.Tk__tok_VariableDeclaration_dummy_89 }
-tok_VariableDeclarator_dummy_88 { L.PosToken _ L.Tk__tok_VariableDeclarator_dummy_88 }
-tok_VariableDeclaratorList_dummy_87 { L.PosToken _ L.Tk__tok_VariableDeclaratorList_dummy_87 }
-tok_VariableInitializer_dummy_86 { L.PosToken _ L.Tk__tok_VariableInitializer_dummy_86 }
-tok_VariableInitializerList_dummy_85 { L.PosToken _ L.Tk__tok_VariableInitializerList_dummy_85 }
-tok_WhileStatement_dummy_84 { L.PosToken _ L.Tk__tok_WhileStatement_dummy_84 }
-tok_WildcardType_dummy_83 { L.PosToken _ L.Tk__tok_WildcardType_dummy_83 }
-tok__tilde__78 { L.PosToken _ L.Tk__tok__tilde__78 }
+tok_AdditiveOp_dummy_169 { L.PosToken _ L.Tk__tok_AdditiveOp_dummy_169 }
+tok_Annotation_dummy_168 { L.PosToken _ L.Tk__tok_Annotation_dummy_168 }
+tok_AnnotationArguments_dummy_167 { L.PosToken _ L.Tk__tok_AnnotationArguments_dummy_167 }
+tok_AnnotationDeclaration_dummy_166 { L.PosToken _ L.Tk__tok_AnnotationDeclaration_dummy_166 }
+tok_AnnotationElement_dummy_165 { L.PosToken _ L.Tk__tok_AnnotationElement_dummy_165 }
+tok_AnnotationList_dummy_164 { L.PosToken _ L.Tk__tok_AnnotationList_dummy_164 }
+tok_AnnotationTypeElement_dummy_163 { L.PosToken _ L.Tk__tok_AnnotationTypeElement_dummy_163 }
+tok_AnnotationTypeElementList_dummy_162 { L.PosToken _ L.Tk__tok_AnnotationTypeElementList_dummy_162 }
+tok_Arglist_dummy_161 { L.PosToken _ L.Tk__tok_Arglist_dummy_161 }
+tok_AssignmentOp_dummy_160 { L.PosToken _ L.Tk__tok_AssignmentOp_dummy_160 }
+tok_CatchList_dummy_159 { L.PosToken _ L.Tk__tok_CatchList_dummy_159 }
+tok_ClassDeclaration_dummy_158 { L.PosToken _ L.Tk__tok_ClassDeclaration_dummy_158 }
+tok_CompilationUnit_dummy_157 { L.PosToken _ L.Tk__tok_CompilationUnit_dummy_157 }
+tok_CompoundName_dummy_156 { L.PosToken _ L.Tk__tok_CompoundName_dummy_156 }
+tok_CreationExpression_dummy_155 { L.PosToken _ L.Tk__tok_CreationExpression_dummy_155 }
+tok_DimExprs_dummy_154 { L.PosToken _ L.Tk__tok_DimExprs_dummy_154 }
+tok_Dims_dummy_153 { L.PosToken _ L.Tk__tok_Dims_dummy_153 }
+tok_DoStatement_dummy_152 { L.PosToken _ L.Tk__tok_DoStatement_dummy_152 }
+tok_DocComment_dummy_151 { L.PosToken _ L.Tk__tok_DocComment_dummy_151 }
+tok_EnumConstant_dummy_150 { L.PosToken _ L.Tk__tok_EnumConstant_dummy_150 }
+tok_EnumConstantList_dummy_149 { L.PosToken _ L.Tk__tok_EnumConstantList_dummy_149 }
+tok_EnumDeclaration_dummy_148 { L.PosToken _ L.Tk__tok_EnumDeclaration_dummy_148 }
+tok_EqualityOp_dummy_147 { L.PosToken _ L.Tk__tok_EqualityOp_dummy_147 }
+tok_Expression_dummy_146 { L.PosToken _ L.Tk__tok_Expression_dummy_146 }
+tok_ExtendsList_dummy_145 { L.PosToken _ L.Tk__tok_ExtendsList_dummy_145 }
+tok_FieldDeclaration_dummy_144 { L.PosToken _ L.Tk__tok_FieldDeclaration_dummy_144 }
+tok_FieldDeclarationList_dummy_143 { L.PosToken _ L.Tk__tok_FieldDeclarationList_dummy_143 }
+tok_ForStatement_dummy_142 { L.PosToken _ L.Tk__tok_ForStatement_dummy_142 }
+tok_IfStatement_dummy_141 { L.PosToken _ L.Tk__tok_IfStatement_dummy_141 }
+tok_ImplementsList_dummy_140 { L.PosToken _ L.Tk__tok_ImplementsList_dummy_140 }
+tok_ImportHead_dummy_139 { L.PosToken _ L.Tk__tok_ImportHead_dummy_139 }
+tok_ImportList_dummy_138 { L.PosToken _ L.Tk__tok_ImportList_dummy_138 }
+tok_ImportName_dummy_137 { L.PosToken _ L.Tk__tok_ImportName_dummy_137 }
+tok_ImportStatement_dummy_136 { L.PosToken _ L.Tk__tok_ImportStatement_dummy_136 }
+tok_InterfaceDeclaration_dummy_135 { L.PosToken _ L.Tk__tok_InterfaceDeclaration_dummy_135 }
+tok_Java_dummy_170 { L.PosToken _ L.Tk__tok_Java_dummy_170 }
+tok_Literal_dummy_134 { L.PosToken _ L.Tk__tok_Literal_dummy_134 }
+tok_MemberAfterFirstId_dummy_133 { L.PosToken _ L.Tk__tok_MemberAfterFirstId_dummy_133 }
+tok_MemberDeclaration_dummy_132 { L.PosToken _ L.Tk__tok_MemberDeclaration_dummy_132 }
+tok_MemberRest_dummy_131 { L.PosToken _ L.Tk__tok_MemberRest_dummy_131 }
+tok_Modifier_dummy_130 { L.PosToken _ L.Tk__tok_Modifier_dummy_130 }
+tok_ModifierList_dummy_129 { L.PosToken _ L.Tk__tok_ModifierList_dummy_129 }
+tok_MoreTypeSpecifier_dummy_128 { L.PosToken _ L.Tk__tok_MoreTypeSpecifier_dummy_128 }
+tok_MoreVariableDeclarators_dummy_127 { L.PosToken _ L.Tk__tok_MoreVariableDeclarators_dummy_127 }
+tok_MultiplicativeOp_dummy_126 { L.PosToken _ L.Tk__tok_MultiplicativeOp_dummy_126 }
+tok_NonEmptyDims_dummy_125 { L.PosToken _ L.Tk__tok_NonEmptyDims_dummy_125 }
+tok_NonEmptyTypeArguments_dummy_124 { L.PosToken _ L.Tk__tok_NonEmptyTypeArguments_dummy_124 }
+tok_OptDocComment_dummy_123 { L.PosToken _ L.Tk__tok_OptDocComment_dummy_123 }
+tok_OptElsePart_dummy_122 { L.PosToken _ L.Tk__tok_OptElsePart_dummy_122 }
+tok_OptExpression_dummy_121 { L.PosToken _ L.Tk__tok_OptExpression_dummy_121 }
+tok_OptFinally_dummy_120 { L.PosToken _ L.Tk__tok_OptFinally_dummy_120 }
+tok_OptId_dummy_119 { L.PosToken _ L.Tk__tok_OptId_dummy_119 }
+tok_OptVariableInitializer_dummy_118 { L.PosToken _ L.Tk__tok_OptVariableInitializer_dummy_118 }
+tok_Package_dummy_117 { L.PosToken _ L.Tk__tok_Package_dummy_117 }
+tok_Parameter_dummy_116 { L.PosToken _ L.Tk__tok_Parameter_dummy_116 }
+tok_ParameterList_dummy_115 { L.PosToken _ L.Tk__tok_ParameterList_dummy_115 }
+tok_PostfixOp_dummy_114 { L.PosToken _ L.Tk__tok_PostfixOp_dummy_114 }
+tok_PrefixOp_dummy_113 { L.PosToken _ L.Tk__tok_PrefixOp_dummy_113 }
+tok_PrimitiveTypeKeyword_dummy_112 { L.PosToken _ L.Tk__tok_PrimitiveTypeKeyword_dummy_112 }
+tok_RelationalOp_dummy_111 { L.PosToken _ L.Tk__tok_RelationalOp_dummy_111 }
+tok_ShiftOp_dummy_110 { L.PosToken _ L.Tk__tok_ShiftOp_dummy_110 }
+tok_Statement_dummy_109 { L.PosToken _ L.Tk__tok_Statement_dummy_109 }
+tok_StatementBlock_dummy_108 { L.PosToken _ L.Tk__tok_StatementBlock_dummy_108 }
+tok_StatementList_dummy_107 { L.PosToken _ L.Tk__tok_StatementList_dummy_107 }
+tok_StaticInitializer_dummy_106 { L.PosToken _ L.Tk__tok_StaticInitializer_dummy_106 }
+tok_SwitchCaseList_dummy_105 { L.PosToken _ L.Tk__tok_SwitchCaseList_dummy_105 }
+tok_SwitchStatement_dummy_104 { L.PosToken _ L.Tk__tok_SwitchStatement_dummy_104 }
+tok_ThrowsClause_dummy_103 { L.PosToken _ L.Tk__tok_ThrowsClause_dummy_103 }
+tok_TryStatement_dummy_102 { L.PosToken _ L.Tk__tok_TryStatement_dummy_102 }
+tok_Type_dummy_101 { L.PosToken _ L.Tk__tok_Type_dummy_101 }
+tok_TypeArgument_dummy_100 { L.PosToken _ L.Tk__tok_TypeArgument_dummy_100 }
+tok_TypeArguments_dummy_99 { L.PosToken _ L.Tk__tok_TypeArguments_dummy_99 }
+tok_TypeDeclRest_dummy_98 { L.PosToken _ L.Tk__tok_TypeDeclRest_dummy_98 }
+tok_TypeDeclaration_dummy_97 { L.PosToken _ L.Tk__tok_TypeDeclaration_dummy_97 }
+tok_TypeParameter_dummy_96 { L.PosToken _ L.Tk__tok_TypeParameter_dummy_96 }
+tok_TypeParameters_dummy_95 { L.PosToken _ L.Tk__tok_TypeParameters_dummy_95 }
+tok_TypeSpecifier_dummy_94 { L.PosToken _ L.Tk__tok_TypeSpecifier_dummy_94 }
+tok_VariableDeclaration_dummy_93 { L.PosToken _ L.Tk__tok_VariableDeclaration_dummy_93 }
+tok_VariableDeclarator_dummy_92 { L.PosToken _ L.Tk__tok_VariableDeclarator_dummy_92 }
+tok_VariableDeclaratorList_dummy_91 { L.PosToken _ L.Tk__tok_VariableDeclaratorList_dummy_91 }
+tok_VariableInitializer_dummy_90 { L.PosToken _ L.Tk__tok_VariableInitializer_dummy_90 }
+tok_VariableInitializerList_dummy_89 { L.PosToken _ L.Tk__tok_VariableInitializerList_dummy_89 }
+tok_WhileStatement_dummy_88 { L.PosToken _ L.Tk__tok_WhileStatement_dummy_88 }
+tok_WildcardType_dummy_87 { L.PosToken _ L.Tk__tok_WildcardType_dummy_87 }
+tok__tilde__80 { L.PosToken _ L.Tk__tok__tilde__80 }
+tok__symbol__15 { L.PosToken _ L.Tk__tok__symbol__15 }
+tok__pipe__pipe__59 { L.PosToken _ L.Tk__tok__pipe__pipe__59 }
+tok__pipe__eql__51 { L.PosToken _ L.Tk__tok__pipe__eql__51 }
+tok__pipe__61 { L.PosToken _ L.Tk__tok__pipe__61 }
 tok__symbol__14 { L.PosToken _ L.Tk__tok__symbol__14 }
-tok__pipe__pipe__57 { L.PosToken _ L.Tk__tok__pipe__pipe__57 }
-tok__pipe__eql__49 { L.PosToken _ L.Tk__tok__pipe__eql__49 }
-tok__pipe__59 { L.PosToken _ L.Tk__tok__pipe__59 }
-tok__symbol__13 { L.PosToken _ L.Tk__tok__symbol__13 }
-tok_while_38 { L.PosToken _ L.Tk__tok_while_38 }
-tok_void_27 { L.PosToken _ L.Tk__tok_void_27 }
-tok_try_42 { L.PosToken _ L.Tk__tok_try_42 }
-tok_true_83 { L.PosToken _ L.Tk__tok_true_83 }
-tok_transient_94 { L.PosToken _ L.Tk__tok_transient_94 }
-tok_throw_31 { L.PosToken _ L.Tk__tok_throw_31 }
-tok_threadsafe_93 { L.PosToken _ L.Tk__tok_threadsafe_93 }
-tok_this_80 { L.PosToken _ L.Tk__tok_this_80 }
-tok_synchronized_30 { L.PosToken _ L.Tk__tok_synchronized_30 }
-tok_switch_44 { L.PosToken _ L.Tk__tok_switch_44 }
-tok_super_81 { L.PosToken _ L.Tk__tok_super_81 }
-tok_static_89 { L.PosToken _ L.Tk__tok_static_89 }
-tok_short_22 { L.PosToken _ L.Tk__tok_short_22 }
-tok_return_29 { L.PosToken _ L.Tk__tok_return_29 }
-tok_public_86 { L.PosToken _ L.Tk__tok_public_86 }
-tok_protected_88 { L.PosToken _ L.Tk__tok_protected_88 }
-tok_private_87 { L.PosToken _ L.Tk__tok_private_87 }
+tok_while_40 { L.PosToken _ L.Tk__tok_while_40 }
+tok_void_28 { L.PosToken _ L.Tk__tok_void_28 }
+tok_try_44 { L.PosToken _ L.Tk__tok_try_44 }
+tok_true_85 { L.PosToken _ L.Tk__tok_true_85 }
+tok_transient_95 { L.PosToken _ L.Tk__tok_transient_95 }
+tok_throws_29 { L.PosToken _ L.Tk__tok_throws_29 }
+tok_throw_33 { L.PosToken _ L.Tk__tok_throw_33 }
+tok_threadsafe_94 { L.PosToken _ L.Tk__tok_threadsafe_94 }
+tok_this_82 { L.PosToken _ L.Tk__tok_this_82 }
+tok_synchronized_32 { L.PosToken _ L.Tk__tok_synchronized_32 }
+tok_switch_46 { L.PosToken _ L.Tk__tok_switch_46 }
+tok_super_83 { L.PosToken _ L.Tk__tok_super_83 }
+tok_static_3 { L.PosToken _ L.Tk__tok_static_3 }
+tok_short_23 { L.PosToken _ L.Tk__tok_short_23 }
+tok_return_31 { L.PosToken _ L.Tk__tok_return_31 }
+tok_public_88 { L.PosToken _ L.Tk__tok_public_88 }
+tok_protected_90 { L.PosToken _ L.Tk__tok_protected_90 }
+tok_private_89 { L.PosToken _ L.Tk__tok_private_89 }
 tok_package_0 { L.PosToken _ L.Tk__tok_package_0 }
-tok_null_85 { L.PosToken _ L.Tk__tok_null_85 }
-tok_new_82 { L.PosToken _ L.Tk__tok_new_82 }
-tok_native_91 { L.PosToken _ L.Tk__tok_native_91 }
-tok_long_25 { L.PosToken _ L.Tk__tok_long_25 }
-tok_interface_15 { L.PosToken _ L.Tk__tok_interface_15 }
-tok_int_23 { L.PosToken _ L.Tk__tok_int_23 }
-tok_instanceof_68 { L.PosToken _ L.Tk__tok_instanceof_68 }
+tok_null_87 { L.PosToken _ L.Tk__tok_null_87 }
+tok_new_84 { L.PosToken _ L.Tk__tok_new_84 }
+tok_native_92 { L.PosToken _ L.Tk__tok_native_92 }
+tok_long_26 { L.PosToken _ L.Tk__tok_long_26 }
+tok_interface_16 { L.PosToken _ L.Tk__tok_interface_16 }
+tok_int_24 { L.PosToken _ L.Tk__tok_int_24 }
+tok_instanceof_70 { L.PosToken _ L.Tk__tok_instanceof_70 }
 tok_import_2 { L.PosToken _ L.Tk__tok_import_2 }
-tok_implements_11 { L.PosToken _ L.Tk__tok_implements_11 }
-tok_if_36 { L.PosToken _ L.Tk__tok_if_36 }
-tok_for_39 { L.PosToken _ L.Tk__tok_for_39 }
-tok_float_24 { L.PosToken _ L.Tk__tok_float_24 }
-tok_finally_41 { L.PosToken _ L.Tk__tok_finally_41 }
-tok_final_90 { L.PosToken _ L.Tk__tok_final_90 }
-tok_false_84 { L.PosToken _ L.Tk__tok_false_84 }
-tok_extends_10 { L.PosToken _ L.Tk__tok_extends_10 }
-tok_enum_16 { L.PosToken _ L.Tk__tok_enum_16 }
-tok_else_35 { L.PosToken _ L.Tk__tok_else_35 }
-tok_double_26 { L.PosToken _ L.Tk__tok_double_26 }
-tok_do_37 { L.PosToken _ L.Tk__tok_do_37 }
-tok_default_28 { L.PosToken _ L.Tk__tok_default_28 }
-tok_continue_34 { L.PosToken _ L.Tk__tok_continue_34 }
-tok_class_12 { L.PosToken _ L.Tk__tok_class_12 }
-tok_char_21 { L.PosToken _ L.Tk__tok_char_21 }
-tok_catch_40 { L.PosToken _ L.Tk__tok_catch_40 }
-tok_case_43 { L.PosToken _ L.Tk__tok_case_43 }
-tok_byte_20 { L.PosToken _ L.Tk__tok_byte_20 }
-tok_break_33 { L.PosToken _ L.Tk__tok_break_33 }
-tok_boolean_19 { L.PosToken _ L.Tk__tok_boolean_19 }
-tok_abstract_92 { L.PosToken _ L.Tk__tok_abstract_92 }
-tok__symbol__eql__51 { L.PosToken _ L.Tk__tok__symbol__eql__51 }
-tok__symbol__60 { L.PosToken _ L.Tk__tok__symbol__60 }
-tok__sq_bkt_r__18 { L.PosToken _ L.Tk__tok__sq_bkt_r__18 }
-tok__sq_bkt_l__17 { L.PosToken _ L.Tk__tok__sq_bkt_l__17 }
-tok__symbol__5 { L.PosToken _ L.Tk__tok__symbol__5 }
-tok__symbol__56 { L.PosToken _ L.Tk__tok__symbol__56 }
-tok__symbol__symbol__symbol__eql__55 { L.PosToken _ L.Tk__tok__symbol__symbol__symbol__eql__55 }
-tok__symbol__symbol__symbol__71 { L.PosToken _ L.Tk__tok__symbol__symbol__symbol__71 }
-tok__symbol__symbol__eql__54 { L.PosToken _ L.Tk__tok__symbol__symbol__eql__54 }
-tok__symbol__symbol__69 { L.PosToken _ L.Tk__tok__symbol__symbol__69 }
-tok__symbol__eql__67 { L.PosToken _ L.Tk__tok__symbol__eql__67 }
-tok__symbol__65 { L.PosToken _ L.Tk__tok__symbol__65 }
-tok__eql__eql__62 { L.PosToken _ L.Tk__tok__eql__eql__62 }
-tok__eql__9 { L.PosToken _ L.Tk__tok__eql__9 }
-tok__symbol__eql__66 { L.PosToken _ L.Tk__tok__symbol__eql__66 }
-tok__symbol__symbol__eql__53 { L.PosToken _ L.Tk__tok__symbol__symbol__eql__53 }
-tok__symbol__symbol__70 { L.PosToken _ L.Tk__tok__symbol__symbol__70 }
-tok__symbol__64 { L.PosToken _ L.Tk__tok__symbol__64 }
+tok_implements_12 { L.PosToken _ L.Tk__tok_implements_12 }
+tok_if_38 { L.PosToken _ L.Tk__tok_if_38 }
+tok_for_41 { L.PosToken _ L.Tk__tok_for_41 }
+tok_float_25 { L.PosToken _ L.Tk__tok_float_25 }
+tok_finally_43 { L.PosToken _ L.Tk__tok_finally_43 }
+tok_final_91 { L.PosToken _ L.Tk__tok_final_91 }
+tok_false_86 { L.PosToken _ L.Tk__tok_false_86 }
+tok_extends_11 { L.PosToken _ L.Tk__tok_extends_11 }
+tok_enum_17 { L.PosToken _ L.Tk__tok_enum_17 }
+tok_else_37 { L.PosToken _ L.Tk__tok_else_37 }
+tok_double_27 { L.PosToken _ L.Tk__tok_double_27 }
+tok_do_39 { L.PosToken _ L.Tk__tok_do_39 }
+tok_default_30 { L.PosToken _ L.Tk__tok_default_30 }
+tok_continue_36 { L.PosToken _ L.Tk__tok_continue_36 }
+tok_class_13 { L.PosToken _ L.Tk__tok_class_13 }
+tok_char_22 { L.PosToken _ L.Tk__tok_char_22 }
+tok_catch_42 { L.PosToken _ L.Tk__tok_catch_42 }
+tok_case_45 { L.PosToken _ L.Tk__tok_case_45 }
+tok_byte_21 { L.PosToken _ L.Tk__tok_byte_21 }
+tok_break_35 { L.PosToken _ L.Tk__tok_break_35 }
+tok_boolean_20 { L.PosToken _ L.Tk__tok_boolean_20 }
+tok_abstract_93 { L.PosToken _ L.Tk__tok_abstract_93 }
+tok__symbol__eql__53 { L.PosToken _ L.Tk__tok__symbol__eql__53 }
+tok__symbol__62 { L.PosToken _ L.Tk__tok__symbol__62 }
+tok__sq_bkt_r__19 { L.PosToken _ L.Tk__tok__sq_bkt_r__19 }
+tok__sq_bkt_l__18 { L.PosToken _ L.Tk__tok__sq_bkt_l__18 }
+tok__symbol__6 { L.PosToken _ L.Tk__tok__symbol__6 }
+tok__symbol__58 { L.PosToken _ L.Tk__tok__symbol__58 }
+tok__symbol__symbol__symbol__eql__57 { L.PosToken _ L.Tk__tok__symbol__symbol__symbol__eql__57 }
+tok__symbol__symbol__symbol__73 { L.PosToken _ L.Tk__tok__symbol__symbol__symbol__73 }
+tok__symbol__symbol__eql__56 { L.PosToken _ L.Tk__tok__symbol__symbol__eql__56 }
+tok__symbol__symbol__71 { L.PosToken _ L.Tk__tok__symbol__symbol__71 }
+tok__symbol__eql__69 { L.PosToken _ L.Tk__tok__symbol__eql__69 }
+tok__symbol__67 { L.PosToken _ L.Tk__tok__symbol__67 }
+tok__eql__eql__64 { L.PosToken _ L.Tk__tok__eql__eql__64 }
+tok__eql__10 { L.PosToken _ L.Tk__tok__eql__10 }
+tok__symbol__eql__68 { L.PosToken _ L.Tk__tok__symbol__eql__68 }
+tok__symbol__symbol__eql__55 { L.PosToken _ L.Tk__tok__symbol__symbol__eql__55 }
+tok__symbol__symbol__72 { L.PosToken _ L.Tk__tok__symbol__symbol__72 }
+tok__symbol__66 { L.PosToken _ L.Tk__tok__symbol__66 }
 tok__semi__1 { L.PosToken _ L.Tk__tok__semi__1 }
-tok__colon__32 { L.PosToken _ L.Tk__tok__colon__32 }
-tok__symbol__eql__48 { L.PosToken _ L.Tk__tok__symbol__eql__48 }
-tok__symbol__74 { L.PosToken _ L.Tk__tok__symbol__74 }
-tok__dot__3 { L.PosToken _ L.Tk__tok__dot__3 }
-tok__minus__eql__46 { L.PosToken _ L.Tk__tok__minus__eql__46 }
-tok__minus__minus__77 { L.PosToken _ L.Tk__tok__minus__minus__77 }
-tok__minus__73 { L.PosToken _ L.Tk__tok__minus__73 }
-tok__coma__8 { L.PosToken _ L.Tk__tok__coma__8 }
-tok__plus__eql__45 { L.PosToken _ L.Tk__tok__plus__eql__45 }
-tok__plus__plus__76 { L.PosToken _ L.Tk__tok__plus__plus__76 }
-tok__plus__72 { L.PosToken _ L.Tk__tok__plus__72 }
-tok__star__eql__47 { L.PosToken _ L.Tk__tok__star__eql__47 }
-tok__star__4 { L.PosToken _ L.Tk__tok__star__4 }
-tok__rparen__7 { L.PosToken _ L.Tk__tok__rparen__7 }
-tok__lparen__6 { L.PosToken _ L.Tk__tok__lparen__6 }
+tok__colon__34 { L.PosToken _ L.Tk__tok__colon__34 }
 tok__symbol__eql__50 { L.PosToken _ L.Tk__tok__symbol__eql__50 }
-tok__symbol__symbol__58 { L.PosToken _ L.Tk__tok__symbol__symbol__58 }
-tok__symbol__61 { L.PosToken _ L.Tk__tok__symbol__61 }
+tok__symbol__76 { L.PosToken _ L.Tk__tok__symbol__76 }
+tok__dot__4 { L.PosToken _ L.Tk__tok__dot__4 }
+tok__minus__eql__48 { L.PosToken _ L.Tk__tok__minus__eql__48 }
+tok__minus__minus__79 { L.PosToken _ L.Tk__tok__minus__minus__79 }
+tok__minus__75 { L.PosToken _ L.Tk__tok__minus__75 }
+tok__coma__9 { L.PosToken _ L.Tk__tok__coma__9 }
+tok__plus__eql__47 { L.PosToken _ L.Tk__tok__plus__eql__47 }
+tok__plus__plus__78 { L.PosToken _ L.Tk__tok__plus__plus__78 }
+tok__plus__74 { L.PosToken _ L.Tk__tok__plus__74 }
+tok__star__eql__49 { L.PosToken _ L.Tk__tok__star__eql__49 }
+tok__star__5 { L.PosToken _ L.Tk__tok__star__5 }
+tok__rparen__8 { L.PosToken _ L.Tk__tok__rparen__8 }
+tok__lparen__7 { L.PosToken _ L.Tk__tok__lparen__7 }
 tok__symbol__eql__52 { L.PosToken _ L.Tk__tok__symbol__eql__52 }
-tok__symbol__75 { L.PosToken _ L.Tk__tok__symbol__75 }
-tok__exclamation__eql__63 { L.PosToken _ L.Tk__tok__exclamation__eql__63 }
-tok__exclamation__79 { L.PosToken _ L.Tk__tok__exclamation__79 }
+tok__symbol__symbol__60 { L.PosToken _ L.Tk__tok__symbol__symbol__60 }
+tok__symbol__63 { L.PosToken _ L.Tk__tok__symbol__63 }
+tok__symbol__eql__54 { L.PosToken _ L.Tk__tok__symbol__eql__54 }
+tok__symbol__77 { L.PosToken _ L.Tk__tok__symbol__77 }
+tok__exclamation__eql__65 { L.PosToken _ L.Tk__tok__exclamation__eql__65 }
+tok__exclamation__81 { L.PosToken _ L.Tk__tok__exclamation__81 }
 doccomment { L.PosToken _ (L.Tk__doccomment _) }
 id { L.PosToken _ (L.Tk__id _) }
 string { L.PosToken _ (L.Tk__string _) }
@@ -246,6 +250,7 @@ qq_VariableDeclaratorList { L.PosToken _ (L.Tk__qq_VariableDeclaratorList _) }
 qq_StatementBlock { L.PosToken _ (L.Tk__qq_StatementBlock _) }
 qq_MoreVariableDeclarators { L.PosToken _ (L.Tk__qq_MoreVariableDeclarators _) }
 qq_MemberRest { L.PosToken _ (L.Tk__qq_MemberRest _) }
+qq_ThrowsClause { L.PosToken _ (L.Tk__qq_ThrowsClause _) }
 qq_MoreTypeSpecifier { L.PosToken _ (L.Tk__qq_MoreTypeSpecifier _) }
 qq_MemberAfterFirstId { L.PosToken _ (L.Tk__qq_MemberAfterFirstId _) }
 qq_PrimitiveTypeKeyword { L.PosToken _ (L.Tk__qq_PrimitiveTypeKeyword _) }
@@ -271,6 +276,8 @@ qq_AnnotationElement { L.PosToken _ (L.Tk__qq_AnnotationElement _) }
 qq_AnnotationArguments { L.PosToken _ (L.Tk__qq_AnnotationArguments _) }
 qq_Annotation { L.PosToken _ (L.Tk__qq_Annotation _) }
 qq_DocComment { L.PosToken _ (L.Tk__qq_DocComment _) }
+qq_ImportHead { L.PosToken _ (L.Tk__qq_ImportHead _) }
+qq_ImportName { L.PosToken _ (L.Tk__qq_ImportName _) }
 qq_ImportStatement { L.PosToken _ (L.Tk__qq_ImportStatement _) }
 qq_Package { L.PosToken _ (L.Tk__qq_Package _) }
 qq_CompilationUnit { L.PosToken _ (L.Tk__qq_CompilationUnit _) }
@@ -283,109 +290,112 @@ qq_Java { L.PosToken _ (L.Tk__qq_Java _) }
 
 Java__top : Java rtk__eof { $1 }
 
-Java : tok_Java_dummy_163 Java tok_Java_dummy_163 { Ctr__Java__0 (rtkPosOf $1) $2 } |
-       tok_AdditiveOp_dummy_162 AdditiveOp tok_AdditiveOp_dummy_162 { Ctr__Java__1 (rtkPosOf $1) $2 } |
-       tok_Annotation_dummy_161 Annotation tok_Annotation_dummy_161 { Ctr__Java__2 (rtkPosOf $1) $2 } |
-       tok_AnnotationArguments_dummy_160 AnnotationArguments tok_AnnotationArguments_dummy_160 { Ctr__Java__3 (rtkPosOf $1) $2 } |
-       tok_AnnotationDeclaration_dummy_159 AnnotationDeclaration tok_AnnotationDeclaration_dummy_159 { Ctr__Java__4 (rtkPosOf $1) $2 } |
-       tok_AnnotationElement_dummy_158 AnnotationElement tok_AnnotationElement_dummy_158 { Ctr__Java__5 (rtkPosOf $1) $2 } |
-       tok_AnnotationList_dummy_157 AnnotationList tok_AnnotationList_dummy_157 { Ctr__Java__6 (rtkPosOf $1) (reverse $2) } |
-       tok_AnnotationTypeElement_dummy_156 AnnotationTypeElement tok_AnnotationTypeElement_dummy_156 { Ctr__Java__7 (rtkPosOf $1) $2 } |
-       tok_AnnotationTypeElementList_dummy_155 AnnotationTypeElementList tok_AnnotationTypeElementList_dummy_155 { Ctr__Java__8 (rtkPosOf $1) (reverse $2) } |
-       tok_Arglist_dummy_154 Arglist tok_Arglist_dummy_154 { Ctr__Java__9 (rtkPosOf $1) $2 } |
-       tok_AssignmentOp_dummy_153 AssignmentOp tok_AssignmentOp_dummy_153 { Ctr__Java__10 (rtkPosOf $1) $2 } |
-       tok_CatchList_dummy_152 CatchList tok_CatchList_dummy_152 { Ctr__Java__11 (rtkPosOf $1) (reverse $2) } |
-       tok_ClassDeclaration_dummy_151 ClassDeclaration tok_ClassDeclaration_dummy_151 { Ctr__Java__12 (rtkPosOf $1) $2 } |
-       tok_CompilationUnit_dummy_150 CompilationUnit tok_CompilationUnit_dummy_150 { Ctr__Java__13 (rtkPosOf $1) $2 } |
-       tok_CompoundName_dummy_149 CompoundName tok_CompoundName_dummy_149 { Ctr__Java__14 (rtkPosOf $1) $2 } |
-       tok_CreationExpression_dummy_148 CreationExpression tok_CreationExpression_dummy_148 { Ctr__Java__15 (rtkPosOf $1) $2 } |
-       tok_DimExprs_dummy_147 DimExprs tok_DimExprs_dummy_147 { Ctr__Java__16 (rtkPosOf $1) (reverse $2) } |
-       tok_Dims_dummy_146 Dims tok_Dims_dummy_146 { Ctr__Java__17 (rtkPosOf $1) (reverse $2) } |
-       tok_DoStatement_dummy_145 DoStatement tok_DoStatement_dummy_145 { Ctr__Java__18 (rtkPosOf $1) $2 } |
-       tok_DocComment_dummy_144 DocComment tok_DocComment_dummy_144 { Ctr__Java__19 (rtkPosOf $1) $2 } |
-       tok_EnumConstant_dummy_143 EnumConstant tok_EnumConstant_dummy_143 { Ctr__Java__20 (rtkPosOf $1) $2 } |
-       tok_EnumConstantList_dummy_142 EnumConstantList tok_EnumConstantList_dummy_142 { Ctr__Java__21 (rtkPosOf $1) $2 } |
-       tok_EnumDeclaration_dummy_141 EnumDeclaration tok_EnumDeclaration_dummy_141 { Ctr__Java__22 (rtkPosOf $1) $2 } |
-       tok_EqualityOp_dummy_140 EqualityOp tok_EqualityOp_dummy_140 { Ctr__Java__23 (rtkPosOf $1) $2 } |
-       tok_Expression_dummy_139 Expression tok_Expression_dummy_139 { Ctr__Java__24 (rtkPosOf $1) $2 } |
-       tok_ExtendsList_dummy_138 ExtendsList tok_ExtendsList_dummy_138 { Ctr__Java__25 (rtkPosOf $1) $2 } |
-       tok_FieldDeclaration_dummy_137 FieldDeclaration tok_FieldDeclaration_dummy_137 { Ctr__Java__26 (rtkPosOf $1) $2 } |
-       tok_FieldDeclarationList_dummy_136 FieldDeclarationList tok_FieldDeclarationList_dummy_136 { Ctr__Java__27 (rtkPosOf $1) (reverse $2) } |
-       tok_ForStatement_dummy_135 ForStatement tok_ForStatement_dummy_135 { Ctr__Java__28 (rtkPosOf $1) $2 } |
-       tok_IfStatement_dummy_134 IfStatement tok_IfStatement_dummy_134 { Ctr__Java__29 (rtkPosOf $1) $2 } |
-       tok_ImplementsList_dummy_133 ImplementsList tok_ImplementsList_dummy_133 { Ctr__Java__30 (rtkPosOf $1) $2 } |
-       tok_ImportList_dummy_132 ImportList tok_ImportList_dummy_132 { Ctr__Java__31 (rtkPosOf $1) (reverse $2) } |
-       tok_ImportStatement_dummy_131 ImportStatement tok_ImportStatement_dummy_131 { Ctr__Java__32 (rtkPosOf $1) $2 } |
-       tok_InterfaceDeclaration_dummy_130 InterfaceDeclaration tok_InterfaceDeclaration_dummy_130 { Ctr__Java__33 (rtkPosOf $1) $2 } |
-       tok_Literal_dummy_129 Literal tok_Literal_dummy_129 { Ctr__Java__34 (rtkPosOf $1) $2 } |
-       tok_MemberAfterFirstId_dummy_128 MemberAfterFirstId tok_MemberAfterFirstId_dummy_128 { Ctr__Java__35 (rtkPosOf $1) $2 } |
-       tok_MemberDeclaration_dummy_127 MemberDeclaration tok_MemberDeclaration_dummy_127 { Ctr__Java__36 (rtkPosOf $1) $2 } |
-       tok_MemberRest_dummy_126 MemberRest tok_MemberRest_dummy_126 { Ctr__Java__37 (rtkPosOf $1) $2 } |
-       tok_Modifier_dummy_125 Modifier tok_Modifier_dummy_125 { Ctr__Java__38 (rtkPosOf $1) $2 } |
-       tok_ModifierList_dummy_124 ModifierList tok_ModifierList_dummy_124 { Ctr__Java__39 (rtkPosOf $1) (reverse $2) } |
-       tok_MoreTypeSpecifier_dummy_123 MoreTypeSpecifier tok_MoreTypeSpecifier_dummy_123 { Ctr__Java__40 (rtkPosOf $1) $2 } |
-       tok_MoreVariableDeclarators_dummy_122 MoreVariableDeclarators tok_MoreVariableDeclarators_dummy_122 { Ctr__Java__41 (rtkPosOf $1) (reverse $2) } |
-       tok_MultiplicativeOp_dummy_121 MultiplicativeOp tok_MultiplicativeOp_dummy_121 { Ctr__Java__42 (rtkPosOf $1) $2 } |
-       tok_NonEmptyDims_dummy_120 NonEmptyDims tok_NonEmptyDims_dummy_120 { Ctr__Java__43 (rtkPosOf $1) (reverse $2) } |
-       tok_NonEmptyTypeArguments_dummy_119 NonEmptyTypeArguments tok_NonEmptyTypeArguments_dummy_119 { Ctr__Java__44 (rtkPosOf $1) $2 } |
-       tok_OptDocComment_dummy_118 OptDocComment tok_OptDocComment_dummy_118 { Ctr__Java__45 (rtkPosOf $1) $2 } |
-       tok_OptElsePart_dummy_117 OptElsePart tok_OptElsePart_dummy_117 { Ctr__Java__46 (rtkPosOf $1) $2 } |
-       tok_OptExpression_dummy_116 OptExpression tok_OptExpression_dummy_116 { Ctr__Java__47 (rtkPosOf $1) $2 } |
-       tok_OptFinally_dummy_115 OptFinally tok_OptFinally_dummy_115 { Ctr__Java__48 (rtkPosOf $1) $2 } |
-       tok_OptId_dummy_114 OptId tok_OptId_dummy_114 { Ctr__Java__49 (rtkPosOf $1) $2 } |
-       tok_OptVariableInitializer_dummy_113 OptVariableInitializer tok_OptVariableInitializer_dummy_113 { Ctr__Java__50 (rtkPosOf $1) $2 } |
-       tok_Package_dummy_112 Package tok_Package_dummy_112 { Ctr__Java__51 (rtkPosOf $1) $2 } |
-       tok_Parameter_dummy_111 Parameter tok_Parameter_dummy_111 { Ctr__Java__52 (rtkPosOf $1) $2 } |
-       tok_ParameterList_dummy_110 ParameterList tok_ParameterList_dummy_110 { Ctr__Java__53 (rtkPosOf $1) $2 } |
-       tok_PostfixOp_dummy_109 PostfixOp tok_PostfixOp_dummy_109 { Ctr__Java__54 (rtkPosOf $1) $2 } |
-       tok_PrefixOp_dummy_108 PrefixOp tok_PrefixOp_dummy_108 { Ctr__Java__55 (rtkPosOf $1) $2 } |
-       tok_PrimitiveTypeKeyword_dummy_107 PrimitiveTypeKeyword tok_PrimitiveTypeKeyword_dummy_107 { Ctr__Java__56 (rtkPosOf $1) $2 } |
-       tok_RelationalOp_dummy_106 RelationalOp tok_RelationalOp_dummy_106 { Ctr__Java__57 (rtkPosOf $1) $2 } |
-       tok_ShiftOp_dummy_105 ShiftOp tok_ShiftOp_dummy_105 { Ctr__Java__58 (rtkPosOf $1) $2 } |
-       tok_Statement_dummy_104 Statement tok_Statement_dummy_104 { Ctr__Java__59 (rtkPosOf $1) $2 } |
-       tok_StatementBlock_dummy_103 StatementBlock tok_StatementBlock_dummy_103 { Ctr__Java__60 (rtkPosOf $1) $2 } |
-       tok_StatementList_dummy_102 StatementList tok_StatementList_dummy_102 { Ctr__Java__61 (rtkPosOf $1) (reverse $2) } |
-       tok_StaticInitializer_dummy_101 StaticInitializer tok_StaticInitializer_dummy_101 { Ctr__Java__62 (rtkPosOf $1) $2 } |
-       tok_SwitchCaseList_dummy_100 SwitchCaseList tok_SwitchCaseList_dummy_100 { Ctr__Java__63 (rtkPosOf $1) (reverse $2) } |
-       tok_SwitchStatement_dummy_99 SwitchStatement tok_SwitchStatement_dummy_99 { Ctr__Java__64 (rtkPosOf $1) $2 } |
-       tok_TryStatement_dummy_98 TryStatement tok_TryStatement_dummy_98 { Ctr__Java__65 (rtkPosOf $1) $2 } |
-       tok_Type_dummy_97 Type tok_Type_dummy_97 { Ctr__Java__66 (rtkPosOf $1) $2 } |
-       tok_TypeArgument_dummy_96 TypeArgument tok_TypeArgument_dummy_96 { Ctr__Java__67 (rtkPosOf $1) $2 } |
-       tok_TypeArguments_dummy_95 TypeArguments tok_TypeArguments_dummy_95 { Ctr__Java__68 (rtkPosOf $1) $2 } |
-       tok_TypeDeclRest_dummy_94 TypeDeclRest tok_TypeDeclRest_dummy_94 { Ctr__Java__69 (rtkPosOf $1) $2 } |
-       tok_TypeDeclaration_dummy_93 TypeDeclaration tok_TypeDeclaration_dummy_93 { Ctr__Java__70 (rtkPosOf $1) $2 } |
-       tok_TypeParameter_dummy_92 TypeParameter tok_TypeParameter_dummy_92 { Ctr__Java__71 (rtkPosOf $1) $2 } |
-       tok_TypeParameters_dummy_91 TypeParameters tok_TypeParameters_dummy_91 { Ctr__Java__72 (rtkPosOf $1) $2 } |
-       tok_TypeSpecifier_dummy_90 TypeSpecifier tok_TypeSpecifier_dummy_90 { Ctr__Java__73 (rtkPosOf $1) $2 } |
-       tok_VariableDeclaration_dummy_89 VariableDeclaration tok_VariableDeclaration_dummy_89 { Ctr__Java__74 (rtkPosOf $1) $2 } |
-       tok_VariableDeclarator_dummy_88 VariableDeclarator tok_VariableDeclarator_dummy_88 { Ctr__Java__75 (rtkPosOf $1) $2 } |
-       tok_VariableDeclaratorList_dummy_87 VariableDeclaratorList tok_VariableDeclaratorList_dummy_87 { Ctr__Java__76 (rtkPosOf $1) $2 } |
-       tok_VariableInitializer_dummy_86 VariableInitializer tok_VariableInitializer_dummy_86 { Ctr__Java__77 (rtkPosOf $1) $2 } |
-       tok_VariableInitializerList_dummy_85 VariableInitializerList tok_VariableInitializerList_dummy_85 { Ctr__Java__78 (rtkPosOf $1) $2 } |
-       tok_WhileStatement_dummy_84 WhileStatement tok_WhileStatement_dummy_84 { Ctr__Java__79 (rtkPosOf $1) $2 } |
-       tok_WildcardType_dummy_83 WildcardType tok_WildcardType_dummy_83 { Ctr__Java__80 (rtkPosOf $1) $2 }
+Java : tok_Java_dummy_170 Java tok_Java_dummy_170 { Ctr__Java__0 (rtkPosOf $1) $2 } |
+       tok_AdditiveOp_dummy_169 AdditiveOp tok_AdditiveOp_dummy_169 { Ctr__Java__1 (rtkPosOf $1) $2 } |
+       tok_Annotation_dummy_168 Annotation tok_Annotation_dummy_168 { Ctr__Java__2 (rtkPosOf $1) $2 } |
+       tok_AnnotationArguments_dummy_167 AnnotationArguments tok_AnnotationArguments_dummy_167 { Ctr__Java__3 (rtkPosOf $1) $2 } |
+       tok_AnnotationDeclaration_dummy_166 AnnotationDeclaration tok_AnnotationDeclaration_dummy_166 { Ctr__Java__4 (rtkPosOf $1) $2 } |
+       tok_AnnotationElement_dummy_165 AnnotationElement tok_AnnotationElement_dummy_165 { Ctr__Java__5 (rtkPosOf $1) $2 } |
+       tok_AnnotationList_dummy_164 AnnotationList tok_AnnotationList_dummy_164 { Ctr__Java__6 (rtkPosOf $1) (reverse $2) } |
+       tok_AnnotationTypeElement_dummy_163 AnnotationTypeElement tok_AnnotationTypeElement_dummy_163 { Ctr__Java__7 (rtkPosOf $1) $2 } |
+       tok_AnnotationTypeElementList_dummy_162 AnnotationTypeElementList tok_AnnotationTypeElementList_dummy_162 { Ctr__Java__8 (rtkPosOf $1) (reverse $2) } |
+       tok_Arglist_dummy_161 Arglist tok_Arglist_dummy_161 { Ctr__Java__9 (rtkPosOf $1) $2 } |
+       tok_AssignmentOp_dummy_160 AssignmentOp tok_AssignmentOp_dummy_160 { Ctr__Java__10 (rtkPosOf $1) $2 } |
+       tok_CatchList_dummy_159 CatchList tok_CatchList_dummy_159 { Ctr__Java__11 (rtkPosOf $1) (reverse $2) } |
+       tok_ClassDeclaration_dummy_158 ClassDeclaration tok_ClassDeclaration_dummy_158 { Ctr__Java__12 (rtkPosOf $1) $2 } |
+       tok_CompilationUnit_dummy_157 CompilationUnit tok_CompilationUnit_dummy_157 { Ctr__Java__13 (rtkPosOf $1) $2 } |
+       tok_CompoundName_dummy_156 CompoundName tok_CompoundName_dummy_156 { Ctr__Java__14 (rtkPosOf $1) $2 } |
+       tok_CreationExpression_dummy_155 CreationExpression tok_CreationExpression_dummy_155 { Ctr__Java__15 (rtkPosOf $1) $2 } |
+       tok_DimExprs_dummy_154 DimExprs tok_DimExprs_dummy_154 { Ctr__Java__16 (rtkPosOf $1) (reverse $2) } |
+       tok_Dims_dummy_153 Dims tok_Dims_dummy_153 { Ctr__Java__17 (rtkPosOf $1) (reverse $2) } |
+       tok_DoStatement_dummy_152 DoStatement tok_DoStatement_dummy_152 { Ctr__Java__18 (rtkPosOf $1) $2 } |
+       tok_DocComment_dummy_151 DocComment tok_DocComment_dummy_151 { Ctr__Java__19 (rtkPosOf $1) $2 } |
+       tok_EnumConstant_dummy_150 EnumConstant tok_EnumConstant_dummy_150 { Ctr__Java__20 (rtkPosOf $1) $2 } |
+       tok_EnumConstantList_dummy_149 EnumConstantList tok_EnumConstantList_dummy_149 { Ctr__Java__21 (rtkPosOf $1) $2 } |
+       tok_EnumDeclaration_dummy_148 EnumDeclaration tok_EnumDeclaration_dummy_148 { Ctr__Java__22 (rtkPosOf $1) $2 } |
+       tok_EqualityOp_dummy_147 EqualityOp tok_EqualityOp_dummy_147 { Ctr__Java__23 (rtkPosOf $1) $2 } |
+       tok_Expression_dummy_146 Expression tok_Expression_dummy_146 { Ctr__Java__24 (rtkPosOf $1) $2 } |
+       tok_ExtendsList_dummy_145 ExtendsList tok_ExtendsList_dummy_145 { Ctr__Java__25 (rtkPosOf $1) $2 } |
+       tok_FieldDeclaration_dummy_144 FieldDeclaration tok_FieldDeclaration_dummy_144 { Ctr__Java__26 (rtkPosOf $1) $2 } |
+       tok_FieldDeclarationList_dummy_143 FieldDeclarationList tok_FieldDeclarationList_dummy_143 { Ctr__Java__27 (rtkPosOf $1) (reverse $2) } |
+       tok_ForStatement_dummy_142 ForStatement tok_ForStatement_dummy_142 { Ctr__Java__28 (rtkPosOf $1) $2 } |
+       tok_IfStatement_dummy_141 IfStatement tok_IfStatement_dummy_141 { Ctr__Java__29 (rtkPosOf $1) $2 } |
+       tok_ImplementsList_dummy_140 ImplementsList tok_ImplementsList_dummy_140 { Ctr__Java__30 (rtkPosOf $1) $2 } |
+       tok_ImportHead_dummy_139 ImportHead tok_ImportHead_dummy_139 { Ctr__Java__31 (rtkPosOf $1) $2 } |
+       tok_ImportList_dummy_138 ImportList tok_ImportList_dummy_138 { Ctr__Java__32 (rtkPosOf $1) (reverse $2) } |
+       tok_ImportName_dummy_137 ImportName tok_ImportName_dummy_137 { Ctr__Java__33 (rtkPosOf $1) $2 } |
+       tok_ImportStatement_dummy_136 ImportStatement tok_ImportStatement_dummy_136 { Ctr__Java__34 (rtkPosOf $1) $2 } |
+       tok_InterfaceDeclaration_dummy_135 InterfaceDeclaration tok_InterfaceDeclaration_dummy_135 { Ctr__Java__35 (rtkPosOf $1) $2 } |
+       tok_Literal_dummy_134 Literal tok_Literal_dummy_134 { Ctr__Java__36 (rtkPosOf $1) $2 } |
+       tok_MemberAfterFirstId_dummy_133 MemberAfterFirstId tok_MemberAfterFirstId_dummy_133 { Ctr__Java__37 (rtkPosOf $1) $2 } |
+       tok_MemberDeclaration_dummy_132 MemberDeclaration tok_MemberDeclaration_dummy_132 { Ctr__Java__38 (rtkPosOf $1) $2 } |
+       tok_MemberRest_dummy_131 MemberRest tok_MemberRest_dummy_131 { Ctr__Java__39 (rtkPosOf $1) $2 } |
+       tok_Modifier_dummy_130 Modifier tok_Modifier_dummy_130 { Ctr__Java__40 (rtkPosOf $1) $2 } |
+       tok_ModifierList_dummy_129 ModifierList tok_ModifierList_dummy_129 { Ctr__Java__41 (rtkPosOf $1) (reverse $2) } |
+       tok_MoreTypeSpecifier_dummy_128 MoreTypeSpecifier tok_MoreTypeSpecifier_dummy_128 { Ctr__Java__42 (rtkPosOf $1) $2 } |
+       tok_MoreVariableDeclarators_dummy_127 MoreVariableDeclarators tok_MoreVariableDeclarators_dummy_127 { Ctr__Java__43 (rtkPosOf $1) (reverse $2) } |
+       tok_MultiplicativeOp_dummy_126 MultiplicativeOp tok_MultiplicativeOp_dummy_126 { Ctr__Java__44 (rtkPosOf $1) $2 } |
+       tok_NonEmptyDims_dummy_125 NonEmptyDims tok_NonEmptyDims_dummy_125 { Ctr__Java__45 (rtkPosOf $1) (reverse $2) } |
+       tok_NonEmptyTypeArguments_dummy_124 NonEmptyTypeArguments tok_NonEmptyTypeArguments_dummy_124 { Ctr__Java__46 (rtkPosOf $1) $2 } |
+       tok_OptDocComment_dummy_123 OptDocComment tok_OptDocComment_dummy_123 { Ctr__Java__47 (rtkPosOf $1) $2 } |
+       tok_OptElsePart_dummy_122 OptElsePart tok_OptElsePart_dummy_122 { Ctr__Java__48 (rtkPosOf $1) $2 } |
+       tok_OptExpression_dummy_121 OptExpression tok_OptExpression_dummy_121 { Ctr__Java__49 (rtkPosOf $1) $2 } |
+       tok_OptFinally_dummy_120 OptFinally tok_OptFinally_dummy_120 { Ctr__Java__50 (rtkPosOf $1) $2 } |
+       tok_OptId_dummy_119 OptId tok_OptId_dummy_119 { Ctr__Java__51 (rtkPosOf $1) $2 } |
+       tok_OptVariableInitializer_dummy_118 OptVariableInitializer tok_OptVariableInitializer_dummy_118 { Ctr__Java__52 (rtkPosOf $1) $2 } |
+       tok_Package_dummy_117 Package tok_Package_dummy_117 { Ctr__Java__53 (rtkPosOf $1) $2 } |
+       tok_Parameter_dummy_116 Parameter tok_Parameter_dummy_116 { Ctr__Java__54 (rtkPosOf $1) $2 } |
+       tok_ParameterList_dummy_115 ParameterList tok_ParameterList_dummy_115 { Ctr__Java__55 (rtkPosOf $1) $2 } |
+       tok_PostfixOp_dummy_114 PostfixOp tok_PostfixOp_dummy_114 { Ctr__Java__56 (rtkPosOf $1) $2 } |
+       tok_PrefixOp_dummy_113 PrefixOp tok_PrefixOp_dummy_113 { Ctr__Java__57 (rtkPosOf $1) $2 } |
+       tok_PrimitiveTypeKeyword_dummy_112 PrimitiveTypeKeyword tok_PrimitiveTypeKeyword_dummy_112 { Ctr__Java__58 (rtkPosOf $1) $2 } |
+       tok_RelationalOp_dummy_111 RelationalOp tok_RelationalOp_dummy_111 { Ctr__Java__59 (rtkPosOf $1) $2 } |
+       tok_ShiftOp_dummy_110 ShiftOp tok_ShiftOp_dummy_110 { Ctr__Java__60 (rtkPosOf $1) $2 } |
+       tok_Statement_dummy_109 Statement tok_Statement_dummy_109 { Ctr__Java__61 (rtkPosOf $1) $2 } |
+       tok_StatementBlock_dummy_108 StatementBlock tok_StatementBlock_dummy_108 { Ctr__Java__62 (rtkPosOf $1) $2 } |
+       tok_StatementList_dummy_107 StatementList tok_StatementList_dummy_107 { Ctr__Java__63 (rtkPosOf $1) (reverse $2) } |
+       tok_StaticInitializer_dummy_106 StaticInitializer tok_StaticInitializer_dummy_106 { Ctr__Java__64 (rtkPosOf $1) $2 } |
+       tok_SwitchCaseList_dummy_105 SwitchCaseList tok_SwitchCaseList_dummy_105 { Ctr__Java__65 (rtkPosOf $1) (reverse $2) } |
+       tok_SwitchStatement_dummy_104 SwitchStatement tok_SwitchStatement_dummy_104 { Ctr__Java__66 (rtkPosOf $1) $2 } |
+       tok_ThrowsClause_dummy_103 ThrowsClause tok_ThrowsClause_dummy_103 { Ctr__Java__67 (rtkPosOf $1) $2 } |
+       tok_TryStatement_dummy_102 TryStatement tok_TryStatement_dummy_102 { Ctr__Java__68 (rtkPosOf $1) $2 } |
+       tok_Type_dummy_101 Type tok_Type_dummy_101 { Ctr__Java__69 (rtkPosOf $1) $2 } |
+       tok_TypeArgument_dummy_100 TypeArgument tok_TypeArgument_dummy_100 { Ctr__Java__70 (rtkPosOf $1) $2 } |
+       tok_TypeArguments_dummy_99 TypeArguments tok_TypeArguments_dummy_99 { Ctr__Java__71 (rtkPosOf $1) $2 } |
+       tok_TypeDeclRest_dummy_98 TypeDeclRest tok_TypeDeclRest_dummy_98 { Ctr__Java__72 (rtkPosOf $1) $2 } |
+       tok_TypeDeclaration_dummy_97 TypeDeclaration tok_TypeDeclaration_dummy_97 { Ctr__Java__73 (rtkPosOf $1) $2 } |
+       tok_TypeParameter_dummy_96 TypeParameter tok_TypeParameter_dummy_96 { Ctr__Java__74 (rtkPosOf $1) $2 } |
+       tok_TypeParameters_dummy_95 TypeParameters tok_TypeParameters_dummy_95 { Ctr__Java__75 (rtkPosOf $1) $2 } |
+       tok_TypeSpecifier_dummy_94 TypeSpecifier tok_TypeSpecifier_dummy_94 { Ctr__Java__76 (rtkPosOf $1) $2 } |
+       tok_VariableDeclaration_dummy_93 VariableDeclaration tok_VariableDeclaration_dummy_93 { Ctr__Java__77 (rtkPosOf $1) $2 } |
+       tok_VariableDeclarator_dummy_92 VariableDeclarator tok_VariableDeclarator_dummy_92 { Ctr__Java__78 (rtkPosOf $1) $2 } |
+       tok_VariableDeclaratorList_dummy_91 VariableDeclaratorList tok_VariableDeclaratorList_dummy_91 { Ctr__Java__79 (rtkPosOf $1) $2 } |
+       tok_VariableInitializer_dummy_90 VariableInitializer tok_VariableInitializer_dummy_90 { Ctr__Java__80 (rtkPosOf $1) $2 } |
+       tok_VariableInitializerList_dummy_89 VariableInitializerList tok_VariableInitializerList_dummy_89 { Ctr__Java__81 (rtkPosOf $1) $2 } |
+       tok_WhileStatement_dummy_88 WhileStatement tok_WhileStatement_dummy_88 { Ctr__Java__82 (rtkPosOf $1) $2 } |
+       tok_WildcardType_dummy_87 WildcardType tok_WildcardType_dummy_87 { Ctr__Java__83 (rtkPosOf $1) $2 }
 
 Java : qq_Java { Anti_Java (tkVal_qq_Java $1) } |
-       CompilationUnit { Ctr__Java__81 (rtkPosOf $1) $1 }
+       CompilationUnit { Ctr__Java__84 (rtkPosOf $1) $1 }
 
 AdditiveOp : qq_AdditiveOp { Anti_AdditiveOp (tkVal_qq_AdditiveOp $1) } |
-             tok__plus__72 { Ctr__AdditiveOp__0 (rtkPosOf $1) } |
-             tok__minus__73 { Ctr__AdditiveOp__1 (rtkPosOf $1) }
+             tok__plus__74 { Ctr__AdditiveOp__0 (rtkPosOf $1) } |
+             tok__minus__75 { Ctr__AdditiveOp__1 (rtkPosOf $1) }
 
 ListElem_AnnotationList9 : qq_AnnotationList { Anti_Annotation (tkVal_qq_AnnotationList $1) } |
                            Annotation { $1 }
 
 Annotation : qq_Annotation { Anti_Annotation (tkVal_qq_Annotation $1) } |
-             tok__symbol__5 CompoundName Rule_4 { Ctr__Annotation__1 (rtkPosOf $1) $2 $3 }
+             tok__symbol__6 CompoundName Rule_4 { Ctr__Annotation__1 (rtkPosOf $1) $2 $3 }
 
 AnnotationArguments : qq_AnnotationArguments { Anti_AnnotationArguments (tkVal_qq_AnnotationArguments $1) } |
                       AnnotationElement Rule_7 { Ctr__AnnotationArguments__0 (rtkPosOf $1) $1 (reverse $2) }
 
 AnnotationDeclaration : qq_AnnotationDeclaration { Anti_AnnotationDeclaration (tkVal_qq_AnnotationDeclaration $1) } |
-                        tok__symbol__5 tok_interface_15 id tok__symbol__13 AnnotationTypeElementList tok__symbol__14 { Ctr__AnnotationDeclaration__0 (rtkPosOf $1) (tkVal_id $3) (reverse $5) }
+                        tok__symbol__6 tok_interface_16 id tok__symbol__14 AnnotationTypeElementList tok__symbol__15 { Ctr__AnnotationDeclaration__0 (rtkPosOf $1) (tkVal_id $3) (reverse $5) }
 
 AnnotationElement : qq_AnnotationElement { Anti_AnnotationElement (tkVal_qq_AnnotationElement $1) } |
-                    id tok__eql__9 ConditionalExpression { Ctr__AnnotationElement__0 (rtkPosOf $1) (tkVal_id $1) $3 } |
+                    id tok__eql__10 ConditionalExpression { Ctr__AnnotationElement__0 (rtkPosOf $1) (tkVal_id $1) $3 } |
                     ConditionalExpression { Ctr__AnnotationElement__1 (rtkPosOf $1) $1 }
 
 AnnotationList : {- empty -} { [] } |
@@ -402,45 +412,45 @@ AnnotationTypeElementList : {- empty -} { [] } |
 
 Arglist : qq_Arglist { Anti_Arglist (tkVal_qq_Arglist $1) } |
           { Ctr__Arglist__0 rtkNoPos } |
-          Rule_69 { Ctr__Arglist__1 (rtkPosOf $1) $1 }
+          Rule_73 { Ctr__Arglist__1 (rtkPosOf $1) $1 }
 
 AssignmentOp : qq_AssignmentOp { Anti_AssignmentOp (tkVal_qq_AssignmentOp $1) } |
-               tok__eql__9 { Ctr__AssignmentOp__0 (rtkPosOf $1) } |
-               tok__plus__eql__45 { Ctr__AssignmentOp__1 (rtkPosOf $1) } |
-               tok__minus__eql__46 { Ctr__AssignmentOp__2 (rtkPosOf $1) } |
-               tok__star__eql__47 { Ctr__AssignmentOp__3 (rtkPosOf $1) } |
-               tok__symbol__eql__48 { Ctr__AssignmentOp__4 (rtkPosOf $1) } |
-               tok__pipe__eql__49 { Ctr__AssignmentOp__5 (rtkPosOf $1) } |
-               tok__symbol__eql__50 { Ctr__AssignmentOp__6 (rtkPosOf $1) } |
-               tok__symbol__eql__51 { Ctr__AssignmentOp__7 (rtkPosOf $1) } |
-               tok__symbol__eql__52 { Ctr__AssignmentOp__8 (rtkPosOf $1) } |
-               tok__symbol__symbol__eql__53 { Ctr__AssignmentOp__9 (rtkPosOf $1) } |
-               tok__symbol__symbol__eql__54 { Ctr__AssignmentOp__10 (rtkPosOf $1) } |
-               tok__symbol__symbol__symbol__eql__55 { Ctr__AssignmentOp__11 (rtkPosOf $1) }
+               tok__eql__10 { Ctr__AssignmentOp__0 (rtkPosOf $1) } |
+               tok__plus__eql__47 { Ctr__AssignmentOp__1 (rtkPosOf $1) } |
+               tok__minus__eql__48 { Ctr__AssignmentOp__2 (rtkPosOf $1) } |
+               tok__star__eql__49 { Ctr__AssignmentOp__3 (rtkPosOf $1) } |
+               tok__symbol__eql__50 { Ctr__AssignmentOp__4 (rtkPosOf $1) } |
+               tok__pipe__eql__51 { Ctr__AssignmentOp__5 (rtkPosOf $1) } |
+               tok__symbol__eql__52 { Ctr__AssignmentOp__6 (rtkPosOf $1) } |
+               tok__symbol__eql__53 { Ctr__AssignmentOp__7 (rtkPosOf $1) } |
+               tok__symbol__eql__54 { Ctr__AssignmentOp__8 (rtkPosOf $1) } |
+               tok__symbol__symbol__eql__55 { Ctr__AssignmentOp__9 (rtkPosOf $1) } |
+               tok__symbol__symbol__eql__56 { Ctr__AssignmentOp__10 (rtkPosOf $1) } |
+               tok__symbol__symbol__symbol__eql__57 { Ctr__AssignmentOp__11 (rtkPosOf $1) }
 
 CatchList : {- empty -} { [] } |
-            CatchList ListElem_CatchList55 { $2 : $1 }
+            CatchList ListElem_CatchList59 { $2 : $1 }
 
 ClassDeclaration : qq_ClassDeclaration { Anti_ClassDeclaration (tkVal_qq_ClassDeclaration $1) } |
-                   tok_class_12 id TypeParameters Rule_16 Rule_17 tok__symbol__13 FieldDeclarationList tok__symbol__14 { Ctr__ClassDeclaration__0 (rtkPosOf $1) (tkVal_id $2) $3 $4 $5 (reverse $7) }
+                   tok_class_13 id TypeParameters Rule_16 Rule_17 tok__symbol__14 FieldDeclarationList tok__symbol__15 { Ctr__ClassDeclaration__0 (rtkPosOf $1) (tkVal_id $2) $3 $4 $5 (reverse $7) }
 
 CompilationUnit : qq_CompilationUnit { Anti_CompilationUnit (tkVal_qq_CompilationUnit $1) } |
                   Rule_1 ImportList Rule_2 { Ctr__CompilationUnit__0 (rtkPosOf $1) $1 (reverse $2) $3 }
 
 CompoundName : qq_CompoundName { Anti_CompoundName (tkVal_qq_CompoundName $1) } |
-               id Rule_81 { Ctr__CompoundName__0 (rtkPosOf $1) (tkVal_id $1) (reverse $2) }
+               id Rule_85 { Ctr__CompoundName__0 (rtkPosOf $1) (tkVal_id $1) (reverse $2) }
 
 CreationExpression : qq_CreationExpression { Anti_CreationExpression (tkVal_qq_CreationExpression $1) } |
-                     tok_new_82 TypeSpecifier Rule_65 { Ctr__CreationExpression__0 (rtkPosOf $1) $2 $3 }
+                     tok_new_84 TypeSpecifier Rule_69 { Ctr__CreationExpression__0 (rtkPosOf $1) $2 $3 }
 
-DimExprs : ListElem_DimExprs68 { [$1] } |
-           DimExprs ListElem_DimExprs68 { $2 : $1 }
+DimExprs : ListElem_DimExprs72 { [$1] } |
+           DimExprs ListElem_DimExprs72 { $2 : $1 }
 
 Dims : {- empty -} { [] } |
        Dims ListElem_Dims32 { $2 : $1 }
 
 DoStatement : qq_DoStatement { Anti_DoStatement (tkVal_qq_DoStatement $1) } |
-              tok_do_37 Statement tok_while_38 tok__lparen__6 Expression tok__rparen__7 tok__semi__1 { Ctr__DoStatement__0 (rtkPosOf $1) $2 $5 }
+              tok_do_39 Statement tok_while_40 tok__lparen__7 Expression tok__rparen__8 tok__semi__1 { Ctr__DoStatement__0 (rtkPosOf $1) $2 $5 }
 
 DocComment : qq_DocComment { Anti_DocComment (tkVal_qq_DocComment $1) } |
              doccomment { Ctr__DocComment__0 (rtkPosOf $1) (tkVal_doccomment $1) }
@@ -452,39 +462,39 @@ EnumConstantList : qq_EnumConstantList { Anti_EnumConstantList (tkVal_qq_EnumCon
                    EnumConstant Rule_24 Rule_26 { Ctr__EnumConstantList__0 (rtkPosOf $1) $1 (reverse $2) $3 }
 
 EnumDeclaration : qq_EnumDeclaration { Anti_EnumDeclaration (tkVal_qq_EnumDeclaration $1) } |
-                  tok_enum_16 id Rule_27 tok__symbol__13 EnumConstantList Rule_28 tok__symbol__14 { Ctr__EnumDeclaration__0 (rtkPosOf $1) (tkVal_id $2) $3 $5 $6 }
+                  tok_enum_17 id Rule_27 tok__symbol__14 EnumConstantList Rule_28 tok__symbol__15 { Ctr__EnumDeclaration__0 (rtkPosOf $1) (tkVal_id $2) $3 $5 $6 }
 
 EqualityOp : qq_EqualityOp { Anti_EqualityOp (tkVal_qq_EqualityOp $1) } |
-             tok__eql__eql__62 { Ctr__EqualityOp__0 (rtkPosOf $1) } |
-             tok__exclamation__eql__63 { Ctr__EqualityOp__1 (rtkPosOf $1) }
+             tok__eql__eql__64 { Ctr__EqualityOp__0 (rtkPosOf $1) } |
+             tok__exclamation__eql__65 { Ctr__EqualityOp__1 (rtkPosOf $1) }
 
 PrimaryNoPostfix : qq_Expression { Anti_Expression (tkVal_qq_Expression $1) } |
                    Literal { Ctr__Expression__0 (rtkPosOf $1) $1 } |
-                   tok_this_80 { Ctr__Expression__1 (rtkPosOf $1) } |
-                   tok__lparen__6 Expression tok__rparen__7 { Ctr__Expression__2 (rtkPosOf $1) $2 } |
+                   tok_this_82 { Ctr__Expression__1 (rtkPosOf $1) } |
+                   tok__lparen__7 Expression tok__rparen__8 { Ctr__Expression__2 (rtkPosOf $1) $2 } |
                    CreationExpression { Ctr__Expression__3 (rtkPosOf $1) $1 } |
-                   CompoundName Rule_61 { Ctr__Expression__4 (rtkPosOf $1) $1 $2 } |
-                   CompoundName tok__sq_bkt_l__17 Expression tok__sq_bkt_r__18 { Ctr__Expression__5 (rtkPosOf $1) $1 $3 } |
-                   tok_super_81 tok__dot__3 id Rule_63 { Ctr__Expression__6 (rtkPosOf $1) (tkVal_id $3) $4 }
+                   CompoundName Rule_65 { Ctr__Expression__4 (rtkPosOf $1) $1 $2 } |
+                   CompoundName tok__sq_bkt_l__18 Expression tok__sq_bkt_r__19 { Ctr__Expression__5 (rtkPosOf $1) $1 $3 } |
+                   tok_super_83 tok__dot__4 id Rule_67 { Ctr__Expression__6 (rtkPosOf $1) (tkVal_id $3) $4 }
 
 PostfixExpression : PrimaryNoPostfix { Ctr__Expression__7 (rtkPosOf $1) $1 } |
                     PostfixExpression PostfixOp { Ctr__Expression__8 (rtkPosOf $1) $1 $2 } |
-                    PostfixExpression tok__dot__3 id { Ctr__Expression__9 (rtkPosOf $1) $1 (tkVal_id $3) } |
-                    PostfixExpression tok__dot__3 id tok__lparen__6 Arglist tok__rparen__7 { Ctr__Expression__10 (rtkPosOf $1) $1 (tkVal_id $3) $5 } |
-                    PostfixExpression tok__sq_bkt_l__17 Expression tok__sq_bkt_r__18 { Ctr__Expression__11 (rtkPosOf $1) $1 $3 }
+                    PostfixExpression tok__dot__4 id { Ctr__Expression__9 (rtkPosOf $1) $1 (tkVal_id $3) } |
+                    PostfixExpression tok__dot__4 id tok__lparen__7 Arglist tok__rparen__8 { Ctr__Expression__10 (rtkPosOf $1) $1 (tkVal_id $3) $5 } |
+                    PostfixExpression tok__sq_bkt_l__18 Expression tok__sq_bkt_r__19 { Ctr__Expression__11 (rtkPosOf $1) $1 $3 }
 
 UnaryExpressionNotPlusMinus : PostfixExpression { Ctr__Expression__12 (rtkPosOf $1) $1 } |
-                              tok__tilde__78 UnaryExpression { Ctr__Expression__13 (rtkPosOf $1) $2 } |
-                              tok__exclamation__79 UnaryExpression { Ctr__Expression__14 (rtkPosOf $1) $2 } |
+                              tok__tilde__80 UnaryExpression { Ctr__Expression__13 (rtkPosOf $1) $2 } |
+                              tok__exclamation__81 UnaryExpression { Ctr__Expression__14 (rtkPosOf $1) $2 } |
                               CastExpression { Ctr__Expression__15 (rtkPosOf $1) $1 }
 
 UnaryExpression : PrefixOp UnaryExpression { Ctr__Expression__16 (rtkPosOf $1) $1 $2 } |
                   UnaryExpressionNotPlusMinus { Ctr__Expression__17 (rtkPosOf $1) $1 }
 
-CastExpression : tok__lparen__6 PrimitiveTypeKeyword Dims tok__rparen__7 UnaryExpression { Ctr__Expression__18 (rtkPosOf $1) $2 (reverse $3) $5 } |
-                 tok__lparen__6 CompoundName NonEmptyTypeArguments Dims tok__rparen__7 UnaryExpressionNotPlusMinus { Ctr__Expression__19 (rtkPosOf $1) $2 $3 (reverse $4) $6 } |
-                 tok__lparen__6 CompoundName NonEmptyDims tok__rparen__7 UnaryExpressionNotPlusMinus { Ctr__Expression__20 (rtkPosOf $1) $2 (reverse $3) $5 } |
-                 tok__lparen__6 Expression tok__rparen__7 UnaryExpressionNotPlusMinus { Ctr__Expression__21 (rtkPosOf $1) $2 $4 }
+CastExpression : tok__lparen__7 PrimitiveTypeKeyword Dims tok__rparen__8 UnaryExpression { Ctr__Expression__18 (rtkPosOf $1) $2 (reverse $3) $5 } |
+                 tok__lparen__7 CompoundName NonEmptyTypeArguments Dims tok__rparen__8 UnaryExpressionNotPlusMinus { Ctr__Expression__19 (rtkPosOf $1) $2 $3 (reverse $4) $6 } |
+                 tok__lparen__7 CompoundName NonEmptyDims tok__rparen__8 UnaryExpressionNotPlusMinus { Ctr__Expression__20 (rtkPosOf $1) $2 (reverse $3) $5 } |
+                 tok__lparen__7 Expression tok__rparen__8 UnaryExpressionNotPlusMinus { Ctr__Expression__21 (rtkPosOf $1) $2 $4 }
 
 MultiplicativeExpression : UnaryExpression { Ctr__Expression__22 (rtkPosOf $1) $1 } |
                            MultiplicativeExpression MultiplicativeOp UnaryExpression { Ctr__Expression__23 (rtkPosOf $1) $1 $2 $3 }
@@ -497,35 +507,35 @@ ShiftExpression : AdditiveExpression { Ctr__Expression__26 (rtkPosOf $1) $1 } |
 
 RelationalExpression : ShiftExpression { Ctr__Expression__28 (rtkPosOf $1) $1 } |
                        RelationalExpression RelationalOp ShiftExpression { Ctr__Expression__29 (rtkPosOf $1) $1 $2 $3 } |
-                       RelationalExpression tok_instanceof_68 Type { Ctr__Expression__30 (rtkPosOf $1) $1 $3 }
+                       RelationalExpression tok_instanceof_70 Type { Ctr__Expression__30 (rtkPosOf $1) $1 $3 }
 
 EqualityExpression : RelationalExpression { Ctr__Expression__31 (rtkPosOf $1) $1 } |
                      EqualityExpression EqualityOp RelationalExpression { Ctr__Expression__32 (rtkPosOf $1) $1 $2 $3 }
 
 AndExpression : EqualityExpression { Ctr__Expression__33 (rtkPosOf $1) $1 } |
-                AndExpression tok__symbol__61 EqualityExpression { Ctr__Expression__34 (rtkPosOf $1) $1 $3 }
+                AndExpression tok__symbol__63 EqualityExpression { Ctr__Expression__34 (rtkPosOf $1) $1 $3 }
 
 ExclusiveOrExpression : AndExpression { Ctr__Expression__35 (rtkPosOf $1) $1 } |
-                        ExclusiveOrExpression tok__symbol__60 AndExpression { Ctr__Expression__36 (rtkPosOf $1) $1 $3 }
+                        ExclusiveOrExpression tok__symbol__62 AndExpression { Ctr__Expression__36 (rtkPosOf $1) $1 $3 }
 
 InclusiveOrEpression : ExclusiveOrExpression { Ctr__Expression__37 (rtkPosOf $1) $1 } |
-                       InclusiveOrEpression tok__pipe__59 ExclusiveOrExpression { Ctr__Expression__38 (rtkPosOf $1) $1 $3 }
+                       InclusiveOrEpression tok__pipe__61 ExclusiveOrExpression { Ctr__Expression__38 (rtkPosOf $1) $1 $3 }
 
 ConditionalAndExpression : InclusiveOrEpression { Ctr__Expression__39 (rtkPosOf $1) $1 } |
-                           ConditionalAndExpression tok__symbol__symbol__58 InclusiveOrEpression { Ctr__Expression__40 (rtkPosOf $1) $1 $3 }
+                           ConditionalAndExpression tok__symbol__symbol__60 InclusiveOrEpression { Ctr__Expression__40 (rtkPosOf $1) $1 $3 }
 
 ConditionalOrExpression : ConditionalAndExpression { Ctr__Expression__41 (rtkPosOf $1) $1 } |
-                          ConditionalOrExpression tok__pipe__pipe__57 ConditionalAndExpression { Ctr__Expression__42 (rtkPosOf $1) $1 $3 }
+                          ConditionalOrExpression tok__pipe__pipe__59 ConditionalAndExpression { Ctr__Expression__42 (rtkPosOf $1) $1 $3 }
 
 ConditionalExpression : ConditionalOrExpression { Ctr__Expression__43 (rtkPosOf $1) $1 } |
-                        ConditionalOrExpression tok__symbol__56 Expression tok__colon__32 ConditionalExpression { Ctr__Expression__44 (rtkPosOf $1) $1 $3 $5 }
+                        ConditionalOrExpression tok__symbol__58 Expression tok__colon__34 ConditionalExpression { Ctr__Expression__44 (rtkPosOf $1) $1 $3 $5 }
 
-AssignmentExpression : ConditionalExpression Rule_59 { Ctr__Expression__45 (rtkPosOf $1) $1 $2 }
+AssignmentExpression : ConditionalExpression Rule_63 { Ctr__Expression__45 (rtkPosOf $1) $1 $2 }
 
 Expression : AssignmentExpression { Ctr__Expression__46 (rtkPosOf $1) $1 }
 
 ExtendsList : qq_ExtendsList { Anti_ExtendsList (tkVal_qq_ExtendsList $1) } |
-              tok_extends_10 CompoundName Rule_12 { Ctr__ExtendsList__0 (rtkPosOf $1) $2 (reverse $3) }
+              tok_extends_11 CompoundName Rule_12 { Ctr__ExtendsList__0 (rtkPosOf $1) $2 (reverse $3) }
 
 FieldDeclaration : qq_FieldDeclaration { Anti_FieldDeclaration (tkVal_qq_FieldDeclaration $1) } |
                    OptDocComment ModifierList Rule_30 { Ctr__FieldDeclaration__0 (rtkPosOf $1) $1 (reverse $2) $3 } |
@@ -538,37 +548,45 @@ FieldDeclarationList : {- empty -} { [] } |
                        FieldDeclarationList ListElem_FieldDeclarationList15 { $2 : $1 }
 
 ForStatement : qq_ForStatement { Anti_ForStatement (tkVal_qq_ForStatement $1) } |
-               tok_for_39 tok__lparen__6 Rule_53 OptExpression tok__semi__1 OptExpression tok__rparen__7 Statement { Ctr__ForStatement__0 (rtkPosOf $1) $3 $4 $6 $8 }
+               tok_for_41 tok__lparen__7 Rule_57 OptExpression tok__semi__1 OptExpression tok__rparen__8 Statement { Ctr__ForStatement__0 (rtkPosOf $1) $3 $4 $6 $8 }
 
 IfStatement : qq_IfStatement { Anti_IfStatement (tkVal_qq_IfStatement $1) } |
-              tok_if_36 tok__lparen__6 Expression tok__rparen__7 Statement OptElsePart { Ctr__IfStatement__0 (rtkPosOf $1) $3 $5 $6 }
+              tok_if_38 tok__lparen__7 Expression tok__rparen__8 Statement OptElsePart { Ctr__IfStatement__0 (rtkPosOf $1) $3 $5 $6 }
 
 ImplementsList : qq_ImplementsList { Anti_ImplementsList (tkVal_qq_ImplementsList $1) } |
-                 tok_implements_11 Rule_14 { Ctr__ImplementsList__0 (rtkPosOf $1) (reverse $2) }
+                 tok_implements_12 Rule_14 { Ctr__ImplementsList__0 (rtkPosOf $1) (reverse $2) }
+
+ImportHead : qq_ImportHead { Anti_ImportHead (tkVal_qq_ImportHead $1) } |
+             id { Ctr__ImportHead__0 (rtkPosOf $1) (tkVal_id $1) } |
+             ImportHead tok__dot__4 id { Ctr__ImportHead__1 (rtkPosOf $1) $1 (tkVal_id $3) }
 
 ImportList : {- empty -} { [] } |
              ImportList ListElem_ImportList0 { $2 : $1 }
 
+ImportName : qq_ImportName { Anti_ImportName (tkVal_qq_ImportName $1) } |
+             ImportHead { Ctr__ImportName__0 (rtkPosOf $1) $1 } |
+             ImportHead tok__dot__4 tok__star__5 { Ctr__ImportName__1 (rtkPosOf $1) $1 }
+
 ImportStatement : qq_ImportStatement { Anti_ImportStatement (tkVal_qq_ImportStatement $1) } |
-                  tok_import_2 Rule_3 tok__semi__1 { Ctr__ImportStatement__0 (rtkPosOf $1) $2 }
+                  tok_import_2 Rule_3 ImportName tok__semi__1 { Ctr__ImportStatement__0 (rtkPosOf $1) $2 $3 }
 
 ListElem_ImportList0 : qq_ImportList { Anti_ImportStatement (tkVal_qq_ImportList $1) } |
                        ImportStatement { $1 }
 
 InterfaceDeclaration : qq_InterfaceDeclaration { Anti_InterfaceDeclaration (tkVal_qq_InterfaceDeclaration $1) } |
-                       tok_interface_15 id TypeParameters Rule_18 tok__symbol__13 FieldDeclarationList tok__symbol__14 { Ctr__InterfaceDeclaration__0 (rtkPosOf $1) (tkVal_id $2) $3 $4 (reverse $6) }
+                       tok_interface_16 id TypeParameters Rule_18 tok__symbol__14 FieldDeclarationList tok__symbol__15 { Ctr__InterfaceDeclaration__0 (rtkPosOf $1) (tkVal_id $2) $3 $4 (reverse $6) }
 
 Literal : qq_Literal { Anti_Literal (tkVal_qq_Literal $1) } |
           integerLiteral { Ctr__Literal__0 (rtkPosOf $1) (tkVal_integerLiteral $1) } |
           floatLiteral { Ctr__Literal__1 (rtkPosOf $1) (tkVal_floatLiteral $1) } |
-          tok_true_83 { Ctr__Literal__2 (rtkPosOf $1) } |
-          tok_false_84 { Ctr__Literal__3 (rtkPosOf $1) } |
+          tok_true_85 { Ctr__Literal__2 (rtkPosOf $1) } |
+          tok_false_86 { Ctr__Literal__3 (rtkPosOf $1) } |
           char { Ctr__Literal__4 (rtkPosOf $1) (tkVal_char $1) } |
           string { Ctr__Literal__5 (rtkPosOf $1) (tkVal_string $1) } |
-          tok_null_85 { Ctr__Literal__6 (rtkPosOf $1) }
+          tok_null_87 { Ctr__Literal__6 (rtkPosOf $1) }
 
 MemberAfterFirstId : qq_MemberAfterFirstId { Anti_MemberAfterFirstId (tkVal_qq_MemberAfterFirstId $1) } |
-                     tok__lparen__6 Rule_35 tok__rparen__7 StatementBlock { Ctr__MemberAfterFirstId__0 (rtkPosOf $1) $2 $4 } |
+                     tok__lparen__7 Rule_35 tok__rparen__8 Rule_36 StatementBlock { Ctr__MemberAfterFirstId__0 (rtkPosOf $1) $2 $4 $5 } |
                      MoreTypeSpecifier id MemberRest { Ctr__MemberAfterFirstId__1 (rtkPosOf $1) $1 (tkVal_id $2) $3 }
 
 MemberDeclaration : qq_MemberDeclaration { Anti_MemberDeclaration (tkVal_qq_MemberDeclaration $1) } |
@@ -577,41 +595,41 @@ MemberDeclaration : qq_MemberDeclaration { Anti_MemberDeclaration (tkVal_qq_Memb
                     id MemberAfterFirstId { Ctr__MemberDeclaration__2 (rtkPosOf $1) (tkVal_id $1) $2 }
 
 MemberRest : qq_MemberRest { Anti_MemberRest (tkVal_qq_MemberRest $1) } |
-             tok__lparen__6 Rule_36 tok__rparen__7 Dims Rule_37 { Ctr__MemberRest__0 (rtkPosOf $1) $2 (reverse $4) $5 } |
+             tok__lparen__7 Rule_39 tok__rparen__8 Dims Rule_40 Rule_41 { Ctr__MemberRest__0 (rtkPosOf $1) $2 (reverse $4) $5 $6 } |
              Dims OptVariableInitializer MoreVariableDeclarators tok__semi__1 { Ctr__MemberRest__1 (rtkPosOf (reverse $1)) (reverse $1) $2 (reverse $3) }
 
 Modifier : qq_Modifier { Anti_Modifier (tkVal_qq_Modifier $1) } |
-           tok_public_86 { Ctr__Modifier__0 (rtkPosOf $1) } |
-           tok_private_87 { Ctr__Modifier__1 (rtkPosOf $1) } |
-           tok_protected_88 { Ctr__Modifier__2 (rtkPosOf $1) } |
-           tok_static_89 { Ctr__Modifier__3 (rtkPosOf $1) } |
-           tok_final_90 { Ctr__Modifier__4 (rtkPosOf $1) } |
-           tok_native_91 { Ctr__Modifier__5 (rtkPosOf $1) } |
-           tok_synchronized_30 { Ctr__Modifier__6 (rtkPosOf $1) } |
-           tok_abstract_92 { Ctr__Modifier__7 (rtkPosOf $1) } |
-           tok_threadsafe_93 { Ctr__Modifier__8 (rtkPosOf $1) } |
-           tok_transient_94 { Ctr__Modifier__9 (rtkPosOf $1) }
+           tok_public_88 { Ctr__Modifier__0 (rtkPosOf $1) } |
+           tok_private_89 { Ctr__Modifier__1 (rtkPosOf $1) } |
+           tok_protected_90 { Ctr__Modifier__2 (rtkPosOf $1) } |
+           tok_static_3 { Ctr__Modifier__3 (rtkPosOf $1) } |
+           tok_final_91 { Ctr__Modifier__4 (rtkPosOf $1) } |
+           tok_native_92 { Ctr__Modifier__5 (rtkPosOf $1) } |
+           tok_synchronized_32 { Ctr__Modifier__6 (rtkPosOf $1) } |
+           tok_abstract_93 { Ctr__Modifier__7 (rtkPosOf $1) } |
+           tok_threadsafe_94 { Ctr__Modifier__8 (rtkPosOf $1) } |
+           tok_transient_95 { Ctr__Modifier__9 (rtkPosOf $1) }
 
 ModifierList : {- empty -} { [] } |
                ModifierList ListElem_ModifierList11 { $2 : $1 }
 
 MoreTypeSpecifier : qq_MoreTypeSpecifier { Anti_MoreTypeSpecifier (tkVal_qq_MoreTypeSpecifier $1) } |
-                    tok__dot__3 id MoreTypeSpecifier { Ctr__MoreTypeSpecifier__0 (rtkPosOf $1) (tkVal_id $2) $3 } |
+                    tok__dot__4 id MoreTypeSpecifier { Ctr__MoreTypeSpecifier__0 (rtkPosOf $1) (tkVal_id $2) $3 } |
                     TypeArguments Dims { Ctr__MoreTypeSpecifier__1 (rtkPosOf $1) $1 (reverse $2) }
 
 MoreVariableDeclarators : {- empty -} { [] } |
-                          MoreVariableDeclarators ListElem_MoreVariableDeclarators41 { $2 : $1 }
+                          MoreVariableDeclarators ListElem_MoreVariableDeclarators45 { $2 : $1 }
 
 MultiplicativeOp : qq_MultiplicativeOp { Anti_MultiplicativeOp (tkVal_qq_MultiplicativeOp $1) } |
-                   tok__star__4 { Ctr__MultiplicativeOp__0 (rtkPosOf $1) } |
-                   tok__symbol__74 { Ctr__MultiplicativeOp__1 (rtkPosOf $1) } |
-                   tok__symbol__75 { Ctr__MultiplicativeOp__2 (rtkPosOf $1) }
+                   tok__star__5 { Ctr__MultiplicativeOp__0 (rtkPosOf $1) } |
+                   tok__symbol__76 { Ctr__MultiplicativeOp__1 (rtkPosOf $1) } |
+                   tok__symbol__77 { Ctr__MultiplicativeOp__2 (rtkPosOf $1) }
 
 NonEmptyDims : ListElem_NonEmptyDims34 { [$1] } |
                NonEmptyDims ListElem_NonEmptyDims34 { $2 : $1 }
 
 NonEmptyTypeArguments : qq_NonEmptyTypeArguments { Anti_NonEmptyTypeArguments (tkVal_qq_NonEmptyTypeArguments $1) } |
-                        tok__symbol__64 TypeArgument Rule_72 tok__symbol__65 { Ctr__NonEmptyTypeArguments__0 (rtkPosOf $1) $2 (reverse $3) }
+                        tok__symbol__66 TypeArgument Rule_76 tok__symbol__67 { Ctr__NonEmptyTypeArguments__0 (rtkPosOf $1) $2 (reverse $3) }
 
 OptDocComment : qq_OptDocComment { Anti_OptDocComment (tkVal_qq_OptDocComment $1) } |
                 { Ctr__OptDocComment__0 rtkNoPos } |
@@ -619,7 +637,7 @@ OptDocComment : qq_OptDocComment { Anti_OptDocComment (tkVal_qq_OptDocComment $1
 
 OptElsePart : qq_OptElsePart { Anti_OptElsePart (tkVal_qq_OptElsePart $1) } |
               { Ctr__OptElsePart__0 rtkNoPos } |
-              Rule_52 { Ctr__OptElsePart__1 (rtkPosOf $1) $1 }
+              Rule_56 { Ctr__OptElsePart__1 (rtkPosOf $1) $1 }
 
 OptExpression : qq_OptExpression { Anti_OptExpression (tkVal_qq_OptExpression $1) } |
                 { Ctr__OptExpression__0 rtkNoPos } |
@@ -627,7 +645,7 @@ OptExpression : qq_OptExpression { Anti_OptExpression (tkVal_qq_OptExpression $1
 
 OptFinally : qq_OptFinally { Anti_OptFinally (tkVal_qq_OptFinally $1) } |
              { Ctr__OptFinally__0 rtkNoPos } |
-             Rule_56 { Ctr__OptFinally__1 (rtkPosOf $1) $1 }
+             Rule_60 { Ctr__OptFinally__1 (rtkPosOf $1) $1 }
 
 OptId : qq_OptId { Anti_OptId (tkVal_qq_OptId $1) } |
         { Ctr__OptId__0 rtkNoPos } |
@@ -635,7 +653,7 @@ OptId : qq_OptId { Anti_OptId (tkVal_qq_OptId $1) } |
 
 OptVariableInitializer : qq_OptVariableInitializer { Anti_OptVariableInitializer (tkVal_qq_OptVariableInitializer $1) } |
                          { Ctr__OptVariableInitializer__0 rtkNoPos } |
-                         Rule_44 { Ctr__OptVariableInitializer__1 (rtkPosOf $1) $1 }
+                         Rule_48 { Ctr__OptVariableInitializer__1 (rtkPosOf $1) $1 }
 
 Package : qq_Package { Anti_Package (tkVal_qq_Package $1) } |
           tok_package_0 CompoundName tok__semi__1 { Ctr__Package__0 (rtkPosOf $1) $2 }
@@ -644,34 +662,34 @@ Parameter : qq_Parameter { Anti_Parameter (tkVal_qq_Parameter $1) } |
             Type id Dims { Ctr__Parameter__0 (rtkPosOf $1) $1 (tkVal_id $2) (reverse $3) }
 
 ParameterList : qq_ParameterList { Anti_ParameterList (tkVal_qq_ParameterList $1) } |
-                Parameter Rule_49 { Ctr__ParameterList__0 (rtkPosOf $1) $1 (reverse $2) }
+                Parameter Rule_53 { Ctr__ParameterList__0 (rtkPosOf $1) $1 (reverse $2) }
 
 PostfixOp : qq_PostfixOp { Anti_PostfixOp (tkVal_qq_PostfixOp $1) } |
-            tok__plus__plus__76 { Ctr__PostfixOp__0 (rtkPosOf $1) } |
-            tok__minus__minus__77 { Ctr__PostfixOp__1 (rtkPosOf $1) }
+            tok__plus__plus__78 { Ctr__PostfixOp__0 (rtkPosOf $1) } |
+            tok__minus__minus__79 { Ctr__PostfixOp__1 (rtkPosOf $1) }
 
 PrefixOp : qq_PrefixOp { Anti_PrefixOp (tkVal_qq_PrefixOp $1) } |
-           tok__plus__plus__76 { Ctr__PrefixOp__0 (rtkPosOf $1) } |
-           tok__minus__minus__77 { Ctr__PrefixOp__1 (rtkPosOf $1) } |
-           tok__plus__72 { Ctr__PrefixOp__2 (rtkPosOf $1) } |
-           tok__minus__73 { Ctr__PrefixOp__3 (rtkPosOf $1) }
+           tok__plus__plus__78 { Ctr__PrefixOp__0 (rtkPosOf $1) } |
+           tok__minus__minus__79 { Ctr__PrefixOp__1 (rtkPosOf $1) } |
+           tok__plus__74 { Ctr__PrefixOp__2 (rtkPosOf $1) } |
+           tok__minus__75 { Ctr__PrefixOp__3 (rtkPosOf $1) }
 
 PrimitiveTypeKeyword : qq_PrimitiveTypeKeyword { Anti_PrimitiveTypeKeyword (tkVal_qq_PrimitiveTypeKeyword $1) } |
-                       tok_boolean_19 { Ctr__PrimitiveTypeKeyword__0 (rtkPosOf $1) } |
-                       tok_byte_20 { Ctr__PrimitiveTypeKeyword__1 (rtkPosOf $1) } |
-                       tok_char_21 { Ctr__PrimitiveTypeKeyword__2 (rtkPosOf $1) } |
-                       tok_short_22 { Ctr__PrimitiveTypeKeyword__3 (rtkPosOf $1) } |
-                       tok_int_23 { Ctr__PrimitiveTypeKeyword__4 (rtkPosOf $1) } |
-                       tok_float_24 { Ctr__PrimitiveTypeKeyword__5 (rtkPosOf $1) } |
-                       tok_long_25 { Ctr__PrimitiveTypeKeyword__6 (rtkPosOf $1) } |
-                       tok_double_26 { Ctr__PrimitiveTypeKeyword__7 (rtkPosOf $1) } |
-                       tok_void_27 { Ctr__PrimitiveTypeKeyword__8 (rtkPosOf $1) }
+                       tok_boolean_20 { Ctr__PrimitiveTypeKeyword__0 (rtkPosOf $1) } |
+                       tok_byte_21 { Ctr__PrimitiveTypeKeyword__1 (rtkPosOf $1) } |
+                       tok_char_22 { Ctr__PrimitiveTypeKeyword__2 (rtkPosOf $1) } |
+                       tok_short_23 { Ctr__PrimitiveTypeKeyword__3 (rtkPosOf $1) } |
+                       tok_int_24 { Ctr__PrimitiveTypeKeyword__4 (rtkPosOf $1) } |
+                       tok_float_25 { Ctr__PrimitiveTypeKeyword__5 (rtkPosOf $1) } |
+                       tok_long_26 { Ctr__PrimitiveTypeKeyword__6 (rtkPosOf $1) } |
+                       tok_double_27 { Ctr__PrimitiveTypeKeyword__7 (rtkPosOf $1) } |
+                       tok_void_28 { Ctr__PrimitiveTypeKeyword__8 (rtkPosOf $1) }
 
 RelationalOp : qq_RelationalOp { Anti_RelationalOp (tkVal_qq_RelationalOp $1) } |
-               tok__symbol__64 { Ctr__RelationalOp__0 (rtkPosOf $1) } |
-               tok__symbol__65 { Ctr__RelationalOp__1 (rtkPosOf $1) } |
-               tok__symbol__eql__66 { Ctr__RelationalOp__2 (rtkPosOf $1) } |
-               tok__symbol__eql__67 { Ctr__RelationalOp__3 (rtkPosOf $1) }
+               tok__symbol__66 { Ctr__RelationalOp__0 (rtkPosOf $1) } |
+               tok__symbol__67 { Ctr__RelationalOp__1 (rtkPosOf $1) } |
+               tok__symbol__eql__68 { Ctr__RelationalOp__2 (rtkPosOf $1) } |
+               tok__symbol__eql__69 { Ctr__RelationalOp__3 (rtkPosOf $1) }
 
 Rule_1 : { Ctr__Rule_1__0 rtkNoPos } |
          Package { Ctr__Rule_1__1 (rtkPosOf $1) $1 }
@@ -685,10 +703,10 @@ Rule_10 : Modifier { Ctr__Rule_10__1 (rtkPosOf $1) $1 } |
 Rule_12 : {- empty -} { [] } |
           Rule_12 Rule_13 { $2 : $1 }
 
-Rule_13 : tok__coma__8 CompoundName { Ctr__Rule_13__0 (rtkPosOf $1) $2 }
+Rule_13 : tok__coma__9 CompoundName { Ctr__Rule_13__0 (rtkPosOf $1) $2 }
 
 Rule_14 : CompoundName { [$1] } |
-          Rule_14 tok__coma__8 CompoundName { $3 : $1 }
+          Rule_14 tok__coma__9 CompoundName { $3 : $1 }
 
 Rule_16 : { Ctr__Rule_16__0 rtkNoPos } |
           ExtendsList { Ctr__Rule_16__1 (rtkPosOf $1) $1 }
@@ -705,20 +723,20 @@ Rule_2 : { Ctr__Rule_2__0 rtkNoPos } |
 Rule_20 : { Ctr__Rule_20__0 rtkNoPos } |
           Rule_21 { Ctr__Rule_20__1 (rtkPosOf $1) $1 }
 
-Rule_21 : tok__lparen__6 Arglist tok__rparen__7 { Ctr__Rule_21__0 (rtkPosOf $1) $2 }
+Rule_21 : tok__lparen__7 Arglist tok__rparen__8 { Ctr__Rule_21__0 (rtkPosOf $1) $2 }
 
 Rule_22 : { Ctr__Rule_22__0 rtkNoPos } |
           Rule_23 { Ctr__Rule_22__1 (rtkPosOf $1) $1 }
 
-Rule_23 : tok__symbol__13 FieldDeclarationList tok__symbol__14 { Ctr__Rule_23__0 (rtkPosOf $1) (reverse $2) }
+Rule_23 : tok__symbol__14 FieldDeclarationList tok__symbol__15 { Ctr__Rule_23__0 (rtkPosOf $1) (reverse $2) }
 
 Rule_24 : {- empty -} { [] } |
           Rule_24 Rule_25 { $2 : $1 }
 
-Rule_25 : tok__coma__8 EnumConstant { Ctr__Rule_25__0 (rtkPosOf $1) $2 }
+Rule_25 : tok__coma__9 EnumConstant { Ctr__Rule_25__0 (rtkPosOf $1) $2 }
 
 Rule_26 : { Ctr__Rule_26__0 rtkNoPos } |
-          tok__coma__8 { Ctr__Rule_26__1 (rtkPosOf $1) }
+          tok__coma__9 { Ctr__Rule_26__1 (rtkPosOf $1) }
 
 Rule_27 : { Ctr__Rule_27__0 rtkNoPos } |
           ImplementsList { Ctr__Rule_27__1 (rtkPosOf $1) $1 }
@@ -728,8 +746,8 @@ Rule_28 : { Ctr__Rule_28__0 rtkNoPos } |
 
 Rule_29 : tok__semi__1 FieldDeclarationList { Ctr__Rule_29__0 (rtkPosOf $1) (reverse $2) }
 
-Rule_3 : CompoundName tok__dot__3 tok__star__4 { Ctr__Rule_3__0 (rtkPosOf $1) $1 } |
-         CompoundName { Ctr__Rule_3__1 (rtkPosOf $1) $1 }
+Rule_3 : { Ctr__Rule_3__0 rtkNoPos } |
+         tok_static_3 { Ctr__Rule_3__1 (rtkPosOf $1) }
 
 Rule_30 : MemberDeclaration { Ctr__Rule_30__0 (rtkPosOf $1) $1 } |
           TypeDeclRest { Ctr__Rule_30__1 (rtkPosOf $1) $1 } |
@@ -738,155 +756,166 @@ Rule_30 : MemberDeclaration { Ctr__Rule_30__0 (rtkPosOf $1) $1 } |
 ListElem_Dims32 : qq_Dims { Anti_Rule_31 (tkVal_qq_Dims $1) } |
                   Rule_31 { $1 }
 
-Rule_31 : tok__sq_bkt_l__17 tok__sq_bkt_r__18 { Ctr__Rule_31__1 (rtkPosOf $1) }
+Rule_31 : tok__sq_bkt_l__18 tok__sq_bkt_r__19 { Ctr__Rule_31__1 (rtkPosOf $1) }
 
 ListElem_NonEmptyDims34 : qq_NonEmptyDims { Anti_Rule_33 (tkVal_qq_NonEmptyDims $1) } |
                           Rule_33 { $1 }
 
-Rule_33 : tok__sq_bkt_l__17 tok__sq_bkt_r__18 { Ctr__Rule_33__1 (rtkPosOf $1) }
+Rule_33 : tok__sq_bkt_l__18 tok__sq_bkt_r__19 { Ctr__Rule_33__1 (rtkPosOf $1) }
 
 Rule_35 : { Ctr__Rule_35__0 rtkNoPos } |
           ParameterList { Ctr__Rule_35__1 (rtkPosOf $1) $1 }
 
 Rule_36 : { Ctr__Rule_36__0 rtkNoPos } |
-          ParameterList { Ctr__Rule_36__1 (rtkPosOf $1) $1 }
+          ThrowsClause { Ctr__Rule_36__1 (rtkPosOf $1) $1 }
 
-Rule_37 : StatementBlock { Ctr__Rule_37__0 (rtkPosOf $1) $1 } |
-          Rule_38 tok__semi__1 { Ctr__Rule_37__1 (rtkPosOf $1) $1 }
+Rule_37 : {- empty -} { [] } |
+          Rule_37 Rule_38 { $2 : $1 }
 
-Rule_38 : { Ctr__Rule_38__0 rtkNoPos } |
-          Rule_39 { Ctr__Rule_38__1 (rtkPosOf $1) $1 }
+Rule_38 : tok__coma__9 CompoundName { Ctr__Rule_38__0 (rtkPosOf $1) $2 }
 
-Rule_39 : tok_default_28 Expression { Ctr__Rule_39__0 (rtkPosOf $1) $2 }
+Rule_39 : { Ctr__Rule_39__0 rtkNoPos } |
+          ParameterList { Ctr__Rule_39__1 (rtkPosOf $1) $1 }
 
 Rule_4 : { Ctr__Rule_4__0 rtkNoPos } |
          Rule_5 { Ctr__Rule_4__1 (rtkPosOf $1) $1 }
 
-ListElem_MoreVariableDeclarators41 : qq_MoreVariableDeclarators { Anti_Rule_40 (tkVal_qq_MoreVariableDeclarators $1) } |
-                                     Rule_40 { $1 }
+Rule_40 : { Ctr__Rule_40__0 rtkNoPos } |
+          ThrowsClause { Ctr__Rule_40__1 (rtkPosOf $1) $1 }
 
-Rule_40 : tok__coma__8 VariableDeclarator { Ctr__Rule_40__1 (rtkPosOf $1) $2 }
+Rule_41 : StatementBlock { Ctr__Rule_41__0 (rtkPosOf $1) $1 } |
+          Rule_42 tok__semi__1 { Ctr__Rule_41__1 (rtkPosOf $1) $1 }
 
-Rule_42 : {- empty -} { [] } |
-          Rule_42 Rule_43 { $2 : $1 }
+Rule_42 : { Ctr__Rule_42__0 rtkNoPos } |
+          Rule_43 { Ctr__Rule_42__1 (rtkPosOf $1) $1 }
 
-Rule_43 : tok__coma__8 VariableDeclarator { Ctr__Rule_43__0 (rtkPosOf $1) $2 }
+Rule_43 : tok_default_30 Expression { Ctr__Rule_43__0 (rtkPosOf $1) $2 }
 
-Rule_44 : tok__eql__9 VariableInitializer { Ctr__Rule_44__0 (rtkPosOf $1) $2 }
+ListElem_MoreVariableDeclarators45 : qq_MoreVariableDeclarators { Anti_Rule_44 (tkVal_qq_MoreVariableDeclarators $1) } |
+                                     Rule_44 { $1 }
 
-Rule_45 : VariableInitializer Rule_46 Rule_48 { Ctr__Rule_45__0 (rtkPosOf $1) $1 (reverse $2) $3 }
+Rule_44 : tok__coma__9 VariableDeclarator { Ctr__Rule_44__1 (rtkPosOf $1) $2 }
 
 Rule_46 : {- empty -} { [] } |
           Rule_46 Rule_47 { $2 : $1 }
 
-Rule_47 : tok__coma__8 VariableInitializer { Ctr__Rule_47__0 (rtkPosOf $1) $2 }
+Rule_47 : tok__coma__9 VariableDeclarator { Ctr__Rule_47__0 (rtkPosOf $1) $2 }
 
-Rule_48 : { Ctr__Rule_48__0 rtkNoPos } |
-          tok__coma__8 { Ctr__Rule_48__1 (rtkPosOf $1) }
+Rule_48 : tok__eql__10 VariableInitializer { Ctr__Rule_48__0 (rtkPosOf $1) $2 }
 
-Rule_49 : {- empty -} { [] } |
-          Rule_49 Rule_50 { $2 : $1 }
+Rule_49 : VariableInitializer Rule_50 Rule_52 { Ctr__Rule_49__0 (rtkPosOf $1) $1 (reverse $2) $3 }
 
-Rule_5 : tok__lparen__6 Rule_6 tok__rparen__7 { Ctr__Rule_5__0 (rtkPosOf $1) $2 }
+Rule_5 : tok__lparen__7 Rule_6 tok__rparen__8 { Ctr__Rule_5__0 (rtkPosOf $1) $2 }
 
-Rule_50 : tok__coma__8 Parameter { Ctr__Rule_50__0 (rtkPosOf $1) $2 }
+Rule_50 : {- empty -} { [] } |
+          Rule_50 Rule_51 { $2 : $1 }
 
-Rule_52 : tok_else_35 Statement { Ctr__Rule_52__0 (rtkPosOf $1) $2 }
+Rule_51 : tok__coma__9 VariableInitializer { Ctr__Rule_51__0 (rtkPosOf $1) $2 }
 
-Rule_53 : VariableDeclaration { Ctr__Rule_53__0 (rtkPosOf $1) $1 } |
-          Expression tok__semi__1 { Ctr__Rule_53__1 (rtkPosOf $1) $1 } |
-          tok__semi__1 { Ctr__Rule_53__2 (rtkPosOf $1) }
+Rule_52 : { Ctr__Rule_52__0 rtkNoPos } |
+          tok__coma__9 { Ctr__Rule_52__1 (rtkPosOf $1) }
 
-ListElem_CatchList55 : qq_CatchList { Anti_Rule_54 (tkVal_qq_CatchList $1) } |
-                       Rule_54 { $1 }
+Rule_53 : {- empty -} { [] } |
+          Rule_53 Rule_54 { $2 : $1 }
 
-Rule_54 : tok_catch_40 tok__lparen__6 Parameter tok__rparen__7 Statement { Ctr__Rule_54__1 (rtkPosOf $1) $3 $5 }
+Rule_54 : tok__coma__9 Parameter { Ctr__Rule_54__0 (rtkPosOf $1) $2 }
 
-Rule_56 : tok_finally_41 Statement { Ctr__Rule_56__0 (rtkPosOf $1) $2 }
+Rule_56 : tok_else_37 Statement { Ctr__Rule_56__0 (rtkPosOf $1) $2 }
 
-ListElem_SwitchCaseList58 : qq_SwitchCaseList { Anti_Rule_57 (tkVal_qq_SwitchCaseList $1) } |
-                            Rule_57 { $1 }
+Rule_57 : VariableDeclaration { Ctr__Rule_57__0 (rtkPosOf $1) $1 } |
+          Expression tok__semi__1 { Ctr__Rule_57__1 (rtkPosOf $1) $1 } |
+          tok__semi__1 { Ctr__Rule_57__2 (rtkPosOf $1) }
 
-Rule_57 : tok_case_43 Expression tok__colon__32 { Ctr__Rule_57__1 (rtkPosOf $1) $2 } |
-          tok_default_28 tok__colon__32 { Ctr__Rule_57__2 (rtkPosOf $1) } |
-          Statement { Ctr__Rule_57__3 (rtkPosOf $1) $1 }
+ListElem_CatchList59 : qq_CatchList { Anti_Rule_58 (tkVal_qq_CatchList $1) } |
+                       Rule_58 { $1 }
 
-Rule_59 : { Ctr__Rule_59__0 rtkNoPos } |
-          Rule_60 { Ctr__Rule_59__1 (rtkPosOf $1) $1 }
+Rule_58 : tok_catch_42 tok__lparen__7 Parameter tok__rparen__8 Statement { Ctr__Rule_58__1 (rtkPosOf $1) $3 $5 }
 
 Rule_6 : { Ctr__Rule_6__0 rtkNoPos } |
          AnnotationArguments { Ctr__Rule_6__1 (rtkPosOf $1) $1 }
 
-Rule_60 : AssignmentOp AssignmentExpression { Ctr__Rule_60__0 (rtkPosOf $1) $1 $2 }
+Rule_60 : tok_finally_43 Statement { Ctr__Rule_60__0 (rtkPosOf $1) $2 }
 
-Rule_61 : { Ctr__Rule_61__0 rtkNoPos } |
-          Rule_62 { Ctr__Rule_61__1 (rtkPosOf $1) $1 }
+ListElem_SwitchCaseList62 : qq_SwitchCaseList { Anti_Rule_61 (tkVal_qq_SwitchCaseList $1) } |
+                            Rule_61 { $1 }
 
-Rule_62 : tok__lparen__6 Arglist tok__rparen__7 { Ctr__Rule_62__0 (rtkPosOf $1) $2 }
+Rule_61 : tok_case_45 Expression tok__colon__34 { Ctr__Rule_61__1 (rtkPosOf $1) $2 } |
+          tok_default_30 tok__colon__34 { Ctr__Rule_61__2 (rtkPosOf $1) } |
+          Statement { Ctr__Rule_61__3 (rtkPosOf $1) $1 }
 
 Rule_63 : { Ctr__Rule_63__0 rtkNoPos } |
           Rule_64 { Ctr__Rule_63__1 (rtkPosOf $1) $1 }
 
-Rule_64 : tok__lparen__6 Arglist tok__rparen__7 { Ctr__Rule_64__0 (rtkPosOf $1) $2 }
+Rule_64 : AssignmentOp AssignmentExpression { Ctr__Rule_64__0 (rtkPosOf $1) $1 $2 }
 
-Rule_65 : tok__lparen__6 Arglist tok__rparen__7 { Ctr__Rule_65__0 (rtkPosOf $1) $2 } |
-          DimExprs Rule_66 { Ctr__Rule_65__1 (rtkPosOf (reverse $1)) (reverse $1) $2 }
+Rule_65 : { Ctr__Rule_65__0 rtkNoPos } |
+          Rule_66 { Ctr__Rule_65__1 (rtkPosOf $1) $1 }
 
-Rule_66 : { Ctr__Rule_66__0 rtkNoPos } |
-          NonEmptyDims { Ctr__Rule_66__1 (rtkPosOf (reverse $1)) (reverse $1) }
+Rule_66 : tok__lparen__7 Arglist tok__rparen__8 { Ctr__Rule_66__0 (rtkPosOf $1) $2 }
 
-ListElem_DimExprs68 : qq_DimExprs { Anti_Rule_67 (tkVal_qq_DimExprs $1) } |
-                      Rule_67 { $1 }
+Rule_67 : { Ctr__Rule_67__0 rtkNoPos } |
+          Rule_68 { Ctr__Rule_67__1 (rtkPosOf $1) $1 }
 
-Rule_67 : tok__sq_bkt_l__17 Expression tok__sq_bkt_r__18 { Ctr__Rule_67__1 (rtkPosOf $1) $2 }
+Rule_68 : tok__lparen__7 Arglist tok__rparen__8 { Ctr__Rule_68__0 (rtkPosOf $1) $2 }
 
-Rule_69 : Expression Rule_70 { Ctr__Rule_69__0 (rtkPosOf $1) $1 (reverse $2) }
+Rule_69 : tok__lparen__7 Arglist tok__rparen__8 { Ctr__Rule_69__0 (rtkPosOf $1) $2 } |
+          DimExprs Rule_70 { Ctr__Rule_69__1 (rtkPosOf (reverse $1)) (reverse $1) $2 }
 
 Rule_7 : {- empty -} { [] } |
          Rule_7 Rule_8 { $2 : $1 }
 
-Rule_70 : {- empty -} { [] } |
-          Rule_70 Rule_71 { $2 : $1 }
+Rule_70 : { Ctr__Rule_70__0 rtkNoPos } |
+          NonEmptyDims { Ctr__Rule_70__1 (rtkPosOf (reverse $1)) (reverse $1) }
 
-Rule_71 : tok__coma__8 Expression { Ctr__Rule_71__0 (rtkPosOf $1) $2 }
+ListElem_DimExprs72 : qq_DimExprs { Anti_Rule_71 (tkVal_qq_DimExprs $1) } |
+                      Rule_71 { $1 }
 
-Rule_72 : {- empty -} { [] } |
-          Rule_72 Rule_73 { $2 : $1 }
+Rule_71 : tok__sq_bkt_l__18 Expression tok__sq_bkt_r__19 { Ctr__Rule_71__1 (rtkPosOf $1) $2 }
 
-Rule_73 : tok__coma__8 TypeArgument { Ctr__Rule_73__0 (rtkPosOf $1) $2 }
+Rule_73 : Expression Rule_74 { Ctr__Rule_73__0 (rtkPosOf $1) $1 (reverse $2) }
 
-Rule_74 : tok__symbol__64 TypeParameter Rule_75 tok__symbol__65 { Ctr__Rule_74__0 (rtkPosOf $1) $2 (reverse $3) }
+Rule_74 : {- empty -} { [] } |
+          Rule_74 Rule_75 { $2 : $1 }
 
-Rule_75 : {- empty -} { [] } |
-          Rule_75 Rule_76 { $2 : $1 }
+Rule_75 : tok__coma__9 Expression { Ctr__Rule_75__0 (rtkPosOf $1) $2 }
 
-Rule_76 : tok__coma__8 TypeParameter { Ctr__Rule_76__0 (rtkPosOf $1) $2 }
+Rule_76 : {- empty -} { [] } |
+          Rule_76 Rule_77 { $2 : $1 }
 
-Rule_77 : { Ctr__Rule_77__0 rtkNoPos } |
-          Rule_78 { Ctr__Rule_77__1 (rtkPosOf $1) $1 }
+Rule_77 : tok__coma__9 TypeArgument { Ctr__Rule_77__0 (rtkPosOf $1) $2 }
 
-Rule_78 : tok_extends_10 Type Rule_79 { Ctr__Rule_78__0 (rtkPosOf $1) $2 (reverse $3) }
+Rule_78 : tok__symbol__66 TypeParameter Rule_79 tok__symbol__67 { Ctr__Rule_78__0 (rtkPosOf $1) $2 (reverse $3) }
 
 Rule_79 : {- empty -} { [] } |
           Rule_79 Rule_80 { $2 : $1 }
 
-Rule_8 : tok__coma__8 AnnotationElement { Ctr__Rule_8__0 (rtkPosOf $1) $2 }
+Rule_8 : tok__coma__9 AnnotationElement { Ctr__Rule_8__0 (rtkPosOf $1) $2 }
 
-Rule_80 : tok__symbol__61 Type { Ctr__Rule_80__0 (rtkPosOf $1) $2 }
+Rule_80 : tok__coma__9 TypeParameter { Ctr__Rule_80__0 (rtkPosOf $1) $2 }
 
-Rule_81 : {- empty -} { [] } |
-          Rule_81 Rule_82 { $2 : $1 }
+Rule_81 : { Ctr__Rule_81__0 rtkNoPos } |
+          Rule_82 { Ctr__Rule_81__1 (rtkPosOf $1) $1 }
 
-Rule_82 : tok__dot__3 id { Ctr__Rule_82__0 (rtkPosOf $1) (tkVal_id $2) }
+Rule_82 : tok_extends_11 Type Rule_83 { Ctr__Rule_82__0 (rtkPosOf $1) $2 (reverse $3) }
+
+Rule_83 : {- empty -} { [] } |
+          Rule_83 Rule_84 { $2 : $1 }
+
+Rule_84 : tok__symbol__63 Type { Ctr__Rule_84__0 (rtkPosOf $1) $2 }
+
+Rule_85 : {- empty -} { [] } |
+          Rule_85 Rule_86 { $2 : $1 }
+
+Rule_86 : tok__dot__4 id { Ctr__Rule_86__0 (rtkPosOf $1) (tkVal_id $2) }
 
 ShiftOp : qq_ShiftOp { Anti_ShiftOp (tkVal_qq_ShiftOp $1) } |
-          tok__symbol__symbol__69 { Ctr__ShiftOp__0 (rtkPosOf $1) } |
-          tok__symbol__symbol__70 { Ctr__ShiftOp__1 (rtkPosOf $1) } |
-          tok__symbol__symbol__symbol__71 { Ctr__ShiftOp__2 (rtkPosOf $1) }
+          tok__symbol__symbol__71 { Ctr__ShiftOp__0 (rtkPosOf $1) } |
+          tok__symbol__symbol__72 { Ctr__ShiftOp__1 (rtkPosOf $1) } |
+          tok__symbol__symbol__symbol__73 { Ctr__ShiftOp__2 (rtkPosOf $1) }
 
 Statement : qq_Statement { Anti_Statement (tkVal_qq_Statement $1) } |
             VariableDeclaration { Ctr__Statement__0 (rtkPosOf $1) $1 } |
-            tok_return_29 OptExpression tok__semi__1 { Ctr__Statement__1 (rtkPosOf $1) $2 } |
+            tok_return_31 OptExpression tok__semi__1 { Ctr__Statement__1 (rtkPosOf $1) $2 } |
             Expression tok__semi__1 { Ctr__Statement__2 (rtkPosOf $1) $1 } |
             StatementBlock { Ctr__Statement__3 (rtkPosOf $1) $1 } |
             IfStatement { Ctr__Statement__4 (rtkPosOf $1) $1 } |
@@ -895,33 +924,36 @@ Statement : qq_Statement { Anti_Statement (tkVal_qq_Statement $1) } |
             ForStatement { Ctr__Statement__7 (rtkPosOf $1) $1 } |
             TryStatement { Ctr__Statement__8 (rtkPosOf $1) $1 } |
             SwitchStatement { Ctr__Statement__9 (rtkPosOf $1) $1 } |
-            tok_synchronized_30 tok__lparen__6 Expression tok__rparen__7 Statement { Ctr__Statement__10 (rtkPosOf $1) $3 $5 } |
-            tok_throw_31 Expression tok__semi__1 { Ctr__Statement__11 (rtkPosOf $1) $2 } |
-            id tok__colon__32 Statement { Ctr__Statement__12 (rtkPosOf $1) (tkVal_id $1) $3 } |
-            tok_break_33 OptId tok__semi__1 { Ctr__Statement__13 (rtkPosOf $1) $2 } |
-            tok_continue_34 OptId tok__semi__1 { Ctr__Statement__14 (rtkPosOf $1) $2 } |
+            tok_synchronized_32 tok__lparen__7 Expression tok__rparen__8 Statement { Ctr__Statement__10 (rtkPosOf $1) $3 $5 } |
+            tok_throw_33 Expression tok__semi__1 { Ctr__Statement__11 (rtkPosOf $1) $2 } |
+            id tok__colon__34 Statement { Ctr__Statement__12 (rtkPosOf $1) (tkVal_id $1) $3 } |
+            tok_break_35 OptId tok__semi__1 { Ctr__Statement__13 (rtkPosOf $1) $2 } |
+            tok_continue_36 OptId tok__semi__1 { Ctr__Statement__14 (rtkPosOf $1) $2 } |
             tok__semi__1 { Ctr__Statement__15 (rtkPosOf $1) }
 
-ListElem_StatementList51 : qq_StatementList { Anti_Statement (tkVal_qq_StatementList $1) } |
+ListElem_StatementList55 : qq_StatementList { Anti_Statement (tkVal_qq_StatementList $1) } |
                            Statement { $1 }
 
 StatementBlock : qq_StatementBlock { Anti_StatementBlock (tkVal_qq_StatementBlock $1) } |
-                 tok__symbol__13 StatementList tok__symbol__14 { Ctr__StatementBlock__0 (rtkPosOf $1) (reverse $2) }
+                 tok__symbol__14 StatementList tok__symbol__15 { Ctr__StatementBlock__0 (rtkPosOf $1) (reverse $2) }
 
 StatementList : {- empty -} { [] } |
-                StatementList ListElem_StatementList51 { $2 : $1 }
+                StatementList ListElem_StatementList55 { $2 : $1 }
 
 StaticInitializer : qq_StaticInitializer { Anti_StaticInitializer (tkVal_qq_StaticInitializer $1) } |
                     StatementBlock { Ctr__StaticInitializer__0 (rtkPosOf $1) $1 }
 
 SwitchCaseList : {- empty -} { [] } |
-                 SwitchCaseList ListElem_SwitchCaseList58 { $2 : $1 }
+                 SwitchCaseList ListElem_SwitchCaseList62 { $2 : $1 }
 
 SwitchStatement : qq_SwitchStatement { Anti_SwitchStatement (tkVal_qq_SwitchStatement $1) } |
-                  tok_switch_44 tok__lparen__6 Expression tok__rparen__7 tok__symbol__13 SwitchCaseList tok__symbol__14 { Ctr__SwitchStatement__0 (rtkPosOf $1) $3 (reverse $6) }
+                  tok_switch_46 tok__lparen__7 Expression tok__rparen__8 tok__symbol__14 SwitchCaseList tok__symbol__15 { Ctr__SwitchStatement__0 (rtkPosOf $1) $3 (reverse $6) }
+
+ThrowsClause : qq_ThrowsClause { Anti_ThrowsClause (tkVal_qq_ThrowsClause $1) } |
+               tok_throws_29 CompoundName Rule_37 { Ctr__ThrowsClause__0 (rtkPosOf $1) $2 (reverse $3) }
 
 TryStatement : qq_TryStatement { Anti_TryStatement (tkVal_qq_TryStatement $1) } |
-               tok_try_42 Statement CatchList OptFinally { Ctr__TryStatement__0 (rtkPosOf $1) $2 (reverse $3) $4 }
+               tok_try_44 Statement CatchList OptFinally { Ctr__TryStatement__0 (rtkPosOf $1) $2 (reverse $3) $4 }
 
 Type : qq_Type { Anti_Type (tkVal_qq_Type $1) } |
        PrimitiveTypeKeyword Dims { Ctr__Type__0 (rtkPosOf $1) $1 (reverse $2) } |
@@ -947,22 +979,22 @@ TypeDeclaration : qq_TypeDeclaration { Anti_TypeDeclaration (tkVal_qq_TypeDeclar
                   OptDocComment ModifierList TypeDeclRest { Ctr__TypeDeclaration__0 (rtkPosOf $1) $1 (reverse $2) $3 }
 
 TypeParameter : qq_TypeParameter { Anti_TypeParameter (tkVal_qq_TypeParameter $1) } |
-                id Rule_77 { Ctr__TypeParameter__0 (rtkPosOf $1) (tkVal_id $1) $2 }
+                id Rule_81 { Ctr__TypeParameter__0 (rtkPosOf $1) (tkVal_id $1) $2 }
 
 TypeParameters : qq_TypeParameters { Anti_TypeParameters (tkVal_qq_TypeParameters $1) } |
                  { Ctr__TypeParameters__0 rtkNoPos } |
-                 Rule_74 { Ctr__TypeParameters__1 (rtkPosOf $1) $1 }
+                 Rule_78 { Ctr__TypeParameters__1 (rtkPosOf $1) $1 }
 
 TypeSpecifier : qq_TypeSpecifier { Anti_TypeSpecifier (tkVal_qq_TypeSpecifier $1) } |
-                tok_boolean_19 { Ctr__TypeSpecifier__0 (rtkPosOf $1) } |
-                tok_byte_20 { Ctr__TypeSpecifier__1 (rtkPosOf $1) } |
-                tok_char_21 { Ctr__TypeSpecifier__2 (rtkPosOf $1) } |
-                tok_short_22 { Ctr__TypeSpecifier__3 (rtkPosOf $1) } |
-                tok_int_23 { Ctr__TypeSpecifier__4 (rtkPosOf $1) } |
-                tok_float_24 { Ctr__TypeSpecifier__5 (rtkPosOf $1) } |
-                tok_long_25 { Ctr__TypeSpecifier__6 (rtkPosOf $1) } |
-                tok_double_26 { Ctr__TypeSpecifier__7 (rtkPosOf $1) } |
-                tok_void_27 { Ctr__TypeSpecifier__8 (rtkPosOf $1) } |
+                tok_boolean_20 { Ctr__TypeSpecifier__0 (rtkPosOf $1) } |
+                tok_byte_21 { Ctr__TypeSpecifier__1 (rtkPosOf $1) } |
+                tok_char_22 { Ctr__TypeSpecifier__2 (rtkPosOf $1) } |
+                tok_short_23 { Ctr__TypeSpecifier__3 (rtkPosOf $1) } |
+                tok_int_24 { Ctr__TypeSpecifier__4 (rtkPosOf $1) } |
+                tok_float_25 { Ctr__TypeSpecifier__5 (rtkPosOf $1) } |
+                tok_long_26 { Ctr__TypeSpecifier__6 (rtkPosOf $1) } |
+                tok_double_27 { Ctr__TypeSpecifier__7 (rtkPosOf $1) } |
+                tok_void_28 { Ctr__TypeSpecifier__8 (rtkPosOf $1) } |
                 CompoundName TypeArguments { Ctr__TypeSpecifier__9 (rtkPosOf $1) $1 $2 }
 
 VariableDeclaration : qq_VariableDeclaration { Anti_VariableDeclaration (tkVal_qq_VariableDeclaration $1) } |
@@ -972,23 +1004,23 @@ VariableDeclarator : qq_VariableDeclarator { Anti_VariableDeclarator (tkVal_qq_V
                      id Dims OptVariableInitializer { Ctr__VariableDeclarator__0 (rtkPosOf $1) (tkVal_id $1) (reverse $2) $3 }
 
 VariableDeclaratorList : qq_VariableDeclaratorList { Anti_VariableDeclaratorList (tkVal_qq_VariableDeclaratorList $1) } |
-                         VariableDeclarator Rule_42 { Ctr__VariableDeclaratorList__0 (rtkPosOf $1) $1 (reverse $2) }
+                         VariableDeclarator Rule_46 { Ctr__VariableDeclaratorList__0 (rtkPosOf $1) $1 (reverse $2) }
 
 VariableInitializer : qq_VariableInitializer { Anti_VariableInitializer (tkVal_qq_VariableInitializer $1) } |
                       Expression { Ctr__VariableInitializer__0 (rtkPosOf $1) $1 } |
-                      tok__symbol__13 VariableInitializerList tok__symbol__14 { Ctr__VariableInitializer__1 (rtkPosOf $1) $2 }
+                      tok__symbol__14 VariableInitializerList tok__symbol__15 { Ctr__VariableInitializer__1 (rtkPosOf $1) $2 }
 
 VariableInitializerList : qq_VariableInitializerList { Anti_VariableInitializerList (tkVal_qq_VariableInitializerList $1) } |
                           { Ctr__VariableInitializerList__0 rtkNoPos } |
-                          Rule_45 { Ctr__VariableInitializerList__1 (rtkPosOf $1) $1 }
+                          Rule_49 { Ctr__VariableInitializerList__1 (rtkPosOf $1) $1 }
 
 WhileStatement : qq_WhileStatement { Anti_WhileStatement (tkVal_qq_WhileStatement $1) } |
-                 tok_while_38 tok__lparen__6 Expression tok__rparen__7 Statement { Ctr__WhileStatement__0 (rtkPosOf $1) $3 $5 }
+                 tok_while_40 tok__lparen__7 Expression tok__rparen__8 Statement { Ctr__WhileStatement__0 (rtkPosOf $1) $3 $5 }
 
 WildcardType : qq_WildcardType { Anti_WildcardType (tkVal_qq_WildcardType $1) } |
-               tok__symbol__56 { Ctr__WildcardType__0 (rtkPosOf $1) } |
-               tok__symbol__56 tok_extends_10 Type { Ctr__WildcardType__1 (rtkPosOf $1) $3 } |
-               tok__symbol__56 tok_super_81 Type { Ctr__WildcardType__2 (rtkPosOf $1) $3 }
+               tok__symbol__58 { Ctr__WildcardType__0 (rtkPosOf $1) } |
+               tok__symbol__58 tok_extends_11 Type { Ctr__WildcardType__1 (rtkPosOf $1) $3 } |
+               tok__symbol__58 tok_super_83 Type { Ctr__WildcardType__2 (rtkPosOf $1) $3 }
 
 
 {
@@ -1000,182 +1032,186 @@ parseError (L.PosToken (L.AlexPn _ line col) tok : _) =
 -- Render a token the way it appears in the source, for error messages
 showRtkToken :: L.Token -> String
 showRtkToken L.EndOfFile = "end of input"
-showRtkToken L.Tk__tok_AdditiveOp_dummy_162 = "'tok_AdditiveOp_dummy_162'"
-showRtkToken L.Tk__tok_Annotation_dummy_161 = "'tok_Annotation_dummy_161'"
-showRtkToken L.Tk__tok_AnnotationArguments_dummy_160 = "'tok_AnnotationArguments_dummy_160'"
-showRtkToken L.Tk__tok_AnnotationDeclaration_dummy_159 = "'tok_AnnotationDeclaration_dummy_159'"
-showRtkToken L.Tk__tok_AnnotationElement_dummy_158 = "'tok_AnnotationElement_dummy_158'"
-showRtkToken L.Tk__tok_AnnotationList_dummy_157 = "'tok_AnnotationList_dummy_157'"
-showRtkToken L.Tk__tok_AnnotationTypeElement_dummy_156 = "'tok_AnnotationTypeElement_dummy_156'"
-showRtkToken L.Tk__tok_AnnotationTypeElementList_dummy_155 = "'tok_AnnotationTypeElementList_dummy_155'"
-showRtkToken L.Tk__tok_Arglist_dummy_154 = "'tok_Arglist_dummy_154'"
-showRtkToken L.Tk__tok_AssignmentOp_dummy_153 = "'tok_AssignmentOp_dummy_153'"
-showRtkToken L.Tk__tok_CatchList_dummy_152 = "'tok_CatchList_dummy_152'"
-showRtkToken L.Tk__tok_ClassDeclaration_dummy_151 = "'tok_ClassDeclaration_dummy_151'"
-showRtkToken L.Tk__tok_CompilationUnit_dummy_150 = "'tok_CompilationUnit_dummy_150'"
-showRtkToken L.Tk__tok_CompoundName_dummy_149 = "'tok_CompoundName_dummy_149'"
-showRtkToken L.Tk__tok_CreationExpression_dummy_148 = "'tok_CreationExpression_dummy_148'"
-showRtkToken L.Tk__tok_DimExprs_dummy_147 = "'tok_DimExprs_dummy_147'"
-showRtkToken L.Tk__tok_Dims_dummy_146 = "'tok_Dims_dummy_146'"
-showRtkToken L.Tk__tok_DoStatement_dummy_145 = "'tok_DoStatement_dummy_145'"
-showRtkToken L.Tk__tok_DocComment_dummy_144 = "'tok_DocComment_dummy_144'"
-showRtkToken L.Tk__tok_EnumConstant_dummy_143 = "'tok_EnumConstant_dummy_143'"
-showRtkToken L.Tk__tok_EnumConstantList_dummy_142 = "'tok_EnumConstantList_dummy_142'"
-showRtkToken L.Tk__tok_EnumDeclaration_dummy_141 = "'tok_EnumDeclaration_dummy_141'"
-showRtkToken L.Tk__tok_EqualityOp_dummy_140 = "'tok_EqualityOp_dummy_140'"
-showRtkToken L.Tk__tok_Expression_dummy_139 = "'tok_Expression_dummy_139'"
-showRtkToken L.Tk__tok_ExtendsList_dummy_138 = "'tok_ExtendsList_dummy_138'"
-showRtkToken L.Tk__tok_FieldDeclaration_dummy_137 = "'tok_FieldDeclaration_dummy_137'"
-showRtkToken L.Tk__tok_FieldDeclarationList_dummy_136 = "'tok_FieldDeclarationList_dummy_136'"
-showRtkToken L.Tk__tok_ForStatement_dummy_135 = "'tok_ForStatement_dummy_135'"
-showRtkToken L.Tk__tok_IfStatement_dummy_134 = "'tok_IfStatement_dummy_134'"
-showRtkToken L.Tk__tok_ImplementsList_dummy_133 = "'tok_ImplementsList_dummy_133'"
-showRtkToken L.Tk__tok_ImportList_dummy_132 = "'tok_ImportList_dummy_132'"
-showRtkToken L.Tk__tok_ImportStatement_dummy_131 = "'tok_ImportStatement_dummy_131'"
-showRtkToken L.Tk__tok_InterfaceDeclaration_dummy_130 = "'tok_InterfaceDeclaration_dummy_130'"
-showRtkToken L.Tk__tok_Java_dummy_163 = "'tok_Java_dummy_163'"
-showRtkToken L.Tk__tok_Literal_dummy_129 = "'tok_Literal_dummy_129'"
-showRtkToken L.Tk__tok_MemberAfterFirstId_dummy_128 = "'tok_MemberAfterFirstId_dummy_128'"
-showRtkToken L.Tk__tok_MemberDeclaration_dummy_127 = "'tok_MemberDeclaration_dummy_127'"
-showRtkToken L.Tk__tok_MemberRest_dummy_126 = "'tok_MemberRest_dummy_126'"
-showRtkToken L.Tk__tok_Modifier_dummy_125 = "'tok_Modifier_dummy_125'"
-showRtkToken L.Tk__tok_ModifierList_dummy_124 = "'tok_ModifierList_dummy_124'"
-showRtkToken L.Tk__tok_MoreTypeSpecifier_dummy_123 = "'tok_MoreTypeSpecifier_dummy_123'"
-showRtkToken L.Tk__tok_MoreVariableDeclarators_dummy_122 = "'tok_MoreVariableDeclarators_dummy_122'"
-showRtkToken L.Tk__tok_MultiplicativeOp_dummy_121 = "'tok_MultiplicativeOp_dummy_121'"
-showRtkToken L.Tk__tok_NonEmptyDims_dummy_120 = "'tok_NonEmptyDims_dummy_120'"
-showRtkToken L.Tk__tok_NonEmptyTypeArguments_dummy_119 = "'tok_NonEmptyTypeArguments_dummy_119'"
-showRtkToken L.Tk__tok_OptDocComment_dummy_118 = "'tok_OptDocComment_dummy_118'"
-showRtkToken L.Tk__tok_OptElsePart_dummy_117 = "'tok_OptElsePart_dummy_117'"
-showRtkToken L.Tk__tok_OptExpression_dummy_116 = "'tok_OptExpression_dummy_116'"
-showRtkToken L.Tk__tok_OptFinally_dummy_115 = "'tok_OptFinally_dummy_115'"
-showRtkToken L.Tk__tok_OptId_dummy_114 = "'tok_OptId_dummy_114'"
-showRtkToken L.Tk__tok_OptVariableInitializer_dummy_113 = "'tok_OptVariableInitializer_dummy_113'"
-showRtkToken L.Tk__tok_Package_dummy_112 = "'tok_Package_dummy_112'"
-showRtkToken L.Tk__tok_Parameter_dummy_111 = "'tok_Parameter_dummy_111'"
-showRtkToken L.Tk__tok_ParameterList_dummy_110 = "'tok_ParameterList_dummy_110'"
-showRtkToken L.Tk__tok_PostfixOp_dummy_109 = "'tok_PostfixOp_dummy_109'"
-showRtkToken L.Tk__tok_PrefixOp_dummy_108 = "'tok_PrefixOp_dummy_108'"
-showRtkToken L.Tk__tok_PrimitiveTypeKeyword_dummy_107 = "'tok_PrimitiveTypeKeyword_dummy_107'"
-showRtkToken L.Tk__tok_RelationalOp_dummy_106 = "'tok_RelationalOp_dummy_106'"
-showRtkToken L.Tk__tok_ShiftOp_dummy_105 = "'tok_ShiftOp_dummy_105'"
-showRtkToken L.Tk__tok_Statement_dummy_104 = "'tok_Statement_dummy_104'"
-showRtkToken L.Tk__tok_StatementBlock_dummy_103 = "'tok_StatementBlock_dummy_103'"
-showRtkToken L.Tk__tok_StatementList_dummy_102 = "'tok_StatementList_dummy_102'"
-showRtkToken L.Tk__tok_StaticInitializer_dummy_101 = "'tok_StaticInitializer_dummy_101'"
-showRtkToken L.Tk__tok_SwitchCaseList_dummy_100 = "'tok_SwitchCaseList_dummy_100'"
-showRtkToken L.Tk__tok_SwitchStatement_dummy_99 = "'tok_SwitchStatement_dummy_99'"
-showRtkToken L.Tk__tok_TryStatement_dummy_98 = "'tok_TryStatement_dummy_98'"
-showRtkToken L.Tk__tok_Type_dummy_97 = "'tok_Type_dummy_97'"
-showRtkToken L.Tk__tok_TypeArgument_dummy_96 = "'tok_TypeArgument_dummy_96'"
-showRtkToken L.Tk__tok_TypeArguments_dummy_95 = "'tok_TypeArguments_dummy_95'"
-showRtkToken L.Tk__tok_TypeDeclRest_dummy_94 = "'tok_TypeDeclRest_dummy_94'"
-showRtkToken L.Tk__tok_TypeDeclaration_dummy_93 = "'tok_TypeDeclaration_dummy_93'"
-showRtkToken L.Tk__tok_TypeParameter_dummy_92 = "'tok_TypeParameter_dummy_92'"
-showRtkToken L.Tk__tok_TypeParameters_dummy_91 = "'tok_TypeParameters_dummy_91'"
-showRtkToken L.Tk__tok_TypeSpecifier_dummy_90 = "'tok_TypeSpecifier_dummy_90'"
-showRtkToken L.Tk__tok_VariableDeclaration_dummy_89 = "'tok_VariableDeclaration_dummy_89'"
-showRtkToken L.Tk__tok_VariableDeclarator_dummy_88 = "'tok_VariableDeclarator_dummy_88'"
-showRtkToken L.Tk__tok_VariableDeclaratorList_dummy_87 = "'tok_VariableDeclaratorList_dummy_87'"
-showRtkToken L.Tk__tok_VariableInitializer_dummy_86 = "'tok_VariableInitializer_dummy_86'"
-showRtkToken L.Tk__tok_VariableInitializerList_dummy_85 = "'tok_VariableInitializerList_dummy_85'"
-showRtkToken L.Tk__tok_WhileStatement_dummy_84 = "'tok_WhileStatement_dummy_84'"
-showRtkToken L.Tk__tok_WildcardType_dummy_83 = "'tok_WildcardType_dummy_83'"
-showRtkToken L.Tk__tok__tilde__78 = "'~'"
-showRtkToken L.Tk__tok__symbol__14 = "'}'"
-showRtkToken L.Tk__tok__pipe__pipe__57 = "'||'"
-showRtkToken L.Tk__tok__pipe__eql__49 = "'|='"
-showRtkToken L.Tk__tok__pipe__59 = "'|'"
-showRtkToken L.Tk__tok__symbol__13 = "'{'"
-showRtkToken L.Tk__tok_while_38 = "'while'"
-showRtkToken L.Tk__tok_void_27 = "'void'"
-showRtkToken L.Tk__tok_try_42 = "'try'"
-showRtkToken L.Tk__tok_true_83 = "'true'"
-showRtkToken L.Tk__tok_transient_94 = "'transient'"
-showRtkToken L.Tk__tok_throw_31 = "'throw'"
-showRtkToken L.Tk__tok_threadsafe_93 = "'threadsafe'"
-showRtkToken L.Tk__tok_this_80 = "'this'"
-showRtkToken L.Tk__tok_synchronized_30 = "'synchronized'"
-showRtkToken L.Tk__tok_switch_44 = "'switch'"
-showRtkToken L.Tk__tok_super_81 = "'super'"
-showRtkToken L.Tk__tok_static_89 = "'static'"
-showRtkToken L.Tk__tok_short_22 = "'short'"
-showRtkToken L.Tk__tok_return_29 = "'return'"
-showRtkToken L.Tk__tok_public_86 = "'public'"
-showRtkToken L.Tk__tok_protected_88 = "'protected'"
-showRtkToken L.Tk__tok_private_87 = "'private'"
+showRtkToken L.Tk__tok_AdditiveOp_dummy_169 = "'tok_AdditiveOp_dummy_169'"
+showRtkToken L.Tk__tok_Annotation_dummy_168 = "'tok_Annotation_dummy_168'"
+showRtkToken L.Tk__tok_AnnotationArguments_dummy_167 = "'tok_AnnotationArguments_dummy_167'"
+showRtkToken L.Tk__tok_AnnotationDeclaration_dummy_166 = "'tok_AnnotationDeclaration_dummy_166'"
+showRtkToken L.Tk__tok_AnnotationElement_dummy_165 = "'tok_AnnotationElement_dummy_165'"
+showRtkToken L.Tk__tok_AnnotationList_dummy_164 = "'tok_AnnotationList_dummy_164'"
+showRtkToken L.Tk__tok_AnnotationTypeElement_dummy_163 = "'tok_AnnotationTypeElement_dummy_163'"
+showRtkToken L.Tk__tok_AnnotationTypeElementList_dummy_162 = "'tok_AnnotationTypeElementList_dummy_162'"
+showRtkToken L.Tk__tok_Arglist_dummy_161 = "'tok_Arglist_dummy_161'"
+showRtkToken L.Tk__tok_AssignmentOp_dummy_160 = "'tok_AssignmentOp_dummy_160'"
+showRtkToken L.Tk__tok_CatchList_dummy_159 = "'tok_CatchList_dummy_159'"
+showRtkToken L.Tk__tok_ClassDeclaration_dummy_158 = "'tok_ClassDeclaration_dummy_158'"
+showRtkToken L.Tk__tok_CompilationUnit_dummy_157 = "'tok_CompilationUnit_dummy_157'"
+showRtkToken L.Tk__tok_CompoundName_dummy_156 = "'tok_CompoundName_dummy_156'"
+showRtkToken L.Tk__tok_CreationExpression_dummy_155 = "'tok_CreationExpression_dummy_155'"
+showRtkToken L.Tk__tok_DimExprs_dummy_154 = "'tok_DimExprs_dummy_154'"
+showRtkToken L.Tk__tok_Dims_dummy_153 = "'tok_Dims_dummy_153'"
+showRtkToken L.Tk__tok_DoStatement_dummy_152 = "'tok_DoStatement_dummy_152'"
+showRtkToken L.Tk__tok_DocComment_dummy_151 = "'tok_DocComment_dummy_151'"
+showRtkToken L.Tk__tok_EnumConstant_dummy_150 = "'tok_EnumConstant_dummy_150'"
+showRtkToken L.Tk__tok_EnumConstantList_dummy_149 = "'tok_EnumConstantList_dummy_149'"
+showRtkToken L.Tk__tok_EnumDeclaration_dummy_148 = "'tok_EnumDeclaration_dummy_148'"
+showRtkToken L.Tk__tok_EqualityOp_dummy_147 = "'tok_EqualityOp_dummy_147'"
+showRtkToken L.Tk__tok_Expression_dummy_146 = "'tok_Expression_dummy_146'"
+showRtkToken L.Tk__tok_ExtendsList_dummy_145 = "'tok_ExtendsList_dummy_145'"
+showRtkToken L.Tk__tok_FieldDeclaration_dummy_144 = "'tok_FieldDeclaration_dummy_144'"
+showRtkToken L.Tk__tok_FieldDeclarationList_dummy_143 = "'tok_FieldDeclarationList_dummy_143'"
+showRtkToken L.Tk__tok_ForStatement_dummy_142 = "'tok_ForStatement_dummy_142'"
+showRtkToken L.Tk__tok_IfStatement_dummy_141 = "'tok_IfStatement_dummy_141'"
+showRtkToken L.Tk__tok_ImplementsList_dummy_140 = "'tok_ImplementsList_dummy_140'"
+showRtkToken L.Tk__tok_ImportHead_dummy_139 = "'tok_ImportHead_dummy_139'"
+showRtkToken L.Tk__tok_ImportList_dummy_138 = "'tok_ImportList_dummy_138'"
+showRtkToken L.Tk__tok_ImportName_dummy_137 = "'tok_ImportName_dummy_137'"
+showRtkToken L.Tk__tok_ImportStatement_dummy_136 = "'tok_ImportStatement_dummy_136'"
+showRtkToken L.Tk__tok_InterfaceDeclaration_dummy_135 = "'tok_InterfaceDeclaration_dummy_135'"
+showRtkToken L.Tk__tok_Java_dummy_170 = "'tok_Java_dummy_170'"
+showRtkToken L.Tk__tok_Literal_dummy_134 = "'tok_Literal_dummy_134'"
+showRtkToken L.Tk__tok_MemberAfterFirstId_dummy_133 = "'tok_MemberAfterFirstId_dummy_133'"
+showRtkToken L.Tk__tok_MemberDeclaration_dummy_132 = "'tok_MemberDeclaration_dummy_132'"
+showRtkToken L.Tk__tok_MemberRest_dummy_131 = "'tok_MemberRest_dummy_131'"
+showRtkToken L.Tk__tok_Modifier_dummy_130 = "'tok_Modifier_dummy_130'"
+showRtkToken L.Tk__tok_ModifierList_dummy_129 = "'tok_ModifierList_dummy_129'"
+showRtkToken L.Tk__tok_MoreTypeSpecifier_dummy_128 = "'tok_MoreTypeSpecifier_dummy_128'"
+showRtkToken L.Tk__tok_MoreVariableDeclarators_dummy_127 = "'tok_MoreVariableDeclarators_dummy_127'"
+showRtkToken L.Tk__tok_MultiplicativeOp_dummy_126 = "'tok_MultiplicativeOp_dummy_126'"
+showRtkToken L.Tk__tok_NonEmptyDims_dummy_125 = "'tok_NonEmptyDims_dummy_125'"
+showRtkToken L.Tk__tok_NonEmptyTypeArguments_dummy_124 = "'tok_NonEmptyTypeArguments_dummy_124'"
+showRtkToken L.Tk__tok_OptDocComment_dummy_123 = "'tok_OptDocComment_dummy_123'"
+showRtkToken L.Tk__tok_OptElsePart_dummy_122 = "'tok_OptElsePart_dummy_122'"
+showRtkToken L.Tk__tok_OptExpression_dummy_121 = "'tok_OptExpression_dummy_121'"
+showRtkToken L.Tk__tok_OptFinally_dummy_120 = "'tok_OptFinally_dummy_120'"
+showRtkToken L.Tk__tok_OptId_dummy_119 = "'tok_OptId_dummy_119'"
+showRtkToken L.Tk__tok_OptVariableInitializer_dummy_118 = "'tok_OptVariableInitializer_dummy_118'"
+showRtkToken L.Tk__tok_Package_dummy_117 = "'tok_Package_dummy_117'"
+showRtkToken L.Tk__tok_Parameter_dummy_116 = "'tok_Parameter_dummy_116'"
+showRtkToken L.Tk__tok_ParameterList_dummy_115 = "'tok_ParameterList_dummy_115'"
+showRtkToken L.Tk__tok_PostfixOp_dummy_114 = "'tok_PostfixOp_dummy_114'"
+showRtkToken L.Tk__tok_PrefixOp_dummy_113 = "'tok_PrefixOp_dummy_113'"
+showRtkToken L.Tk__tok_PrimitiveTypeKeyword_dummy_112 = "'tok_PrimitiveTypeKeyword_dummy_112'"
+showRtkToken L.Tk__tok_RelationalOp_dummy_111 = "'tok_RelationalOp_dummy_111'"
+showRtkToken L.Tk__tok_ShiftOp_dummy_110 = "'tok_ShiftOp_dummy_110'"
+showRtkToken L.Tk__tok_Statement_dummy_109 = "'tok_Statement_dummy_109'"
+showRtkToken L.Tk__tok_StatementBlock_dummy_108 = "'tok_StatementBlock_dummy_108'"
+showRtkToken L.Tk__tok_StatementList_dummy_107 = "'tok_StatementList_dummy_107'"
+showRtkToken L.Tk__tok_StaticInitializer_dummy_106 = "'tok_StaticInitializer_dummy_106'"
+showRtkToken L.Tk__tok_SwitchCaseList_dummy_105 = "'tok_SwitchCaseList_dummy_105'"
+showRtkToken L.Tk__tok_SwitchStatement_dummy_104 = "'tok_SwitchStatement_dummy_104'"
+showRtkToken L.Tk__tok_ThrowsClause_dummy_103 = "'tok_ThrowsClause_dummy_103'"
+showRtkToken L.Tk__tok_TryStatement_dummy_102 = "'tok_TryStatement_dummy_102'"
+showRtkToken L.Tk__tok_Type_dummy_101 = "'tok_Type_dummy_101'"
+showRtkToken L.Tk__tok_TypeArgument_dummy_100 = "'tok_TypeArgument_dummy_100'"
+showRtkToken L.Tk__tok_TypeArguments_dummy_99 = "'tok_TypeArguments_dummy_99'"
+showRtkToken L.Tk__tok_TypeDeclRest_dummy_98 = "'tok_TypeDeclRest_dummy_98'"
+showRtkToken L.Tk__tok_TypeDeclaration_dummy_97 = "'tok_TypeDeclaration_dummy_97'"
+showRtkToken L.Tk__tok_TypeParameter_dummy_96 = "'tok_TypeParameter_dummy_96'"
+showRtkToken L.Tk__tok_TypeParameters_dummy_95 = "'tok_TypeParameters_dummy_95'"
+showRtkToken L.Tk__tok_TypeSpecifier_dummy_94 = "'tok_TypeSpecifier_dummy_94'"
+showRtkToken L.Tk__tok_VariableDeclaration_dummy_93 = "'tok_VariableDeclaration_dummy_93'"
+showRtkToken L.Tk__tok_VariableDeclarator_dummy_92 = "'tok_VariableDeclarator_dummy_92'"
+showRtkToken L.Tk__tok_VariableDeclaratorList_dummy_91 = "'tok_VariableDeclaratorList_dummy_91'"
+showRtkToken L.Tk__tok_VariableInitializer_dummy_90 = "'tok_VariableInitializer_dummy_90'"
+showRtkToken L.Tk__tok_VariableInitializerList_dummy_89 = "'tok_VariableInitializerList_dummy_89'"
+showRtkToken L.Tk__tok_WhileStatement_dummy_88 = "'tok_WhileStatement_dummy_88'"
+showRtkToken L.Tk__tok_WildcardType_dummy_87 = "'tok_WildcardType_dummy_87'"
+showRtkToken L.Tk__tok__tilde__80 = "'~'"
+showRtkToken L.Tk__tok__symbol__15 = "'}'"
+showRtkToken L.Tk__tok__pipe__pipe__59 = "'||'"
+showRtkToken L.Tk__tok__pipe__eql__51 = "'|='"
+showRtkToken L.Tk__tok__pipe__61 = "'|'"
+showRtkToken L.Tk__tok__symbol__14 = "'{'"
+showRtkToken L.Tk__tok_while_40 = "'while'"
+showRtkToken L.Tk__tok_void_28 = "'void'"
+showRtkToken L.Tk__tok_try_44 = "'try'"
+showRtkToken L.Tk__tok_true_85 = "'true'"
+showRtkToken L.Tk__tok_transient_95 = "'transient'"
+showRtkToken L.Tk__tok_throws_29 = "'throws'"
+showRtkToken L.Tk__tok_throw_33 = "'throw'"
+showRtkToken L.Tk__tok_threadsafe_94 = "'threadsafe'"
+showRtkToken L.Tk__tok_this_82 = "'this'"
+showRtkToken L.Tk__tok_synchronized_32 = "'synchronized'"
+showRtkToken L.Tk__tok_switch_46 = "'switch'"
+showRtkToken L.Tk__tok_super_83 = "'super'"
+showRtkToken L.Tk__tok_static_3 = "'static'"
+showRtkToken L.Tk__tok_short_23 = "'short'"
+showRtkToken L.Tk__tok_return_31 = "'return'"
+showRtkToken L.Tk__tok_public_88 = "'public'"
+showRtkToken L.Tk__tok_protected_90 = "'protected'"
+showRtkToken L.Tk__tok_private_89 = "'private'"
 showRtkToken L.Tk__tok_package_0 = "'package'"
-showRtkToken L.Tk__tok_null_85 = "'null'"
-showRtkToken L.Tk__tok_new_82 = "'new'"
-showRtkToken L.Tk__tok_native_91 = "'native'"
-showRtkToken L.Tk__tok_long_25 = "'long'"
-showRtkToken L.Tk__tok_interface_15 = "'interface'"
-showRtkToken L.Tk__tok_int_23 = "'int'"
-showRtkToken L.Tk__tok_instanceof_68 = "'instanceof'"
+showRtkToken L.Tk__tok_null_87 = "'null'"
+showRtkToken L.Tk__tok_new_84 = "'new'"
+showRtkToken L.Tk__tok_native_92 = "'native'"
+showRtkToken L.Tk__tok_long_26 = "'long'"
+showRtkToken L.Tk__tok_interface_16 = "'interface'"
+showRtkToken L.Tk__tok_int_24 = "'int'"
+showRtkToken L.Tk__tok_instanceof_70 = "'instanceof'"
 showRtkToken L.Tk__tok_import_2 = "'import'"
-showRtkToken L.Tk__tok_implements_11 = "'implements'"
-showRtkToken L.Tk__tok_if_36 = "'if'"
-showRtkToken L.Tk__tok_for_39 = "'for'"
-showRtkToken L.Tk__tok_float_24 = "'float'"
-showRtkToken L.Tk__tok_finally_41 = "'finally'"
-showRtkToken L.Tk__tok_final_90 = "'final'"
-showRtkToken L.Tk__tok_false_84 = "'false'"
-showRtkToken L.Tk__tok_extends_10 = "'extends'"
-showRtkToken L.Tk__tok_enum_16 = "'enum'"
-showRtkToken L.Tk__tok_else_35 = "'else'"
-showRtkToken L.Tk__tok_double_26 = "'double'"
-showRtkToken L.Tk__tok_do_37 = "'do'"
-showRtkToken L.Tk__tok_default_28 = "'default'"
-showRtkToken L.Tk__tok_continue_34 = "'continue'"
-showRtkToken L.Tk__tok_class_12 = "'class'"
-showRtkToken L.Tk__tok_char_21 = "'char'"
-showRtkToken L.Tk__tok_catch_40 = "'catch'"
-showRtkToken L.Tk__tok_case_43 = "'case'"
-showRtkToken L.Tk__tok_byte_20 = "'byte'"
-showRtkToken L.Tk__tok_break_33 = "'break'"
-showRtkToken L.Tk__tok_boolean_19 = "'boolean'"
-showRtkToken L.Tk__tok_abstract_92 = "'abstract'"
-showRtkToken L.Tk__tok__symbol__eql__51 = "'^='"
-showRtkToken L.Tk__tok__symbol__60 = "'^'"
-showRtkToken L.Tk__tok__sq_bkt_r__18 = "']'"
-showRtkToken L.Tk__tok__sq_bkt_l__17 = "'['"
-showRtkToken L.Tk__tok__symbol__5 = "'@'"
-showRtkToken L.Tk__tok__symbol__56 = "'?'"
-showRtkToken L.Tk__tok__symbol__symbol__symbol__eql__55 = "'>>>='"
-showRtkToken L.Tk__tok__symbol__symbol__symbol__71 = "'>>>'"
-showRtkToken L.Tk__tok__symbol__symbol__eql__54 = "'>>='"
-showRtkToken L.Tk__tok__symbol__symbol__69 = "'>>'"
-showRtkToken L.Tk__tok__symbol__eql__67 = "'>='"
-showRtkToken L.Tk__tok__symbol__65 = "'>'"
-showRtkToken L.Tk__tok__eql__eql__62 = "'=='"
-showRtkToken L.Tk__tok__eql__9 = "'='"
-showRtkToken L.Tk__tok__symbol__eql__66 = "'<='"
-showRtkToken L.Tk__tok__symbol__symbol__eql__53 = "'<<='"
-showRtkToken L.Tk__tok__symbol__symbol__70 = "'<<'"
-showRtkToken L.Tk__tok__symbol__64 = "'<'"
+showRtkToken L.Tk__tok_implements_12 = "'implements'"
+showRtkToken L.Tk__tok_if_38 = "'if'"
+showRtkToken L.Tk__tok_for_41 = "'for'"
+showRtkToken L.Tk__tok_float_25 = "'float'"
+showRtkToken L.Tk__tok_finally_43 = "'finally'"
+showRtkToken L.Tk__tok_final_91 = "'final'"
+showRtkToken L.Tk__tok_false_86 = "'false'"
+showRtkToken L.Tk__tok_extends_11 = "'extends'"
+showRtkToken L.Tk__tok_enum_17 = "'enum'"
+showRtkToken L.Tk__tok_else_37 = "'else'"
+showRtkToken L.Tk__tok_double_27 = "'double'"
+showRtkToken L.Tk__tok_do_39 = "'do'"
+showRtkToken L.Tk__tok_default_30 = "'default'"
+showRtkToken L.Tk__tok_continue_36 = "'continue'"
+showRtkToken L.Tk__tok_class_13 = "'class'"
+showRtkToken L.Tk__tok_char_22 = "'char'"
+showRtkToken L.Tk__tok_catch_42 = "'catch'"
+showRtkToken L.Tk__tok_case_45 = "'case'"
+showRtkToken L.Tk__tok_byte_21 = "'byte'"
+showRtkToken L.Tk__tok_break_35 = "'break'"
+showRtkToken L.Tk__tok_boolean_20 = "'boolean'"
+showRtkToken L.Tk__tok_abstract_93 = "'abstract'"
+showRtkToken L.Tk__tok__symbol__eql__53 = "'^='"
+showRtkToken L.Tk__tok__symbol__62 = "'^'"
+showRtkToken L.Tk__tok__sq_bkt_r__19 = "']'"
+showRtkToken L.Tk__tok__sq_bkt_l__18 = "'['"
+showRtkToken L.Tk__tok__symbol__6 = "'@'"
+showRtkToken L.Tk__tok__symbol__58 = "'?'"
+showRtkToken L.Tk__tok__symbol__symbol__symbol__eql__57 = "'>>>='"
+showRtkToken L.Tk__tok__symbol__symbol__symbol__73 = "'>>>'"
+showRtkToken L.Tk__tok__symbol__symbol__eql__56 = "'>>='"
+showRtkToken L.Tk__tok__symbol__symbol__71 = "'>>'"
+showRtkToken L.Tk__tok__symbol__eql__69 = "'>='"
+showRtkToken L.Tk__tok__symbol__67 = "'>'"
+showRtkToken L.Tk__tok__eql__eql__64 = "'=='"
+showRtkToken L.Tk__tok__eql__10 = "'='"
+showRtkToken L.Tk__tok__symbol__eql__68 = "'<='"
+showRtkToken L.Tk__tok__symbol__symbol__eql__55 = "'<<='"
+showRtkToken L.Tk__tok__symbol__symbol__72 = "'<<'"
+showRtkToken L.Tk__tok__symbol__66 = "'<'"
 showRtkToken L.Tk__tok__semi__1 = "';'"
-showRtkToken L.Tk__tok__colon__32 = "':'"
-showRtkToken L.Tk__tok__symbol__eql__48 = "'/='"
-showRtkToken L.Tk__tok__symbol__74 = "'/'"
-showRtkToken L.Tk__tok__dot__3 = "'.'"
-showRtkToken L.Tk__tok__minus__eql__46 = "'-='"
-showRtkToken L.Tk__tok__minus__minus__77 = "'--'"
-showRtkToken L.Tk__tok__minus__73 = "'-'"
-showRtkToken L.Tk__tok__coma__8 = "','"
-showRtkToken L.Tk__tok__plus__eql__45 = "'+='"
-showRtkToken L.Tk__tok__plus__plus__76 = "'++'"
-showRtkToken L.Tk__tok__plus__72 = "'+'"
-showRtkToken L.Tk__tok__star__eql__47 = "'*='"
-showRtkToken L.Tk__tok__star__4 = "'*'"
-showRtkToken L.Tk__tok__rparen__7 = "')'"
-showRtkToken L.Tk__tok__lparen__6 = "'('"
-showRtkToken L.Tk__tok__symbol__eql__50 = "'&='"
-showRtkToken L.Tk__tok__symbol__symbol__58 = "'&&'"
-showRtkToken L.Tk__tok__symbol__61 = "'&'"
-showRtkToken L.Tk__tok__symbol__eql__52 = "'%='"
-showRtkToken L.Tk__tok__symbol__75 = "'%'"
-showRtkToken L.Tk__tok__exclamation__eql__63 = "'!='"
-showRtkToken L.Tk__tok__exclamation__79 = "'!'"
+showRtkToken L.Tk__tok__colon__34 = "':'"
+showRtkToken L.Tk__tok__symbol__eql__50 = "'/='"
+showRtkToken L.Tk__tok__symbol__76 = "'/'"
+showRtkToken L.Tk__tok__dot__4 = "'.'"
+showRtkToken L.Tk__tok__minus__eql__48 = "'-='"
+showRtkToken L.Tk__tok__minus__minus__79 = "'--'"
+showRtkToken L.Tk__tok__minus__75 = "'-'"
+showRtkToken L.Tk__tok__coma__9 = "','"
+showRtkToken L.Tk__tok__plus__eql__47 = "'+='"
+showRtkToken L.Tk__tok__plus__plus__78 = "'++'"
+showRtkToken L.Tk__tok__plus__74 = "'+'"
+showRtkToken L.Tk__tok__star__eql__49 = "'*='"
+showRtkToken L.Tk__tok__star__5 = "'*'"
+showRtkToken L.Tk__tok__rparen__8 = "')'"
+showRtkToken L.Tk__tok__lparen__7 = "'('"
+showRtkToken L.Tk__tok__symbol__eql__52 = "'&='"
+showRtkToken L.Tk__tok__symbol__symbol__60 = "'&&'"
+showRtkToken L.Tk__tok__symbol__63 = "'&'"
+showRtkToken L.Tk__tok__symbol__eql__54 = "'%='"
+showRtkToken L.Tk__tok__symbol__77 = "'%'"
+showRtkToken L.Tk__tok__exclamation__eql__65 = "'!='"
+showRtkToken L.Tk__tok__exclamation__81 = "'!'"
 showRtkToken (L.Tk__doccomment v) = "doccomment " ++ show v
 showRtkToken (L.Tk__id v) = "id " ++ show v
 showRtkToken (L.Tk__string v) = "string " ++ show v
@@ -1233,6 +1269,7 @@ showRtkToken (L.Tk__qq_VariableDeclaratorList v) = "qq_VariableDeclaratorList " 
 showRtkToken (L.Tk__qq_StatementBlock v) = "qq_StatementBlock " ++ show v
 showRtkToken (L.Tk__qq_MoreVariableDeclarators v) = "qq_MoreVariableDeclarators " ++ show v
 showRtkToken (L.Tk__qq_MemberRest v) = "qq_MemberRest " ++ show v
+showRtkToken (L.Tk__qq_ThrowsClause v) = "qq_ThrowsClause " ++ show v
 showRtkToken (L.Tk__qq_MoreTypeSpecifier v) = "qq_MoreTypeSpecifier " ++ show v
 showRtkToken (L.Tk__qq_MemberAfterFirstId v) = "qq_MemberAfterFirstId " ++ show v
 showRtkToken (L.Tk__qq_PrimitiveTypeKeyword v) = "qq_PrimitiveTypeKeyword " ++ show v
@@ -1258,6 +1295,8 @@ showRtkToken (L.Tk__qq_AnnotationElement v) = "qq_AnnotationElement " ++ show v
 showRtkToken (L.Tk__qq_AnnotationArguments v) = "qq_AnnotationArguments " ++ show v
 showRtkToken (L.Tk__qq_Annotation v) = "qq_Annotation " ++ show v
 showRtkToken (L.Tk__qq_DocComment v) = "qq_DocComment " ++ show v
+showRtkToken (L.Tk__qq_ImportHead v) = "qq_ImportHead " ++ show v
+showRtkToken (L.Tk__qq_ImportName v) = "qq_ImportName " ++ show v
 showRtkToken (L.Tk__qq_ImportStatement v) = "qq_ImportStatement " ++ show v
 showRtkToken (L.Tk__qq_Package v) = "qq_Package " ++ show v
 showRtkToken (L.Tk__qq_CompilationUnit v) = "qq_CompilationUnit " ++ show v
@@ -1467,6 +1506,9 @@ tkVal_qq_MoreVariableDeclarators t = error ("rtk internal error: token qq_MoreVa
 tkVal_qq_MemberRest :: L.PosToken -> String
 tkVal_qq_MemberRest (L.PosToken _ (L.Tk__qq_MemberRest v)) = v
 tkVal_qq_MemberRest t = error ("rtk internal error: token qq_MemberRest expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_ThrowsClause :: L.PosToken -> String
+tkVal_qq_ThrowsClause (L.PosToken _ (L.Tk__qq_ThrowsClause v)) = v
+tkVal_qq_ThrowsClause t = error ("rtk internal error: token qq_ThrowsClause expected, got " ++ showRtkToken (L.ptToken t))
 tkVal_qq_MoreTypeSpecifier :: L.PosToken -> String
 tkVal_qq_MoreTypeSpecifier (L.PosToken _ (L.Tk__qq_MoreTypeSpecifier v)) = v
 tkVal_qq_MoreTypeSpecifier t = error ("rtk internal error: token qq_MoreTypeSpecifier expected, got " ++ showRtkToken (L.ptToken t))
@@ -1542,6 +1584,12 @@ tkVal_qq_Annotation t = error ("rtk internal error: token qq_Annotation expected
 tkVal_qq_DocComment :: L.PosToken -> String
 tkVal_qq_DocComment (L.PosToken _ (L.Tk__qq_DocComment v)) = v
 tkVal_qq_DocComment t = error ("rtk internal error: token qq_DocComment expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_ImportHead :: L.PosToken -> String
+tkVal_qq_ImportHead (L.PosToken _ (L.Tk__qq_ImportHead v)) = v
+tkVal_qq_ImportHead t = error ("rtk internal error: token qq_ImportHead expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_ImportName :: L.PosToken -> String
+tkVal_qq_ImportName (L.PosToken _ (L.Tk__qq_ImportName v)) = v
+tkVal_qq_ImportName t = error ("rtk internal error: token qq_ImportName expected, got " ++ showRtkToken (L.ptToken t))
 tkVal_qq_ImportStatement :: L.PosToken -> String
 tkVal_qq_ImportStatement (L.PosToken _ (L.Tk__qq_ImportStatement v)) = v
 tkVal_qq_ImportStatement t = error ("rtk internal error: token qq_ImportStatement expected, got " ++ showRtkToken (L.ptToken t))
@@ -1595,58 +1643,61 @@ data Java = Ctr__Java__0 RtkPos Java |
             Ctr__Java__28 RtkPos ForStatement |
             Ctr__Java__29 RtkPos IfStatement |
             Ctr__Java__30 RtkPos ImplementsList |
-            Ctr__Java__31 RtkPos ImportList |
-            Ctr__Java__32 RtkPos ImportStatement |
-            Ctr__Java__33 RtkPos InterfaceDeclaration |
-            Ctr__Java__34 RtkPos Literal |
-            Ctr__Java__35 RtkPos MemberAfterFirstId |
-            Ctr__Java__36 RtkPos MemberDeclaration |
-            Ctr__Java__37 RtkPos MemberRest |
-            Ctr__Java__38 RtkPos Modifier |
-            Ctr__Java__39 RtkPos ModifierList |
-            Ctr__Java__40 RtkPos MoreTypeSpecifier |
-            Ctr__Java__41 RtkPos MoreVariableDeclarators |
-            Ctr__Java__42 RtkPos MultiplicativeOp |
-            Ctr__Java__43 RtkPos NonEmptyDims |
-            Ctr__Java__44 RtkPos NonEmptyTypeArguments |
-            Ctr__Java__45 RtkPos OptDocComment |
-            Ctr__Java__46 RtkPos OptElsePart |
-            Ctr__Java__47 RtkPos OptExpression |
-            Ctr__Java__48 RtkPos OptFinally |
-            Ctr__Java__49 RtkPos OptId |
-            Ctr__Java__50 RtkPos OptVariableInitializer |
-            Ctr__Java__51 RtkPos Package |
-            Ctr__Java__52 RtkPos Parameter |
-            Ctr__Java__53 RtkPos ParameterList |
-            Ctr__Java__54 RtkPos PostfixOp |
-            Ctr__Java__55 RtkPos PrefixOp |
-            Ctr__Java__56 RtkPos PrimitiveTypeKeyword |
-            Ctr__Java__57 RtkPos RelationalOp |
-            Ctr__Java__58 RtkPos ShiftOp |
-            Ctr__Java__59 RtkPos Statement |
-            Ctr__Java__60 RtkPos StatementBlock |
-            Ctr__Java__61 RtkPos StatementList |
-            Ctr__Java__62 RtkPos StaticInitializer |
-            Ctr__Java__63 RtkPos SwitchCaseList |
-            Ctr__Java__64 RtkPos SwitchStatement |
-            Ctr__Java__65 RtkPos TryStatement |
-            Ctr__Java__66 RtkPos Type |
-            Ctr__Java__67 RtkPos TypeArgument |
-            Ctr__Java__68 RtkPos TypeArguments |
-            Ctr__Java__69 RtkPos TypeDeclRest |
-            Ctr__Java__70 RtkPos TypeDeclaration |
-            Ctr__Java__71 RtkPos TypeParameter |
-            Ctr__Java__72 RtkPos TypeParameters |
-            Ctr__Java__73 RtkPos TypeSpecifier |
-            Ctr__Java__74 RtkPos VariableDeclaration |
-            Ctr__Java__75 RtkPos VariableDeclarator |
-            Ctr__Java__76 RtkPos VariableDeclaratorList |
-            Ctr__Java__77 RtkPos VariableInitializer |
-            Ctr__Java__78 RtkPos VariableInitializerList |
-            Ctr__Java__79 RtkPos WhileStatement |
-            Ctr__Java__80 RtkPos WildcardType |
+            Ctr__Java__31 RtkPos ImportHead |
+            Ctr__Java__32 RtkPos ImportList |
+            Ctr__Java__33 RtkPos ImportName |
+            Ctr__Java__34 RtkPos ImportStatement |
+            Ctr__Java__35 RtkPos InterfaceDeclaration |
+            Ctr__Java__36 RtkPos Literal |
+            Ctr__Java__37 RtkPos MemberAfterFirstId |
+            Ctr__Java__38 RtkPos MemberDeclaration |
+            Ctr__Java__39 RtkPos MemberRest |
+            Ctr__Java__40 RtkPos Modifier |
+            Ctr__Java__41 RtkPos ModifierList |
+            Ctr__Java__42 RtkPos MoreTypeSpecifier |
+            Ctr__Java__43 RtkPos MoreVariableDeclarators |
+            Ctr__Java__44 RtkPos MultiplicativeOp |
+            Ctr__Java__45 RtkPos NonEmptyDims |
+            Ctr__Java__46 RtkPos NonEmptyTypeArguments |
+            Ctr__Java__47 RtkPos OptDocComment |
+            Ctr__Java__48 RtkPos OptElsePart |
+            Ctr__Java__49 RtkPos OptExpression |
+            Ctr__Java__50 RtkPos OptFinally |
+            Ctr__Java__51 RtkPos OptId |
+            Ctr__Java__52 RtkPos OptVariableInitializer |
+            Ctr__Java__53 RtkPos Package |
+            Ctr__Java__54 RtkPos Parameter |
+            Ctr__Java__55 RtkPos ParameterList |
+            Ctr__Java__56 RtkPos PostfixOp |
+            Ctr__Java__57 RtkPos PrefixOp |
+            Ctr__Java__58 RtkPos PrimitiveTypeKeyword |
+            Ctr__Java__59 RtkPos RelationalOp |
+            Ctr__Java__60 RtkPos ShiftOp |
+            Ctr__Java__61 RtkPos Statement |
+            Ctr__Java__62 RtkPos StatementBlock |
+            Ctr__Java__63 RtkPos StatementList |
+            Ctr__Java__64 RtkPos StaticInitializer |
+            Ctr__Java__65 RtkPos SwitchCaseList |
+            Ctr__Java__66 RtkPos SwitchStatement |
+            Ctr__Java__67 RtkPos ThrowsClause |
+            Ctr__Java__68 RtkPos TryStatement |
+            Ctr__Java__69 RtkPos Type |
+            Ctr__Java__70 RtkPos TypeArgument |
+            Ctr__Java__71 RtkPos TypeArguments |
+            Ctr__Java__72 RtkPos TypeDeclRest |
+            Ctr__Java__73 RtkPos TypeDeclaration |
+            Ctr__Java__74 RtkPos TypeParameter |
+            Ctr__Java__75 RtkPos TypeParameters |
+            Ctr__Java__76 RtkPos TypeSpecifier |
+            Ctr__Java__77 RtkPos VariableDeclaration |
+            Ctr__Java__78 RtkPos VariableDeclarator |
+            Ctr__Java__79 RtkPos VariableDeclaratorList |
+            Ctr__Java__80 RtkPos VariableInitializer |
+            Ctr__Java__81 RtkPos VariableInitializerList |
+            Ctr__Java__82 RtkPos WhileStatement |
+            Ctr__Java__83 RtkPos WildcardType |
             Anti_Java String |
-            Ctr__Java__81 RtkPos CompilationUnit
+            Ctr__Java__84 RtkPos CompilationUnit
             deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Java where
     rtkPosOf (Ctr__Java__0 p _) = p
@@ -1730,8 +1781,11 @@ instance RtkPosOf Java where
     rtkPosOf (Ctr__Java__78 p _) = p
     rtkPosOf (Ctr__Java__79 p _) = p
     rtkPosOf (Ctr__Java__80 p _) = p
-    rtkPosOf (Anti_Java _) = rtkNoPos
     rtkPosOf (Ctr__Java__81 p _) = p
+    rtkPosOf (Ctr__Java__82 p _) = p
+    rtkPosOf (Ctr__Java__83 p _) = p
+    rtkPosOf (Anti_Java _) = rtkNoPos
+    rtkPosOf (Ctr__Java__84 p _) = p
 data AdditiveOp = Anti_AdditiveOp String |
                   Ctr__AdditiveOp__0 RtkPos |
                   Ctr__AdditiveOp__1 RtkPos
@@ -1776,7 +1830,7 @@ instance RtkPosOf AnnotationTypeElement where
 type AnnotationTypeElementList = [AnnotationTypeElement]
 data Arglist = Anti_Arglist String |
                Ctr__Arglist__0 RtkPos |
-               Ctr__Arglist__1 RtkPos Rule_69
+               Ctr__Arglist__1 RtkPos Rule_73
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Arglist where
     rtkPosOf (Anti_Arglist _) = rtkNoPos
@@ -1810,7 +1864,7 @@ instance RtkPosOf AssignmentOp where
     rtkPosOf (Ctr__AssignmentOp__9 p) = p
     rtkPosOf (Ctr__AssignmentOp__10 p) = p
     rtkPosOf (Ctr__AssignmentOp__11 p) = p
-type CatchList = [Rule_54]
+type CatchList = [Rule_58]
 data ClassDeclaration = Anti_ClassDeclaration String |
                         Ctr__ClassDeclaration__0 RtkPos String TypeParameters Rule_16 Rule_17 FieldDeclarationList
                         deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
@@ -1824,18 +1878,18 @@ instance RtkPosOf CompilationUnit where
     rtkPosOf (Anti_CompilationUnit _) = rtkNoPos
     rtkPosOf (Ctr__CompilationUnit__0 p _ _ _) = p
 data CompoundName = Anti_CompoundName String |
-                    Ctr__CompoundName__0 RtkPos String Rule_81
+                    Ctr__CompoundName__0 RtkPos String Rule_85
                     deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf CompoundName where
     rtkPosOf (Anti_CompoundName _) = rtkNoPos
     rtkPosOf (Ctr__CompoundName__0 p _ _) = p
 data CreationExpression = Anti_CreationExpression String |
-                          Ctr__CreationExpression__0 RtkPos TypeSpecifier Rule_65
+                          Ctr__CreationExpression__0 RtkPos TypeSpecifier Rule_69
                           deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf CreationExpression where
     rtkPosOf (Anti_CreationExpression _) = rtkNoPos
     rtkPosOf (Ctr__CreationExpression__0 p _ _) = p
-type DimExprs = [Rule_67]
+type DimExprs = [Rule_71]
 type Dims = [Rule_31]
 data DoStatement = Anti_DoStatement String |
                    Ctr__DoStatement__0 RtkPos Statement Expression
@@ -1880,9 +1934,9 @@ data Expression = Anti_Expression String |
                   Ctr__Expression__1 RtkPos |
                   Ctr__Expression__2 RtkPos Expression |
                   Ctr__Expression__3 RtkPos CreationExpression |
-                  Ctr__Expression__4 RtkPos CompoundName Rule_61 |
+                  Ctr__Expression__4 RtkPos CompoundName Rule_65 |
                   Ctr__Expression__5 RtkPos CompoundName Expression |
-                  Ctr__Expression__6 RtkPos String Rule_63 |
+                  Ctr__Expression__6 RtkPos String Rule_67 |
                   Ctr__Expression__7 RtkPos Expression |
                   Ctr__Expression__8 RtkPos Expression PostfixOp |
                   Ctr__Expression__9 RtkPos Expression String |
@@ -1921,7 +1975,7 @@ data Expression = Anti_Expression String |
                   Ctr__Expression__42 RtkPos Expression Expression |
                   Ctr__Expression__43 RtkPos Expression |
                   Ctr__Expression__44 RtkPos Expression Expression Expression |
-                  Ctr__Expression__45 RtkPos Expression Rule_59 |
+                  Ctr__Expression__45 RtkPos Expression Rule_63 |
                   Ctr__Expression__46 RtkPos Expression
                   deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Expression where
@@ -1989,7 +2043,7 @@ instance RtkPosOf FieldDeclaration where
     rtkPosOf (Ctr__FieldDeclaration__1 p) = p
 type FieldDeclarationList = [FieldDeclaration]
 data ForStatement = Anti_ForStatement String |
-                    Ctr__ForStatement__0 RtkPos Rule_53 OptExpression OptExpression Statement
+                    Ctr__ForStatement__0 RtkPos Rule_57 OptExpression OptExpression Statement
                     deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf ForStatement where
     rtkPosOf (Anti_ForStatement _) = rtkNoPos
@@ -2006,13 +2060,29 @@ data ImplementsList = Anti_ImplementsList String |
 instance RtkPosOf ImplementsList where
     rtkPosOf (Anti_ImplementsList _) = rtkNoPos
     rtkPosOf (Ctr__ImplementsList__0 p _) = p
+data ImportHead = Anti_ImportHead String |
+                  Ctr__ImportHead__0 RtkPos String |
+                  Ctr__ImportHead__1 RtkPos ImportHead String
+                  deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf ImportHead where
+    rtkPosOf (Anti_ImportHead _) = rtkNoPos
+    rtkPosOf (Ctr__ImportHead__0 p _) = p
+    rtkPosOf (Ctr__ImportHead__1 p _ _) = p
 type ImportList = [ImportStatement]
+data ImportName = Anti_ImportName String |
+                  Ctr__ImportName__0 RtkPos ImportHead |
+                  Ctr__ImportName__1 RtkPos ImportHead
+                  deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf ImportName where
+    rtkPosOf (Anti_ImportName _) = rtkNoPos
+    rtkPosOf (Ctr__ImportName__0 p _) = p
+    rtkPosOf (Ctr__ImportName__1 p _) = p
 data ImportStatement = Anti_ImportStatement String |
-                       Ctr__ImportStatement__0 RtkPos Rule_3
+                       Ctr__ImportStatement__0 RtkPos Rule_3 ImportName
                        deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf ImportStatement where
     rtkPosOf (Anti_ImportStatement _) = rtkNoPos
-    rtkPosOf (Ctr__ImportStatement__0 p _) = p
+    rtkPosOf (Ctr__ImportStatement__0 p _ _) = p
 data InterfaceDeclaration = Anti_InterfaceDeclaration String |
                             Ctr__InterfaceDeclaration__0 RtkPos String TypeParameters Rule_18 FieldDeclarationList
                             deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
@@ -2038,12 +2108,12 @@ instance RtkPosOf Literal where
     rtkPosOf (Ctr__Literal__5 p _) = p
     rtkPosOf (Ctr__Literal__6 p) = p
 data MemberAfterFirstId = Anti_MemberAfterFirstId String |
-                          Ctr__MemberAfterFirstId__0 RtkPos Rule_35 StatementBlock |
+                          Ctr__MemberAfterFirstId__0 RtkPos Rule_35 Rule_36 StatementBlock |
                           Ctr__MemberAfterFirstId__1 RtkPos MoreTypeSpecifier String MemberRest
                           deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf MemberAfterFirstId where
     rtkPosOf (Anti_MemberAfterFirstId _) = rtkNoPos
-    rtkPosOf (Ctr__MemberAfterFirstId__0 p _ _) = p
+    rtkPosOf (Ctr__MemberAfterFirstId__0 p _ _ _) = p
     rtkPosOf (Ctr__MemberAfterFirstId__1 p _ _ _) = p
 data MemberDeclaration = Anti_MemberDeclaration String |
                          Ctr__MemberDeclaration__0 RtkPos PrimitiveTypeKeyword Dims String MemberRest |
@@ -2056,12 +2126,12 @@ instance RtkPosOf MemberDeclaration where
     rtkPosOf (Ctr__MemberDeclaration__1 p _ _ _ _ _) = p
     rtkPosOf (Ctr__MemberDeclaration__2 p _ _) = p
 data MemberRest = Anti_MemberRest String |
-                  Ctr__MemberRest__0 RtkPos Rule_36 Dims Rule_37 |
+                  Ctr__MemberRest__0 RtkPos Rule_39 Dims Rule_40 Rule_41 |
                   Ctr__MemberRest__1 RtkPos Dims OptVariableInitializer MoreVariableDeclarators
                   deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf MemberRest where
     rtkPosOf (Anti_MemberRest _) = rtkNoPos
-    rtkPosOf (Ctr__MemberRest__0 p _ _ _) = p
+    rtkPosOf (Ctr__MemberRest__0 p _ _ _ _) = p
     rtkPosOf (Ctr__MemberRest__1 p _ _ _) = p
 data Modifier = Anti_Modifier String |
                 Ctr__Modifier__0 RtkPos |
@@ -2096,7 +2166,7 @@ instance RtkPosOf MoreTypeSpecifier where
     rtkPosOf (Anti_MoreTypeSpecifier _) = rtkNoPos
     rtkPosOf (Ctr__MoreTypeSpecifier__0 p _ _) = p
     rtkPosOf (Ctr__MoreTypeSpecifier__1 p _ _) = p
-type MoreVariableDeclarators = [Rule_40]
+type MoreVariableDeclarators = [Rule_44]
 data MultiplicativeOp = Anti_MultiplicativeOp String |
                         Ctr__MultiplicativeOp__0 RtkPos |
                         Ctr__MultiplicativeOp__1 RtkPos |
@@ -2109,7 +2179,7 @@ instance RtkPosOf MultiplicativeOp where
     rtkPosOf (Ctr__MultiplicativeOp__2 p) = p
 type NonEmptyDims = [Rule_33]
 data NonEmptyTypeArguments = Anti_NonEmptyTypeArguments String |
-                             Ctr__NonEmptyTypeArguments__0 RtkPos TypeArgument Rule_72
+                             Ctr__NonEmptyTypeArguments__0 RtkPos TypeArgument Rule_76
                              deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf NonEmptyTypeArguments where
     rtkPosOf (Anti_NonEmptyTypeArguments _) = rtkNoPos
@@ -2124,7 +2194,7 @@ instance RtkPosOf OptDocComment where
     rtkPosOf (Ctr__OptDocComment__1 p _) = p
 data OptElsePart = Anti_OptElsePart String |
                    Ctr__OptElsePart__0 RtkPos |
-                   Ctr__OptElsePart__1 RtkPos Rule_52
+                   Ctr__OptElsePart__1 RtkPos Rule_56
                    deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf OptElsePart where
     rtkPosOf (Anti_OptElsePart _) = rtkNoPos
@@ -2140,7 +2210,7 @@ instance RtkPosOf OptExpression where
     rtkPosOf (Ctr__OptExpression__1 p _) = p
 data OptFinally = Anti_OptFinally String |
                   Ctr__OptFinally__0 RtkPos |
-                  Ctr__OptFinally__1 RtkPos Rule_56
+                  Ctr__OptFinally__1 RtkPos Rule_60
                   deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf OptFinally where
     rtkPosOf (Anti_OptFinally _) = rtkNoPos
@@ -2156,7 +2226,7 @@ instance RtkPosOf OptId where
     rtkPosOf (Ctr__OptId__1 p _) = p
 data OptVariableInitializer = Anti_OptVariableInitializer String |
                               Ctr__OptVariableInitializer__0 RtkPos |
-                              Ctr__OptVariableInitializer__1 RtkPos Rule_44
+                              Ctr__OptVariableInitializer__1 RtkPos Rule_48
                               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf OptVariableInitializer where
     rtkPosOf (Anti_OptVariableInitializer _) = rtkNoPos
@@ -2175,7 +2245,7 @@ instance RtkPosOf Parameter where
     rtkPosOf (Anti_Parameter _) = rtkNoPos
     rtkPosOf (Ctr__Parameter__0 p _ _ _) = p
 data ParameterList = Anti_ParameterList String |
-                     Ctr__ParameterList__0 RtkPos Parameter Rule_49
+                     Ctr__ParameterList__0 RtkPos Parameter Rule_53
                      deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf ParameterList where
     rtkPosOf (Anti_ParameterList _) = rtkNoPos
@@ -2325,12 +2395,12 @@ data Rule_29 = Ctr__Rule_29__0 RtkPos FieldDeclarationList
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_29 where
     rtkPosOf (Ctr__Rule_29__0 p _) = p
-data Rule_3 = Ctr__Rule_3__0 RtkPos CompoundName |
-              Ctr__Rule_3__1 RtkPos CompoundName
+data Rule_3 = Ctr__Rule_3__0 RtkPos |
+              Ctr__Rule_3__1 RtkPos
               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_3 where
-    rtkPosOf (Ctr__Rule_3__0 p _) = p
-    rtkPosOf (Ctr__Rule_3__1 p _) = p
+    rtkPosOf (Ctr__Rule_3__0 p) = p
+    rtkPosOf (Ctr__Rule_3__1 p) = p
 data Rule_30 = Ctr__Rule_30__0 RtkPos MemberDeclaration |
                Ctr__Rule_30__1 RtkPos TypeDeclRest |
                Ctr__Rule_30__2 RtkPos StaticInitializer
@@ -2358,189 +2428,191 @@ instance RtkPosOf Rule_35 where
     rtkPosOf (Ctr__Rule_35__0 p) = p
     rtkPosOf (Ctr__Rule_35__1 p _) = p
 data Rule_36 = Ctr__Rule_36__0 RtkPos |
-               Ctr__Rule_36__1 RtkPos ParameterList
+               Ctr__Rule_36__1 RtkPos ThrowsClause
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_36 where
     rtkPosOf (Ctr__Rule_36__0 p) = p
     rtkPosOf (Ctr__Rule_36__1 p _) = p
-data Rule_37 = Ctr__Rule_37__0 RtkPos StatementBlock |
-               Ctr__Rule_37__1 RtkPos Rule_38
-               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-instance RtkPosOf Rule_37 where
-    rtkPosOf (Ctr__Rule_37__0 p _) = p
-    rtkPosOf (Ctr__Rule_37__1 p _) = p
-data Rule_38 = Ctr__Rule_38__0 RtkPos |
-               Ctr__Rule_38__1 RtkPos Rule_39
+type Rule_37 = [Rule_38]
+data Rule_38 = Ctr__Rule_38__0 RtkPos CompoundName
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_38 where
-    rtkPosOf (Ctr__Rule_38__0 p) = p
-    rtkPosOf (Ctr__Rule_38__1 p _) = p
-data Rule_39 = Ctr__Rule_39__0 RtkPos Expression
+    rtkPosOf (Ctr__Rule_38__0 p _) = p
+data Rule_39 = Ctr__Rule_39__0 RtkPos |
+               Ctr__Rule_39__1 RtkPos ParameterList
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_39 where
-    rtkPosOf (Ctr__Rule_39__0 p _) = p
+    rtkPosOf (Ctr__Rule_39__0 p) = p
+    rtkPosOf (Ctr__Rule_39__1 p _) = p
 data Rule_4 = Ctr__Rule_4__0 RtkPos |
               Ctr__Rule_4__1 RtkPos Rule_5
               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_4 where
     rtkPosOf (Ctr__Rule_4__0 p) = p
     rtkPosOf (Ctr__Rule_4__1 p _) = p
-data Rule_40 = Anti_Rule_40 String |
-               Ctr__Rule_40__1 RtkPos VariableDeclarator
+data Rule_40 = Ctr__Rule_40__0 RtkPos |
+               Ctr__Rule_40__1 RtkPos ThrowsClause
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_40 where
-    rtkPosOf (Anti_Rule_40 _) = rtkNoPos
+    rtkPosOf (Ctr__Rule_40__0 p) = p
     rtkPosOf (Ctr__Rule_40__1 p _) = p
-type Rule_42 = [Rule_43]
-data Rule_43 = Ctr__Rule_43__0 RtkPos VariableDeclarator
+data Rule_41 = Ctr__Rule_41__0 RtkPos StatementBlock |
+               Ctr__Rule_41__1 RtkPos Rule_42
+               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_41 where
+    rtkPosOf (Ctr__Rule_41__0 p _) = p
+    rtkPosOf (Ctr__Rule_41__1 p _) = p
+data Rule_42 = Ctr__Rule_42__0 RtkPos |
+               Ctr__Rule_42__1 RtkPos Rule_43
+               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_42 where
+    rtkPosOf (Ctr__Rule_42__0 p) = p
+    rtkPosOf (Ctr__Rule_42__1 p _) = p
+data Rule_43 = Ctr__Rule_43__0 RtkPos Expression
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_43 where
     rtkPosOf (Ctr__Rule_43__0 p _) = p
-data Rule_44 = Ctr__Rule_44__0 RtkPos VariableInitializer
+data Rule_44 = Anti_Rule_44 String |
+               Ctr__Rule_44__1 RtkPos VariableDeclarator
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_44 where
-    rtkPosOf (Ctr__Rule_44__0 p _) = p
-data Rule_45 = Ctr__Rule_45__0 RtkPos VariableInitializer Rule_46 Rule_48
-               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-instance RtkPosOf Rule_45 where
-    rtkPosOf (Ctr__Rule_45__0 p _ _ _) = p
+    rtkPosOf (Anti_Rule_44 _) = rtkNoPos
+    rtkPosOf (Ctr__Rule_44__1 p _) = p
 type Rule_46 = [Rule_47]
-data Rule_47 = Ctr__Rule_47__0 RtkPos VariableInitializer
+data Rule_47 = Ctr__Rule_47__0 RtkPos VariableDeclarator
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_47 where
     rtkPosOf (Ctr__Rule_47__0 p _) = p
-data Rule_48 = Ctr__Rule_48__0 RtkPos |
-               Ctr__Rule_48__1 RtkPos
+data Rule_48 = Ctr__Rule_48__0 RtkPos VariableInitializer
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_48 where
-    rtkPosOf (Ctr__Rule_48__0 p) = p
-    rtkPosOf (Ctr__Rule_48__1 p) = p
-type Rule_49 = [Rule_50]
+    rtkPosOf (Ctr__Rule_48__0 p _) = p
+data Rule_49 = Ctr__Rule_49__0 RtkPos VariableInitializer Rule_50 Rule_52
+               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_49 where
+    rtkPosOf (Ctr__Rule_49__0 p _ _ _) = p
 data Rule_5 = Ctr__Rule_5__0 RtkPos Rule_6
               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_5 where
     rtkPosOf (Ctr__Rule_5__0 p _) = p
-data Rule_50 = Ctr__Rule_50__0 RtkPos Parameter
+type Rule_50 = [Rule_51]
+data Rule_51 = Ctr__Rule_51__0 RtkPos VariableInitializer
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-instance RtkPosOf Rule_50 where
-    rtkPosOf (Ctr__Rule_50__0 p _) = p
-data Rule_52 = Ctr__Rule_52__0 RtkPos Statement
+instance RtkPosOf Rule_51 where
+    rtkPosOf (Ctr__Rule_51__0 p _) = p
+data Rule_52 = Ctr__Rule_52__0 RtkPos |
+               Ctr__Rule_52__1 RtkPos
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_52 where
-    rtkPosOf (Ctr__Rule_52__0 p _) = p
-data Rule_53 = Ctr__Rule_53__0 RtkPos VariableDeclaration |
-               Ctr__Rule_53__1 RtkPos Expression |
-               Ctr__Rule_53__2 RtkPos
-               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-instance RtkPosOf Rule_53 where
-    rtkPosOf (Ctr__Rule_53__0 p _) = p
-    rtkPosOf (Ctr__Rule_53__1 p _) = p
-    rtkPosOf (Ctr__Rule_53__2 p) = p
-data Rule_54 = Anti_Rule_54 String |
-               Ctr__Rule_54__1 RtkPos Parameter Statement
+    rtkPosOf (Ctr__Rule_52__0 p) = p
+    rtkPosOf (Ctr__Rule_52__1 p) = p
+type Rule_53 = [Rule_54]
+data Rule_54 = Ctr__Rule_54__0 RtkPos Parameter
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_54 where
-    rtkPosOf (Anti_Rule_54 _) = rtkNoPos
-    rtkPosOf (Ctr__Rule_54__1 p _ _) = p
+    rtkPosOf (Ctr__Rule_54__0 p _) = p
 data Rule_56 = Ctr__Rule_56__0 RtkPos Statement
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_56 where
     rtkPosOf (Ctr__Rule_56__0 p _) = p
-data Rule_57 = Anti_Rule_57 String |
+data Rule_57 = Ctr__Rule_57__0 RtkPos VariableDeclaration |
                Ctr__Rule_57__1 RtkPos Expression |
-               Ctr__Rule_57__2 RtkPos |
-               Ctr__Rule_57__3 RtkPos Statement
+               Ctr__Rule_57__2 RtkPos
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_57 where
-    rtkPosOf (Anti_Rule_57 _) = rtkNoPos
+    rtkPosOf (Ctr__Rule_57__0 p _) = p
     rtkPosOf (Ctr__Rule_57__1 p _) = p
     rtkPosOf (Ctr__Rule_57__2 p) = p
-    rtkPosOf (Ctr__Rule_57__3 p _) = p
-data Rule_59 = Ctr__Rule_59__0 RtkPos |
-               Ctr__Rule_59__1 RtkPos Rule_60
+data Rule_58 = Anti_Rule_58 String |
+               Ctr__Rule_58__1 RtkPos Parameter Statement
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-instance RtkPosOf Rule_59 where
-    rtkPosOf (Ctr__Rule_59__0 p) = p
-    rtkPosOf (Ctr__Rule_59__1 p _) = p
+instance RtkPosOf Rule_58 where
+    rtkPosOf (Anti_Rule_58 _) = rtkNoPos
+    rtkPosOf (Ctr__Rule_58__1 p _ _) = p
 data Rule_6 = Ctr__Rule_6__0 RtkPos |
               Ctr__Rule_6__1 RtkPos AnnotationArguments
               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_6 where
     rtkPosOf (Ctr__Rule_6__0 p) = p
     rtkPosOf (Ctr__Rule_6__1 p _) = p
-data Rule_60 = Ctr__Rule_60__0 RtkPos AssignmentOp Expression
+data Rule_60 = Ctr__Rule_60__0 RtkPos Statement
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_60 where
-    rtkPosOf (Ctr__Rule_60__0 p _ _) = p
-data Rule_61 = Ctr__Rule_61__0 RtkPos |
-               Ctr__Rule_61__1 RtkPos Rule_62
+    rtkPosOf (Ctr__Rule_60__0 p _) = p
+data Rule_61 = Anti_Rule_61 String |
+               Ctr__Rule_61__1 RtkPos Expression |
+               Ctr__Rule_61__2 RtkPos |
+               Ctr__Rule_61__3 RtkPos Statement
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_61 where
-    rtkPosOf (Ctr__Rule_61__0 p) = p
+    rtkPosOf (Anti_Rule_61 _) = rtkNoPos
     rtkPosOf (Ctr__Rule_61__1 p _) = p
-data Rule_62 = Ctr__Rule_62__0 RtkPos Arglist
-               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-instance RtkPosOf Rule_62 where
-    rtkPosOf (Ctr__Rule_62__0 p _) = p
+    rtkPosOf (Ctr__Rule_61__2 p) = p
+    rtkPosOf (Ctr__Rule_61__3 p _) = p
 data Rule_63 = Ctr__Rule_63__0 RtkPos |
                Ctr__Rule_63__1 RtkPos Rule_64
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_63 where
     rtkPosOf (Ctr__Rule_63__0 p) = p
     rtkPosOf (Ctr__Rule_63__1 p _) = p
-data Rule_64 = Ctr__Rule_64__0 RtkPos Arglist
+data Rule_64 = Ctr__Rule_64__0 RtkPos AssignmentOp Expression
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_64 where
-    rtkPosOf (Ctr__Rule_64__0 p _) = p
-data Rule_65 = Ctr__Rule_65__0 RtkPos Arglist |
-               Ctr__Rule_65__1 RtkPos DimExprs Rule_66
+    rtkPosOf (Ctr__Rule_64__0 p _ _) = p
+data Rule_65 = Ctr__Rule_65__0 RtkPos |
+               Ctr__Rule_65__1 RtkPos Rule_66
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_65 where
-    rtkPosOf (Ctr__Rule_65__0 p _) = p
-    rtkPosOf (Ctr__Rule_65__1 p _ _) = p
-data Rule_66 = Ctr__Rule_66__0 RtkPos |
-               Ctr__Rule_66__1 RtkPos NonEmptyDims
+    rtkPosOf (Ctr__Rule_65__0 p) = p
+    rtkPosOf (Ctr__Rule_65__1 p _) = p
+data Rule_66 = Ctr__Rule_66__0 RtkPos Arglist
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_66 where
-    rtkPosOf (Ctr__Rule_66__0 p) = p
-    rtkPosOf (Ctr__Rule_66__1 p _) = p
-data Rule_67 = Anti_Rule_67 String |
-               Ctr__Rule_67__1 RtkPos Expression
+    rtkPosOf (Ctr__Rule_66__0 p _) = p
+data Rule_67 = Ctr__Rule_67__0 RtkPos |
+               Ctr__Rule_67__1 RtkPos Rule_68
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_67 where
-    rtkPosOf (Anti_Rule_67 _) = rtkNoPos
+    rtkPosOf (Ctr__Rule_67__0 p) = p
     rtkPosOf (Ctr__Rule_67__1 p _) = p
-data Rule_69 = Ctr__Rule_69__0 RtkPos Expression Rule_70
+data Rule_68 = Ctr__Rule_68__0 RtkPos Arglist
+               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_68 where
+    rtkPosOf (Ctr__Rule_68__0 p _) = p
+data Rule_69 = Ctr__Rule_69__0 RtkPos Arglist |
+               Ctr__Rule_69__1 RtkPos DimExprs Rule_70
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_69 where
-    rtkPosOf (Ctr__Rule_69__0 p _ _) = p
+    rtkPosOf (Ctr__Rule_69__0 p _) = p
+    rtkPosOf (Ctr__Rule_69__1 p _ _) = p
 type Rule_7 = [Rule_8]
-type Rule_70 = [Rule_71]
-data Rule_71 = Ctr__Rule_71__0 RtkPos Expression
+data Rule_70 = Ctr__Rule_70__0 RtkPos |
+               Ctr__Rule_70__1 RtkPos NonEmptyDims
+               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_70 where
+    rtkPosOf (Ctr__Rule_70__0 p) = p
+    rtkPosOf (Ctr__Rule_70__1 p _) = p
+data Rule_71 = Anti_Rule_71 String |
+               Ctr__Rule_71__1 RtkPos Expression
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_71 where
-    rtkPosOf (Ctr__Rule_71__0 p _) = p
-type Rule_72 = [Rule_73]
-data Rule_73 = Ctr__Rule_73__0 RtkPos TypeArgument
+    rtkPosOf (Anti_Rule_71 _) = rtkNoPos
+    rtkPosOf (Ctr__Rule_71__1 p _) = p
+data Rule_73 = Ctr__Rule_73__0 RtkPos Expression Rule_74
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_73 where
-    rtkPosOf (Ctr__Rule_73__0 p _) = p
-data Rule_74 = Ctr__Rule_74__0 RtkPos TypeParameter Rule_75
+    rtkPosOf (Ctr__Rule_73__0 p _ _) = p
+type Rule_74 = [Rule_75]
+data Rule_75 = Ctr__Rule_75__0 RtkPos Expression
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-instance RtkPosOf Rule_74 where
-    rtkPosOf (Ctr__Rule_74__0 p _ _) = p
-type Rule_75 = [Rule_76]
-data Rule_76 = Ctr__Rule_76__0 RtkPos TypeParameter
-               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-instance RtkPosOf Rule_76 where
-    rtkPosOf (Ctr__Rule_76__0 p _) = p
-data Rule_77 = Ctr__Rule_77__0 RtkPos |
-               Ctr__Rule_77__1 RtkPos Rule_78
+instance RtkPosOf Rule_75 where
+    rtkPosOf (Ctr__Rule_75__0 p _) = p
+type Rule_76 = [Rule_77]
+data Rule_77 = Ctr__Rule_77__0 RtkPos TypeArgument
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_77 where
-    rtkPosOf (Ctr__Rule_77__0 p) = p
-    rtkPosOf (Ctr__Rule_77__1 p _) = p
-data Rule_78 = Ctr__Rule_78__0 RtkPos Type Rule_79
+    rtkPosOf (Ctr__Rule_77__0 p _) = p
+data Rule_78 = Ctr__Rule_78__0 RtkPos TypeParameter Rule_79
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_78 where
     rtkPosOf (Ctr__Rule_78__0 p _ _) = p
@@ -2549,15 +2621,30 @@ data Rule_8 = Ctr__Rule_8__0 RtkPos AnnotationElement
               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_8 where
     rtkPosOf (Ctr__Rule_8__0 p _) = p
-data Rule_80 = Ctr__Rule_80__0 RtkPos Type
+data Rule_80 = Ctr__Rule_80__0 RtkPos TypeParameter
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_80 where
     rtkPosOf (Ctr__Rule_80__0 p _) = p
-type Rule_81 = [Rule_82]
-data Rule_82 = Ctr__Rule_82__0 RtkPos String
+data Rule_81 = Ctr__Rule_81__0 RtkPos |
+               Ctr__Rule_81__1 RtkPos Rule_82
+               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_81 where
+    rtkPosOf (Ctr__Rule_81__0 p) = p
+    rtkPosOf (Ctr__Rule_81__1 p _) = p
+data Rule_82 = Ctr__Rule_82__0 RtkPos Type Rule_83
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_82 where
-    rtkPosOf (Ctr__Rule_82__0 p _) = p
+    rtkPosOf (Ctr__Rule_82__0 p _ _) = p
+type Rule_83 = [Rule_84]
+data Rule_84 = Ctr__Rule_84__0 RtkPos Type
+               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_84 where
+    rtkPosOf (Ctr__Rule_84__0 p _) = p
+type Rule_85 = [Rule_86]
+data Rule_86 = Ctr__Rule_86__0 RtkPos String
+               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_86 where
+    rtkPosOf (Ctr__Rule_86__0 p _) = p
 data ShiftOp = Anti_ShiftOp String |
                Ctr__ShiftOp__0 RtkPos |
                Ctr__ShiftOp__1 RtkPos |
@@ -2617,13 +2704,19 @@ data StaticInitializer = Anti_StaticInitializer String |
 instance RtkPosOf StaticInitializer where
     rtkPosOf (Anti_StaticInitializer _) = rtkNoPos
     rtkPosOf (Ctr__StaticInitializer__0 p _) = p
-type SwitchCaseList = [Rule_57]
+type SwitchCaseList = [Rule_61]
 data SwitchStatement = Anti_SwitchStatement String |
                        Ctr__SwitchStatement__0 RtkPos Expression SwitchCaseList
                        deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf SwitchStatement where
     rtkPosOf (Anti_SwitchStatement _) = rtkNoPos
     rtkPosOf (Ctr__SwitchStatement__0 p _ _) = p
+data ThrowsClause = Anti_ThrowsClause String |
+                    Ctr__ThrowsClause__0 RtkPos CompoundName Rule_37
+                    deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf ThrowsClause where
+    rtkPosOf (Anti_ThrowsClause _) = rtkNoPos
+    rtkPosOf (Ctr__ThrowsClause__0 p _ _) = p
 data TryStatement = Anti_TryStatement String |
                     Ctr__TryStatement__0 RtkPos Statement CatchList OptFinally
                     deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
@@ -2677,14 +2770,14 @@ instance RtkPosOf TypeDeclaration where
     rtkPosOf (Anti_TypeDeclaration _) = rtkNoPos
     rtkPosOf (Ctr__TypeDeclaration__0 p _ _ _) = p
 data TypeParameter = Anti_TypeParameter String |
-                     Ctr__TypeParameter__0 RtkPos String Rule_77
+                     Ctr__TypeParameter__0 RtkPos String Rule_81
                      deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf TypeParameter where
     rtkPosOf (Anti_TypeParameter _) = rtkNoPos
     rtkPosOf (Ctr__TypeParameter__0 p _ _) = p
 data TypeParameters = Anti_TypeParameters String |
                       Ctr__TypeParameters__0 RtkPos |
-                      Ctr__TypeParameters__1 RtkPos Rule_74
+                      Ctr__TypeParameters__1 RtkPos Rule_78
                       deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf TypeParameters where
     rtkPosOf (Anti_TypeParameters _) = rtkNoPos
@@ -2727,7 +2820,7 @@ instance RtkPosOf VariableDeclarator where
     rtkPosOf (Anti_VariableDeclarator _) = rtkNoPos
     rtkPosOf (Ctr__VariableDeclarator__0 p _ _ _) = p
 data VariableDeclaratorList = Anti_VariableDeclaratorList String |
-                              Ctr__VariableDeclaratorList__0 RtkPos VariableDeclarator Rule_42
+                              Ctr__VariableDeclaratorList__0 RtkPos VariableDeclarator Rule_46
                               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf VariableDeclaratorList where
     rtkPosOf (Anti_VariableDeclaratorList _) = rtkNoPos
@@ -2742,7 +2835,7 @@ instance RtkPosOf VariableInitializer where
     rtkPosOf (Ctr__VariableInitializer__1 p _) = p
 data VariableInitializerList = Anti_VariableInitializerList String |
                                Ctr__VariableInitializerList__0 RtkPos |
-                               Ctr__VariableInitializerList__1 RtkPos Rule_45
+                               Ctr__VariableInitializerList__1 RtkPos Rule_49
                                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf VariableInitializerList where
     rtkPosOf (Anti_VariableInitializerList _) = rtkNoPos

--- a/test/golden/java/JavaQQ.hs
+++ b/test/golden/java/JavaQQ.hs
@@ -63,7 +63,7 @@ rtkRenderError err =
                 _ -> err
         _ -> err
 
-qqShortcuts = M.fromList [ ("java","Java"),("additiveOp","AdditiveOp"),("annotation","Annotation"),("annotationArguments","AnnotationArguments"),("annotationDeclaration","AnnotationDeclaration"),("annotationElement","AnnotationElement"),("annotationList","AnnotationList"),("annotationTypeElement","AnnotationTypeElement"),("annotationTypeElementList","AnnotationTypeElementList"),("arglist","Arglist"),("assignmentOp","AssignmentOp"),("catchList","CatchList"),("classDeclaration","ClassDeclaration"),("compilationUnit","CompilationUnit"),("compoundName","CompoundName"),("creationExpression","CreationExpression"),("dimExprs","DimExprs"),("dims","Dims"),("doStatement","DoStatement"),("docComment","DocComment"),("enumConstant","EnumConstant"),("enumConstantList","EnumConstantList"),("enumDeclaration","EnumDeclaration"),("equalityOp","EqualityOp"),("expression","Expression"),("extendsList","ExtendsList"),("fieldDeclaration","FieldDeclaration"),("fieldDeclarationList","FieldDeclarationList"),("forStatement","ForStatement"),("ifStatement","IfStatement"),("implementsList","ImplementsList"),("importList","ImportList"),("importStatement","ImportStatement"),("interfaceDeclaration","InterfaceDeclaration"),("literal","Literal"),("memberAfterFirstId","MemberAfterFirstId"),("memberDeclaration","MemberDeclaration"),("memberRest","MemberRest"),("modifier","Modifier"),("modifierList","ModifierList"),("moreTypeSpecifier","MoreTypeSpecifier"),("moreVariableDeclarators","MoreVariableDeclarators"),("multiplicativeOp","MultiplicativeOp"),("nonEmptyDims","NonEmptyDims"),("nonEmptyTypeArguments","NonEmptyTypeArguments"),("optDocComment","OptDocComment"),("optElsePart","OptElsePart"),("optExpression","OptExpression"),("optFinally","OptFinally"),("optId","OptId"),("optVariableInitializer","OptVariableInitializer"),("package","Package"),("parameter","Parameter"),("parameterList","ParameterList"),("postfixOp","PostfixOp"),("prefixOp","PrefixOp"),("primitiveTypeKeyword","PrimitiveTypeKeyword"),("relationalOp","RelationalOp"),("shiftOp","ShiftOp"),("statement","Statement"),("statementBlock","StatementBlock"),("statementList","StatementList"),("staticInitializer","StaticInitializer"),("switchCaseList","SwitchCaseList"),("switchStatement","SwitchStatement"),("tryStatement","TryStatement"),("type","Type"),("typeArgument","TypeArgument"),("typeArguments","TypeArguments"),("typeDeclRest","TypeDeclRest"),("typeDeclaration","TypeDeclaration"),("typeParameter","TypeParameter"),("typeParameters","TypeParameters"),("typeSpecifier","TypeSpecifier"),("variableDeclaration","VariableDeclaration"),("variableDeclarator","VariableDeclarator"),("variableDeclaratorList","VariableDeclaratorList"),("variableInitializer","VariableInitializer"),("variableInitializerList","VariableInitializerList"),("whileStatement","WhileStatement"),("wildcardType","WildcardType")]
+qqShortcuts = M.fromList [ ("java","Java"),("additiveOp","AdditiveOp"),("annotation","Annotation"),("annotationArguments","AnnotationArguments"),("annotationDeclaration","AnnotationDeclaration"),("annotationElement","AnnotationElement"),("annotationList","AnnotationList"),("annotationTypeElement","AnnotationTypeElement"),("annotationTypeElementList","AnnotationTypeElementList"),("arglist","Arglist"),("assignmentOp","AssignmentOp"),("catchList","CatchList"),("classDeclaration","ClassDeclaration"),("compilationUnit","CompilationUnit"),("compoundName","CompoundName"),("creationExpression","CreationExpression"),("dimExprs","DimExprs"),("dims","Dims"),("doStatement","DoStatement"),("docComment","DocComment"),("enumConstant","EnumConstant"),("enumConstantList","EnumConstantList"),("enumDeclaration","EnumDeclaration"),("equalityOp","EqualityOp"),("expression","Expression"),("extendsList","ExtendsList"),("fieldDeclaration","FieldDeclaration"),("fieldDeclarationList","FieldDeclarationList"),("forStatement","ForStatement"),("ifStatement","IfStatement"),("implementsList","ImplementsList"),("importHead","ImportHead"),("importList","ImportList"),("importName","ImportName"),("importStatement","ImportStatement"),("interfaceDeclaration","InterfaceDeclaration"),("literal","Literal"),("memberAfterFirstId","MemberAfterFirstId"),("memberDeclaration","MemberDeclaration"),("memberRest","MemberRest"),("modifier","Modifier"),("modifierList","ModifierList"),("moreTypeSpecifier","MoreTypeSpecifier"),("moreVariableDeclarators","MoreVariableDeclarators"),("multiplicativeOp","MultiplicativeOp"),("nonEmptyDims","NonEmptyDims"),("nonEmptyTypeArguments","NonEmptyTypeArguments"),("optDocComment","OptDocComment"),("optElsePart","OptElsePart"),("optExpression","OptExpression"),("optFinally","OptFinally"),("optId","OptId"),("optVariableInitializer","OptVariableInitializer"),("package","Package"),("parameter","Parameter"),("parameterList","ParameterList"),("postfixOp","PostfixOp"),("prefixOp","PrefixOp"),("primitiveTypeKeyword","PrimitiveTypeKeyword"),("relationalOp","RelationalOp"),("shiftOp","ShiftOp"),("statement","Statement"),("statementBlock","StatementBlock"),("statementList","StatementList"),("staticInitializer","StaticInitializer"),("switchCaseList","SwitchCaseList"),("switchStatement","SwitchStatement"),("throwsClause","ThrowsClause"),("tryStatement","TryStatement"),("type","Type"),("typeArgument","TypeArgument"),("typeArguments","TypeArguments"),("typeDeclRest","TypeDeclRest"),("typeDeclaration","TypeDeclaration"),("typeParameter","TypeParameter"),("typeParameters","TypeParameters"),("typeSpecifier","TypeSpecifier"),("variableDeclaration","VariableDeclaration"),("variableDeclarator","VariableDeclarator"),("variableDeclaratorList","VariableDeclaratorList"),("variableInitializer","VariableInitializer"),("variableInitializerList","VariableInitializerList"),("whileStatement","WhileStatement"),("wildcardType","WildcardType")]
 
 -- A quasi-quote pattern must match an AST parsed from anywhere in a source
 -- file, while the pattern itself was parsed from the quote body - so every
@@ -80,7 +80,7 @@ quoteJavaExp dummy func s = do
            Left err -> fail (rtkRenderError err)
            Right a -> return a
   let expr = func ast
-  dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_40Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_54Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_67Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) expr
+  dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_58Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_61Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_71Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) expr
 quoteJavaPat :: Data.Data a => String -> (Java -> a) -> String -> TH.PatQ
 quoteJavaPat dummy func s = do
   s1 <- either fail return (replaceAllPatterns s)
@@ -88,7 +88,7 @@ quoteJavaPat dummy func s = do
            Left err -> fail (rtkRenderError err)
            Right a -> return a
   let expr = func ast
-  dataToPatQ (const Nothing `Generics.extQ` rtkPosWildPat `Generics.extQ` antiJavaPat `Generics.extQ` antiOptDocCommentPat `Generics.extQ` antiTypeDeclarationPat `Generics.extQ` antiImportStatementPat `Generics.extQ` antiCompilationUnitPat `Generics.extQ` antiPackagePat `Generics.extQ` antiDocCommentPat `Generics.extQ` antiAnnotationPat `Generics.extQ` antiAnnotationArgumentsPat `Generics.extQ` antiAnnotationElementPat `Generics.extQ` antiRule_10Pat `Generics.extQ` antiExtendsListPat `Generics.extQ` antiImplementsListPat `Generics.extQ` antiFieldDeclarationPat `Generics.extQ` antiClassDeclarationPat `Generics.extQ` antiInterfaceDeclarationPat `Generics.extQ` antiAnnotationDeclarationPat `Generics.extQ` antiAnnotationTypeElementPat `Generics.extQ` antiEnumConstantPat `Generics.extQ` antiEnumConstantListPat `Generics.extQ` antiEnumDeclarationPat `Generics.extQ` antiTypeDeclRestPat `Generics.extQ` antiRule_31Pat `Generics.extQ` antiRule_33Pat `Generics.extQ` antiMemberDeclarationPat `Generics.extQ` antiPrimitiveTypeKeywordPat `Generics.extQ` antiMemberAfterFirstIdPat `Generics.extQ` antiMoreTypeSpecifierPat `Generics.extQ` antiMemberRestPat `Generics.extQ` antiRule_40Pat `Generics.extQ` antiStatementBlockPat `Generics.extQ` antiVariableDeclaratorListPat `Generics.extQ` antiVariableDeclarationPat `Generics.extQ` antiOptVariableInitializerPat `Generics.extQ` antiVariableDeclaratorPat `Generics.extQ` antiVariableInitializerListPat `Generics.extQ` antiVariableInitializerPat `Generics.extQ` antiStaticInitializerPat `Generics.extQ` antiParameterListPat `Generics.extQ` antiParameterPat `Generics.extQ` antiStatementPat `Generics.extQ` antiOptExpressionPat `Generics.extQ` antiOptIdPat `Generics.extQ` antiOptElsePartPat `Generics.extQ` antiIfStatementPat `Generics.extQ` antiDoStatementPat `Generics.extQ` antiWhileStatementPat `Generics.extQ` antiForStatementPat `Generics.extQ` antiRule_54Pat `Generics.extQ` antiOptFinallyPat `Generics.extQ` antiTryStatementPat `Generics.extQ` antiRule_57Pat `Generics.extQ` antiSwitchStatementPat `Generics.extQ` antiExpressionPat `Generics.extQ` antiAssignmentOpPat `Generics.extQ` antiEqualityOpPat `Generics.extQ` antiRelationalOpPat `Generics.extQ` antiShiftOpPat `Generics.extQ` antiAdditiveOpPat `Generics.extQ` antiMultiplicativeOpPat `Generics.extQ` antiPrefixOpPat `Generics.extQ` antiPostfixOpPat `Generics.extQ` antiCreationExpressionPat `Generics.extQ` antiRule_67Pat `Generics.extQ` antiLiteralPat `Generics.extQ` antiArglistPat `Generics.extQ` antiTypeArgumentsPat `Generics.extQ` antiNonEmptyTypeArgumentsPat `Generics.extQ` antiTypeArgumentPat `Generics.extQ` antiWildcardTypePat `Generics.extQ` antiTypeParametersPat `Generics.extQ` antiTypeParameterPat `Generics.extQ` antiTypePat `Generics.extQ` antiTypeSpecifierPat `Generics.extQ` antiModifierPat `Generics.extQ` antiCompoundNamePat) expr
+  dataToPatQ (const Nothing `Generics.extQ` rtkPosWildPat `Generics.extQ` antiJavaPat `Generics.extQ` antiOptDocCommentPat `Generics.extQ` antiTypeDeclarationPat `Generics.extQ` antiImportStatementPat `Generics.extQ` antiCompilationUnitPat `Generics.extQ` antiPackagePat `Generics.extQ` antiImportNamePat `Generics.extQ` antiImportHeadPat `Generics.extQ` antiDocCommentPat `Generics.extQ` antiAnnotationPat `Generics.extQ` antiAnnotationArgumentsPat `Generics.extQ` antiAnnotationElementPat `Generics.extQ` antiRule_10Pat `Generics.extQ` antiExtendsListPat `Generics.extQ` antiImplementsListPat `Generics.extQ` antiFieldDeclarationPat `Generics.extQ` antiClassDeclarationPat `Generics.extQ` antiInterfaceDeclarationPat `Generics.extQ` antiAnnotationDeclarationPat `Generics.extQ` antiAnnotationTypeElementPat `Generics.extQ` antiEnumConstantPat `Generics.extQ` antiEnumConstantListPat `Generics.extQ` antiEnumDeclarationPat `Generics.extQ` antiTypeDeclRestPat `Generics.extQ` antiRule_31Pat `Generics.extQ` antiRule_33Pat `Generics.extQ` antiMemberDeclarationPat `Generics.extQ` antiPrimitiveTypeKeywordPat `Generics.extQ` antiMemberAfterFirstIdPat `Generics.extQ` antiMoreTypeSpecifierPat `Generics.extQ` antiThrowsClausePat `Generics.extQ` antiMemberRestPat `Generics.extQ` antiRule_44Pat `Generics.extQ` antiStatementBlockPat `Generics.extQ` antiVariableDeclaratorListPat `Generics.extQ` antiVariableDeclarationPat `Generics.extQ` antiOptVariableInitializerPat `Generics.extQ` antiVariableDeclaratorPat `Generics.extQ` antiVariableInitializerListPat `Generics.extQ` antiVariableInitializerPat `Generics.extQ` antiStaticInitializerPat `Generics.extQ` antiParameterListPat `Generics.extQ` antiParameterPat `Generics.extQ` antiStatementPat `Generics.extQ` antiOptExpressionPat `Generics.extQ` antiOptIdPat `Generics.extQ` antiOptElsePartPat `Generics.extQ` antiIfStatementPat `Generics.extQ` antiDoStatementPat `Generics.extQ` antiWhileStatementPat `Generics.extQ` antiForStatementPat `Generics.extQ` antiRule_58Pat `Generics.extQ` antiOptFinallyPat `Generics.extQ` antiTryStatementPat `Generics.extQ` antiRule_61Pat `Generics.extQ` antiSwitchStatementPat `Generics.extQ` antiExpressionPat `Generics.extQ` antiAssignmentOpPat `Generics.extQ` antiEqualityOpPat `Generics.extQ` antiRelationalOpPat `Generics.extQ` antiShiftOpPat `Generics.extQ` antiAdditiveOpPat `Generics.extQ` antiMultiplicativeOpPat `Generics.extQ` antiPrefixOpPat `Generics.extQ` antiPostfixOpPat `Generics.extQ` antiCreationExpressionPat `Generics.extQ` antiRule_71Pat `Generics.extQ` antiLiteralPat `Generics.extQ` antiArglistPat `Generics.extQ` antiTypeArgumentsPat `Generics.extQ` antiNonEmptyTypeArgumentsPat `Generics.extQ` antiTypeArgumentPat `Generics.extQ` antiWildcardTypePat `Generics.extQ` antiTypeParametersPat `Generics.extQ` antiTypeParameterPat `Generics.extQ` antiTypePat `Generics.extQ` antiTypeSpecifierPat `Generics.extQ` antiModifierPat `Generics.extQ` antiCompoundNamePat) expr
 
 antiCompoundNameExp :: CompoundName -> Maybe (TH.Q TH.Exp )
 antiCompoundNameExp ( Anti_CompoundName v) = Just $ TH.varE (TH.mkName v)
@@ -150,12 +150,12 @@ antiLiteralExp ( Anti_Literal v) = Just $ TH.varE (TH.mkName v)
 antiLiteralExp _ = Nothing
 
 
-antiRule_67Exp :: [ Rule_67 ] -> Maybe (TH.Q TH.Exp)
-antiRule_67Exp ((Anti_Rule_67 v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_40Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_54Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_67Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
+antiRule_71Exp :: [ Rule_71 ] -> Maybe (TH.Q TH.Exp)
+antiRule_71Exp ((Anti_Rule_71 v):rest) =
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_58Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_61Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_71Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
-antiRule_67Exp _ = Nothing
+antiRule_71Exp _ = Nothing
 
 
 antiCreationExpressionExp :: CreationExpression -> Maybe (TH.Q TH.Exp )
@@ -213,12 +213,12 @@ antiSwitchStatementExp ( Anti_SwitchStatement v) = Just $ TH.varE (TH.mkName v)
 antiSwitchStatementExp _ = Nothing
 
 
-antiRule_57Exp :: [ Rule_57 ] -> Maybe (TH.Q TH.Exp)
-antiRule_57Exp ((Anti_Rule_57 v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_40Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_54Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_67Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
+antiRule_61Exp :: [ Rule_61 ] -> Maybe (TH.Q TH.Exp)
+antiRule_61Exp ((Anti_Rule_61 v):rest) =
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_58Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_61Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_71Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
-antiRule_57Exp _ = Nothing
+antiRule_61Exp _ = Nothing
 
 
 antiTryStatementExp :: TryStatement -> Maybe (TH.Q TH.Exp )
@@ -231,12 +231,12 @@ antiOptFinallyExp ( Anti_OptFinally v) = Just $ TH.varE (TH.mkName v)
 antiOptFinallyExp _ = Nothing
 
 
-antiRule_54Exp :: [ Rule_54 ] -> Maybe (TH.Q TH.Exp)
-antiRule_54Exp ((Anti_Rule_54 v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_40Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_54Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_67Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
+antiRule_58Exp :: [ Rule_58 ] -> Maybe (TH.Q TH.Exp)
+antiRule_58Exp ((Anti_Rule_58 v):rest) =
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_58Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_61Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_71Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
-antiRule_54Exp _ = Nothing
+antiRule_58Exp _ = Nothing
 
 
 antiForStatementExp :: ForStatement -> Maybe (TH.Q TH.Exp )
@@ -276,7 +276,7 @@ antiOptExpressionExp _ = Nothing
 
 antiStatementExp :: [ Statement ] -> Maybe (TH.Q TH.Exp)
 antiStatementExp ((Anti_Statement v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_40Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_54Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_67Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_58Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_61Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_71Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
 antiStatementExp _ = Nothing
@@ -332,17 +332,22 @@ antiStatementBlockExp ( Anti_StatementBlock v) = Just $ TH.varE (TH.mkName v)
 antiStatementBlockExp _ = Nothing
 
 
-antiRule_40Exp :: [ Rule_40 ] -> Maybe (TH.Q TH.Exp)
-antiRule_40Exp ((Anti_Rule_40 v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_40Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_54Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_67Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
+antiRule_44Exp :: [ Rule_44 ] -> Maybe (TH.Q TH.Exp)
+antiRule_44Exp ((Anti_Rule_44 v):rest) =
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_58Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_61Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_71Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
-antiRule_40Exp _ = Nothing
+antiRule_44Exp _ = Nothing
 
 
 antiMemberRestExp :: MemberRest -> Maybe (TH.Q TH.Exp )
 antiMemberRestExp ( Anti_MemberRest v) = Just $ TH.varE (TH.mkName v)
 antiMemberRestExp _ = Nothing
+
+
+antiThrowsClauseExp :: ThrowsClause -> Maybe (TH.Q TH.Exp )
+antiThrowsClauseExp ( Anti_ThrowsClause v) = Just $ TH.varE (TH.mkName v)
+antiThrowsClauseExp _ = Nothing
 
 
 antiMoreTypeSpecifierExp :: MoreTypeSpecifier -> Maybe (TH.Q TH.Exp )
@@ -367,7 +372,7 @@ antiMemberDeclarationExp _ = Nothing
 
 antiRule_33Exp :: [ Rule_33 ] -> Maybe (TH.Q TH.Exp)
 antiRule_33Exp ((Anti_Rule_33 v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_40Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_54Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_67Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_58Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_61Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_71Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
 antiRule_33Exp _ = Nothing
@@ -375,7 +380,7 @@ antiRule_33Exp _ = Nothing
 
 antiRule_31Exp :: [ Rule_31 ] -> Maybe (TH.Q TH.Exp)
 antiRule_31Exp ((Anti_Rule_31 v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_40Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_54Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_67Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_58Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_61Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_71Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
 antiRule_31Exp _ = Nothing
@@ -403,7 +408,7 @@ antiEnumConstantExp _ = Nothing
 
 antiAnnotationTypeElementExp :: [ AnnotationTypeElement ] -> Maybe (TH.Q TH.Exp)
 antiAnnotationTypeElementExp ((Anti_AnnotationTypeElement v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_40Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_54Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_67Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_58Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_61Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_71Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
 antiAnnotationTypeElementExp _ = Nothing
@@ -426,7 +431,7 @@ antiClassDeclarationExp _ = Nothing
 
 antiFieldDeclarationExp :: [ FieldDeclaration ] -> Maybe (TH.Q TH.Exp)
 antiFieldDeclarationExp ((Anti_FieldDeclaration v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_40Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_54Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_67Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_58Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_61Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_71Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
 antiFieldDeclarationExp _ = Nothing
@@ -444,7 +449,7 @@ antiExtendsListExp _ = Nothing
 
 antiRule_10Exp :: [ Rule_10 ] -> Maybe (TH.Q TH.Exp)
 antiRule_10Exp ((Anti_Rule_10 v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_40Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_54Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_67Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_58Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_61Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_71Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
 antiRule_10Exp _ = Nothing
@@ -470,6 +475,16 @@ antiDocCommentExp ( Anti_DocComment v) = Just $ TH.varE (TH.mkName v)
 antiDocCommentExp _ = Nothing
 
 
+antiImportHeadExp :: ImportHead -> Maybe (TH.Q TH.Exp )
+antiImportHeadExp ( Anti_ImportHead v) = Just $ TH.varE (TH.mkName v)
+antiImportHeadExp _ = Nothing
+
+
+antiImportNameExp :: ImportName -> Maybe (TH.Q TH.Exp )
+antiImportNameExp ( Anti_ImportName v) = Just $ TH.varE (TH.mkName v)
+antiImportNameExp _ = Nothing
+
+
 antiPackageExp :: Package -> Maybe (TH.Q TH.Exp )
 antiPackageExp ( Anti_Package v) = Just $ TH.varE (TH.mkName v)
 antiPackageExp _ = Nothing
@@ -482,7 +497,7 @@ antiCompilationUnitExp _ = Nothing
 
 antiImportStatementExp :: [ ImportStatement ] -> Maybe (TH.Q TH.Exp)
 antiImportStatementExp ((Anti_ImportStatement v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_40Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_54Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_67Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_58Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_61Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_71Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
 antiImportStatementExp _ = Nothing
@@ -564,9 +579,9 @@ antiLiteralPat ( Anti_Literal v) = Just $ TH.varP (TH.mkName v)
 antiLiteralPat _ = Nothing
 
 
-antiRule_67Pat :: [ Rule_67 ] -> Maybe (TH.Q TH.Pat)
-antiRule_67Pat [Anti_Rule_67 v] = Just $ TH.varP (TH.mkName v)
-antiRule_67Pat _ = Nothing
+antiRule_71Pat :: [ Rule_71 ] -> Maybe (TH.Q TH.Pat)
+antiRule_71Pat [Anti_Rule_71 v] = Just $ TH.varP (TH.mkName v)
+antiRule_71Pat _ = Nothing
 
 
 antiCreationExpressionPat :: CreationExpression -> Maybe (TH.Q TH.Pat )
@@ -624,9 +639,9 @@ antiSwitchStatementPat ( Anti_SwitchStatement v) = Just $ TH.varP (TH.mkName v)
 antiSwitchStatementPat _ = Nothing
 
 
-antiRule_57Pat :: [ Rule_57 ] -> Maybe (TH.Q TH.Pat)
-antiRule_57Pat [Anti_Rule_57 v] = Just $ TH.varP (TH.mkName v)
-antiRule_57Pat _ = Nothing
+antiRule_61Pat :: [ Rule_61 ] -> Maybe (TH.Q TH.Pat)
+antiRule_61Pat [Anti_Rule_61 v] = Just $ TH.varP (TH.mkName v)
+antiRule_61Pat _ = Nothing
 
 
 antiTryStatementPat :: TryStatement -> Maybe (TH.Q TH.Pat )
@@ -639,9 +654,9 @@ antiOptFinallyPat ( Anti_OptFinally v) = Just $ TH.varP (TH.mkName v)
 antiOptFinallyPat _ = Nothing
 
 
-antiRule_54Pat :: [ Rule_54 ] -> Maybe (TH.Q TH.Pat)
-antiRule_54Pat [Anti_Rule_54 v] = Just $ TH.varP (TH.mkName v)
-antiRule_54Pat _ = Nothing
+antiRule_58Pat :: [ Rule_58 ] -> Maybe (TH.Q TH.Pat)
+antiRule_58Pat [Anti_Rule_58 v] = Just $ TH.varP (TH.mkName v)
+antiRule_58Pat _ = Nothing
 
 
 antiForStatementPat :: ForStatement -> Maybe (TH.Q TH.Pat )
@@ -734,14 +749,19 @@ antiStatementBlockPat ( Anti_StatementBlock v) = Just $ TH.varP (TH.mkName v)
 antiStatementBlockPat _ = Nothing
 
 
-antiRule_40Pat :: [ Rule_40 ] -> Maybe (TH.Q TH.Pat)
-antiRule_40Pat [Anti_Rule_40 v] = Just $ TH.varP (TH.mkName v)
-antiRule_40Pat _ = Nothing
+antiRule_44Pat :: [ Rule_44 ] -> Maybe (TH.Q TH.Pat)
+antiRule_44Pat [Anti_Rule_44 v] = Just $ TH.varP (TH.mkName v)
+antiRule_44Pat _ = Nothing
 
 
 antiMemberRestPat :: MemberRest -> Maybe (TH.Q TH.Pat )
 antiMemberRestPat ( Anti_MemberRest v) = Just $ TH.varP (TH.mkName v)
 antiMemberRestPat _ = Nothing
+
+
+antiThrowsClausePat :: ThrowsClause -> Maybe (TH.Q TH.Pat )
+antiThrowsClausePat ( Anti_ThrowsClause v) = Just $ TH.varP (TH.mkName v)
+antiThrowsClausePat _ = Nothing
 
 
 antiMoreTypeSpecifierPat :: MoreTypeSpecifier -> Maybe (TH.Q TH.Pat )
@@ -854,6 +874,16 @@ antiDocCommentPat ( Anti_DocComment v) = Just $ TH.varP (TH.mkName v)
 antiDocCommentPat _ = Nothing
 
 
+antiImportHeadPat :: ImportHead -> Maybe (TH.Q TH.Pat )
+antiImportHeadPat ( Anti_ImportHead v) = Just $ TH.varP (TH.mkName v)
+antiImportHeadPat _ = Nothing
+
+
+antiImportNamePat :: ImportName -> Maybe (TH.Q TH.Pat )
+antiImportNamePat ( Anti_ImportName v) = Just $ TH.varP (TH.mkName v)
+antiImportNamePat _ = Nothing
+
+
 antiPackagePat :: Package -> Maybe (TH.Q TH.Pat )
 antiPackagePat ( Anti_Package v) = Just $ TH.varP (TH.mkName v)
 antiPackagePat _ = Nothing
@@ -891,405 +921,420 @@ quoteJavaDecs s = return []
 getJava ( Ctr__Java__0 _ s) = s
 
 java :: QuasiQuoter
-java = QuasiQuoter (quoteJavaExp "tok_Java_dummy_163" getJava ) (quoteJavaPat "tok_Java_dummy_163" getJava ) quoteJavaType quoteJavaDecs
+java = QuasiQuoter (quoteJavaExp "tok_Java_dummy_170" getJava ) (quoteJavaPat "tok_Java_dummy_170" getJava ) quoteJavaType quoteJavaDecs
 
 getAdditiveOp ( Ctr__Java__1 _ s) = s
 
 additiveOp :: QuasiQuoter
-additiveOp = QuasiQuoter (quoteJavaExp "tok_AdditiveOp_dummy_162" getAdditiveOp ) (quoteJavaPat "tok_AdditiveOp_dummy_162" getAdditiveOp ) quoteJavaType quoteJavaDecs
+additiveOp = QuasiQuoter (quoteJavaExp "tok_AdditiveOp_dummy_169" getAdditiveOp ) (quoteJavaPat "tok_AdditiveOp_dummy_169" getAdditiveOp ) quoteJavaType quoteJavaDecs
 
 getAnnotation ( Ctr__Java__2 _ s) = s
 
 annotation :: QuasiQuoter
-annotation = QuasiQuoter (quoteJavaExp "tok_Annotation_dummy_161" getAnnotation ) (quoteJavaPat "tok_Annotation_dummy_161" getAnnotation ) quoteJavaType quoteJavaDecs
+annotation = QuasiQuoter (quoteJavaExp "tok_Annotation_dummy_168" getAnnotation ) (quoteJavaPat "tok_Annotation_dummy_168" getAnnotation ) quoteJavaType quoteJavaDecs
 
 getAnnotationArguments ( Ctr__Java__3 _ s) = s
 
 annotationArguments :: QuasiQuoter
-annotationArguments = QuasiQuoter (quoteJavaExp "tok_AnnotationArguments_dummy_160" getAnnotationArguments ) (quoteJavaPat "tok_AnnotationArguments_dummy_160" getAnnotationArguments ) quoteJavaType quoteJavaDecs
+annotationArguments = QuasiQuoter (quoteJavaExp "tok_AnnotationArguments_dummy_167" getAnnotationArguments ) (quoteJavaPat "tok_AnnotationArguments_dummy_167" getAnnotationArguments ) quoteJavaType quoteJavaDecs
 
 getAnnotationDeclaration ( Ctr__Java__4 _ s) = s
 
 annotationDeclaration :: QuasiQuoter
-annotationDeclaration = QuasiQuoter (quoteJavaExp "tok_AnnotationDeclaration_dummy_159" getAnnotationDeclaration ) (quoteJavaPat "tok_AnnotationDeclaration_dummy_159" getAnnotationDeclaration ) quoteJavaType quoteJavaDecs
+annotationDeclaration = QuasiQuoter (quoteJavaExp "tok_AnnotationDeclaration_dummy_166" getAnnotationDeclaration ) (quoteJavaPat "tok_AnnotationDeclaration_dummy_166" getAnnotationDeclaration ) quoteJavaType quoteJavaDecs
 
 getAnnotationElement ( Ctr__Java__5 _ s) = s
 
 annotationElement :: QuasiQuoter
-annotationElement = QuasiQuoter (quoteJavaExp "tok_AnnotationElement_dummy_158" getAnnotationElement ) (quoteJavaPat "tok_AnnotationElement_dummy_158" getAnnotationElement ) quoteJavaType quoteJavaDecs
+annotationElement = QuasiQuoter (quoteJavaExp "tok_AnnotationElement_dummy_165" getAnnotationElement ) (quoteJavaPat "tok_AnnotationElement_dummy_165" getAnnotationElement ) quoteJavaType quoteJavaDecs
 
 getAnnotationList ( Ctr__Java__6 _ s) = s
 
 annotationList :: QuasiQuoter
-annotationList = QuasiQuoter (quoteJavaExp "tok_AnnotationList_dummy_157" getAnnotationList ) (quoteJavaPat "tok_AnnotationList_dummy_157" getAnnotationList ) quoteJavaType quoteJavaDecs
+annotationList = QuasiQuoter (quoteJavaExp "tok_AnnotationList_dummy_164" getAnnotationList ) (quoteJavaPat "tok_AnnotationList_dummy_164" getAnnotationList ) quoteJavaType quoteJavaDecs
 
 getAnnotationTypeElement ( Ctr__Java__7 _ s) = s
 
 annotationTypeElement :: QuasiQuoter
-annotationTypeElement = QuasiQuoter (quoteJavaExp "tok_AnnotationTypeElement_dummy_156" getAnnotationTypeElement ) (quoteJavaPat "tok_AnnotationTypeElement_dummy_156" getAnnotationTypeElement ) quoteJavaType quoteJavaDecs
+annotationTypeElement = QuasiQuoter (quoteJavaExp "tok_AnnotationTypeElement_dummy_163" getAnnotationTypeElement ) (quoteJavaPat "tok_AnnotationTypeElement_dummy_163" getAnnotationTypeElement ) quoteJavaType quoteJavaDecs
 
 getAnnotationTypeElementList ( Ctr__Java__8 _ s) = s
 
 annotationTypeElementList :: QuasiQuoter
-annotationTypeElementList = QuasiQuoter (quoteJavaExp "tok_AnnotationTypeElementList_dummy_155" getAnnotationTypeElementList ) (quoteJavaPat "tok_AnnotationTypeElementList_dummy_155" getAnnotationTypeElementList ) quoteJavaType quoteJavaDecs
+annotationTypeElementList = QuasiQuoter (quoteJavaExp "tok_AnnotationTypeElementList_dummy_162" getAnnotationTypeElementList ) (quoteJavaPat "tok_AnnotationTypeElementList_dummy_162" getAnnotationTypeElementList ) quoteJavaType quoteJavaDecs
 
 getArglist ( Ctr__Java__9 _ s) = s
 
 arglist :: QuasiQuoter
-arglist = QuasiQuoter (quoteJavaExp "tok_Arglist_dummy_154" getArglist ) (quoteJavaPat "tok_Arglist_dummy_154" getArglist ) quoteJavaType quoteJavaDecs
+arglist = QuasiQuoter (quoteJavaExp "tok_Arglist_dummy_161" getArglist ) (quoteJavaPat "tok_Arglist_dummy_161" getArglist ) quoteJavaType quoteJavaDecs
 
 getAssignmentOp ( Ctr__Java__10 _ s) = s
 
 assignmentOp :: QuasiQuoter
-assignmentOp = QuasiQuoter (quoteJavaExp "tok_AssignmentOp_dummy_153" getAssignmentOp ) (quoteJavaPat "tok_AssignmentOp_dummy_153" getAssignmentOp ) quoteJavaType quoteJavaDecs
+assignmentOp = QuasiQuoter (quoteJavaExp "tok_AssignmentOp_dummy_160" getAssignmentOp ) (quoteJavaPat "tok_AssignmentOp_dummy_160" getAssignmentOp ) quoteJavaType quoteJavaDecs
 
 getCatchList ( Ctr__Java__11 _ s) = s
 
 catchList :: QuasiQuoter
-catchList = QuasiQuoter (quoteJavaExp "tok_CatchList_dummy_152" getCatchList ) (quoteJavaPat "tok_CatchList_dummy_152" getCatchList ) quoteJavaType quoteJavaDecs
+catchList = QuasiQuoter (quoteJavaExp "tok_CatchList_dummy_159" getCatchList ) (quoteJavaPat "tok_CatchList_dummy_159" getCatchList ) quoteJavaType quoteJavaDecs
 
 getClassDeclaration ( Ctr__Java__12 _ s) = s
 
 classDeclaration :: QuasiQuoter
-classDeclaration = QuasiQuoter (quoteJavaExp "tok_ClassDeclaration_dummy_151" getClassDeclaration ) (quoteJavaPat "tok_ClassDeclaration_dummy_151" getClassDeclaration ) quoteJavaType quoteJavaDecs
+classDeclaration = QuasiQuoter (quoteJavaExp "tok_ClassDeclaration_dummy_158" getClassDeclaration ) (quoteJavaPat "tok_ClassDeclaration_dummy_158" getClassDeclaration ) quoteJavaType quoteJavaDecs
 
 getCompilationUnit ( Ctr__Java__13 _ s) = s
 
 compilationUnit :: QuasiQuoter
-compilationUnit = QuasiQuoter (quoteJavaExp "tok_CompilationUnit_dummy_150" getCompilationUnit ) (quoteJavaPat "tok_CompilationUnit_dummy_150" getCompilationUnit ) quoteJavaType quoteJavaDecs
+compilationUnit = QuasiQuoter (quoteJavaExp "tok_CompilationUnit_dummy_157" getCompilationUnit ) (quoteJavaPat "tok_CompilationUnit_dummy_157" getCompilationUnit ) quoteJavaType quoteJavaDecs
 
 getCompoundName ( Ctr__Java__14 _ s) = s
 
 compoundName :: QuasiQuoter
-compoundName = QuasiQuoter (quoteJavaExp "tok_CompoundName_dummy_149" getCompoundName ) (quoteJavaPat "tok_CompoundName_dummy_149" getCompoundName ) quoteJavaType quoteJavaDecs
+compoundName = QuasiQuoter (quoteJavaExp "tok_CompoundName_dummy_156" getCompoundName ) (quoteJavaPat "tok_CompoundName_dummy_156" getCompoundName ) quoteJavaType quoteJavaDecs
 
 getCreationExpression ( Ctr__Java__15 _ s) = s
 
 creationExpression :: QuasiQuoter
-creationExpression = QuasiQuoter (quoteJavaExp "tok_CreationExpression_dummy_148" getCreationExpression ) (quoteJavaPat "tok_CreationExpression_dummy_148" getCreationExpression ) quoteJavaType quoteJavaDecs
+creationExpression = QuasiQuoter (quoteJavaExp "tok_CreationExpression_dummy_155" getCreationExpression ) (quoteJavaPat "tok_CreationExpression_dummy_155" getCreationExpression ) quoteJavaType quoteJavaDecs
 
 getDimExprs ( Ctr__Java__16 _ s) = s
 
 dimExprs :: QuasiQuoter
-dimExprs = QuasiQuoter (quoteJavaExp "tok_DimExprs_dummy_147" getDimExprs ) (quoteJavaPat "tok_DimExprs_dummy_147" getDimExprs ) quoteJavaType quoteJavaDecs
+dimExprs = QuasiQuoter (quoteJavaExp "tok_DimExprs_dummy_154" getDimExprs ) (quoteJavaPat "tok_DimExprs_dummy_154" getDimExprs ) quoteJavaType quoteJavaDecs
 
 getDims ( Ctr__Java__17 _ s) = s
 
 dims :: QuasiQuoter
-dims = QuasiQuoter (quoteJavaExp "tok_Dims_dummy_146" getDims ) (quoteJavaPat "tok_Dims_dummy_146" getDims ) quoteJavaType quoteJavaDecs
+dims = QuasiQuoter (quoteJavaExp "tok_Dims_dummy_153" getDims ) (quoteJavaPat "tok_Dims_dummy_153" getDims ) quoteJavaType quoteJavaDecs
 
 getDoStatement ( Ctr__Java__18 _ s) = s
 
 doStatement :: QuasiQuoter
-doStatement = QuasiQuoter (quoteJavaExp "tok_DoStatement_dummy_145" getDoStatement ) (quoteJavaPat "tok_DoStatement_dummy_145" getDoStatement ) quoteJavaType quoteJavaDecs
+doStatement = QuasiQuoter (quoteJavaExp "tok_DoStatement_dummy_152" getDoStatement ) (quoteJavaPat "tok_DoStatement_dummy_152" getDoStatement ) quoteJavaType quoteJavaDecs
 
 getDocComment ( Ctr__Java__19 _ s) = s
 
 docComment :: QuasiQuoter
-docComment = QuasiQuoter (quoteJavaExp "tok_DocComment_dummy_144" getDocComment ) (quoteJavaPat "tok_DocComment_dummy_144" getDocComment ) quoteJavaType quoteJavaDecs
+docComment = QuasiQuoter (quoteJavaExp "tok_DocComment_dummy_151" getDocComment ) (quoteJavaPat "tok_DocComment_dummy_151" getDocComment ) quoteJavaType quoteJavaDecs
 
 getEnumConstant ( Ctr__Java__20 _ s) = s
 
 enumConstant :: QuasiQuoter
-enumConstant = QuasiQuoter (quoteJavaExp "tok_EnumConstant_dummy_143" getEnumConstant ) (quoteJavaPat "tok_EnumConstant_dummy_143" getEnumConstant ) quoteJavaType quoteJavaDecs
+enumConstant = QuasiQuoter (quoteJavaExp "tok_EnumConstant_dummy_150" getEnumConstant ) (quoteJavaPat "tok_EnumConstant_dummy_150" getEnumConstant ) quoteJavaType quoteJavaDecs
 
 getEnumConstantList ( Ctr__Java__21 _ s) = s
 
 enumConstantList :: QuasiQuoter
-enumConstantList = QuasiQuoter (quoteJavaExp "tok_EnumConstantList_dummy_142" getEnumConstantList ) (quoteJavaPat "tok_EnumConstantList_dummy_142" getEnumConstantList ) quoteJavaType quoteJavaDecs
+enumConstantList = QuasiQuoter (quoteJavaExp "tok_EnumConstantList_dummy_149" getEnumConstantList ) (quoteJavaPat "tok_EnumConstantList_dummy_149" getEnumConstantList ) quoteJavaType quoteJavaDecs
 
 getEnumDeclaration ( Ctr__Java__22 _ s) = s
 
 enumDeclaration :: QuasiQuoter
-enumDeclaration = QuasiQuoter (quoteJavaExp "tok_EnumDeclaration_dummy_141" getEnumDeclaration ) (quoteJavaPat "tok_EnumDeclaration_dummy_141" getEnumDeclaration ) quoteJavaType quoteJavaDecs
+enumDeclaration = QuasiQuoter (quoteJavaExp "tok_EnumDeclaration_dummy_148" getEnumDeclaration ) (quoteJavaPat "tok_EnumDeclaration_dummy_148" getEnumDeclaration ) quoteJavaType quoteJavaDecs
 
 getEqualityOp ( Ctr__Java__23 _ s) = s
 
 equalityOp :: QuasiQuoter
-equalityOp = QuasiQuoter (quoteJavaExp "tok_EqualityOp_dummy_140" getEqualityOp ) (quoteJavaPat "tok_EqualityOp_dummy_140" getEqualityOp ) quoteJavaType quoteJavaDecs
+equalityOp = QuasiQuoter (quoteJavaExp "tok_EqualityOp_dummy_147" getEqualityOp ) (quoteJavaPat "tok_EqualityOp_dummy_147" getEqualityOp ) quoteJavaType quoteJavaDecs
 
 getExpression ( Ctr__Java__24 _ s) = s
 
 expression :: QuasiQuoter
-expression = QuasiQuoter (quoteJavaExp "tok_Expression_dummy_139" getExpression ) (quoteJavaPat "tok_Expression_dummy_139" getExpression ) quoteJavaType quoteJavaDecs
+expression = QuasiQuoter (quoteJavaExp "tok_Expression_dummy_146" getExpression ) (quoteJavaPat "tok_Expression_dummy_146" getExpression ) quoteJavaType quoteJavaDecs
 
 getExtendsList ( Ctr__Java__25 _ s) = s
 
 extendsList :: QuasiQuoter
-extendsList = QuasiQuoter (quoteJavaExp "tok_ExtendsList_dummy_138" getExtendsList ) (quoteJavaPat "tok_ExtendsList_dummy_138" getExtendsList ) quoteJavaType quoteJavaDecs
+extendsList = QuasiQuoter (quoteJavaExp "tok_ExtendsList_dummy_145" getExtendsList ) (quoteJavaPat "tok_ExtendsList_dummy_145" getExtendsList ) quoteJavaType quoteJavaDecs
 
 getFieldDeclaration ( Ctr__Java__26 _ s) = s
 
 fieldDeclaration :: QuasiQuoter
-fieldDeclaration = QuasiQuoter (quoteJavaExp "tok_FieldDeclaration_dummy_137" getFieldDeclaration ) (quoteJavaPat "tok_FieldDeclaration_dummy_137" getFieldDeclaration ) quoteJavaType quoteJavaDecs
+fieldDeclaration = QuasiQuoter (quoteJavaExp "tok_FieldDeclaration_dummy_144" getFieldDeclaration ) (quoteJavaPat "tok_FieldDeclaration_dummy_144" getFieldDeclaration ) quoteJavaType quoteJavaDecs
 
 getFieldDeclarationList ( Ctr__Java__27 _ s) = s
 
 fieldDeclarationList :: QuasiQuoter
-fieldDeclarationList = QuasiQuoter (quoteJavaExp "tok_FieldDeclarationList_dummy_136" getFieldDeclarationList ) (quoteJavaPat "tok_FieldDeclarationList_dummy_136" getFieldDeclarationList ) quoteJavaType quoteJavaDecs
+fieldDeclarationList = QuasiQuoter (quoteJavaExp "tok_FieldDeclarationList_dummy_143" getFieldDeclarationList ) (quoteJavaPat "tok_FieldDeclarationList_dummy_143" getFieldDeclarationList ) quoteJavaType quoteJavaDecs
 
 getForStatement ( Ctr__Java__28 _ s) = s
 
 forStatement :: QuasiQuoter
-forStatement = QuasiQuoter (quoteJavaExp "tok_ForStatement_dummy_135" getForStatement ) (quoteJavaPat "tok_ForStatement_dummy_135" getForStatement ) quoteJavaType quoteJavaDecs
+forStatement = QuasiQuoter (quoteJavaExp "tok_ForStatement_dummy_142" getForStatement ) (quoteJavaPat "tok_ForStatement_dummy_142" getForStatement ) quoteJavaType quoteJavaDecs
 
 getIfStatement ( Ctr__Java__29 _ s) = s
 
 ifStatement :: QuasiQuoter
-ifStatement = QuasiQuoter (quoteJavaExp "tok_IfStatement_dummy_134" getIfStatement ) (quoteJavaPat "tok_IfStatement_dummy_134" getIfStatement ) quoteJavaType quoteJavaDecs
+ifStatement = QuasiQuoter (quoteJavaExp "tok_IfStatement_dummy_141" getIfStatement ) (quoteJavaPat "tok_IfStatement_dummy_141" getIfStatement ) quoteJavaType quoteJavaDecs
 
 getImplementsList ( Ctr__Java__30 _ s) = s
 
 implementsList :: QuasiQuoter
-implementsList = QuasiQuoter (quoteJavaExp "tok_ImplementsList_dummy_133" getImplementsList ) (quoteJavaPat "tok_ImplementsList_dummy_133" getImplementsList ) quoteJavaType quoteJavaDecs
+implementsList = QuasiQuoter (quoteJavaExp "tok_ImplementsList_dummy_140" getImplementsList ) (quoteJavaPat "tok_ImplementsList_dummy_140" getImplementsList ) quoteJavaType quoteJavaDecs
 
-getImportList ( Ctr__Java__31 _ s) = s
+getImportHead ( Ctr__Java__31 _ s) = s
+
+importHead :: QuasiQuoter
+importHead = QuasiQuoter (quoteJavaExp "tok_ImportHead_dummy_139" getImportHead ) (quoteJavaPat "tok_ImportHead_dummy_139" getImportHead ) quoteJavaType quoteJavaDecs
+
+getImportList ( Ctr__Java__32 _ s) = s
 
 importList :: QuasiQuoter
-importList = QuasiQuoter (quoteJavaExp "tok_ImportList_dummy_132" getImportList ) (quoteJavaPat "tok_ImportList_dummy_132" getImportList ) quoteJavaType quoteJavaDecs
+importList = QuasiQuoter (quoteJavaExp "tok_ImportList_dummy_138" getImportList ) (quoteJavaPat "tok_ImportList_dummy_138" getImportList ) quoteJavaType quoteJavaDecs
 
-getImportStatement ( Ctr__Java__32 _ s) = s
+getImportName ( Ctr__Java__33 _ s) = s
+
+importName :: QuasiQuoter
+importName = QuasiQuoter (quoteJavaExp "tok_ImportName_dummy_137" getImportName ) (quoteJavaPat "tok_ImportName_dummy_137" getImportName ) quoteJavaType quoteJavaDecs
+
+getImportStatement ( Ctr__Java__34 _ s) = s
 
 importStatement :: QuasiQuoter
-importStatement = QuasiQuoter (quoteJavaExp "tok_ImportStatement_dummy_131" getImportStatement ) (quoteJavaPat "tok_ImportStatement_dummy_131" getImportStatement ) quoteJavaType quoteJavaDecs
+importStatement = QuasiQuoter (quoteJavaExp "tok_ImportStatement_dummy_136" getImportStatement ) (quoteJavaPat "tok_ImportStatement_dummy_136" getImportStatement ) quoteJavaType quoteJavaDecs
 
-getInterfaceDeclaration ( Ctr__Java__33 _ s) = s
+getInterfaceDeclaration ( Ctr__Java__35 _ s) = s
 
 interfaceDeclaration :: QuasiQuoter
-interfaceDeclaration = QuasiQuoter (quoteJavaExp "tok_InterfaceDeclaration_dummy_130" getInterfaceDeclaration ) (quoteJavaPat "tok_InterfaceDeclaration_dummy_130" getInterfaceDeclaration ) quoteJavaType quoteJavaDecs
+interfaceDeclaration = QuasiQuoter (quoteJavaExp "tok_InterfaceDeclaration_dummy_135" getInterfaceDeclaration ) (quoteJavaPat "tok_InterfaceDeclaration_dummy_135" getInterfaceDeclaration ) quoteJavaType quoteJavaDecs
 
-getLiteral ( Ctr__Java__34 _ s) = s
+getLiteral ( Ctr__Java__36 _ s) = s
 
 literal :: QuasiQuoter
-literal = QuasiQuoter (quoteJavaExp "tok_Literal_dummy_129" getLiteral ) (quoteJavaPat "tok_Literal_dummy_129" getLiteral ) quoteJavaType quoteJavaDecs
+literal = QuasiQuoter (quoteJavaExp "tok_Literal_dummy_134" getLiteral ) (quoteJavaPat "tok_Literal_dummy_134" getLiteral ) quoteJavaType quoteJavaDecs
 
-getMemberAfterFirstId ( Ctr__Java__35 _ s) = s
+getMemberAfterFirstId ( Ctr__Java__37 _ s) = s
 
 memberAfterFirstId :: QuasiQuoter
-memberAfterFirstId = QuasiQuoter (quoteJavaExp "tok_MemberAfterFirstId_dummy_128" getMemberAfterFirstId ) (quoteJavaPat "tok_MemberAfterFirstId_dummy_128" getMemberAfterFirstId ) quoteJavaType quoteJavaDecs
+memberAfterFirstId = QuasiQuoter (quoteJavaExp "tok_MemberAfterFirstId_dummy_133" getMemberAfterFirstId ) (quoteJavaPat "tok_MemberAfterFirstId_dummy_133" getMemberAfterFirstId ) quoteJavaType quoteJavaDecs
 
-getMemberDeclaration ( Ctr__Java__36 _ s) = s
+getMemberDeclaration ( Ctr__Java__38 _ s) = s
 
 memberDeclaration :: QuasiQuoter
-memberDeclaration = QuasiQuoter (quoteJavaExp "tok_MemberDeclaration_dummy_127" getMemberDeclaration ) (quoteJavaPat "tok_MemberDeclaration_dummy_127" getMemberDeclaration ) quoteJavaType quoteJavaDecs
+memberDeclaration = QuasiQuoter (quoteJavaExp "tok_MemberDeclaration_dummy_132" getMemberDeclaration ) (quoteJavaPat "tok_MemberDeclaration_dummy_132" getMemberDeclaration ) quoteJavaType quoteJavaDecs
 
-getMemberRest ( Ctr__Java__37 _ s) = s
+getMemberRest ( Ctr__Java__39 _ s) = s
 
 memberRest :: QuasiQuoter
-memberRest = QuasiQuoter (quoteJavaExp "tok_MemberRest_dummy_126" getMemberRest ) (quoteJavaPat "tok_MemberRest_dummy_126" getMemberRest ) quoteJavaType quoteJavaDecs
+memberRest = QuasiQuoter (quoteJavaExp "tok_MemberRest_dummy_131" getMemberRest ) (quoteJavaPat "tok_MemberRest_dummy_131" getMemberRest ) quoteJavaType quoteJavaDecs
 
-getModifier ( Ctr__Java__38 _ s) = s
+getModifier ( Ctr__Java__40 _ s) = s
 
 modifier :: QuasiQuoter
-modifier = QuasiQuoter (quoteJavaExp "tok_Modifier_dummy_125" getModifier ) (quoteJavaPat "tok_Modifier_dummy_125" getModifier ) quoteJavaType quoteJavaDecs
+modifier = QuasiQuoter (quoteJavaExp "tok_Modifier_dummy_130" getModifier ) (quoteJavaPat "tok_Modifier_dummy_130" getModifier ) quoteJavaType quoteJavaDecs
 
-getModifierList ( Ctr__Java__39 _ s) = s
+getModifierList ( Ctr__Java__41 _ s) = s
 
 modifierList :: QuasiQuoter
-modifierList = QuasiQuoter (quoteJavaExp "tok_ModifierList_dummy_124" getModifierList ) (quoteJavaPat "tok_ModifierList_dummy_124" getModifierList ) quoteJavaType quoteJavaDecs
+modifierList = QuasiQuoter (quoteJavaExp "tok_ModifierList_dummy_129" getModifierList ) (quoteJavaPat "tok_ModifierList_dummy_129" getModifierList ) quoteJavaType quoteJavaDecs
 
-getMoreTypeSpecifier ( Ctr__Java__40 _ s) = s
+getMoreTypeSpecifier ( Ctr__Java__42 _ s) = s
 
 moreTypeSpecifier :: QuasiQuoter
-moreTypeSpecifier = QuasiQuoter (quoteJavaExp "tok_MoreTypeSpecifier_dummy_123" getMoreTypeSpecifier ) (quoteJavaPat "tok_MoreTypeSpecifier_dummy_123" getMoreTypeSpecifier ) quoteJavaType quoteJavaDecs
+moreTypeSpecifier = QuasiQuoter (quoteJavaExp "tok_MoreTypeSpecifier_dummy_128" getMoreTypeSpecifier ) (quoteJavaPat "tok_MoreTypeSpecifier_dummy_128" getMoreTypeSpecifier ) quoteJavaType quoteJavaDecs
 
-getMoreVariableDeclarators ( Ctr__Java__41 _ s) = s
+getMoreVariableDeclarators ( Ctr__Java__43 _ s) = s
 
 moreVariableDeclarators :: QuasiQuoter
-moreVariableDeclarators = QuasiQuoter (quoteJavaExp "tok_MoreVariableDeclarators_dummy_122" getMoreVariableDeclarators ) (quoteJavaPat "tok_MoreVariableDeclarators_dummy_122" getMoreVariableDeclarators ) quoteJavaType quoteJavaDecs
+moreVariableDeclarators = QuasiQuoter (quoteJavaExp "tok_MoreVariableDeclarators_dummy_127" getMoreVariableDeclarators ) (quoteJavaPat "tok_MoreVariableDeclarators_dummy_127" getMoreVariableDeclarators ) quoteJavaType quoteJavaDecs
 
-getMultiplicativeOp ( Ctr__Java__42 _ s) = s
+getMultiplicativeOp ( Ctr__Java__44 _ s) = s
 
 multiplicativeOp :: QuasiQuoter
-multiplicativeOp = QuasiQuoter (quoteJavaExp "tok_MultiplicativeOp_dummy_121" getMultiplicativeOp ) (quoteJavaPat "tok_MultiplicativeOp_dummy_121" getMultiplicativeOp ) quoteJavaType quoteJavaDecs
+multiplicativeOp = QuasiQuoter (quoteJavaExp "tok_MultiplicativeOp_dummy_126" getMultiplicativeOp ) (quoteJavaPat "tok_MultiplicativeOp_dummy_126" getMultiplicativeOp ) quoteJavaType quoteJavaDecs
 
-getNonEmptyDims ( Ctr__Java__43 _ s) = s
+getNonEmptyDims ( Ctr__Java__45 _ s) = s
 
 nonEmptyDims :: QuasiQuoter
-nonEmptyDims = QuasiQuoter (quoteJavaExp "tok_NonEmptyDims_dummy_120" getNonEmptyDims ) (quoteJavaPat "tok_NonEmptyDims_dummy_120" getNonEmptyDims ) quoteJavaType quoteJavaDecs
+nonEmptyDims = QuasiQuoter (quoteJavaExp "tok_NonEmptyDims_dummy_125" getNonEmptyDims ) (quoteJavaPat "tok_NonEmptyDims_dummy_125" getNonEmptyDims ) quoteJavaType quoteJavaDecs
 
-getNonEmptyTypeArguments ( Ctr__Java__44 _ s) = s
+getNonEmptyTypeArguments ( Ctr__Java__46 _ s) = s
 
 nonEmptyTypeArguments :: QuasiQuoter
-nonEmptyTypeArguments = QuasiQuoter (quoteJavaExp "tok_NonEmptyTypeArguments_dummy_119" getNonEmptyTypeArguments ) (quoteJavaPat "tok_NonEmptyTypeArguments_dummy_119" getNonEmptyTypeArguments ) quoteJavaType quoteJavaDecs
+nonEmptyTypeArguments = QuasiQuoter (quoteJavaExp "tok_NonEmptyTypeArguments_dummy_124" getNonEmptyTypeArguments ) (quoteJavaPat "tok_NonEmptyTypeArguments_dummy_124" getNonEmptyTypeArguments ) quoteJavaType quoteJavaDecs
 
-getOptDocComment ( Ctr__Java__45 _ s) = s
+getOptDocComment ( Ctr__Java__47 _ s) = s
 
 optDocComment :: QuasiQuoter
-optDocComment = QuasiQuoter (quoteJavaExp "tok_OptDocComment_dummy_118" getOptDocComment ) (quoteJavaPat "tok_OptDocComment_dummy_118" getOptDocComment ) quoteJavaType quoteJavaDecs
+optDocComment = QuasiQuoter (quoteJavaExp "tok_OptDocComment_dummy_123" getOptDocComment ) (quoteJavaPat "tok_OptDocComment_dummy_123" getOptDocComment ) quoteJavaType quoteJavaDecs
 
-getOptElsePart ( Ctr__Java__46 _ s) = s
+getOptElsePart ( Ctr__Java__48 _ s) = s
 
 optElsePart :: QuasiQuoter
-optElsePart = QuasiQuoter (quoteJavaExp "tok_OptElsePart_dummy_117" getOptElsePart ) (quoteJavaPat "tok_OptElsePart_dummy_117" getOptElsePart ) quoteJavaType quoteJavaDecs
+optElsePart = QuasiQuoter (quoteJavaExp "tok_OptElsePart_dummy_122" getOptElsePart ) (quoteJavaPat "tok_OptElsePart_dummy_122" getOptElsePart ) quoteJavaType quoteJavaDecs
 
-getOptExpression ( Ctr__Java__47 _ s) = s
+getOptExpression ( Ctr__Java__49 _ s) = s
 
 optExpression :: QuasiQuoter
-optExpression = QuasiQuoter (quoteJavaExp "tok_OptExpression_dummy_116" getOptExpression ) (quoteJavaPat "tok_OptExpression_dummy_116" getOptExpression ) quoteJavaType quoteJavaDecs
+optExpression = QuasiQuoter (quoteJavaExp "tok_OptExpression_dummy_121" getOptExpression ) (quoteJavaPat "tok_OptExpression_dummy_121" getOptExpression ) quoteJavaType quoteJavaDecs
 
-getOptFinally ( Ctr__Java__48 _ s) = s
+getOptFinally ( Ctr__Java__50 _ s) = s
 
 optFinally :: QuasiQuoter
-optFinally = QuasiQuoter (quoteJavaExp "tok_OptFinally_dummy_115" getOptFinally ) (quoteJavaPat "tok_OptFinally_dummy_115" getOptFinally ) quoteJavaType quoteJavaDecs
+optFinally = QuasiQuoter (quoteJavaExp "tok_OptFinally_dummy_120" getOptFinally ) (quoteJavaPat "tok_OptFinally_dummy_120" getOptFinally ) quoteJavaType quoteJavaDecs
 
-getOptId ( Ctr__Java__49 _ s) = s
+getOptId ( Ctr__Java__51 _ s) = s
 
 optId :: QuasiQuoter
-optId = QuasiQuoter (quoteJavaExp "tok_OptId_dummy_114" getOptId ) (quoteJavaPat "tok_OptId_dummy_114" getOptId ) quoteJavaType quoteJavaDecs
+optId = QuasiQuoter (quoteJavaExp "tok_OptId_dummy_119" getOptId ) (quoteJavaPat "tok_OptId_dummy_119" getOptId ) quoteJavaType quoteJavaDecs
 
-getOptVariableInitializer ( Ctr__Java__50 _ s) = s
+getOptVariableInitializer ( Ctr__Java__52 _ s) = s
 
 optVariableInitializer :: QuasiQuoter
-optVariableInitializer = QuasiQuoter (quoteJavaExp "tok_OptVariableInitializer_dummy_113" getOptVariableInitializer ) (quoteJavaPat "tok_OptVariableInitializer_dummy_113" getOptVariableInitializer ) quoteJavaType quoteJavaDecs
+optVariableInitializer = QuasiQuoter (quoteJavaExp "tok_OptVariableInitializer_dummy_118" getOptVariableInitializer ) (quoteJavaPat "tok_OptVariableInitializer_dummy_118" getOptVariableInitializer ) quoteJavaType quoteJavaDecs
 
-getPackage ( Ctr__Java__51 _ s) = s
+getPackage ( Ctr__Java__53 _ s) = s
 
 package :: QuasiQuoter
-package = QuasiQuoter (quoteJavaExp "tok_Package_dummy_112" getPackage ) (quoteJavaPat "tok_Package_dummy_112" getPackage ) quoteJavaType quoteJavaDecs
+package = QuasiQuoter (quoteJavaExp "tok_Package_dummy_117" getPackage ) (quoteJavaPat "tok_Package_dummy_117" getPackage ) quoteJavaType quoteJavaDecs
 
-getParameter ( Ctr__Java__52 _ s) = s
+getParameter ( Ctr__Java__54 _ s) = s
 
 parameter :: QuasiQuoter
-parameter = QuasiQuoter (quoteJavaExp "tok_Parameter_dummy_111" getParameter ) (quoteJavaPat "tok_Parameter_dummy_111" getParameter ) quoteJavaType quoteJavaDecs
+parameter = QuasiQuoter (quoteJavaExp "tok_Parameter_dummy_116" getParameter ) (quoteJavaPat "tok_Parameter_dummy_116" getParameter ) quoteJavaType quoteJavaDecs
 
-getParameterList ( Ctr__Java__53 _ s) = s
+getParameterList ( Ctr__Java__55 _ s) = s
 
 parameterList :: QuasiQuoter
-parameterList = QuasiQuoter (quoteJavaExp "tok_ParameterList_dummy_110" getParameterList ) (quoteJavaPat "tok_ParameterList_dummy_110" getParameterList ) quoteJavaType quoteJavaDecs
+parameterList = QuasiQuoter (quoteJavaExp "tok_ParameterList_dummy_115" getParameterList ) (quoteJavaPat "tok_ParameterList_dummy_115" getParameterList ) quoteJavaType quoteJavaDecs
 
-getPostfixOp ( Ctr__Java__54 _ s) = s
+getPostfixOp ( Ctr__Java__56 _ s) = s
 
 postfixOp :: QuasiQuoter
-postfixOp = QuasiQuoter (quoteJavaExp "tok_PostfixOp_dummy_109" getPostfixOp ) (quoteJavaPat "tok_PostfixOp_dummy_109" getPostfixOp ) quoteJavaType quoteJavaDecs
+postfixOp = QuasiQuoter (quoteJavaExp "tok_PostfixOp_dummy_114" getPostfixOp ) (quoteJavaPat "tok_PostfixOp_dummy_114" getPostfixOp ) quoteJavaType quoteJavaDecs
 
-getPrefixOp ( Ctr__Java__55 _ s) = s
+getPrefixOp ( Ctr__Java__57 _ s) = s
 
 prefixOp :: QuasiQuoter
-prefixOp = QuasiQuoter (quoteJavaExp "tok_PrefixOp_dummy_108" getPrefixOp ) (quoteJavaPat "tok_PrefixOp_dummy_108" getPrefixOp ) quoteJavaType quoteJavaDecs
+prefixOp = QuasiQuoter (quoteJavaExp "tok_PrefixOp_dummy_113" getPrefixOp ) (quoteJavaPat "tok_PrefixOp_dummy_113" getPrefixOp ) quoteJavaType quoteJavaDecs
 
-getPrimitiveTypeKeyword ( Ctr__Java__56 _ s) = s
+getPrimitiveTypeKeyword ( Ctr__Java__58 _ s) = s
 
 primitiveTypeKeyword :: QuasiQuoter
-primitiveTypeKeyword = QuasiQuoter (quoteJavaExp "tok_PrimitiveTypeKeyword_dummy_107" getPrimitiveTypeKeyword ) (quoteJavaPat "tok_PrimitiveTypeKeyword_dummy_107" getPrimitiveTypeKeyword ) quoteJavaType quoteJavaDecs
+primitiveTypeKeyword = QuasiQuoter (quoteJavaExp "tok_PrimitiveTypeKeyword_dummy_112" getPrimitiveTypeKeyword ) (quoteJavaPat "tok_PrimitiveTypeKeyword_dummy_112" getPrimitiveTypeKeyword ) quoteJavaType quoteJavaDecs
 
-getRelationalOp ( Ctr__Java__57 _ s) = s
+getRelationalOp ( Ctr__Java__59 _ s) = s
 
 relationalOp :: QuasiQuoter
-relationalOp = QuasiQuoter (quoteJavaExp "tok_RelationalOp_dummy_106" getRelationalOp ) (quoteJavaPat "tok_RelationalOp_dummy_106" getRelationalOp ) quoteJavaType quoteJavaDecs
+relationalOp = QuasiQuoter (quoteJavaExp "tok_RelationalOp_dummy_111" getRelationalOp ) (quoteJavaPat "tok_RelationalOp_dummy_111" getRelationalOp ) quoteJavaType quoteJavaDecs
 
-getShiftOp ( Ctr__Java__58 _ s) = s
+getShiftOp ( Ctr__Java__60 _ s) = s
 
 shiftOp :: QuasiQuoter
-shiftOp = QuasiQuoter (quoteJavaExp "tok_ShiftOp_dummy_105" getShiftOp ) (quoteJavaPat "tok_ShiftOp_dummy_105" getShiftOp ) quoteJavaType quoteJavaDecs
+shiftOp = QuasiQuoter (quoteJavaExp "tok_ShiftOp_dummy_110" getShiftOp ) (quoteJavaPat "tok_ShiftOp_dummy_110" getShiftOp ) quoteJavaType quoteJavaDecs
 
-getStatement ( Ctr__Java__59 _ s) = s
+getStatement ( Ctr__Java__61 _ s) = s
 
 statement :: QuasiQuoter
-statement = QuasiQuoter (quoteJavaExp "tok_Statement_dummy_104" getStatement ) (quoteJavaPat "tok_Statement_dummy_104" getStatement ) quoteJavaType quoteJavaDecs
+statement = QuasiQuoter (quoteJavaExp "tok_Statement_dummy_109" getStatement ) (quoteJavaPat "tok_Statement_dummy_109" getStatement ) quoteJavaType quoteJavaDecs
 
-getStatementBlock ( Ctr__Java__60 _ s) = s
+getStatementBlock ( Ctr__Java__62 _ s) = s
 
 statementBlock :: QuasiQuoter
-statementBlock = QuasiQuoter (quoteJavaExp "tok_StatementBlock_dummy_103" getStatementBlock ) (quoteJavaPat "tok_StatementBlock_dummy_103" getStatementBlock ) quoteJavaType quoteJavaDecs
+statementBlock = QuasiQuoter (quoteJavaExp "tok_StatementBlock_dummy_108" getStatementBlock ) (quoteJavaPat "tok_StatementBlock_dummy_108" getStatementBlock ) quoteJavaType quoteJavaDecs
 
-getStatementList ( Ctr__Java__61 _ s) = s
+getStatementList ( Ctr__Java__63 _ s) = s
 
 statementList :: QuasiQuoter
-statementList = QuasiQuoter (quoteJavaExp "tok_StatementList_dummy_102" getStatementList ) (quoteJavaPat "tok_StatementList_dummy_102" getStatementList ) quoteJavaType quoteJavaDecs
+statementList = QuasiQuoter (quoteJavaExp "tok_StatementList_dummy_107" getStatementList ) (quoteJavaPat "tok_StatementList_dummy_107" getStatementList ) quoteJavaType quoteJavaDecs
 
-getStaticInitializer ( Ctr__Java__62 _ s) = s
+getStaticInitializer ( Ctr__Java__64 _ s) = s
 
 staticInitializer :: QuasiQuoter
-staticInitializer = QuasiQuoter (quoteJavaExp "tok_StaticInitializer_dummy_101" getStaticInitializer ) (quoteJavaPat "tok_StaticInitializer_dummy_101" getStaticInitializer ) quoteJavaType quoteJavaDecs
+staticInitializer = QuasiQuoter (quoteJavaExp "tok_StaticInitializer_dummy_106" getStaticInitializer ) (quoteJavaPat "tok_StaticInitializer_dummy_106" getStaticInitializer ) quoteJavaType quoteJavaDecs
 
-getSwitchCaseList ( Ctr__Java__63 _ s) = s
+getSwitchCaseList ( Ctr__Java__65 _ s) = s
 
 switchCaseList :: QuasiQuoter
-switchCaseList = QuasiQuoter (quoteJavaExp "tok_SwitchCaseList_dummy_100" getSwitchCaseList ) (quoteJavaPat "tok_SwitchCaseList_dummy_100" getSwitchCaseList ) quoteJavaType quoteJavaDecs
+switchCaseList = QuasiQuoter (quoteJavaExp "tok_SwitchCaseList_dummy_105" getSwitchCaseList ) (quoteJavaPat "tok_SwitchCaseList_dummy_105" getSwitchCaseList ) quoteJavaType quoteJavaDecs
 
-getSwitchStatement ( Ctr__Java__64 _ s) = s
+getSwitchStatement ( Ctr__Java__66 _ s) = s
 
 switchStatement :: QuasiQuoter
-switchStatement = QuasiQuoter (quoteJavaExp "tok_SwitchStatement_dummy_99" getSwitchStatement ) (quoteJavaPat "tok_SwitchStatement_dummy_99" getSwitchStatement ) quoteJavaType quoteJavaDecs
+switchStatement = QuasiQuoter (quoteJavaExp "tok_SwitchStatement_dummy_104" getSwitchStatement ) (quoteJavaPat "tok_SwitchStatement_dummy_104" getSwitchStatement ) quoteJavaType quoteJavaDecs
 
-getTryStatement ( Ctr__Java__65 _ s) = s
+getThrowsClause ( Ctr__Java__67 _ s) = s
+
+throwsClause :: QuasiQuoter
+throwsClause = QuasiQuoter (quoteJavaExp "tok_ThrowsClause_dummy_103" getThrowsClause ) (quoteJavaPat "tok_ThrowsClause_dummy_103" getThrowsClause ) quoteJavaType quoteJavaDecs
+
+getTryStatement ( Ctr__Java__68 _ s) = s
 
 tryStatement :: QuasiQuoter
-tryStatement = QuasiQuoter (quoteJavaExp "tok_TryStatement_dummy_98" getTryStatement ) (quoteJavaPat "tok_TryStatement_dummy_98" getTryStatement ) quoteJavaType quoteJavaDecs
+tryStatement = QuasiQuoter (quoteJavaExp "tok_TryStatement_dummy_102" getTryStatement ) (quoteJavaPat "tok_TryStatement_dummy_102" getTryStatement ) quoteJavaType quoteJavaDecs
 
-getType ( Ctr__Java__66 _ s) = s
+getType ( Ctr__Java__69 _ s) = s
 
 __type :: QuasiQuoter
-__type = QuasiQuoter (quoteJavaExp "tok_Type_dummy_97" getType ) (quoteJavaPat "tok_Type_dummy_97" getType ) quoteJavaType quoteJavaDecs
+__type = QuasiQuoter (quoteJavaExp "tok_Type_dummy_101" getType ) (quoteJavaPat "tok_Type_dummy_101" getType ) quoteJavaType quoteJavaDecs
 
-getTypeArgument ( Ctr__Java__67 _ s) = s
+getTypeArgument ( Ctr__Java__70 _ s) = s
 
 typeArgument :: QuasiQuoter
-typeArgument = QuasiQuoter (quoteJavaExp "tok_TypeArgument_dummy_96" getTypeArgument ) (quoteJavaPat "tok_TypeArgument_dummy_96" getTypeArgument ) quoteJavaType quoteJavaDecs
+typeArgument = QuasiQuoter (quoteJavaExp "tok_TypeArgument_dummy_100" getTypeArgument ) (quoteJavaPat "tok_TypeArgument_dummy_100" getTypeArgument ) quoteJavaType quoteJavaDecs
 
-getTypeArguments ( Ctr__Java__68 _ s) = s
+getTypeArguments ( Ctr__Java__71 _ s) = s
 
 typeArguments :: QuasiQuoter
-typeArguments = QuasiQuoter (quoteJavaExp "tok_TypeArguments_dummy_95" getTypeArguments ) (quoteJavaPat "tok_TypeArguments_dummy_95" getTypeArguments ) quoteJavaType quoteJavaDecs
+typeArguments = QuasiQuoter (quoteJavaExp "tok_TypeArguments_dummy_99" getTypeArguments ) (quoteJavaPat "tok_TypeArguments_dummy_99" getTypeArguments ) quoteJavaType quoteJavaDecs
 
-getTypeDeclRest ( Ctr__Java__69 _ s) = s
+getTypeDeclRest ( Ctr__Java__72 _ s) = s
 
 typeDeclRest :: QuasiQuoter
-typeDeclRest = QuasiQuoter (quoteJavaExp "tok_TypeDeclRest_dummy_94" getTypeDeclRest ) (quoteJavaPat "tok_TypeDeclRest_dummy_94" getTypeDeclRest ) quoteJavaType quoteJavaDecs
+typeDeclRest = QuasiQuoter (quoteJavaExp "tok_TypeDeclRest_dummy_98" getTypeDeclRest ) (quoteJavaPat "tok_TypeDeclRest_dummy_98" getTypeDeclRest ) quoteJavaType quoteJavaDecs
 
-getTypeDeclaration ( Ctr__Java__70 _ s) = s
+getTypeDeclaration ( Ctr__Java__73 _ s) = s
 
 typeDeclaration :: QuasiQuoter
-typeDeclaration = QuasiQuoter (quoteJavaExp "tok_TypeDeclaration_dummy_93" getTypeDeclaration ) (quoteJavaPat "tok_TypeDeclaration_dummy_93" getTypeDeclaration ) quoteJavaType quoteJavaDecs
+typeDeclaration = QuasiQuoter (quoteJavaExp "tok_TypeDeclaration_dummy_97" getTypeDeclaration ) (quoteJavaPat "tok_TypeDeclaration_dummy_97" getTypeDeclaration ) quoteJavaType quoteJavaDecs
 
-getTypeParameter ( Ctr__Java__71 _ s) = s
+getTypeParameter ( Ctr__Java__74 _ s) = s
 
 typeParameter :: QuasiQuoter
-typeParameter = QuasiQuoter (quoteJavaExp "tok_TypeParameter_dummy_92" getTypeParameter ) (quoteJavaPat "tok_TypeParameter_dummy_92" getTypeParameter ) quoteJavaType quoteJavaDecs
+typeParameter = QuasiQuoter (quoteJavaExp "tok_TypeParameter_dummy_96" getTypeParameter ) (quoteJavaPat "tok_TypeParameter_dummy_96" getTypeParameter ) quoteJavaType quoteJavaDecs
 
-getTypeParameters ( Ctr__Java__72 _ s) = s
+getTypeParameters ( Ctr__Java__75 _ s) = s
 
 typeParameters :: QuasiQuoter
-typeParameters = QuasiQuoter (quoteJavaExp "tok_TypeParameters_dummy_91" getTypeParameters ) (quoteJavaPat "tok_TypeParameters_dummy_91" getTypeParameters ) quoteJavaType quoteJavaDecs
+typeParameters = QuasiQuoter (quoteJavaExp "tok_TypeParameters_dummy_95" getTypeParameters ) (quoteJavaPat "tok_TypeParameters_dummy_95" getTypeParameters ) quoteJavaType quoteJavaDecs
 
-getTypeSpecifier ( Ctr__Java__73 _ s) = s
+getTypeSpecifier ( Ctr__Java__76 _ s) = s
 
 typeSpecifier :: QuasiQuoter
-typeSpecifier = QuasiQuoter (quoteJavaExp "tok_TypeSpecifier_dummy_90" getTypeSpecifier ) (quoteJavaPat "tok_TypeSpecifier_dummy_90" getTypeSpecifier ) quoteJavaType quoteJavaDecs
+typeSpecifier = QuasiQuoter (quoteJavaExp "tok_TypeSpecifier_dummy_94" getTypeSpecifier ) (quoteJavaPat "tok_TypeSpecifier_dummy_94" getTypeSpecifier ) quoteJavaType quoteJavaDecs
 
-getVariableDeclaration ( Ctr__Java__74 _ s) = s
+getVariableDeclaration ( Ctr__Java__77 _ s) = s
 
 variableDeclaration :: QuasiQuoter
-variableDeclaration = QuasiQuoter (quoteJavaExp "tok_VariableDeclaration_dummy_89" getVariableDeclaration ) (quoteJavaPat "tok_VariableDeclaration_dummy_89" getVariableDeclaration ) quoteJavaType quoteJavaDecs
+variableDeclaration = QuasiQuoter (quoteJavaExp "tok_VariableDeclaration_dummy_93" getVariableDeclaration ) (quoteJavaPat "tok_VariableDeclaration_dummy_93" getVariableDeclaration ) quoteJavaType quoteJavaDecs
 
-getVariableDeclarator ( Ctr__Java__75 _ s) = s
+getVariableDeclarator ( Ctr__Java__78 _ s) = s
 
 variableDeclarator :: QuasiQuoter
-variableDeclarator = QuasiQuoter (quoteJavaExp "tok_VariableDeclarator_dummy_88" getVariableDeclarator ) (quoteJavaPat "tok_VariableDeclarator_dummy_88" getVariableDeclarator ) quoteJavaType quoteJavaDecs
+variableDeclarator = QuasiQuoter (quoteJavaExp "tok_VariableDeclarator_dummy_92" getVariableDeclarator ) (quoteJavaPat "tok_VariableDeclarator_dummy_92" getVariableDeclarator ) quoteJavaType quoteJavaDecs
 
-getVariableDeclaratorList ( Ctr__Java__76 _ s) = s
+getVariableDeclaratorList ( Ctr__Java__79 _ s) = s
 
 variableDeclaratorList :: QuasiQuoter
-variableDeclaratorList = QuasiQuoter (quoteJavaExp "tok_VariableDeclaratorList_dummy_87" getVariableDeclaratorList ) (quoteJavaPat "tok_VariableDeclaratorList_dummy_87" getVariableDeclaratorList ) quoteJavaType quoteJavaDecs
+variableDeclaratorList = QuasiQuoter (quoteJavaExp "tok_VariableDeclaratorList_dummy_91" getVariableDeclaratorList ) (quoteJavaPat "tok_VariableDeclaratorList_dummy_91" getVariableDeclaratorList ) quoteJavaType quoteJavaDecs
 
-getVariableInitializer ( Ctr__Java__77 _ s) = s
+getVariableInitializer ( Ctr__Java__80 _ s) = s
 
 variableInitializer :: QuasiQuoter
-variableInitializer = QuasiQuoter (quoteJavaExp "tok_VariableInitializer_dummy_86" getVariableInitializer ) (quoteJavaPat "tok_VariableInitializer_dummy_86" getVariableInitializer ) quoteJavaType quoteJavaDecs
+variableInitializer = QuasiQuoter (quoteJavaExp "tok_VariableInitializer_dummy_90" getVariableInitializer ) (quoteJavaPat "tok_VariableInitializer_dummy_90" getVariableInitializer ) quoteJavaType quoteJavaDecs
 
-getVariableInitializerList ( Ctr__Java__78 _ s) = s
+getVariableInitializerList ( Ctr__Java__81 _ s) = s
 
 variableInitializerList :: QuasiQuoter
-variableInitializerList = QuasiQuoter (quoteJavaExp "tok_VariableInitializerList_dummy_85" getVariableInitializerList ) (quoteJavaPat "tok_VariableInitializerList_dummy_85" getVariableInitializerList ) quoteJavaType quoteJavaDecs
+variableInitializerList = QuasiQuoter (quoteJavaExp "tok_VariableInitializerList_dummy_89" getVariableInitializerList ) (quoteJavaPat "tok_VariableInitializerList_dummy_89" getVariableInitializerList ) quoteJavaType quoteJavaDecs
 
-getWhileStatement ( Ctr__Java__79 _ s) = s
+getWhileStatement ( Ctr__Java__82 _ s) = s
 
 whileStatement :: QuasiQuoter
-whileStatement = QuasiQuoter (quoteJavaExp "tok_WhileStatement_dummy_84" getWhileStatement ) (quoteJavaPat "tok_WhileStatement_dummy_84" getWhileStatement ) quoteJavaType quoteJavaDecs
+whileStatement = QuasiQuoter (quoteJavaExp "tok_WhileStatement_dummy_88" getWhileStatement ) (quoteJavaPat "tok_WhileStatement_dummy_88" getWhileStatement ) quoteJavaType quoteJavaDecs
 
-getWildcardType ( Ctr__Java__80 _ s) = s
+getWildcardType ( Ctr__Java__83 _ s) = s
 
 wildcardType :: QuasiQuoter
-wildcardType = QuasiQuoter (quoteJavaExp "tok_WildcardType_dummy_83" getWildcardType ) (quoteJavaPat "tok_WildcardType_dummy_83" getWildcardType ) quoteJavaType quoteJavaDecs
+wildcardType = QuasiQuoter (quoteJavaExp "tok_WildcardType_dummy_87" getWildcardType ) (quoteJavaPat "tok_WildcardType_dummy_87" getWildcardType ) quoteJavaType quoteJavaDecs
 


### PR DESCRIPTION
ImportStatement takes an optional 'static' ('import' is followed by a
keyword, so no conflict), and a new ThrowsClause ('throws' CompoundName
(',' CompoundName)*) hangs optionally off every method/constructor header:
MemberRest's method branch between the C-style dims and the
StatementBlock-or-';' tail (keeping the annotation 'default' arm), and the
constructor branch of MemberAfterFirstId. 'throws' sits in follow position
before '{'/';'/'default', so the conflict inventory is unchanged: 18
shift/reduce across the same 12 states, 0 reduce/reduce.

While in ImportStatement, fix the on-demand form, which had never parsed:
taking the (CompoundName '.' '*') branch needs CompoundName reduced on
lookahead '.', and that reduce always lost to the greedy name-extension
shift (family 4), so 'import a.b.*;' was rejected. Import names now get
their own left-recursive ImportName/ImportHead spelling that keeps both
'.' continuations in one item set; the token after each '.' (id vs '*')
picks the branch.

Goldens refreshed (test/golden/java/, and the lexical .tokens files whose
generated token names renumbered - token streams themselves unchanged).
commons-lang corpus: main 14 -> 27, tests 16 -> 29 passing, no
regressions; the 26 newly passing files leave the parser blacklists and
the headers now name the current top blockers ('final' on parameters,
generics in expressions, class literals) instead of the stale Java 8 list.

https://claude.ai/code/session_01RJyfg7DjVp4pJ36jFDNuHq