### PR TITLE
Support final/annotations on parameters and locals, and varargs (Phase 4b)

### DIFF
--- a/test-grammars/java.pg
+++ b/test-grammars/java.pg
@@ -280,9 +280,21 @@ VariableDeclaratorList = VariableDeclarator (',' VariableDeclarator)* ;
 # 1. Local variable declarations inside method bodies (via Statement)
 # 2. For loops (via ForStatement)
 # Note: Field-level variable declarations use MemberDeclaration above
+#
+# The modified alternative carries a NON-EMPTY modifier list - deliberately
+# not Parameter's nullable ParamModifierList: at statement start the parser
+# already weighs "Type vs Expression" after an identifier, and a nullable
+# prefix would force an epsilon-reduce decision BEFORE that identifier is
+# shifted, sending 'Foo x;' down the expression path. 'final' and '@' cannot
+# start an expression, so the modified alternative is keyword-anchored and
+# the unmodified one keeps today's exact automaton.
 VariableDeclaration  =
  Type VariableDeclaratorList
-   ';'  ;
+   ';'
+ | LocalModifierList1 Type VariableDeclaratorList ';' ;
+
+# Local variable modifiers (JLS 14.4 VariableModifier), at least one.
+LocalModifierList1 = ('final' | Annotation)+ ;
 
 OptVariableInitializer = ('=' VariableInitializer)? ;
 
@@ -301,8 +313,20 @@ StaticInitializer  =
 ParameterList  =
 Parameter (',' Parameter)* ;
 
+# Parameter modifiers (JLS 8.4.1 VariableModifier: 'final' and annotations).
+# The NULLABLE prefix is safe here because parameter positions (after '(' or
+# ',' in a parameter list, and in 'catch (...)') have no competing expression
+# interpretation: the epsilon-reduce of the empty list on a type-start token
+# is the state's only action. Do NOT reuse this at statement level, where a
+# nullable prefix would break 'Foo x;' - see the NOTE at VariableDeclaration.
+ParamModifierList = ('final' | Annotation)* ;
+
+# '...' (varargs, JLS 8.4.1) is one lexer token: Alex's maximal munch prefers
+# it over '.', and no float literal can follow '..'. That only the LAST
+# parameter may be variadic is a semantic check (javac's job): the parser
+# accepts the ellipsis on any parameter, including a catch parameter.
 Parameter  =
-Type id Dims ;
+ParamModifierList Type ('...')? id Dims ;
 
 StatementList = Statement *;
 

--- a/test-grammars/java/lexical/operators.tokens
+++ b/test-grammars/java/lexical/operators.tokens
@@ -10,131 +10,131 @@ Tk__tok_int_24
 Tk__id "a"
 Tk__tok__eql__10
 Tk__integerLiteral "1"
-Tk__tok__plus__74
+Tk__tok__plus__76
 Tk__integerLiteral "2"
-Tk__tok__minus__75
+Tk__tok__minus__77
 Tk__integerLiteral "3"
 Tk__tok__star__5
 Tk__integerLiteral "4"
-Tk__tok__symbol__76
+Tk__tok__symbol__78
 Tk__integerLiteral "5"
-Tk__tok__symbol__77
+Tk__tok__symbol__79
 Tk__integerLiteral "6"
 Tk__tok__semi__1
 Tk__id "a"
-Tk__tok__plus__eql__47
+Tk__tok__plus__eql__49
 Tk__integerLiteral "1"
 Tk__tok__semi__1
 Tk__id "a"
-Tk__tok__minus__eql__48
+Tk__tok__minus__eql__50
 Tk__integerLiteral "1"
 Tk__tok__semi__1
 Tk__id "a"
-Tk__tok__star__eql__49
+Tk__tok__star__eql__51
 Tk__integerLiteral "2"
-Tk__tok__semi__1
-Tk__id "a"
-Tk__tok__symbol__eql__50
-Tk__integerLiteral "2"
-Tk__tok__semi__1
-Tk__id "a"
-Tk__tok__symbol__eql__54
-Tk__integerLiteral "2"
-Tk__tok__semi__1
-Tk__id "a"
-Tk__tok__symbol__symbol__eql__55
-Tk__integerLiteral "1"
-Tk__tok__semi__1
-Tk__id "a"
-Tk__tok__symbol__symbol__eql__56
-Tk__integerLiteral "1"
-Tk__tok__semi__1
-Tk__id "a"
-Tk__tok__symbol__symbol__symbol__eql__57
-Tk__integerLiteral "1"
 Tk__tok__semi__1
 Tk__id "a"
 Tk__tok__symbol__eql__52
+Tk__integerLiteral "2"
+Tk__tok__semi__1
+Tk__id "a"
+Tk__tok__symbol__eql__56
+Tk__integerLiteral "2"
+Tk__tok__semi__1
+Tk__id "a"
+Tk__tok__symbol__symbol__eql__57
 Tk__integerLiteral "1"
 Tk__tok__semi__1
 Tk__id "a"
-Tk__tok__pipe__eql__51
+Tk__tok__symbol__symbol__eql__58
 Tk__integerLiteral "1"
 Tk__tok__semi__1
 Tk__id "a"
-Tk__tok__symbol__eql__53
+Tk__tok__symbol__symbol__symbol__eql__59
+Tk__integerLiteral "1"
+Tk__tok__semi__1
+Tk__id "a"
+Tk__tok__symbol__eql__54
+Tk__integerLiteral "1"
+Tk__tok__semi__1
+Tk__id "a"
+Tk__tok__pipe__eql__53
+Tk__integerLiteral "1"
+Tk__tok__semi__1
+Tk__id "a"
+Tk__tok__symbol__eql__55
 Tk__integerLiteral "1"
 Tk__tok__semi__1
 Tk__tok_int_24
 Tk__id "b"
 Tk__tok__eql__10
 Tk__id "a"
-Tk__tok__symbol__symbol__72
+Tk__tok__symbol__symbol__74
 Tk__integerLiteral "1"
-Tk__tok__pipe__61
+Tk__tok__pipe__63
 Tk__id "a"
-Tk__tok__symbol__symbol__71
+Tk__tok__symbol__symbol__73
 Tk__integerLiteral "2"
-Tk__tok__symbol__63
+Tk__tok__symbol__65
 Tk__id "a"
-Tk__tok__symbol__symbol__symbol__73
+Tk__tok__symbol__symbol__symbol__75
 Tk__integerLiteral "3"
-Tk__tok__symbol__62
-Tk__tok__tilde__80
+Tk__tok__symbol__64
+Tk__tok__tilde__82
 Tk__id "a"
 Tk__tok__semi__1
 Tk__tok_boolean_20
 Tk__id "c"
 Tk__tok__eql__10
 Tk__id "a"
-Tk__tok__symbol__66
+Tk__tok__symbol__68
 Tk__id "b"
-Tk__tok__pipe__pipe__59
+Tk__tok__pipe__pipe__61
 Tk__id "a"
-Tk__tok__symbol__67
+Tk__tok__symbol__69
 Tk__id "b"
-Tk__tok__symbol__symbol__60
+Tk__tok__symbol__symbol__62
 Tk__id "a"
-Tk__tok__symbol__eql__68
+Tk__tok__symbol__eql__70
 Tk__id "b"
-Tk__tok__pipe__61
+Tk__tok__pipe__63
 Tk__id "a"
-Tk__tok__symbol__eql__69
+Tk__tok__symbol__eql__71
 Tk__id "b"
-Tk__tok__symbol__63
+Tk__tok__symbol__65
 Tk__id "a"
-Tk__tok__eql__eql__64
+Tk__tok__eql__eql__66
 Tk__id "b"
-Tk__tok__symbol__62
+Tk__tok__symbol__64
 Tk__id "a"
-Tk__tok__exclamation__eql__65
+Tk__tok__exclamation__eql__67
 Tk__id "b"
 Tk__tok__semi__1
 Tk__tok_boolean_20
 Tk__id "d"
 Tk__tok__eql__10
-Tk__tok__exclamation__81
+Tk__tok__exclamation__83
 Tk__id "c"
 Tk__tok__semi__1
 Tk__id "a"
-Tk__tok__plus__plus__78
+Tk__tok__plus__plus__80
 Tk__tok__semi__1
 Tk__id "a"
-Tk__tok__minus__minus__79
+Tk__tok__minus__minus__81
 Tk__tok__semi__1
-Tk__tok__plus__plus__78
+Tk__tok__plus__plus__80
 Tk__id "a"
 Tk__tok__semi__1
-Tk__tok__minus__minus__79
+Tk__tok__minus__minus__81
 Tk__id "a"
 Tk__tok__semi__1
 Tk__tok_int_24
 Tk__id "e"
 Tk__tok__eql__10
 Tk__id "c"
-Tk__tok__symbol__58
+Tk__tok__symbol__60
 Tk__id "a"
-Tk__tok__colon__34
+Tk__tok__colon__36
 Tk__id "b"
 Tk__tok__semi__1
 Tk__tok__symbol__15

--- a/test-suites/commons-lang-parser-blacklist-tests.txt
+++ b/test-suites/commons-lang-parser-blacklist-tests.txt
@@ -1,11 +1,11 @@
 # Blacklist for full parsing tests (test sources)
 # These files use features not yet supported by the grammar, chiefly:
-# - 'final' (and annotations) on method parameters
 # - generic method calls / nested generics in expressions
 # - class literals (Foo.class), lambda expressions (->), method
 #   references (::), anonymous inner classes, enhanced for (:)
+# - array initializers in 'new' (new int[] {...})
 #
-# Total: 238 files blacklisted, 29 files passing
+# Total: 205 files blacklisted, 62 files passing
 # As grammar support is added, remove files from this list
 
 org/apache/commons/lang3/AnnotationUtilsTest.java
@@ -19,10 +19,8 @@ org/apache/commons/lang3/ArrayUtilsRemoveMultipleTest.java
 org/apache/commons/lang3/ArrayUtilsRemoveTest.java
 org/apache/commons/lang3/ArrayUtilsSetTest.java
 org/apache/commons/lang3/ArrayUtilsTest.java
-org/apache/commons/lang3/BitFieldTest.java
 org/apache/commons/lang3/BooleanUtilsTest.java
 org/apache/commons/lang3/CachedRandomBitsTest.java
-org/apache/commons/lang3/CharEncodingTest.java
 org/apache/commons/lang3/CharRangeTest.java
 org/apache/commons/lang3/CharSequenceUtilsTest.java
 org/apache/commons/lang3/CharSetTest.java
@@ -42,8 +40,6 @@ org/apache/commons/lang3/IntegerRangeTest.java
 org/apache/commons/lang3/LangAssertions.java
 org/apache/commons/lang3/LocaleUtilsTest.java
 org/apache/commons/lang3/LongRangeTest.java
-org/apache/commons/lang3/NotImplementedExceptionTest.java
-org/apache/commons/lang3/ObjectToStringRuntimeException.java
 org/apache/commons/lang3/ObjectUtilsTest.java
 org/apache/commons/lang3/RandomStringUtilsTest.java
 org/apache/commons/lang3/RandomUtilsTest.java
@@ -56,11 +52,9 @@ org/apache/commons/lang3/StringEscapeUtilsTest.java
 org/apache/commons/lang3/StringUtilsAbbreviateTest.java
 org/apache/commons/lang3/StringUtilsContainsTest.java
 org/apache/commons/lang3/StringUtilsEqualsIndexOfTest.java
-org/apache/commons/lang3/StringUtilsIsMixedCaseTest.java
 org/apache/commons/lang3/StringUtilsTest.java
 org/apache/commons/lang3/StringUtilsTrimStripTest.java
 org/apache/commons/lang3/StringUtilsValueOfTest.java
-org/apache/commons/lang3/StringsTest.java
 org/apache/commons/lang3/SystemPropertiesTest.java
 org/apache/commons/lang3/SystemUtilsTest.java
 org/apache/commons/lang3/ThreadUtilsTest.java
@@ -84,9 +78,7 @@ org/apache/commons/lang3/builder/RecursiveToStringStyleTest.java
 org/apache/commons/lang3/builder/ReflectionDiffBuilderTest.java
 org/apache/commons/lang3/builder/ReflectionToStringBuilderConcurrencyTest.java
 org/apache/commons/lang3/builder/ReflectionToStringBuilderCustomImplementationTest.java
-org/apache/commons/lang3/builder/ReflectionToStringBuilderExcludeNullValuesTest.java
 org/apache/commons/lang3/builder/ReflectionToStringBuilderExcludeTest.java
-org/apache/commons/lang3/builder/ReflectionToStringBuilderExcludeWithAnnotationTest.java
 org/apache/commons/lang3/builder/ReflectionToStringBuilderIncludeTest.java
 org/apache/commons/lang3/builder/ReflectionToStringBuilderMutateInspectConcurrencyTest.java
 org/apache/commons/lang3/builder/ShortPrefixToStringStyleTest.java
@@ -95,9 +87,7 @@ org/apache/commons/lang3/builder/StandardToStringStyleTest.java
 org/apache/commons/lang3/builder/TestClassBuilder.java
 org/apache/commons/lang3/builder/ToStringBuilderTest.java
 org/apache/commons/lang3/builder/ToStringStyleConcurrencyTest.java
-org/apache/commons/lang3/builder/ToStringStyleTest.java
 org/apache/commons/lang3/compare/ComparableUtilsTest.java
-org/apache/commons/lang3/compare/ObjectToStringComparatorTest.java
 org/apache/commons/lang3/concurrent/AbstractConcurrentInitializerCloseAndExceptionsTest.java
 org/apache/commons/lang3/concurrent/AbstractConcurrentInitializerTest.java
 org/apache/commons/lang3/concurrent/AtomicInitializerNonObjectTest.java
@@ -126,11 +116,8 @@ org/apache/commons/lang3/concurrent/MemoizerComputableTest.java
 org/apache/commons/lang3/concurrent/MemoizerFunctionTest.java
 org/apache/commons/lang3/concurrent/MultiBackgroundInitializerSupplierTest.java
 org/apache/commons/lang3/concurrent/MultiBackgroundInitializerTest.java
-org/apache/commons/lang3/concurrent/ThresholdCircuitBreakerTest.java
 org/apache/commons/lang3/concurrent/TimedSemaphoreTest.java
-org/apache/commons/lang3/concurrent/UncheckedExecutionExceptionTest.java
 org/apache/commons/lang3/concurrent/UncheckedFutureTest.java
-org/apache/commons/lang3/concurrent/UncheckedTimeoutExceptionTest.java
 org/apache/commons/lang3/concurrent/locks/LockingVisitorsTest.java
 org/apache/commons/lang3/event/EventListenerSupportTest.java
 org/apache/commons/lang3/event/EventUtilsTest.java
@@ -142,10 +129,6 @@ org/apache/commons/lang3/exception/CustomCheckedException.java
 org/apache/commons/lang3/exception/CustomUncheckedException.java
 org/apache/commons/lang3/exception/DefaultExceptionContextTest.java
 org/apache/commons/lang3/exception/ExceptionUtilsTest.java
-org/apache/commons/lang3/exception/UncheckedExceptionTest.java
-org/apache/commons/lang3/exception/UncheckedIllegalAccessExceptionTest.java
-org/apache/commons/lang3/exception/UncheckedInterruptedExceptionTest.java
-org/apache/commons/lang3/exception/UncheckedReflectiveOperationExceptionTest.java
 org/apache/commons/lang3/function/AnnotationTestFixture.java
 org/apache/commons/lang3/function/BooleanConsumerTest.java
 org/apache/commons/lang3/function/ByteConsumerTest.java
@@ -162,10 +145,8 @@ org/apache/commons/lang3/function/MethodInvokersFailableBiConsumerTest.java
 org/apache/commons/lang3/function/MethodInvokersFailableBiFunctionTest.java
 org/apache/commons/lang3/function/MethodInvokersFailableFunctionTest.java
 org/apache/commons/lang3/function/MethodInvokersFunctionTest.java
-org/apache/commons/lang3/function/MethodInvokersSupplierTest.java
 org/apache/commons/lang3/function/Objects.java
 org/apache/commons/lang3/function/ObjectsTest.java
-org/apache/commons/lang3/function/PredicatesTest.java
 org/apache/commons/lang3/function/SuppliersTest.java
 org/apache/commons/lang3/function/ToBooleanBiFunctionTest.java
 org/apache/commons/lang3/function/TriConsumerTest.java
@@ -187,21 +168,16 @@ org/apache/commons/lang3/reflect/FieldUtilsTest.java
 org/apache/commons/lang3/reflect/InheritanceUtilsTest.java
 org/apache/commons/lang3/reflect/Lang1703Test.java
 org/apache/commons/lang3/reflect/MethodUtilsTest.java
-org/apache/commons/lang3/reflect/PackageBean.java
-org/apache/commons/lang3/reflect/PublicSubBean.java
 org/apache/commons/lang3/reflect/TypeLiteralTest.java
 org/apache/commons/lang3/reflect/TypeUtilsTest.java
 org/apache/commons/lang3/reflect/testbed/Annotated.java
 org/apache/commons/lang3/reflect/testbed/GenericParent.java
-org/apache/commons/lang3/reflect/testbed/PackageBeanOtherPackage.java
 org/apache/commons/lang3/reflect/testbed/PrivatelyShadowedChild.java
-org/apache/commons/lang3/reflect/testbed/PublicSubBeanOtherPackage.java
 org/apache/commons/lang3/reflect/testbed/StringParameterizedChild.java
 org/apache/commons/lang3/stream/FailableStreamTest.java
 org/apache/commons/lang3/stream/IntStreamsTest.java
 org/apache/commons/lang3/stream/LangCollectorsTest.java
 org/apache/commons/lang3/stream/StreamsTest.java
-org/apache/commons/lang3/test/NotVisibleExceptionFactory.java
 org/apache/commons/lang3/text/CompositeFormatTest.java
 org/apache/commons/lang3/text/ExtendedMessageFormatTest.java
 org/apache/commons/lang3/text/FormattableUtilsTest.java
@@ -214,30 +190,21 @@ org/apache/commons/lang3/text/StrTokenizerTest.java
 org/apache/commons/lang3/text/WordUtilsTest.java
 org/apache/commons/lang3/text/translate/EntityArraysTest.java
 org/apache/commons/lang3/text/translate/LookupTranslatorTest.java
-org/apache/commons/lang3/text/translate/NumericEntityEscaperTest.java
 org/apache/commons/lang3/text/translate/NumericEntityUnescaperTest.java
-org/apache/commons/lang3/text/translate/OctalUnescaperTest.java
-org/apache/commons/lang3/text/translate/UnicodeEscaperTest.java
 org/apache/commons/lang3/text/translate/UnicodeUnescaperTest.java
-org/apache/commons/lang3/time/CalendarUtilsTest.java
 org/apache/commons/lang3/time/DateFormatUtilsTest.java
 org/apache/commons/lang3/time/DateUtilsFragmentTest.java
-org/apache/commons/lang3/time/DateUtilsRoundingTest.java
 org/apache/commons/lang3/time/DateUtilsTest.java
 org/apache/commons/lang3/time/DurationFormatUtilsTest.java
 org/apache/commons/lang3/time/DurationUtilsTest.java
 org/apache/commons/lang3/time/FastDateFormatTest.java
-org/apache/commons/lang3/time/FastDateFormat_PrinterTest.java
-org/apache/commons/lang3/time/FastDateParserSDFTest.java
 org/apache/commons/lang3/time/FastDateParserTest.java
-org/apache/commons/lang3/time/FastDateParser_MoreOrLessTest.java
 org/apache/commons/lang3/time/FastDateParser_TimeZoneStrategyTest.java
 org/apache/commons/lang3/time/FastDatePrinterTest.java
 org/apache/commons/lang3/time/FastDatePrinterTimeZonesTest.java
 org/apache/commons/lang3/time/GmtTimeZoneTest.java
 org/apache/commons/lang3/time/Java15BugFastDateParserTest.java
 org/apache/commons/lang3/time/StopWatchTest.java
-org/apache/commons/lang3/time/WeekYearTest.java
 org/apache/commons/lang3/tuple/ImmutablePairTest.java
 org/apache/commons/lang3/tuple/ImmutableTripleTest.java
 org/apache/commons/lang3/tuple/MutablePairTest.java

--- a/test-suites/commons-lang-parser-blacklist.txt
+++ b/test-suites/commons-lang-parser-blacklist.txt
@@ -1,31 +1,24 @@
 # Blacklist for full parsing tests (main sources)
 # These files use features not yet supported by the grammar, chiefly:
-# - 'final' (and annotations) on method parameters
 # - generic method calls / nested generics in expressions
 # - class literals (Foo.class), lambda expressions (->), method
 #   references (::), anonymous inner classes, enhanced for (:)
+# - a doc comment directly before 'package' (package-info.java)
 #
-# Total: 232 files blacklisted, 27 files passing
+# Total: 206 files blacklisted, 53 files passing
 # As grammar support is added, remove files from this list
 
 org/apache/commons/lang3/AnnotationUtils.java
 org/apache/commons/lang3/AppendableJoiner.java
 org/apache/commons/lang3/ArchUtils.java
-org/apache/commons/lang3/ArrayFill.java
-org/apache/commons/lang3/ArraySorter.java
 org/apache/commons/lang3/ArrayUtils.java
-org/apache/commons/lang3/BitField.java
 org/apache/commons/lang3/BooleanUtils.java
 org/apache/commons/lang3/CachedRandomBits.java
-org/apache/commons/lang3/CharEncoding.java
 org/apache/commons/lang3/CharRange.java
 org/apache/commons/lang3/CharSequenceUtils.java
 org/apache/commons/lang3/CharSet.java
 org/apache/commons/lang3/CharSetUtils.java
 org/apache/commons/lang3/CharUtils.java
-org/apache/commons/lang3/Charsets.java
-org/apache/commons/lang3/ClassLoaderUtils.java
-org/apache/commons/lang3/ClassPathUtils.java
 org/apache/commons/lang3/ClassUtils.java
 org/apache/commons/lang3/Conversion.java
 org/apache/commons/lang3/DoubleRange.java
@@ -41,7 +34,6 @@ org/apache/commons/lang3/ObjectUtils.java
 org/apache/commons/lang3/RandomStringUtils.java
 org/apache/commons/lang3/RandomUtils.java
 org/apache/commons/lang3/Range.java
-org/apache/commons/lang3/RegExUtils.java
 org/apache/commons/lang3/RuntimeEnvironment.java
 org/apache/commons/lang3/SerializationException.java
 org/apache/commons/lang3/SerializationUtils.java
@@ -62,13 +54,10 @@ org/apache/commons/lang3/builder/DiffBuilder.java
 org/apache/commons/lang3/builder/DiffResult.java
 org/apache/commons/lang3/builder/EqualsBuilder.java
 org/apache/commons/lang3/builder/HashCodeBuilder.java
-org/apache/commons/lang3/builder/IDKey.java
 org/apache/commons/lang3/builder/MultilineRecursiveToStringStyle.java
 org/apache/commons/lang3/builder/RecursiveToStringStyle.java
-org/apache/commons/lang3/builder/Reflection.java
 org/apache/commons/lang3/builder/ReflectionDiffBuilder.java
 org/apache/commons/lang3/builder/ReflectionToStringBuilder.java
-org/apache/commons/lang3/builder/StandardToStringStyle.java
 org/apache/commons/lang3/builder/ToStringBuilder.java
 org/apache/commons/lang3/builder/ToStringStyle.java
 org/apache/commons/lang3/builder/package-info.java
@@ -158,7 +147,6 @@ org/apache/commons/lang3/function/FailableToIntBiFunction.java
 org/apache/commons/lang3/function/FailableToIntFunction.java
 org/apache/commons/lang3/function/FailableToLongBiFunction.java
 org/apache/commons/lang3/function/FailableToLongFunction.java
-org/apache/commons/lang3/function/Functions.java
 org/apache/commons/lang3/function/MethodInvokers.java
 org/apache/commons/lang3/function/Predicates.java
 org/apache/commons/lang3/function/Suppliers.java
@@ -166,7 +154,6 @@ org/apache/commons/lang3/function/TriConsumer.java
 org/apache/commons/lang3/function/TriFunction.java
 org/apache/commons/lang3/function/package-info.java
 org/apache/commons/lang3/math/Fraction.java
-org/apache/commons/lang3/math/IEEE754rUtils.java
 org/apache/commons/lang3/math/NumberUtils.java
 org/apache/commons/lang3/math/package-info.java
 org/apache/commons/lang3/mutable/Mutable.java
@@ -180,22 +167,17 @@ org/apache/commons/lang3/mutable/MutableObject.java
 org/apache/commons/lang3/mutable/MutableShort.java
 org/apache/commons/lang3/mutable/package-info.java
 org/apache/commons/lang3/package-info.java
-org/apache/commons/lang3/reflect/AccessibleObjects.java
 org/apache/commons/lang3/reflect/ConstructorUtils.java
 org/apache/commons/lang3/reflect/FieldUtils.java
-org/apache/commons/lang3/reflect/InheritanceUtils.java
 org/apache/commons/lang3/reflect/MemberUtils.java
 org/apache/commons/lang3/reflect/MethodUtils.java
 org/apache/commons/lang3/reflect/TypeLiteral.java
 org/apache/commons/lang3/reflect/TypeUtils.java
 org/apache/commons/lang3/reflect/package-info.java
-org/apache/commons/lang3/stream/IntStreams.java
 org/apache/commons/lang3/stream/LangCollectors.java
 org/apache/commons/lang3/stream/Streams.java
 org/apache/commons/lang3/stream/package-info.java
-org/apache/commons/lang3/text/CompositeFormat.java
 org/apache/commons/lang3/text/ExtendedMessageFormat.java
-org/apache/commons/lang3/text/FormattableUtils.java
 org/apache/commons/lang3/text/StrBuilder.java
 org/apache/commons/lang3/text/StrLookup.java
 org/apache/commons/lang3/text/StrMatcher.java
@@ -204,29 +186,21 @@ org/apache/commons/lang3/text/StrTokenizer.java
 org/apache/commons/lang3/text/WordUtils.java
 org/apache/commons/lang3/text/package-info.java
 org/apache/commons/lang3/text/translate/AggregateTranslator.java
-org/apache/commons/lang3/text/translate/CharSequenceTranslator.java
-org/apache/commons/lang3/text/translate/CodePointTranslator.java
 org/apache/commons/lang3/text/translate/EntityArrays.java
 org/apache/commons/lang3/text/translate/JavaUnicodeEscaper.java
 org/apache/commons/lang3/text/translate/LookupTranslator.java
 org/apache/commons/lang3/text/translate/NumericEntityEscaper.java
 org/apache/commons/lang3/text/translate/NumericEntityUnescaper.java
-org/apache/commons/lang3/text/translate/OctalUnescaper.java
 org/apache/commons/lang3/text/translate/UnicodeEscaper.java
-org/apache/commons/lang3/text/translate/UnicodeUnescaper.java
-org/apache/commons/lang3/text/translate/UnicodeUnpairedSurrogateRemover.java
 org/apache/commons/lang3/text/translate/package-info.java
 org/apache/commons/lang3/time/AbstractFormatCache.java
 org/apache/commons/lang3/time/CalendarUtils.java
-org/apache/commons/lang3/time/DateFormatUtils.java
 org/apache/commons/lang3/time/DateUtils.java
 org/apache/commons/lang3/time/DurationFormatUtils.java
 org/apache/commons/lang3/time/DurationUtils.java
 org/apache/commons/lang3/time/FastDateFormat.java
 org/apache/commons/lang3/time/FastDateParser.java
 org/apache/commons/lang3/time/FastDatePrinter.java
-org/apache/commons/lang3/time/FastTimeZone.java
-org/apache/commons/lang3/time/GmtTimeZone.java
 org/apache/commons/lang3/time/StopWatch.java
 org/apache/commons/lang3/time/TimeZones.java
 org/apache/commons/lang3/time/package-info.java

--- a/test/golden/java/JavaLexer.x
+++ b/test/golden/java/JavaLexer.x
@@ -10,186 +10,189 @@ import Data.Data (Data)
 @exponentPart = ([eE]  ("+"| "-") ?  [0-9]  ([0-9_]*  [0-9]) ?)
 @floatTypeSuffix = ([fFdD])
 
-tokens :- "tok_AdditiveOp_dummy_169" { simple Tk__tok_AdditiveOp_dummy_169 }
-          "tok_Annotation_dummy_168" { simple Tk__tok_Annotation_dummy_168 }
-          "tok_AnnotationArguments_dummy_167" { simple Tk__tok_AnnotationArguments_dummy_167 }
-          "tok_AnnotationDeclaration_dummy_166" { simple Tk__tok_AnnotationDeclaration_dummy_166 }
-          "tok_AnnotationElement_dummy_165" { simple Tk__tok_AnnotationElement_dummy_165 }
-          "tok_AnnotationList_dummy_164" { simple Tk__tok_AnnotationList_dummy_164 }
-          "tok_AnnotationTypeElement_dummy_163" { simple Tk__tok_AnnotationTypeElement_dummy_163 }
-          "tok_AnnotationTypeElementList_dummy_162" { simple Tk__tok_AnnotationTypeElementList_dummy_162 }
-          "tok_Arglist_dummy_161" { simple Tk__tok_Arglist_dummy_161 }
-          "tok_AssignmentOp_dummy_160" { simple Tk__tok_AssignmentOp_dummy_160 }
-          "tok_CatchList_dummy_159" { simple Tk__tok_CatchList_dummy_159 }
-          "tok_ClassDeclaration_dummy_158" { simple Tk__tok_ClassDeclaration_dummy_158 }
-          "tok_CompilationUnit_dummy_157" { simple Tk__tok_CompilationUnit_dummy_157 }
-          "tok_CompoundName_dummy_156" { simple Tk__tok_CompoundName_dummy_156 }
-          "tok_CreationExpression_dummy_155" { simple Tk__tok_CreationExpression_dummy_155 }
-          "tok_DimExprs_dummy_154" { simple Tk__tok_DimExprs_dummy_154 }
-          "tok_Dims_dummy_153" { simple Tk__tok_Dims_dummy_153 }
-          "tok_DoStatement_dummy_152" { simple Tk__tok_DoStatement_dummy_152 }
-          "tok_DocComment_dummy_151" { simple Tk__tok_DocComment_dummy_151 }
-          "tok_EnumConstant_dummy_150" { simple Tk__tok_EnumConstant_dummy_150 }
-          "tok_EnumConstantList_dummy_149" { simple Tk__tok_EnumConstantList_dummy_149 }
-          "tok_EnumDeclaration_dummy_148" { simple Tk__tok_EnumDeclaration_dummy_148 }
-          "tok_EqualityOp_dummy_147" { simple Tk__tok_EqualityOp_dummy_147 }
-          "tok_Expression_dummy_146" { simple Tk__tok_Expression_dummy_146 }
-          "tok_ExtendsList_dummy_145" { simple Tk__tok_ExtendsList_dummy_145 }
-          "tok_FieldDeclaration_dummy_144" { simple Tk__tok_FieldDeclaration_dummy_144 }
-          "tok_FieldDeclarationList_dummy_143" { simple Tk__tok_FieldDeclarationList_dummy_143 }
-          "tok_ForStatement_dummy_142" { simple Tk__tok_ForStatement_dummy_142 }
-          "tok_IfStatement_dummy_141" { simple Tk__tok_IfStatement_dummy_141 }
-          "tok_ImplementsList_dummy_140" { simple Tk__tok_ImplementsList_dummy_140 }
-          "tok_ImportHead_dummy_139" { simple Tk__tok_ImportHead_dummy_139 }
-          "tok_ImportList_dummy_138" { simple Tk__tok_ImportList_dummy_138 }
-          "tok_ImportName_dummy_137" { simple Tk__tok_ImportName_dummy_137 }
-          "tok_ImportStatement_dummy_136" { simple Tk__tok_ImportStatement_dummy_136 }
-          "tok_InterfaceDeclaration_dummy_135" { simple Tk__tok_InterfaceDeclaration_dummy_135 }
-          "tok_Java_dummy_170" { simple Tk__tok_Java_dummy_170 }
-          "tok_Literal_dummy_134" { simple Tk__tok_Literal_dummy_134 }
-          "tok_MemberAfterFirstId_dummy_133" { simple Tk__tok_MemberAfterFirstId_dummy_133 }
-          "tok_MemberDeclaration_dummy_132" { simple Tk__tok_MemberDeclaration_dummy_132 }
-          "tok_MemberRest_dummy_131" { simple Tk__tok_MemberRest_dummy_131 }
-          "tok_Modifier_dummy_130" { simple Tk__tok_Modifier_dummy_130 }
-          "tok_ModifierList_dummy_129" { simple Tk__tok_ModifierList_dummy_129 }
-          "tok_MoreTypeSpecifier_dummy_128" { simple Tk__tok_MoreTypeSpecifier_dummy_128 }
-          "tok_MoreVariableDeclarators_dummy_127" { simple Tk__tok_MoreVariableDeclarators_dummy_127 }
-          "tok_MultiplicativeOp_dummy_126" { simple Tk__tok_MultiplicativeOp_dummy_126 }
-          "tok_NonEmptyDims_dummy_125" { simple Tk__tok_NonEmptyDims_dummy_125 }
-          "tok_NonEmptyTypeArguments_dummy_124" { simple Tk__tok_NonEmptyTypeArguments_dummy_124 }
-          "tok_OptDocComment_dummy_123" { simple Tk__tok_OptDocComment_dummy_123 }
-          "tok_OptElsePart_dummy_122" { simple Tk__tok_OptElsePart_dummy_122 }
-          "tok_OptExpression_dummy_121" { simple Tk__tok_OptExpression_dummy_121 }
-          "tok_OptFinally_dummy_120" { simple Tk__tok_OptFinally_dummy_120 }
-          "tok_OptId_dummy_119" { simple Tk__tok_OptId_dummy_119 }
-          "tok_OptVariableInitializer_dummy_118" { simple Tk__tok_OptVariableInitializer_dummy_118 }
-          "tok_Package_dummy_117" { simple Tk__tok_Package_dummy_117 }
-          "tok_Parameter_dummy_116" { simple Tk__tok_Parameter_dummy_116 }
-          "tok_ParameterList_dummy_115" { simple Tk__tok_ParameterList_dummy_115 }
-          "tok_PostfixOp_dummy_114" { simple Tk__tok_PostfixOp_dummy_114 }
-          "tok_PrefixOp_dummy_113" { simple Tk__tok_PrefixOp_dummy_113 }
-          "tok_PrimitiveTypeKeyword_dummy_112" { simple Tk__tok_PrimitiveTypeKeyword_dummy_112 }
-          "tok_RelationalOp_dummy_111" { simple Tk__tok_RelationalOp_dummy_111 }
-          "tok_ShiftOp_dummy_110" { simple Tk__tok_ShiftOp_dummy_110 }
-          "tok_Statement_dummy_109" { simple Tk__tok_Statement_dummy_109 }
-          "tok_StatementBlock_dummy_108" { simple Tk__tok_StatementBlock_dummy_108 }
-          "tok_StatementList_dummy_107" { simple Tk__tok_StatementList_dummy_107 }
-          "tok_StaticInitializer_dummy_106" { simple Tk__tok_StaticInitializer_dummy_106 }
-          "tok_SwitchCaseList_dummy_105" { simple Tk__tok_SwitchCaseList_dummy_105 }
-          "tok_SwitchStatement_dummy_104" { simple Tk__tok_SwitchStatement_dummy_104 }
-          "tok_ThrowsClause_dummy_103" { simple Tk__tok_ThrowsClause_dummy_103 }
-          "tok_TryStatement_dummy_102" { simple Tk__tok_TryStatement_dummy_102 }
-          "tok_Type_dummy_101" { simple Tk__tok_Type_dummy_101 }
-          "tok_TypeArgument_dummy_100" { simple Tk__tok_TypeArgument_dummy_100 }
-          "tok_TypeArguments_dummy_99" { simple Tk__tok_TypeArguments_dummy_99 }
-          "tok_TypeDeclRest_dummy_98" { simple Tk__tok_TypeDeclRest_dummy_98 }
-          "tok_TypeDeclaration_dummy_97" { simple Tk__tok_TypeDeclaration_dummy_97 }
-          "tok_TypeParameter_dummy_96" { simple Tk__tok_TypeParameter_dummy_96 }
-          "tok_TypeParameters_dummy_95" { simple Tk__tok_TypeParameters_dummy_95 }
-          "tok_TypeSpecifier_dummy_94" { simple Tk__tok_TypeSpecifier_dummy_94 }
-          "tok_VariableDeclaration_dummy_93" { simple Tk__tok_VariableDeclaration_dummy_93 }
-          "tok_VariableDeclarator_dummy_92" { simple Tk__tok_VariableDeclarator_dummy_92 }
-          "tok_VariableDeclaratorList_dummy_91" { simple Tk__tok_VariableDeclaratorList_dummy_91 }
-          "tok_VariableInitializer_dummy_90" { simple Tk__tok_VariableInitializer_dummy_90 }
-          "tok_VariableInitializerList_dummy_89" { simple Tk__tok_VariableInitializerList_dummy_89 }
-          "tok_WhileStatement_dummy_88" { simple Tk__tok_WhileStatement_dummy_88 }
-          "tok_WildcardType_dummy_87" { simple Tk__tok_WildcardType_dummy_87 }
-          "~" { simple Tk__tok__tilde__80 }
+tokens :- "tok_AdditiveOp_dummy_176" { simple Tk__tok_AdditiveOp_dummy_176 }
+          "tok_Annotation_dummy_175" { simple Tk__tok_Annotation_dummy_175 }
+          "tok_AnnotationArguments_dummy_174" { simple Tk__tok_AnnotationArguments_dummy_174 }
+          "tok_AnnotationDeclaration_dummy_173" { simple Tk__tok_AnnotationDeclaration_dummy_173 }
+          "tok_AnnotationElement_dummy_172" { simple Tk__tok_AnnotationElement_dummy_172 }
+          "tok_AnnotationList_dummy_171" { simple Tk__tok_AnnotationList_dummy_171 }
+          "tok_AnnotationTypeElement_dummy_170" { simple Tk__tok_AnnotationTypeElement_dummy_170 }
+          "tok_AnnotationTypeElementList_dummy_169" { simple Tk__tok_AnnotationTypeElementList_dummy_169 }
+          "tok_Arglist_dummy_168" { simple Tk__tok_Arglist_dummy_168 }
+          "tok_AssignmentOp_dummy_167" { simple Tk__tok_AssignmentOp_dummy_167 }
+          "tok_CatchList_dummy_166" { simple Tk__tok_CatchList_dummy_166 }
+          "tok_ClassDeclaration_dummy_165" { simple Tk__tok_ClassDeclaration_dummy_165 }
+          "tok_CompilationUnit_dummy_164" { simple Tk__tok_CompilationUnit_dummy_164 }
+          "tok_CompoundName_dummy_163" { simple Tk__tok_CompoundName_dummy_163 }
+          "tok_CreationExpression_dummy_162" { simple Tk__tok_CreationExpression_dummy_162 }
+          "tok_DimExprs_dummy_161" { simple Tk__tok_DimExprs_dummy_161 }
+          "tok_Dims_dummy_160" { simple Tk__tok_Dims_dummy_160 }
+          "tok_DoStatement_dummy_159" { simple Tk__tok_DoStatement_dummy_159 }
+          "tok_DocComment_dummy_158" { simple Tk__tok_DocComment_dummy_158 }
+          "tok_EnumConstant_dummy_157" { simple Tk__tok_EnumConstant_dummy_157 }
+          "tok_EnumConstantList_dummy_156" { simple Tk__tok_EnumConstantList_dummy_156 }
+          "tok_EnumDeclaration_dummy_155" { simple Tk__tok_EnumDeclaration_dummy_155 }
+          "tok_EqualityOp_dummy_154" { simple Tk__tok_EqualityOp_dummy_154 }
+          "tok_Expression_dummy_153" { simple Tk__tok_Expression_dummy_153 }
+          "tok_ExtendsList_dummy_152" { simple Tk__tok_ExtendsList_dummy_152 }
+          "tok_FieldDeclaration_dummy_151" { simple Tk__tok_FieldDeclaration_dummy_151 }
+          "tok_FieldDeclarationList_dummy_150" { simple Tk__tok_FieldDeclarationList_dummy_150 }
+          "tok_ForStatement_dummy_149" { simple Tk__tok_ForStatement_dummy_149 }
+          "tok_IfStatement_dummy_148" { simple Tk__tok_IfStatement_dummy_148 }
+          "tok_ImplementsList_dummy_147" { simple Tk__tok_ImplementsList_dummy_147 }
+          "tok_ImportHead_dummy_146" { simple Tk__tok_ImportHead_dummy_146 }
+          "tok_ImportList_dummy_145" { simple Tk__tok_ImportList_dummy_145 }
+          "tok_ImportName_dummy_144" { simple Tk__tok_ImportName_dummy_144 }
+          "tok_ImportStatement_dummy_143" { simple Tk__tok_ImportStatement_dummy_143 }
+          "tok_InterfaceDeclaration_dummy_142" { simple Tk__tok_InterfaceDeclaration_dummy_142 }
+          "tok_Java_dummy_177" { simple Tk__tok_Java_dummy_177 }
+          "tok_Literal_dummy_141" { simple Tk__tok_Literal_dummy_141 }
+          "tok_LocalModifierList1_dummy_140" { simple Tk__tok_LocalModifierList1_dummy_140 }
+          "tok_MemberAfterFirstId_dummy_139" { simple Tk__tok_MemberAfterFirstId_dummy_139 }
+          "tok_MemberDeclaration_dummy_138" { simple Tk__tok_MemberDeclaration_dummy_138 }
+          "tok_MemberRest_dummy_137" { simple Tk__tok_MemberRest_dummy_137 }
+          "tok_Modifier_dummy_136" { simple Tk__tok_Modifier_dummy_136 }
+          "tok_ModifierList_dummy_135" { simple Tk__tok_ModifierList_dummy_135 }
+          "tok_MoreTypeSpecifier_dummy_134" { simple Tk__tok_MoreTypeSpecifier_dummy_134 }
+          "tok_MoreVariableDeclarators_dummy_133" { simple Tk__tok_MoreVariableDeclarators_dummy_133 }
+          "tok_MultiplicativeOp_dummy_132" { simple Tk__tok_MultiplicativeOp_dummy_132 }
+          "tok_NonEmptyDims_dummy_131" { simple Tk__tok_NonEmptyDims_dummy_131 }
+          "tok_NonEmptyTypeArguments_dummy_130" { simple Tk__tok_NonEmptyTypeArguments_dummy_130 }
+          "tok_OptDocComment_dummy_129" { simple Tk__tok_OptDocComment_dummy_129 }
+          "tok_OptElsePart_dummy_128" { simple Tk__tok_OptElsePart_dummy_128 }
+          "tok_OptExpression_dummy_127" { simple Tk__tok_OptExpression_dummy_127 }
+          "tok_OptFinally_dummy_126" { simple Tk__tok_OptFinally_dummy_126 }
+          "tok_OptId_dummy_125" { simple Tk__tok_OptId_dummy_125 }
+          "tok_OptVariableInitializer_dummy_124" { simple Tk__tok_OptVariableInitializer_dummy_124 }
+          "tok_Package_dummy_123" { simple Tk__tok_Package_dummy_123 }
+          "tok_ParamModifierList_dummy_122" { simple Tk__tok_ParamModifierList_dummy_122 }
+          "tok_Parameter_dummy_121" { simple Tk__tok_Parameter_dummy_121 }
+          "tok_ParameterList_dummy_120" { simple Tk__tok_ParameterList_dummy_120 }
+          "tok_PostfixOp_dummy_119" { simple Tk__tok_PostfixOp_dummy_119 }
+          "tok_PrefixOp_dummy_118" { simple Tk__tok_PrefixOp_dummy_118 }
+          "tok_PrimitiveTypeKeyword_dummy_117" { simple Tk__tok_PrimitiveTypeKeyword_dummy_117 }
+          "tok_RelationalOp_dummy_116" { simple Tk__tok_RelationalOp_dummy_116 }
+          "tok_ShiftOp_dummy_115" { simple Tk__tok_ShiftOp_dummy_115 }
+          "tok_Statement_dummy_114" { simple Tk__tok_Statement_dummy_114 }
+          "tok_StatementBlock_dummy_113" { simple Tk__tok_StatementBlock_dummy_113 }
+          "tok_StatementList_dummy_112" { simple Tk__tok_StatementList_dummy_112 }
+          "tok_StaticInitializer_dummy_111" { simple Tk__tok_StaticInitializer_dummy_111 }
+          "tok_SwitchCaseList_dummy_110" { simple Tk__tok_SwitchCaseList_dummy_110 }
+          "tok_SwitchStatement_dummy_109" { simple Tk__tok_SwitchStatement_dummy_109 }
+          "tok_ThrowsClause_dummy_108" { simple Tk__tok_ThrowsClause_dummy_108 }
+          "tok_TryStatement_dummy_107" { simple Tk__tok_TryStatement_dummy_107 }
+          "tok_Type_dummy_106" { simple Tk__tok_Type_dummy_106 }
+          "tok_TypeArgument_dummy_105" { simple Tk__tok_TypeArgument_dummy_105 }
+          "tok_TypeArguments_dummy_104" { simple Tk__tok_TypeArguments_dummy_104 }
+          "tok_TypeDeclRest_dummy_103" { simple Tk__tok_TypeDeclRest_dummy_103 }
+          "tok_TypeDeclaration_dummy_102" { simple Tk__tok_TypeDeclaration_dummy_102 }
+          "tok_TypeParameter_dummy_101" { simple Tk__tok_TypeParameter_dummy_101 }
+          "tok_TypeParameters_dummy_100" { simple Tk__tok_TypeParameters_dummy_100 }
+          "tok_TypeSpecifier_dummy_99" { simple Tk__tok_TypeSpecifier_dummy_99 }
+          "tok_VariableDeclaration_dummy_98" { simple Tk__tok_VariableDeclaration_dummy_98 }
+          "tok_VariableDeclarator_dummy_97" { simple Tk__tok_VariableDeclarator_dummy_97 }
+          "tok_VariableDeclaratorList_dummy_96" { simple Tk__tok_VariableDeclaratorList_dummy_96 }
+          "tok_VariableInitializer_dummy_95" { simple Tk__tok_VariableInitializer_dummy_95 }
+          "tok_VariableInitializerList_dummy_94" { simple Tk__tok_VariableInitializerList_dummy_94 }
+          "tok_WhileStatement_dummy_93" { simple Tk__tok_WhileStatement_dummy_93 }
+          "tok_WildcardType_dummy_92" { simple Tk__tok_WildcardType_dummy_92 }
+          "~" { simple Tk__tok__tilde__82 }
           "}" { simple Tk__tok__symbol__15 }
-          "||" { simple Tk__tok__pipe__pipe__59 }
-          "|=" { simple Tk__tok__pipe__eql__51 }
-          "|" { simple Tk__tok__pipe__61 }
+          "||" { simple Tk__tok__pipe__pipe__61 }
+          "|=" { simple Tk__tok__pipe__eql__53 }
+          "|" { simple Tk__tok__pipe__63 }
           "{" { simple Tk__tok__symbol__14 }
-          "while" { simple Tk__tok_while_40 }
+          "while" { simple Tk__tok_while_42 }
           "void" { simple Tk__tok_void_28 }
-          "try" { simple Tk__tok_try_44 }
-          "true" { simple Tk__tok_true_85 }
-          "transient" { simple Tk__tok_transient_95 }
+          "try" { simple Tk__tok_try_46 }
+          "true" { simple Tk__tok_true_87 }
+          "transient" { simple Tk__tok_transient_96 }
           "throws" { simple Tk__tok_throws_29 }
-          "throw" { simple Tk__tok_throw_33 }
-          "threadsafe" { simple Tk__tok_threadsafe_94 }
-          "this" { simple Tk__tok_this_82 }
-          "synchronized" { simple Tk__tok_synchronized_32 }
-          "switch" { simple Tk__tok_switch_46 }
-          "super" { simple Tk__tok_super_83 }
+          "throw" { simple Tk__tok_throw_35 }
+          "threadsafe" { simple Tk__tok_threadsafe_95 }
+          "this" { simple Tk__tok_this_84 }
+          "synchronized" { simple Tk__tok_synchronized_34 }
+          "switch" { simple Tk__tok_switch_48 }
+          "super" { simple Tk__tok_super_85 }
           "static" { simple Tk__tok_static_3 }
           "short" { simple Tk__tok_short_23 }
-          "return" { simple Tk__tok_return_31 }
-          "public" { simple Tk__tok_public_88 }
-          "protected" { simple Tk__tok_protected_90 }
-          "private" { simple Tk__tok_private_89 }
+          "return" { simple Tk__tok_return_33 }
+          "public" { simple Tk__tok_public_90 }
+          "protected" { simple Tk__tok_protected_92 }
+          "private" { simple Tk__tok_private_91 }
           "package" { simple Tk__tok_package_0 }
-          "null" { simple Tk__tok_null_87 }
-          "new" { simple Tk__tok_new_84 }
-          "native" { simple Tk__tok_native_92 }
+          "null" { simple Tk__tok_null_89 }
+          "new" { simple Tk__tok_new_86 }
+          "native" { simple Tk__tok_native_93 }
           "long" { simple Tk__tok_long_26 }
           "interface" { simple Tk__tok_interface_16 }
           "int" { simple Tk__tok_int_24 }
-          "instanceof" { simple Tk__tok_instanceof_70 }
+          "instanceof" { simple Tk__tok_instanceof_72 }
           "import" { simple Tk__tok_import_2 }
           "implements" { simple Tk__tok_implements_12 }
-          "if" { simple Tk__tok_if_38 }
-          "for" { simple Tk__tok_for_41 }
+          "if" { simple Tk__tok_if_40 }
+          "for" { simple Tk__tok_for_43 }
           "float" { simple Tk__tok_float_25 }
-          "finally" { simple Tk__tok_finally_43 }
-          "final" { simple Tk__tok_final_91 }
-          "false" { simple Tk__tok_false_86 }
+          "finally" { simple Tk__tok_finally_45 }
+          "final" { simple Tk__tok_final_31 }
+          "false" { simple Tk__tok_false_88 }
           "extends" { simple Tk__tok_extends_11 }
           "enum" { simple Tk__tok_enum_17 }
-          "else" { simple Tk__tok_else_37 }
+          "else" { simple Tk__tok_else_39 }
           "double" { simple Tk__tok_double_27 }
-          "do" { simple Tk__tok_do_39 }
+          "do" { simple Tk__tok_do_41 }
           "default" { simple Tk__tok_default_30 }
-          "continue" { simple Tk__tok_continue_36 }
+          "continue" { simple Tk__tok_continue_38 }
           "class" { simple Tk__tok_class_13 }
           "char" { simple Tk__tok_char_22 }
-          "catch" { simple Tk__tok_catch_42 }
-          "case" { simple Tk__tok_case_45 }
+          "catch" { simple Tk__tok_catch_44 }
+          "case" { simple Tk__tok_case_47 }
           "byte" { simple Tk__tok_byte_21 }
-          "break" { simple Tk__tok_break_35 }
+          "break" { simple Tk__tok_break_37 }
           "boolean" { simple Tk__tok_boolean_20 }
-          "abstract" { simple Tk__tok_abstract_93 }
-          "^=" { simple Tk__tok__symbol__eql__53 }
-          "^" { simple Tk__tok__symbol__62 }
+          "abstract" { simple Tk__tok_abstract_94 }
+          "^=" { simple Tk__tok__symbol__eql__55 }
+          "^" { simple Tk__tok__symbol__64 }
           "]" { simple Tk__tok__sq_bkt_r__19 }
           "[" { simple Tk__tok__sq_bkt_l__18 }
           "@" { simple Tk__tok__symbol__6 }
-          "?" { simple Tk__tok__symbol__58 }
-          ">>>=" { simple Tk__tok__symbol__symbol__symbol__eql__57 }
-          ">>>" { simple Tk__tok__symbol__symbol__symbol__73 }
-          ">>=" { simple Tk__tok__symbol__symbol__eql__56 }
-          ">>" { simple Tk__tok__symbol__symbol__71 }
-          ">=" { simple Tk__tok__symbol__eql__69 }
-          ">" { simple Tk__tok__symbol__67 }
-          "==" { simple Tk__tok__eql__eql__64 }
+          "?" { simple Tk__tok__symbol__60 }
+          ">>>=" { simple Tk__tok__symbol__symbol__symbol__eql__59 }
+          ">>>" { simple Tk__tok__symbol__symbol__symbol__75 }
+          ">>=" { simple Tk__tok__symbol__symbol__eql__58 }
+          ">>" { simple Tk__tok__symbol__symbol__73 }
+          ">=" { simple Tk__tok__symbol__eql__71 }
+          ">" { simple Tk__tok__symbol__69 }
+          "==" { simple Tk__tok__eql__eql__66 }
           "=" { simple Tk__tok__eql__10 }
-          "<=" { simple Tk__tok__symbol__eql__68 }
-          "<<=" { simple Tk__tok__symbol__symbol__eql__55 }
-          "<<" { simple Tk__tok__symbol__symbol__72 }
-          "<" { simple Tk__tok__symbol__66 }
+          "<=" { simple Tk__tok__symbol__eql__70 }
+          "<<=" { simple Tk__tok__symbol__symbol__eql__57 }
+          "<<" { simple Tk__tok__symbol__symbol__74 }
+          "<" { simple Tk__tok__symbol__68 }
           ";" { simple Tk__tok__semi__1 }
-          ":" { simple Tk__tok__colon__34 }
-          "/=" { simple Tk__tok__symbol__eql__50 }
-          "/" { simple Tk__tok__symbol__76 }
+          ":" { simple Tk__tok__colon__36 }
+          "/=" { simple Tk__tok__symbol__eql__52 }
+          "/" { simple Tk__tok__symbol__78 }
+          "..." { simple Tk__tok__dot__dot__dot__32 }
           "." { simple Tk__tok__dot__4 }
-          "-=" { simple Tk__tok__minus__eql__48 }
-          "--" { simple Tk__tok__minus__minus__79 }
-          "-" { simple Tk__tok__minus__75 }
+          "-=" { simple Tk__tok__minus__eql__50 }
+          "--" { simple Tk__tok__minus__minus__81 }
+          "-" { simple Tk__tok__minus__77 }
           "," { simple Tk__tok__coma__9 }
-          "+=" { simple Tk__tok__plus__eql__47 }
-          "++" { simple Tk__tok__plus__plus__78 }
-          "+" { simple Tk__tok__plus__74 }
-          "*=" { simple Tk__tok__star__eql__49 }
+          "+=" { simple Tk__tok__plus__eql__49 }
+          "++" { simple Tk__tok__plus__plus__80 }
+          "+" { simple Tk__tok__plus__76 }
+          "*=" { simple Tk__tok__star__eql__51 }
           "*" { simple Tk__tok__star__5 }
           ")" { simple Tk__tok__rparen__8 }
           "(" { simple Tk__tok__lparen__7 }
-          "&=" { simple Tk__tok__symbol__eql__52 }
-          "&&" { simple Tk__tok__symbol__symbol__60 }
-          "&" { simple Tk__tok__symbol__63 }
-          "%=" { simple Tk__tok__symbol__eql__54 }
-          "%" { simple Tk__tok__symbol__77 }
-          "!=" { simple Tk__tok__exclamation__eql__65 }
-          "!" { simple Tk__tok__exclamation__81 }
+          "&=" { simple Tk__tok__symbol__eql__54 }
+          "&&" { simple Tk__tok__symbol__symbol__62 }
+          "&" { simple Tk__tok__symbol__65 }
+          "%=" { simple Tk__tok__symbol__eql__56 }
+          "%" { simple Tk__tok__symbol__79 }
+          "!=" { simple Tk__tok__exclamation__eql__67 }
+          "!" { simple Tk__tok__exclamation__83 }
           ("/*"  ([^\*\n]| [\n])  ([\n]| [^\*\n]| [\*]  [^\/\n]| [\*]  [\n])*  "*/") ;
           ("//"  [^\n]*  \n) ;
           ([\ \t\n\r]+) ;
@@ -239,12 +242,14 @@ tokens :- "tok_AdditiveOp_dummy_169" { simple Tk__tok_AdditiveOp_dummy_169 }
           ("$"  "OptExpression"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_OptExpression . ((tail . dropWhile (/= ':'))) }
           ("$"  "StatementList"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_StatementList . ((tail . dropWhile (/= ':'))) }
           ("$"  "Parameter"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_Parameter . ((tail . dropWhile (/= ':'))) }
+          ("$"  "ParamModifierList"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_ParamModifierList . ((tail . dropWhile (/= ':'))) }
           ("$"  "ParameterList"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_ParameterList . ((tail . dropWhile (/= ':'))) }
           ("$"  "StaticInitializer"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_StaticInitializer . ((tail . dropWhile (/= ':'))) }
           ("$"  "VariableInitializer"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_VariableInitializer . ((tail . dropWhile (/= ':'))) }
           ("$"  "VariableInitializerList"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_VariableInitializerList . ((tail . dropWhile (/= ':'))) }
           ("$"  "VariableDeclarator"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_VariableDeclarator . ((tail . dropWhile (/= ':'))) }
           ("$"  "OptVariableInitializer"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_OptVariableInitializer . ((tail . dropWhile (/= ':'))) }
+          ("$"  "LocalModifierList1"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_LocalModifierList1 . ((tail . dropWhile (/= ':'))) }
           ("$"  "VariableDeclaration"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_VariableDeclaration . ((tail . dropWhile (/= ':'))) }
           ("$"  "VariableDeclaratorList"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_VariableDeclaratorList . ((tail . dropWhile (/= ':'))) }
           ("$"  "StatementBlock"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_StatementBlock . ((tail . dropWhile (/= ':'))) }
@@ -289,186 +294,189 @@ tokens :- "tok_AdditiveOp_dummy_169" { simple Tk__tok_AdditiveOp_dummy_169 }
 
 {
 data Token = EndOfFile |
-             Tk__tok_AdditiveOp_dummy_169 |
-             Tk__tok_Annotation_dummy_168 |
-             Tk__tok_AnnotationArguments_dummy_167 |
-             Tk__tok_AnnotationDeclaration_dummy_166 |
-             Tk__tok_AnnotationElement_dummy_165 |
-             Tk__tok_AnnotationList_dummy_164 |
-             Tk__tok_AnnotationTypeElement_dummy_163 |
-             Tk__tok_AnnotationTypeElementList_dummy_162 |
-             Tk__tok_Arglist_dummy_161 |
-             Tk__tok_AssignmentOp_dummy_160 |
-             Tk__tok_CatchList_dummy_159 |
-             Tk__tok_ClassDeclaration_dummy_158 |
-             Tk__tok_CompilationUnit_dummy_157 |
-             Tk__tok_CompoundName_dummy_156 |
-             Tk__tok_CreationExpression_dummy_155 |
-             Tk__tok_DimExprs_dummy_154 |
-             Tk__tok_Dims_dummy_153 |
-             Tk__tok_DoStatement_dummy_152 |
-             Tk__tok_DocComment_dummy_151 |
-             Tk__tok_EnumConstant_dummy_150 |
-             Tk__tok_EnumConstantList_dummy_149 |
-             Tk__tok_EnumDeclaration_dummy_148 |
-             Tk__tok_EqualityOp_dummy_147 |
-             Tk__tok_Expression_dummy_146 |
-             Tk__tok_ExtendsList_dummy_145 |
-             Tk__tok_FieldDeclaration_dummy_144 |
-             Tk__tok_FieldDeclarationList_dummy_143 |
-             Tk__tok_ForStatement_dummy_142 |
-             Tk__tok_IfStatement_dummy_141 |
-             Tk__tok_ImplementsList_dummy_140 |
-             Tk__tok_ImportHead_dummy_139 |
-             Tk__tok_ImportList_dummy_138 |
-             Tk__tok_ImportName_dummy_137 |
-             Tk__tok_ImportStatement_dummy_136 |
-             Tk__tok_InterfaceDeclaration_dummy_135 |
-             Tk__tok_Java_dummy_170 |
-             Tk__tok_Literal_dummy_134 |
-             Tk__tok_MemberAfterFirstId_dummy_133 |
-             Tk__tok_MemberDeclaration_dummy_132 |
-             Tk__tok_MemberRest_dummy_131 |
-             Tk__tok_Modifier_dummy_130 |
-             Tk__tok_ModifierList_dummy_129 |
-             Tk__tok_MoreTypeSpecifier_dummy_128 |
-             Tk__tok_MoreVariableDeclarators_dummy_127 |
-             Tk__tok_MultiplicativeOp_dummy_126 |
-             Tk__tok_NonEmptyDims_dummy_125 |
-             Tk__tok_NonEmptyTypeArguments_dummy_124 |
-             Tk__tok_OptDocComment_dummy_123 |
-             Tk__tok_OptElsePart_dummy_122 |
-             Tk__tok_OptExpression_dummy_121 |
-             Tk__tok_OptFinally_dummy_120 |
-             Tk__tok_OptId_dummy_119 |
-             Tk__tok_OptVariableInitializer_dummy_118 |
-             Tk__tok_Package_dummy_117 |
-             Tk__tok_Parameter_dummy_116 |
-             Tk__tok_ParameterList_dummy_115 |
-             Tk__tok_PostfixOp_dummy_114 |
-             Tk__tok_PrefixOp_dummy_113 |
-             Tk__tok_PrimitiveTypeKeyword_dummy_112 |
-             Tk__tok_RelationalOp_dummy_111 |
-             Tk__tok_ShiftOp_dummy_110 |
-             Tk__tok_Statement_dummy_109 |
-             Tk__tok_StatementBlock_dummy_108 |
-             Tk__tok_StatementList_dummy_107 |
-             Tk__tok_StaticInitializer_dummy_106 |
-             Tk__tok_SwitchCaseList_dummy_105 |
-             Tk__tok_SwitchStatement_dummy_104 |
-             Tk__tok_ThrowsClause_dummy_103 |
-             Tk__tok_TryStatement_dummy_102 |
-             Tk__tok_Type_dummy_101 |
-             Tk__tok_TypeArgument_dummy_100 |
-             Tk__tok_TypeArguments_dummy_99 |
-             Tk__tok_TypeDeclRest_dummy_98 |
-             Tk__tok_TypeDeclaration_dummy_97 |
-             Tk__tok_TypeParameter_dummy_96 |
-             Tk__tok_TypeParameters_dummy_95 |
-             Tk__tok_TypeSpecifier_dummy_94 |
-             Tk__tok_VariableDeclaration_dummy_93 |
-             Tk__tok_VariableDeclarator_dummy_92 |
-             Tk__tok_VariableDeclaratorList_dummy_91 |
-             Tk__tok_VariableInitializer_dummy_90 |
-             Tk__tok_VariableInitializerList_dummy_89 |
-             Tk__tok_WhileStatement_dummy_88 |
-             Tk__tok_WildcardType_dummy_87 |
-             Tk__tok__tilde__80 |
+             Tk__tok_AdditiveOp_dummy_176 |
+             Tk__tok_Annotation_dummy_175 |
+             Tk__tok_AnnotationArguments_dummy_174 |
+             Tk__tok_AnnotationDeclaration_dummy_173 |
+             Tk__tok_AnnotationElement_dummy_172 |
+             Tk__tok_AnnotationList_dummy_171 |
+             Tk__tok_AnnotationTypeElement_dummy_170 |
+             Tk__tok_AnnotationTypeElementList_dummy_169 |
+             Tk__tok_Arglist_dummy_168 |
+             Tk__tok_AssignmentOp_dummy_167 |
+             Tk__tok_CatchList_dummy_166 |
+             Tk__tok_ClassDeclaration_dummy_165 |
+             Tk__tok_CompilationUnit_dummy_164 |
+             Tk__tok_CompoundName_dummy_163 |
+             Tk__tok_CreationExpression_dummy_162 |
+             Tk__tok_DimExprs_dummy_161 |
+             Tk__tok_Dims_dummy_160 |
+             Tk__tok_DoStatement_dummy_159 |
+             Tk__tok_DocComment_dummy_158 |
+             Tk__tok_EnumConstant_dummy_157 |
+             Tk__tok_EnumConstantList_dummy_156 |
+             Tk__tok_EnumDeclaration_dummy_155 |
+             Tk__tok_EqualityOp_dummy_154 |
+             Tk__tok_Expression_dummy_153 |
+             Tk__tok_ExtendsList_dummy_152 |
+             Tk__tok_FieldDeclaration_dummy_151 |
+             Tk__tok_FieldDeclarationList_dummy_150 |
+             Tk__tok_ForStatement_dummy_149 |
+             Tk__tok_IfStatement_dummy_148 |
+             Tk__tok_ImplementsList_dummy_147 |
+             Tk__tok_ImportHead_dummy_146 |
+             Tk__tok_ImportList_dummy_145 |
+             Tk__tok_ImportName_dummy_144 |
+             Tk__tok_ImportStatement_dummy_143 |
+             Tk__tok_InterfaceDeclaration_dummy_142 |
+             Tk__tok_Java_dummy_177 |
+             Tk__tok_Literal_dummy_141 |
+             Tk__tok_LocalModifierList1_dummy_140 |
+             Tk__tok_MemberAfterFirstId_dummy_139 |
+             Tk__tok_MemberDeclaration_dummy_138 |
+             Tk__tok_MemberRest_dummy_137 |
+             Tk__tok_Modifier_dummy_136 |
+             Tk__tok_ModifierList_dummy_135 |
+             Tk__tok_MoreTypeSpecifier_dummy_134 |
+             Tk__tok_MoreVariableDeclarators_dummy_133 |
+             Tk__tok_MultiplicativeOp_dummy_132 |
+             Tk__tok_NonEmptyDims_dummy_131 |
+             Tk__tok_NonEmptyTypeArguments_dummy_130 |
+             Tk__tok_OptDocComment_dummy_129 |
+             Tk__tok_OptElsePart_dummy_128 |
+             Tk__tok_OptExpression_dummy_127 |
+             Tk__tok_OptFinally_dummy_126 |
+             Tk__tok_OptId_dummy_125 |
+             Tk__tok_OptVariableInitializer_dummy_124 |
+             Tk__tok_Package_dummy_123 |
+             Tk__tok_ParamModifierList_dummy_122 |
+             Tk__tok_Parameter_dummy_121 |
+             Tk__tok_ParameterList_dummy_120 |
+             Tk__tok_PostfixOp_dummy_119 |
+             Tk__tok_PrefixOp_dummy_118 |
+             Tk__tok_PrimitiveTypeKeyword_dummy_117 |
+             Tk__tok_RelationalOp_dummy_116 |
+             Tk__tok_ShiftOp_dummy_115 |
+             Tk__tok_Statement_dummy_114 |
+             Tk__tok_StatementBlock_dummy_113 |
+             Tk__tok_StatementList_dummy_112 |
+             Tk__tok_StaticInitializer_dummy_111 |
+             Tk__tok_SwitchCaseList_dummy_110 |
+             Tk__tok_SwitchStatement_dummy_109 |
+             Tk__tok_ThrowsClause_dummy_108 |
+             Tk__tok_TryStatement_dummy_107 |
+             Tk__tok_Type_dummy_106 |
+             Tk__tok_TypeArgument_dummy_105 |
+             Tk__tok_TypeArguments_dummy_104 |
+             Tk__tok_TypeDeclRest_dummy_103 |
+             Tk__tok_TypeDeclaration_dummy_102 |
+             Tk__tok_TypeParameter_dummy_101 |
+             Tk__tok_TypeParameters_dummy_100 |
+             Tk__tok_TypeSpecifier_dummy_99 |
+             Tk__tok_VariableDeclaration_dummy_98 |
+             Tk__tok_VariableDeclarator_dummy_97 |
+             Tk__tok_VariableDeclaratorList_dummy_96 |
+             Tk__tok_VariableInitializer_dummy_95 |
+             Tk__tok_VariableInitializerList_dummy_94 |
+             Tk__tok_WhileStatement_dummy_93 |
+             Tk__tok_WildcardType_dummy_92 |
+             Tk__tok__tilde__82 |
              Tk__tok__symbol__15 |
-             Tk__tok__pipe__pipe__59 |
-             Tk__tok__pipe__eql__51 |
-             Tk__tok__pipe__61 |
+             Tk__tok__pipe__pipe__61 |
+             Tk__tok__pipe__eql__53 |
+             Tk__tok__pipe__63 |
              Tk__tok__symbol__14 |
-             Tk__tok_while_40 |
+             Tk__tok_while_42 |
              Tk__tok_void_28 |
-             Tk__tok_try_44 |
-             Tk__tok_true_85 |
-             Tk__tok_transient_95 |
+             Tk__tok_try_46 |
+             Tk__tok_true_87 |
+             Tk__tok_transient_96 |
              Tk__tok_throws_29 |
-             Tk__tok_throw_33 |
-             Tk__tok_threadsafe_94 |
-             Tk__tok_this_82 |
-             Tk__tok_synchronized_32 |
-             Tk__tok_switch_46 |
-             Tk__tok_super_83 |
+             Tk__tok_throw_35 |
+             Tk__tok_threadsafe_95 |
+             Tk__tok_this_84 |
+             Tk__tok_synchronized_34 |
+             Tk__tok_switch_48 |
+             Tk__tok_super_85 |
              Tk__tok_static_3 |
              Tk__tok_short_23 |
-             Tk__tok_return_31 |
-             Tk__tok_public_88 |
-             Tk__tok_protected_90 |
-             Tk__tok_private_89 |
+             Tk__tok_return_33 |
+             Tk__tok_public_90 |
+             Tk__tok_protected_92 |
+             Tk__tok_private_91 |
              Tk__tok_package_0 |
-             Tk__tok_null_87 |
-             Tk__tok_new_84 |
-             Tk__tok_native_92 |
+             Tk__tok_null_89 |
+             Tk__tok_new_86 |
+             Tk__tok_native_93 |
              Tk__tok_long_26 |
              Tk__tok_interface_16 |
              Tk__tok_int_24 |
-             Tk__tok_instanceof_70 |
+             Tk__tok_instanceof_72 |
              Tk__tok_import_2 |
              Tk__tok_implements_12 |
-             Tk__tok_if_38 |
-             Tk__tok_for_41 |
+             Tk__tok_if_40 |
+             Tk__tok_for_43 |
              Tk__tok_float_25 |
-             Tk__tok_finally_43 |
-             Tk__tok_final_91 |
-             Tk__tok_false_86 |
+             Tk__tok_finally_45 |
+             Tk__tok_final_31 |
+             Tk__tok_false_88 |
              Tk__tok_extends_11 |
              Tk__tok_enum_17 |
-             Tk__tok_else_37 |
+             Tk__tok_else_39 |
              Tk__tok_double_27 |
-             Tk__tok_do_39 |
+             Tk__tok_do_41 |
              Tk__tok_default_30 |
-             Tk__tok_continue_36 |
+             Tk__tok_continue_38 |
              Tk__tok_class_13 |
              Tk__tok_char_22 |
-             Tk__tok_catch_42 |
-             Tk__tok_case_45 |
+             Tk__tok_catch_44 |
+             Tk__tok_case_47 |
              Tk__tok_byte_21 |
-             Tk__tok_break_35 |
+             Tk__tok_break_37 |
              Tk__tok_boolean_20 |
-             Tk__tok_abstract_93 |
-             Tk__tok__symbol__eql__53 |
-             Tk__tok__symbol__62 |
+             Tk__tok_abstract_94 |
+             Tk__tok__symbol__eql__55 |
+             Tk__tok__symbol__64 |
              Tk__tok__sq_bkt_r__19 |
              Tk__tok__sq_bkt_l__18 |
              Tk__tok__symbol__6 |
-             Tk__tok__symbol__58 |
-             Tk__tok__symbol__symbol__symbol__eql__57 |
-             Tk__tok__symbol__symbol__symbol__73 |
-             Tk__tok__symbol__symbol__eql__56 |
-             Tk__tok__symbol__symbol__71 |
-             Tk__tok__symbol__eql__69 |
-             Tk__tok__symbol__67 |
-             Tk__tok__eql__eql__64 |
+             Tk__tok__symbol__60 |
+             Tk__tok__symbol__symbol__symbol__eql__59 |
+             Tk__tok__symbol__symbol__symbol__75 |
+             Tk__tok__symbol__symbol__eql__58 |
+             Tk__tok__symbol__symbol__73 |
+             Tk__tok__symbol__eql__71 |
+             Tk__tok__symbol__69 |
+             Tk__tok__eql__eql__66 |
              Tk__tok__eql__10 |
-             Tk__tok__symbol__eql__68 |
-             Tk__tok__symbol__symbol__eql__55 |
-             Tk__tok__symbol__symbol__72 |
-             Tk__tok__symbol__66 |
+             Tk__tok__symbol__eql__70 |
+             Tk__tok__symbol__symbol__eql__57 |
+             Tk__tok__symbol__symbol__74 |
+             Tk__tok__symbol__68 |
              Tk__tok__semi__1 |
-             Tk__tok__colon__34 |
-             Tk__tok__symbol__eql__50 |
-             Tk__tok__symbol__76 |
+             Tk__tok__colon__36 |
+             Tk__tok__symbol__eql__52 |
+             Tk__tok__symbol__78 |
+             Tk__tok__dot__dot__dot__32 |
              Tk__tok__dot__4 |
-             Tk__tok__minus__eql__48 |
-             Tk__tok__minus__minus__79 |
-             Tk__tok__minus__75 |
+             Tk__tok__minus__eql__50 |
+             Tk__tok__minus__minus__81 |
+             Tk__tok__minus__77 |
              Tk__tok__coma__9 |
-             Tk__tok__plus__eql__47 |
-             Tk__tok__plus__plus__78 |
-             Tk__tok__plus__74 |
-             Tk__tok__star__eql__49 |
+             Tk__tok__plus__eql__49 |
+             Tk__tok__plus__plus__80 |
+             Tk__tok__plus__76 |
+             Tk__tok__star__eql__51 |
              Tk__tok__star__5 |
              Tk__tok__rparen__8 |
              Tk__tok__lparen__7 |
-             Tk__tok__symbol__eql__52 |
-             Tk__tok__symbol__symbol__60 |
-             Tk__tok__symbol__63 |
              Tk__tok__symbol__eql__54 |
-             Tk__tok__symbol__77 |
-             Tk__tok__exclamation__eql__65 |
-             Tk__tok__exclamation__81 |
+             Tk__tok__symbol__symbol__62 |
+             Tk__tok__symbol__65 |
+             Tk__tok__symbol__eql__56 |
+             Tk__tok__symbol__79 |
+             Tk__tok__exclamation__eql__67 |
+             Tk__tok__exclamation__83 |
              Tk__doccomment String |
              Tk__id String |
              Tk__string String |
@@ -515,12 +523,14 @@ data Token = EndOfFile |
              Tk__qq_OptExpression String |
              Tk__qq_StatementList String |
              Tk__qq_Parameter String |
+             Tk__qq_ParamModifierList String |
              Tk__qq_ParameterList String |
              Tk__qq_StaticInitializer String |
              Tk__qq_VariableInitializer String |
              Tk__qq_VariableInitializerList String |
              Tk__qq_VariableDeclarator String |
              Tk__qq_OptVariableInitializer String |
+             Tk__qq_LocalModifierList1 String |
              Tk__qq_VariableDeclaration String |
              Tk__qq_VariableDeclaratorList String |
              Tk__qq_StatementBlock String |

--- a/test/golden/java/JavaParser.y
+++ b/test/golden/java/JavaParser.y
@@ -13,186 +13,189 @@ import qualified JavaLexer as L (Token(..), PosToken(..), AlexPosn(..), alexScan
 %token
 
 rtk__eof { L.PosToken _ L.EndOfFile }
-tok_AdditiveOp_dummy_169 { L.PosToken _ L.Tk__tok_AdditiveOp_dummy_169 }
-tok_Annotation_dummy_168 { L.PosToken _ L.Tk__tok_Annotation_dummy_168 }
-tok_AnnotationArguments_dummy_167 { L.PosToken _ L.Tk__tok_AnnotationArguments_dummy_167 }
-tok_AnnotationDeclaration_dummy_166 { L.PosToken _ L.Tk__tok_AnnotationDeclaration_dummy_166 }
-tok_AnnotationElement_dummy_165 { L.PosToken _ L.Tk__tok_AnnotationElement_dummy_165 }
-tok_AnnotationList_dummy_164 { L.PosToken _ L.Tk__tok_AnnotationList_dummy_164 }
-tok_AnnotationTypeElement_dummy_163 { L.PosToken _ L.Tk__tok_AnnotationTypeElement_dummy_163 }
-tok_AnnotationTypeElementList_dummy_162 { L.PosToken _ L.Tk__tok_AnnotationTypeElementList_dummy_162 }
-tok_Arglist_dummy_161 { L.PosToken _ L.Tk__tok_Arglist_dummy_161 }
-tok_AssignmentOp_dummy_160 { L.PosToken _ L.Tk__tok_AssignmentOp_dummy_160 }
-tok_CatchList_dummy_159 { L.PosToken _ L.Tk__tok_CatchList_dummy_159 }
-tok_ClassDeclaration_dummy_158 { L.PosToken _ L.Tk__tok_ClassDeclaration_dummy_158 }
-tok_CompilationUnit_dummy_157 { L.PosToken _ L.Tk__tok_CompilationUnit_dummy_157 }
-tok_CompoundName_dummy_156 { L.PosToken _ L.Tk__tok_CompoundName_dummy_156 }
-tok_CreationExpression_dummy_155 { L.PosToken _ L.Tk__tok_CreationExpression_dummy_155 }
-tok_DimExprs_dummy_154 { L.PosToken _ L.Tk__tok_DimExprs_dummy_154 }
-tok_Dims_dummy_153 { L.PosToken _ L.Tk__tok_Dims_dummy_153 }
-tok_DoStatement_dummy_152 { L.PosToken _ L.Tk__tok_DoStatement_dummy_152 }
-tok_DocComment_dummy_151 { L.PosToken _ L.Tk__tok_DocComment_dummy_151 }
-tok_EnumConstant_dummy_150 { L.PosToken _ L.Tk__tok_EnumConstant_dummy_150 }
-tok_EnumConstantList_dummy_149 { L.PosToken _ L.Tk__tok_EnumConstantList_dummy_149 }
-tok_EnumDeclaration_dummy_148 { L.PosToken _ L.Tk__tok_EnumDeclaration_dummy_148 }
-tok_EqualityOp_dummy_147 { L.PosToken _ L.Tk__tok_EqualityOp_dummy_147 }
-tok_Expression_dummy_146 { L.PosToken _ L.Tk__tok_Expression_dummy_146 }
-tok_ExtendsList_dummy_145 { L.PosToken _ L.Tk__tok_ExtendsList_dummy_145 }
-tok_FieldDeclaration_dummy_144 { L.PosToken _ L.Tk__tok_FieldDeclaration_dummy_144 }
-tok_FieldDeclarationList_dummy_143 { L.PosToken _ L.Tk__tok_FieldDeclarationList_dummy_143 }
-tok_ForStatement_dummy_142 { L.PosToken _ L.Tk__tok_ForStatement_dummy_142 }
-tok_IfStatement_dummy_141 { L.PosToken _ L.Tk__tok_IfStatement_dummy_141 }
-tok_ImplementsList_dummy_140 { L.PosToken _ L.Tk__tok_ImplementsList_dummy_140 }
-tok_ImportHead_dummy_139 { L.PosToken _ L.Tk__tok_ImportHead_dummy_139 }
-tok_ImportList_dummy_138 { L.PosToken _ L.Tk__tok_ImportList_dummy_138 }
-tok_ImportName_dummy_137 { L.PosToken _ L.Tk__tok_ImportName_dummy_137 }
-tok_ImportStatement_dummy_136 { L.PosToken _ L.Tk__tok_ImportStatement_dummy_136 }
-tok_InterfaceDeclaration_dummy_135 { L.PosToken _ L.Tk__tok_InterfaceDeclaration_dummy_135 }
-tok_Java_dummy_170 { L.PosToken _ L.Tk__tok_Java_dummy_170 }
-tok_Literal_dummy_134 { L.PosToken _ L.Tk__tok_Literal_dummy_134 }
-tok_MemberAfterFirstId_dummy_133 { L.PosToken _ L.Tk__tok_MemberAfterFirstId_dummy_133 }
-tok_MemberDeclaration_dummy_132 { L.PosToken _ L.Tk__tok_MemberDeclaration_dummy_132 }
-tok_MemberRest_dummy_131 { L.PosToken _ L.Tk__tok_MemberRest_dummy_131 }
-tok_Modifier_dummy_130 { L.PosToken _ L.Tk__tok_Modifier_dummy_130 }
-tok_ModifierList_dummy_129 { L.PosToken _ L.Tk__tok_ModifierList_dummy_129 }
-tok_MoreTypeSpecifier_dummy_128 { L.PosToken _ L.Tk__tok_MoreTypeSpecifier_dummy_128 }
-tok_MoreVariableDeclarators_dummy_127 { L.PosToken _ L.Tk__tok_MoreVariableDeclarators_dummy_127 }
-tok_MultiplicativeOp_dummy_126 { L.PosToken _ L.Tk__tok_MultiplicativeOp_dummy_126 }
-tok_NonEmptyDims_dummy_125 { L.PosToken _ L.Tk__tok_NonEmptyDims_dummy_125 }
-tok_NonEmptyTypeArguments_dummy_124 { L.PosToken _ L.Tk__tok_NonEmptyTypeArguments_dummy_124 }
-tok_OptDocComment_dummy_123 { L.PosToken _ L.Tk__tok_OptDocComment_dummy_123 }
-tok_OptElsePart_dummy_122 { L.PosToken _ L.Tk__tok_OptElsePart_dummy_122 }
-tok_OptExpression_dummy_121 { L.PosToken _ L.Tk__tok_OptExpression_dummy_121 }
-tok_OptFinally_dummy_120 { L.PosToken _ L.Tk__tok_OptFinally_dummy_120 }
-tok_OptId_dummy_119 { L.PosToken _ L.Tk__tok_OptId_dummy_119 }
-tok_OptVariableInitializer_dummy_118 { L.PosToken _ L.Tk__tok_OptVariableInitializer_dummy_118 }
-tok_Package_dummy_117 { L.PosToken _ L.Tk__tok_Package_dummy_117 }
-tok_Parameter_dummy_116 { L.PosToken _ L.Tk__tok_Parameter_dummy_116 }
-tok_ParameterList_dummy_115 { L.PosToken _ L.Tk__tok_ParameterList_dummy_115 }
-tok_PostfixOp_dummy_114 { L.PosToken _ L.Tk__tok_PostfixOp_dummy_114 }
-tok_PrefixOp_dummy_113 { L.PosToken _ L.Tk__tok_PrefixOp_dummy_113 }
-tok_PrimitiveTypeKeyword_dummy_112 { L.PosToken _ L.Tk__tok_PrimitiveTypeKeyword_dummy_112 }
-tok_RelationalOp_dummy_111 { L.PosToken _ L.Tk__tok_RelationalOp_dummy_111 }
-tok_ShiftOp_dummy_110 { L.PosToken _ L.Tk__tok_ShiftOp_dummy_110 }
-tok_Statement_dummy_109 { L.PosToken _ L.Tk__tok_Statement_dummy_109 }
-tok_StatementBlock_dummy_108 { L.PosToken _ L.Tk__tok_StatementBlock_dummy_108 }
-tok_StatementList_dummy_107 { L.PosToken _ L.Tk__tok_StatementList_dummy_107 }
-tok_StaticInitializer_dummy_106 { L.PosToken _ L.Tk__tok_StaticInitializer_dummy_106 }
-tok_SwitchCaseList_dummy_105 { L.PosToken _ L.Tk__tok_SwitchCaseList_dummy_105 }
-tok_SwitchStatement_dummy_104 { L.PosToken _ L.Tk__tok_SwitchStatement_dummy_104 }
-tok_ThrowsClause_dummy_103 { L.PosToken _ L.Tk__tok_ThrowsClause_dummy_103 }
-tok_TryStatement_dummy_102 { L.PosToken _ L.Tk__tok_TryStatement_dummy_102 }
-tok_Type_dummy_101 { L.PosToken _ L.Tk__tok_Type_dummy_101 }
-tok_TypeArgument_dummy_100 { L.PosToken _ L.Tk__tok_TypeArgument_dummy_100 }
-tok_TypeArguments_dummy_99 { L.PosToken _ L.Tk__tok_TypeArguments_dummy_99 }
-tok_TypeDeclRest_dummy_98 { L.PosToken _ L.Tk__tok_TypeDeclRest_dummy_98 }
-tok_TypeDeclaration_dummy_97 { L.PosToken _ L.Tk__tok_TypeDeclaration_dummy_97 }
-tok_TypeParameter_dummy_96 { L.PosToken _ L.Tk__tok_TypeParameter_dummy_96 }
-tok_TypeParameters_dummy_95 { L.PosToken _ L.Tk__tok_TypeParameters_dummy_95 }
-tok_TypeSpecifier_dummy_94 { L.PosToken _ L.Tk__tok_TypeSpecifier_dummy_94 }
-tok_VariableDeclaration_dummy_93 { L.PosToken _ L.Tk__tok_VariableDeclaration_dummy_93 }
-tok_VariableDeclarator_dummy_92 { L.PosToken _ L.Tk__tok_VariableDeclarator_dummy_92 }
-tok_VariableDeclaratorList_dummy_91 { L.PosToken _ L.Tk__tok_VariableDeclaratorList_dummy_91 }
-tok_VariableInitializer_dummy_90 { L.PosToken _ L.Tk__tok_VariableInitializer_dummy_90 }
-tok_VariableInitializerList_dummy_89 { L.PosToken _ L.Tk__tok_VariableInitializerList_dummy_89 }
-tok_WhileStatement_dummy_88 { L.PosToken _ L.Tk__tok_WhileStatement_dummy_88 }
-tok_WildcardType_dummy_87 { L.PosToken _ L.Tk__tok_WildcardType_dummy_87 }
-tok__tilde__80 { L.PosToken _ L.Tk__tok__tilde__80 }
+tok_AdditiveOp_dummy_176 { L.PosToken _ L.Tk__tok_AdditiveOp_dummy_176 }
+tok_Annotation_dummy_175 { L.PosToken _ L.Tk__tok_Annotation_dummy_175 }
+tok_AnnotationArguments_dummy_174 { L.PosToken _ L.Tk__tok_AnnotationArguments_dummy_174 }
+tok_AnnotationDeclaration_dummy_173 { L.PosToken _ L.Tk__tok_AnnotationDeclaration_dummy_173 }
+tok_AnnotationElement_dummy_172 { L.PosToken _ L.Tk__tok_AnnotationElement_dummy_172 }
+tok_AnnotationList_dummy_171 { L.PosToken _ L.Tk__tok_AnnotationList_dummy_171 }
+tok_AnnotationTypeElement_dummy_170 { L.PosToken _ L.Tk__tok_AnnotationTypeElement_dummy_170 }
+tok_AnnotationTypeElementList_dummy_169 { L.PosToken _ L.Tk__tok_AnnotationTypeElementList_dummy_169 }
+tok_Arglist_dummy_168 { L.PosToken _ L.Tk__tok_Arglist_dummy_168 }
+tok_AssignmentOp_dummy_167 { L.PosToken _ L.Tk__tok_AssignmentOp_dummy_167 }
+tok_CatchList_dummy_166 { L.PosToken _ L.Tk__tok_CatchList_dummy_166 }
+tok_ClassDeclaration_dummy_165 { L.PosToken _ L.Tk__tok_ClassDeclaration_dummy_165 }
+tok_CompilationUnit_dummy_164 { L.PosToken _ L.Tk__tok_CompilationUnit_dummy_164 }
+tok_CompoundName_dummy_163 { L.PosToken _ L.Tk__tok_CompoundName_dummy_163 }
+tok_CreationExpression_dummy_162 { L.PosToken _ L.Tk__tok_CreationExpression_dummy_162 }
+tok_DimExprs_dummy_161 { L.PosToken _ L.Tk__tok_DimExprs_dummy_161 }
+tok_Dims_dummy_160 { L.PosToken _ L.Tk__tok_Dims_dummy_160 }
+tok_DoStatement_dummy_159 { L.PosToken _ L.Tk__tok_DoStatement_dummy_159 }
+tok_DocComment_dummy_158 { L.PosToken _ L.Tk__tok_DocComment_dummy_158 }
+tok_EnumConstant_dummy_157 { L.PosToken _ L.Tk__tok_EnumConstant_dummy_157 }
+tok_EnumConstantList_dummy_156 { L.PosToken _ L.Tk__tok_EnumConstantList_dummy_156 }
+tok_EnumDeclaration_dummy_155 { L.PosToken _ L.Tk__tok_EnumDeclaration_dummy_155 }
+tok_EqualityOp_dummy_154 { L.PosToken _ L.Tk__tok_EqualityOp_dummy_154 }
+tok_Expression_dummy_153 { L.PosToken _ L.Tk__tok_Expression_dummy_153 }
+tok_ExtendsList_dummy_152 { L.PosToken _ L.Tk__tok_ExtendsList_dummy_152 }
+tok_FieldDeclaration_dummy_151 { L.PosToken _ L.Tk__tok_FieldDeclaration_dummy_151 }
+tok_FieldDeclarationList_dummy_150 { L.PosToken _ L.Tk__tok_FieldDeclarationList_dummy_150 }
+tok_ForStatement_dummy_149 { L.PosToken _ L.Tk__tok_ForStatement_dummy_149 }
+tok_IfStatement_dummy_148 { L.PosToken _ L.Tk__tok_IfStatement_dummy_148 }
+tok_ImplementsList_dummy_147 { L.PosToken _ L.Tk__tok_ImplementsList_dummy_147 }
+tok_ImportHead_dummy_146 { L.PosToken _ L.Tk__tok_ImportHead_dummy_146 }
+tok_ImportList_dummy_145 { L.PosToken _ L.Tk__tok_ImportList_dummy_145 }
+tok_ImportName_dummy_144 { L.PosToken _ L.Tk__tok_ImportName_dummy_144 }
+tok_ImportStatement_dummy_143 { L.PosToken _ L.Tk__tok_ImportStatement_dummy_143 }
+tok_InterfaceDeclaration_dummy_142 { L.PosToken _ L.Tk__tok_InterfaceDeclaration_dummy_142 }
+tok_Java_dummy_177 { L.PosToken _ L.Tk__tok_Java_dummy_177 }
+tok_Literal_dummy_141 { L.PosToken _ L.Tk__tok_Literal_dummy_141 }
+tok_LocalModifierList1_dummy_140 { L.PosToken _ L.Tk__tok_LocalModifierList1_dummy_140 }
+tok_MemberAfterFirstId_dummy_139 { L.PosToken _ L.Tk__tok_MemberAfterFirstId_dummy_139 }
+tok_MemberDeclaration_dummy_138 { L.PosToken _ L.Tk__tok_MemberDeclaration_dummy_138 }
+tok_MemberRest_dummy_137 { L.PosToken _ L.Tk__tok_MemberRest_dummy_137 }
+tok_Modifier_dummy_136 { L.PosToken _ L.Tk__tok_Modifier_dummy_136 }
+tok_ModifierList_dummy_135 { L.PosToken _ L.Tk__tok_ModifierList_dummy_135 }
+tok_MoreTypeSpecifier_dummy_134 { L.PosToken _ L.Tk__tok_MoreTypeSpecifier_dummy_134 }
+tok_MoreVariableDeclarators_dummy_133 { L.PosToken _ L.Tk__tok_MoreVariableDeclarators_dummy_133 }
+tok_MultiplicativeOp_dummy_132 { L.PosToken _ L.Tk__tok_MultiplicativeOp_dummy_132 }
+tok_NonEmptyDims_dummy_131 { L.PosToken _ L.Tk__tok_NonEmptyDims_dummy_131 }
+tok_NonEmptyTypeArguments_dummy_130 { L.PosToken _ L.Tk__tok_NonEmptyTypeArguments_dummy_130 }
+tok_OptDocComment_dummy_129 { L.PosToken _ L.Tk__tok_OptDocComment_dummy_129 }
+tok_OptElsePart_dummy_128 { L.PosToken _ L.Tk__tok_OptElsePart_dummy_128 }
+tok_OptExpression_dummy_127 { L.PosToken _ L.Tk__tok_OptExpression_dummy_127 }
+tok_OptFinally_dummy_126 { L.PosToken _ L.Tk__tok_OptFinally_dummy_126 }
+tok_OptId_dummy_125 { L.PosToken _ L.Tk__tok_OptId_dummy_125 }
+tok_OptVariableInitializer_dummy_124 { L.PosToken _ L.Tk__tok_OptVariableInitializer_dummy_124 }
+tok_Package_dummy_123 { L.PosToken _ L.Tk__tok_Package_dummy_123 }
+tok_ParamModifierList_dummy_122 { L.PosToken _ L.Tk__tok_ParamModifierList_dummy_122 }
+tok_Parameter_dummy_121 { L.PosToken _ L.Tk__tok_Parameter_dummy_121 }
+tok_ParameterList_dummy_120 { L.PosToken _ L.Tk__tok_ParameterList_dummy_120 }
+tok_PostfixOp_dummy_119 { L.PosToken _ L.Tk__tok_PostfixOp_dummy_119 }
+tok_PrefixOp_dummy_118 { L.PosToken _ L.Tk__tok_PrefixOp_dummy_118 }
+tok_PrimitiveTypeKeyword_dummy_117 { L.PosToken _ L.Tk__tok_PrimitiveTypeKeyword_dummy_117 }
+tok_RelationalOp_dummy_116 { L.PosToken _ L.Tk__tok_RelationalOp_dummy_116 }
+tok_ShiftOp_dummy_115 { L.PosToken _ L.Tk__tok_ShiftOp_dummy_115 }
+tok_Statement_dummy_114 { L.PosToken _ L.Tk__tok_Statement_dummy_114 }
+tok_StatementBlock_dummy_113 { L.PosToken _ L.Tk__tok_StatementBlock_dummy_113 }
+tok_StatementList_dummy_112 { L.PosToken _ L.Tk__tok_StatementList_dummy_112 }
+tok_StaticInitializer_dummy_111 { L.PosToken _ L.Tk__tok_StaticInitializer_dummy_111 }
+tok_SwitchCaseList_dummy_110 { L.PosToken _ L.Tk__tok_SwitchCaseList_dummy_110 }
+tok_SwitchStatement_dummy_109 { L.PosToken _ L.Tk__tok_SwitchStatement_dummy_109 }
+tok_ThrowsClause_dummy_108 { L.PosToken _ L.Tk__tok_ThrowsClause_dummy_108 }
+tok_TryStatement_dummy_107 { L.PosToken _ L.Tk__tok_TryStatement_dummy_107 }
+tok_Type_dummy_106 { L.PosToken _ L.Tk__tok_Type_dummy_106 }
+tok_TypeArgument_dummy_105 { L.PosToken _ L.Tk__tok_TypeArgument_dummy_105 }
+tok_TypeArguments_dummy_104 { L.PosToken _ L.Tk__tok_TypeArguments_dummy_104 }
+tok_TypeDeclRest_dummy_103 { L.PosToken _ L.Tk__tok_TypeDeclRest_dummy_103 }
+tok_TypeDeclaration_dummy_102 { L.PosToken _ L.Tk__tok_TypeDeclaration_dummy_102 }
+tok_TypeParameter_dummy_101 { L.PosToken _ L.Tk__tok_TypeParameter_dummy_101 }
+tok_TypeParameters_dummy_100 { L.PosToken _ L.Tk__tok_TypeParameters_dummy_100 }
+tok_TypeSpecifier_dummy_99 { L.PosToken _ L.Tk__tok_TypeSpecifier_dummy_99 }
+tok_VariableDeclaration_dummy_98 { L.PosToken _ L.Tk__tok_VariableDeclaration_dummy_98 }
+tok_VariableDeclarator_dummy_97 { L.PosToken _ L.Tk__tok_VariableDeclarator_dummy_97 }
+tok_VariableDeclaratorList_dummy_96 { L.PosToken _ L.Tk__tok_VariableDeclaratorList_dummy_96 }
+tok_VariableInitializer_dummy_95 { L.PosToken _ L.Tk__tok_VariableInitializer_dummy_95 }
+tok_VariableInitializerList_dummy_94 { L.PosToken _ L.Tk__tok_VariableInitializerList_dummy_94 }
+tok_WhileStatement_dummy_93 { L.PosToken _ L.Tk__tok_WhileStatement_dummy_93 }
+tok_WildcardType_dummy_92 { L.PosToken _ L.Tk__tok_WildcardType_dummy_92 }
+tok__tilde__82 { L.PosToken _ L.Tk__tok__tilde__82 }
 tok__symbol__15 { L.PosToken _ L.Tk__tok__symbol__15 }
-tok__pipe__pipe__59 { L.PosToken _ L.Tk__tok__pipe__pipe__59 }
-tok__pipe__eql__51 { L.PosToken _ L.Tk__tok__pipe__eql__51 }
-tok__pipe__61 { L.PosToken _ L.Tk__tok__pipe__61 }
+tok__pipe__pipe__61 { L.PosToken _ L.Tk__tok__pipe__pipe__61 }
+tok__pipe__eql__53 { L.PosToken _ L.Tk__tok__pipe__eql__53 }
+tok__pipe__63 { L.PosToken _ L.Tk__tok__pipe__63 }
 tok__symbol__14 { L.PosToken _ L.Tk__tok__symbol__14 }
-tok_while_40 { L.PosToken _ L.Tk__tok_while_40 }
+tok_while_42 { L.PosToken _ L.Tk__tok_while_42 }
 tok_void_28 { L.PosToken _ L.Tk__tok_void_28 }
-tok_try_44 { L.PosToken _ L.Tk__tok_try_44 }
-tok_true_85 { L.PosToken _ L.Tk__tok_true_85 }
-tok_transient_95 { L.PosToken _ L.Tk__tok_transient_95 }
+tok_try_46 { L.PosToken _ L.Tk__tok_try_46 }
+tok_true_87 { L.PosToken _ L.Tk__tok_true_87 }
+tok_transient_96 { L.PosToken _ L.Tk__tok_transient_96 }
 tok_throws_29 { L.PosToken _ L.Tk__tok_throws_29 }
-tok_throw_33 { L.PosToken _ L.Tk__tok_throw_33 }
-tok_threadsafe_94 { L.PosToken _ L.Tk__tok_threadsafe_94 }
-tok_this_82 { L.PosToken _ L.Tk__tok_this_82 }
-tok_synchronized_32 { L.PosToken _ L.Tk__tok_synchronized_32 }
-tok_switch_46 { L.PosToken _ L.Tk__tok_switch_46 }
-tok_super_83 { L.PosToken _ L.Tk__tok_super_83 }
+tok_throw_35 { L.PosToken _ L.Tk__tok_throw_35 }
+tok_threadsafe_95 { L.PosToken _ L.Tk__tok_threadsafe_95 }
+tok_this_84 { L.PosToken _ L.Tk__tok_this_84 }
+tok_synchronized_34 { L.PosToken _ L.Tk__tok_synchronized_34 }
+tok_switch_48 { L.PosToken _ L.Tk__tok_switch_48 }
+tok_super_85 { L.PosToken _ L.Tk__tok_super_85 }
 tok_static_3 { L.PosToken _ L.Tk__tok_static_3 }
 tok_short_23 { L.PosToken _ L.Tk__tok_short_23 }
-tok_return_31 { L.PosToken _ L.Tk__tok_return_31 }
-tok_public_88 { L.PosToken _ L.Tk__tok_public_88 }
-tok_protected_90 { L.PosToken _ L.Tk__tok_protected_90 }
-tok_private_89 { L.PosToken _ L.Tk__tok_private_89 }
+tok_return_33 { L.PosToken _ L.Tk__tok_return_33 }
+tok_public_90 { L.PosToken _ L.Tk__tok_public_90 }
+tok_protected_92 { L.PosToken _ L.Tk__tok_protected_92 }
+tok_private_91 { L.PosToken _ L.Tk__tok_private_91 }
 tok_package_0 { L.PosToken _ L.Tk__tok_package_0 }
-tok_null_87 { L.PosToken _ L.Tk__tok_null_87 }
-tok_new_84 { L.PosToken _ L.Tk__tok_new_84 }
-tok_native_92 { L.PosToken _ L.Tk__tok_native_92 }
+tok_null_89 { L.PosToken _ L.Tk__tok_null_89 }
+tok_new_86 { L.PosToken _ L.Tk__tok_new_86 }
+tok_native_93 { L.PosToken _ L.Tk__tok_native_93 }
 tok_long_26 { L.PosToken _ L.Tk__tok_long_26 }
 tok_interface_16 { L.PosToken _ L.Tk__tok_interface_16 }
 tok_int_24 { L.PosToken _ L.Tk__tok_int_24 }
-tok_instanceof_70 { L.PosToken _ L.Tk__tok_instanceof_70 }
+tok_instanceof_72 { L.PosToken _ L.Tk__tok_instanceof_72 }
 tok_import_2 { L.PosToken _ L.Tk__tok_import_2 }
 tok_implements_12 { L.PosToken _ L.Tk__tok_implements_12 }
-tok_if_38 { L.PosToken _ L.Tk__tok_if_38 }
-tok_for_41 { L.PosToken _ L.Tk__tok_for_41 }
+tok_if_40 { L.PosToken _ L.Tk__tok_if_40 }
+tok_for_43 { L.PosToken _ L.Tk__tok_for_43 }
 tok_float_25 { L.PosToken _ L.Tk__tok_float_25 }
-tok_finally_43 { L.PosToken _ L.Tk__tok_finally_43 }
-tok_final_91 { L.PosToken _ L.Tk__tok_final_91 }
-tok_false_86 { L.PosToken _ L.Tk__tok_false_86 }
+tok_finally_45 { L.PosToken _ L.Tk__tok_finally_45 }
+tok_final_31 { L.PosToken _ L.Tk__tok_final_31 }
+tok_false_88 { L.PosToken _ L.Tk__tok_false_88 }
 tok_extends_11 { L.PosToken _ L.Tk__tok_extends_11 }
 tok_enum_17 { L.PosToken _ L.Tk__tok_enum_17 }
-tok_else_37 { L.PosToken _ L.Tk__tok_else_37 }
+tok_else_39 { L.PosToken _ L.Tk__tok_else_39 }
 tok_double_27 { L.PosToken _ L.Tk__tok_double_27 }
-tok_do_39 { L.PosToken _ L.Tk__tok_do_39 }
+tok_do_41 { L.PosToken _ L.Tk__tok_do_41 }
 tok_default_30 { L.PosToken _ L.Tk__tok_default_30 }
-tok_continue_36 { L.PosToken _ L.Tk__tok_continue_36 }
+tok_continue_38 { L.PosToken _ L.Tk__tok_continue_38 }
 tok_class_13 { L.PosToken _ L.Tk__tok_class_13 }
 tok_char_22 { L.PosToken _ L.Tk__tok_char_22 }
-tok_catch_42 { L.PosToken _ L.Tk__tok_catch_42 }
-tok_case_45 { L.PosToken _ L.Tk__tok_case_45 }
+tok_catch_44 { L.PosToken _ L.Tk__tok_catch_44 }
+tok_case_47 { L.PosToken _ L.Tk__tok_case_47 }
 tok_byte_21 { L.PosToken _ L.Tk__tok_byte_21 }
-tok_break_35 { L.PosToken _ L.Tk__tok_break_35 }
+tok_break_37 { L.PosToken _ L.Tk__tok_break_37 }
 tok_boolean_20 { L.PosToken _ L.Tk__tok_boolean_20 }
-tok_abstract_93 { L.PosToken _ L.Tk__tok_abstract_93 }
-tok__symbol__eql__53 { L.PosToken _ L.Tk__tok__symbol__eql__53 }
-tok__symbol__62 { L.PosToken _ L.Tk__tok__symbol__62 }
+tok_abstract_94 { L.PosToken _ L.Tk__tok_abstract_94 }
+tok__symbol__eql__55 { L.PosToken _ L.Tk__tok__symbol__eql__55 }
+tok__symbol__64 { L.PosToken _ L.Tk__tok__symbol__64 }
 tok__sq_bkt_r__19 { L.PosToken _ L.Tk__tok__sq_bkt_r__19 }
 tok__sq_bkt_l__18 { L.PosToken _ L.Tk__tok__sq_bkt_l__18 }
 tok__symbol__6 { L.PosToken _ L.Tk__tok__symbol__6 }
-tok__symbol__58 { L.PosToken _ L.Tk__tok__symbol__58 }
-tok__symbol__symbol__symbol__eql__57 { L.PosToken _ L.Tk__tok__symbol__symbol__symbol__eql__57 }
-tok__symbol__symbol__symbol__73 { L.PosToken _ L.Tk__tok__symbol__symbol__symbol__73 }
-tok__symbol__symbol__eql__56 { L.PosToken _ L.Tk__tok__symbol__symbol__eql__56 }
-tok__symbol__symbol__71 { L.PosToken _ L.Tk__tok__symbol__symbol__71 }
-tok__symbol__eql__69 { L.PosToken _ L.Tk__tok__symbol__eql__69 }
-tok__symbol__67 { L.PosToken _ L.Tk__tok__symbol__67 }
-tok__eql__eql__64 { L.PosToken _ L.Tk__tok__eql__eql__64 }
+tok__symbol__60 { L.PosToken _ L.Tk__tok__symbol__60 }
+tok__symbol__symbol__symbol__eql__59 { L.PosToken _ L.Tk__tok__symbol__symbol__symbol__eql__59 }
+tok__symbol__symbol__symbol__75 { L.PosToken _ L.Tk__tok__symbol__symbol__symbol__75 }
+tok__symbol__symbol__eql__58 { L.PosToken _ L.Tk__tok__symbol__symbol__eql__58 }
+tok__symbol__symbol__73 { L.PosToken _ L.Tk__tok__symbol__symbol__73 }
+tok__symbol__eql__71 { L.PosToken _ L.Tk__tok__symbol__eql__71 }
+tok__symbol__69 { L.PosToken _ L.Tk__tok__symbol__69 }
+tok__eql__eql__66 { L.PosToken _ L.Tk__tok__eql__eql__66 }
 tok__eql__10 { L.PosToken _ L.Tk__tok__eql__10 }
-tok__symbol__eql__68 { L.PosToken _ L.Tk__tok__symbol__eql__68 }
-tok__symbol__symbol__eql__55 { L.PosToken _ L.Tk__tok__symbol__symbol__eql__55 }
-tok__symbol__symbol__72 { L.PosToken _ L.Tk__tok__symbol__symbol__72 }
-tok__symbol__66 { L.PosToken _ L.Tk__tok__symbol__66 }
+tok__symbol__eql__70 { L.PosToken _ L.Tk__tok__symbol__eql__70 }
+tok__symbol__symbol__eql__57 { L.PosToken _ L.Tk__tok__symbol__symbol__eql__57 }
+tok__symbol__symbol__74 { L.PosToken _ L.Tk__tok__symbol__symbol__74 }
+tok__symbol__68 { L.PosToken _ L.Tk__tok__symbol__68 }
 tok__semi__1 { L.PosToken _ L.Tk__tok__semi__1 }
-tok__colon__34 { L.PosToken _ L.Tk__tok__colon__34 }
-tok__symbol__eql__50 { L.PosToken _ L.Tk__tok__symbol__eql__50 }
-tok__symbol__76 { L.PosToken _ L.Tk__tok__symbol__76 }
+tok__colon__36 { L.PosToken _ L.Tk__tok__colon__36 }
+tok__symbol__eql__52 { L.PosToken _ L.Tk__tok__symbol__eql__52 }
+tok__symbol__78 { L.PosToken _ L.Tk__tok__symbol__78 }
+tok__dot__dot__dot__32 { L.PosToken _ L.Tk__tok__dot__dot__dot__32 }
 tok__dot__4 { L.PosToken _ L.Tk__tok__dot__4 }
-tok__minus__eql__48 { L.PosToken _ L.Tk__tok__minus__eql__48 }
-tok__minus__minus__79 { L.PosToken _ L.Tk__tok__minus__minus__79 }
-tok__minus__75 { L.PosToken _ L.Tk__tok__minus__75 }
+tok__minus__eql__50 { L.PosToken _ L.Tk__tok__minus__eql__50 }
+tok__minus__minus__81 { L.PosToken _ L.Tk__tok__minus__minus__81 }
+tok__minus__77 { L.PosToken _ L.Tk__tok__minus__77 }
 tok__coma__9 { L.PosToken _ L.Tk__tok__coma__9 }
-tok__plus__eql__47 { L.PosToken _ L.Tk__tok__plus__eql__47 }
-tok__plus__plus__78 { L.PosToken _ L.Tk__tok__plus__plus__78 }
-tok__plus__74 { L.PosToken _ L.Tk__tok__plus__74 }
-tok__star__eql__49 { L.PosToken _ L.Tk__tok__star__eql__49 }
+tok__plus__eql__49 { L.PosToken _ L.Tk__tok__plus__eql__49 }
+tok__plus__plus__80 { L.PosToken _ L.Tk__tok__plus__plus__80 }
+tok__plus__76 { L.PosToken _ L.Tk__tok__plus__76 }
+tok__star__eql__51 { L.PosToken _ L.Tk__tok__star__eql__51 }
 tok__star__5 { L.PosToken _ L.Tk__tok__star__5 }
 tok__rparen__8 { L.PosToken _ L.Tk__tok__rparen__8 }
 tok__lparen__7 { L.PosToken _ L.Tk__tok__lparen__7 }
-tok__symbol__eql__52 { L.PosToken _ L.Tk__tok__symbol__eql__52 }
-tok__symbol__symbol__60 { L.PosToken _ L.Tk__tok__symbol__symbol__60 }
-tok__symbol__63 { L.PosToken _ L.Tk__tok__symbol__63 }
 tok__symbol__eql__54 { L.PosToken _ L.Tk__tok__symbol__eql__54 }
-tok__symbol__77 { L.PosToken _ L.Tk__tok__symbol__77 }
-tok__exclamation__eql__65 { L.PosToken _ L.Tk__tok__exclamation__eql__65 }
-tok__exclamation__81 { L.PosToken _ L.Tk__tok__exclamation__81 }
+tok__symbol__symbol__62 { L.PosToken _ L.Tk__tok__symbol__symbol__62 }
+tok__symbol__65 { L.PosToken _ L.Tk__tok__symbol__65 }
+tok__symbol__eql__56 { L.PosToken _ L.Tk__tok__symbol__eql__56 }
+tok__symbol__79 { L.PosToken _ L.Tk__tok__symbol__79 }
+tok__exclamation__eql__67 { L.PosToken _ L.Tk__tok__exclamation__eql__67 }
+tok__exclamation__83 { L.PosToken _ L.Tk__tok__exclamation__83 }
 doccomment { L.PosToken _ (L.Tk__doccomment _) }
 id { L.PosToken _ (L.Tk__id _) }
 string { L.PosToken _ (L.Tk__string _) }
@@ -239,12 +242,14 @@ qq_OptId { L.PosToken _ (L.Tk__qq_OptId _) }
 qq_OptExpression { L.PosToken _ (L.Tk__qq_OptExpression _) }
 qq_StatementList { L.PosToken _ (L.Tk__qq_StatementList _) }
 qq_Parameter { L.PosToken _ (L.Tk__qq_Parameter _) }
+qq_ParamModifierList { L.PosToken _ (L.Tk__qq_ParamModifierList _) }
 qq_ParameterList { L.PosToken _ (L.Tk__qq_ParameterList _) }
 qq_StaticInitializer { L.PosToken _ (L.Tk__qq_StaticInitializer _) }
 qq_VariableInitializer { L.PosToken _ (L.Tk__qq_VariableInitializer _) }
 qq_VariableInitializerList { L.PosToken _ (L.Tk__qq_VariableInitializerList _) }
 qq_VariableDeclarator { L.PosToken _ (L.Tk__qq_VariableDeclarator _) }
 qq_OptVariableInitializer { L.PosToken _ (L.Tk__qq_OptVariableInitializer _) }
+qq_LocalModifierList1 { L.PosToken _ (L.Tk__qq_LocalModifierList1 _) }
 qq_VariableDeclaration { L.PosToken _ (L.Tk__qq_VariableDeclaration _) }
 qq_VariableDeclaratorList { L.PosToken _ (L.Tk__qq_VariableDeclaratorList _) }
 qq_StatementBlock { L.PosToken _ (L.Tk__qq_StatementBlock _) }
@@ -290,97 +295,99 @@ qq_Java { L.PosToken _ (L.Tk__qq_Java _) }
 
 Java__top : Java rtk__eof { $1 }
 
-Java : tok_Java_dummy_170 Java tok_Java_dummy_170 { Ctr__Java__0 (rtkPosOf $1) $2 } |
-       tok_AdditiveOp_dummy_169 AdditiveOp tok_AdditiveOp_dummy_169 { Ctr__Java__1 (rtkPosOf $1) $2 } |
-       tok_Annotation_dummy_168 Annotation tok_Annotation_dummy_168 { Ctr__Java__2 (rtkPosOf $1) $2 } |
-       tok_AnnotationArguments_dummy_167 AnnotationArguments tok_AnnotationArguments_dummy_167 { Ctr__Java__3 (rtkPosOf $1) $2 } |
-       tok_AnnotationDeclaration_dummy_166 AnnotationDeclaration tok_AnnotationDeclaration_dummy_166 { Ctr__Java__4 (rtkPosOf $1) $2 } |
-       tok_AnnotationElement_dummy_165 AnnotationElement tok_AnnotationElement_dummy_165 { Ctr__Java__5 (rtkPosOf $1) $2 } |
-       tok_AnnotationList_dummy_164 AnnotationList tok_AnnotationList_dummy_164 { Ctr__Java__6 (rtkPosOf $1) (reverse $2) } |
-       tok_AnnotationTypeElement_dummy_163 AnnotationTypeElement tok_AnnotationTypeElement_dummy_163 { Ctr__Java__7 (rtkPosOf $1) $2 } |
-       tok_AnnotationTypeElementList_dummy_162 AnnotationTypeElementList tok_AnnotationTypeElementList_dummy_162 { Ctr__Java__8 (rtkPosOf $1) (reverse $2) } |
-       tok_Arglist_dummy_161 Arglist tok_Arglist_dummy_161 { Ctr__Java__9 (rtkPosOf $1) $2 } |
-       tok_AssignmentOp_dummy_160 AssignmentOp tok_AssignmentOp_dummy_160 { Ctr__Java__10 (rtkPosOf $1) $2 } |
-       tok_CatchList_dummy_159 CatchList tok_CatchList_dummy_159 { Ctr__Java__11 (rtkPosOf $1) (reverse $2) } |
-       tok_ClassDeclaration_dummy_158 ClassDeclaration tok_ClassDeclaration_dummy_158 { Ctr__Java__12 (rtkPosOf $1) $2 } |
-       tok_CompilationUnit_dummy_157 CompilationUnit tok_CompilationUnit_dummy_157 { Ctr__Java__13 (rtkPosOf $1) $2 } |
-       tok_CompoundName_dummy_156 CompoundName tok_CompoundName_dummy_156 { Ctr__Java__14 (rtkPosOf $1) $2 } |
-       tok_CreationExpression_dummy_155 CreationExpression tok_CreationExpression_dummy_155 { Ctr__Java__15 (rtkPosOf $1) $2 } |
-       tok_DimExprs_dummy_154 DimExprs tok_DimExprs_dummy_154 { Ctr__Java__16 (rtkPosOf $1) (reverse $2) } |
-       tok_Dims_dummy_153 Dims tok_Dims_dummy_153 { Ctr__Java__17 (rtkPosOf $1) (reverse $2) } |
-       tok_DoStatement_dummy_152 DoStatement tok_DoStatement_dummy_152 { Ctr__Java__18 (rtkPosOf $1) $2 } |
-       tok_DocComment_dummy_151 DocComment tok_DocComment_dummy_151 { Ctr__Java__19 (rtkPosOf $1) $2 } |
-       tok_EnumConstant_dummy_150 EnumConstant tok_EnumConstant_dummy_150 { Ctr__Java__20 (rtkPosOf $1) $2 } |
-       tok_EnumConstantList_dummy_149 EnumConstantList tok_EnumConstantList_dummy_149 { Ctr__Java__21 (rtkPosOf $1) $2 } |
-       tok_EnumDeclaration_dummy_148 EnumDeclaration tok_EnumDeclaration_dummy_148 { Ctr__Java__22 (rtkPosOf $1) $2 } |
-       tok_EqualityOp_dummy_147 EqualityOp tok_EqualityOp_dummy_147 { Ctr__Java__23 (rtkPosOf $1) $2 } |
-       tok_Expression_dummy_146 Expression tok_Expression_dummy_146 { Ctr__Java__24 (rtkPosOf $1) $2 } |
-       tok_ExtendsList_dummy_145 ExtendsList tok_ExtendsList_dummy_145 { Ctr__Java__25 (rtkPosOf $1) $2 } |
-       tok_FieldDeclaration_dummy_144 FieldDeclaration tok_FieldDeclaration_dummy_144 { Ctr__Java__26 (rtkPosOf $1) $2 } |
-       tok_FieldDeclarationList_dummy_143 FieldDeclarationList tok_FieldDeclarationList_dummy_143 { Ctr__Java__27 (rtkPosOf $1) (reverse $2) } |
-       tok_ForStatement_dummy_142 ForStatement tok_ForStatement_dummy_142 { Ctr__Java__28 (rtkPosOf $1) $2 } |
-       tok_IfStatement_dummy_141 IfStatement tok_IfStatement_dummy_141 { Ctr__Java__29 (rtkPosOf $1) $2 } |
-       tok_ImplementsList_dummy_140 ImplementsList tok_ImplementsList_dummy_140 { Ctr__Java__30 (rtkPosOf $1) $2 } |
-       tok_ImportHead_dummy_139 ImportHead tok_ImportHead_dummy_139 { Ctr__Java__31 (rtkPosOf $1) $2 } |
-       tok_ImportList_dummy_138 ImportList tok_ImportList_dummy_138 { Ctr__Java__32 (rtkPosOf $1) (reverse $2) } |
-       tok_ImportName_dummy_137 ImportName tok_ImportName_dummy_137 { Ctr__Java__33 (rtkPosOf $1) $2 } |
-       tok_ImportStatement_dummy_136 ImportStatement tok_ImportStatement_dummy_136 { Ctr__Java__34 (rtkPosOf $1) $2 } |
-       tok_InterfaceDeclaration_dummy_135 InterfaceDeclaration tok_InterfaceDeclaration_dummy_135 { Ctr__Java__35 (rtkPosOf $1) $2 } |
-       tok_Literal_dummy_134 Literal tok_Literal_dummy_134 { Ctr__Java__36 (rtkPosOf $1) $2 } |
-       tok_MemberAfterFirstId_dummy_133 MemberAfterFirstId tok_MemberAfterFirstId_dummy_133 { Ctr__Java__37 (rtkPosOf $1) $2 } |
-       tok_MemberDeclaration_dummy_132 MemberDeclaration tok_MemberDeclaration_dummy_132 { Ctr__Java__38 (rtkPosOf $1) $2 } |
-       tok_MemberRest_dummy_131 MemberRest tok_MemberRest_dummy_131 { Ctr__Java__39 (rtkPosOf $1) $2 } |
-       tok_Modifier_dummy_130 Modifier tok_Modifier_dummy_130 { Ctr__Java__40 (rtkPosOf $1) $2 } |
-       tok_ModifierList_dummy_129 ModifierList tok_ModifierList_dummy_129 { Ctr__Java__41 (rtkPosOf $1) (reverse $2) } |
-       tok_MoreTypeSpecifier_dummy_128 MoreTypeSpecifier tok_MoreTypeSpecifier_dummy_128 { Ctr__Java__42 (rtkPosOf $1) $2 } |
-       tok_MoreVariableDeclarators_dummy_127 MoreVariableDeclarators tok_MoreVariableDeclarators_dummy_127 { Ctr__Java__43 (rtkPosOf $1) (reverse $2) } |
-       tok_MultiplicativeOp_dummy_126 MultiplicativeOp tok_MultiplicativeOp_dummy_126 { Ctr__Java__44 (rtkPosOf $1) $2 } |
-       tok_NonEmptyDims_dummy_125 NonEmptyDims tok_NonEmptyDims_dummy_125 { Ctr__Java__45 (rtkPosOf $1) (reverse $2) } |
-       tok_NonEmptyTypeArguments_dummy_124 NonEmptyTypeArguments tok_NonEmptyTypeArguments_dummy_124 { Ctr__Java__46 (rtkPosOf $1) $2 } |
-       tok_OptDocComment_dummy_123 OptDocComment tok_OptDocComment_dummy_123 { Ctr__Java__47 (rtkPosOf $1) $2 } |
-       tok_OptElsePart_dummy_122 OptElsePart tok_OptElsePart_dummy_122 { Ctr__Java__48 (rtkPosOf $1) $2 } |
-       tok_OptExpression_dummy_121 OptExpression tok_OptExpression_dummy_121 { Ctr__Java__49 (rtkPosOf $1) $2 } |
-       tok_OptFinally_dummy_120 OptFinally tok_OptFinally_dummy_120 { Ctr__Java__50 (rtkPosOf $1) $2 } |
-       tok_OptId_dummy_119 OptId tok_OptId_dummy_119 { Ctr__Java__51 (rtkPosOf $1) $2 } |
-       tok_OptVariableInitializer_dummy_118 OptVariableInitializer tok_OptVariableInitializer_dummy_118 { Ctr__Java__52 (rtkPosOf $1) $2 } |
-       tok_Package_dummy_117 Package tok_Package_dummy_117 { Ctr__Java__53 (rtkPosOf $1) $2 } |
-       tok_Parameter_dummy_116 Parameter tok_Parameter_dummy_116 { Ctr__Java__54 (rtkPosOf $1) $2 } |
-       tok_ParameterList_dummy_115 ParameterList tok_ParameterList_dummy_115 { Ctr__Java__55 (rtkPosOf $1) $2 } |
-       tok_PostfixOp_dummy_114 PostfixOp tok_PostfixOp_dummy_114 { Ctr__Java__56 (rtkPosOf $1) $2 } |
-       tok_PrefixOp_dummy_113 PrefixOp tok_PrefixOp_dummy_113 { Ctr__Java__57 (rtkPosOf $1) $2 } |
-       tok_PrimitiveTypeKeyword_dummy_112 PrimitiveTypeKeyword tok_PrimitiveTypeKeyword_dummy_112 { Ctr__Java__58 (rtkPosOf $1) $2 } |
-       tok_RelationalOp_dummy_111 RelationalOp tok_RelationalOp_dummy_111 { Ctr__Java__59 (rtkPosOf $1) $2 } |
-       tok_ShiftOp_dummy_110 ShiftOp tok_ShiftOp_dummy_110 { Ctr__Java__60 (rtkPosOf $1) $2 } |
-       tok_Statement_dummy_109 Statement tok_Statement_dummy_109 { Ctr__Java__61 (rtkPosOf $1) $2 } |
-       tok_StatementBlock_dummy_108 StatementBlock tok_StatementBlock_dummy_108 { Ctr__Java__62 (rtkPosOf $1) $2 } |
-       tok_StatementList_dummy_107 StatementList tok_StatementList_dummy_107 { Ctr__Java__63 (rtkPosOf $1) (reverse $2) } |
-       tok_StaticInitializer_dummy_106 StaticInitializer tok_StaticInitializer_dummy_106 { Ctr__Java__64 (rtkPosOf $1) $2 } |
-       tok_SwitchCaseList_dummy_105 SwitchCaseList tok_SwitchCaseList_dummy_105 { Ctr__Java__65 (rtkPosOf $1) (reverse $2) } |
-       tok_SwitchStatement_dummy_104 SwitchStatement tok_SwitchStatement_dummy_104 { Ctr__Java__66 (rtkPosOf $1) $2 } |
-       tok_ThrowsClause_dummy_103 ThrowsClause tok_ThrowsClause_dummy_103 { Ctr__Java__67 (rtkPosOf $1) $2 } |
-       tok_TryStatement_dummy_102 TryStatement tok_TryStatement_dummy_102 { Ctr__Java__68 (rtkPosOf $1) $2 } |
-       tok_Type_dummy_101 Type tok_Type_dummy_101 { Ctr__Java__69 (rtkPosOf $1) $2 } |
-       tok_TypeArgument_dummy_100 TypeArgument tok_TypeArgument_dummy_100 { Ctr__Java__70 (rtkPosOf $1) $2 } |
-       tok_TypeArguments_dummy_99 TypeArguments tok_TypeArguments_dummy_99 { Ctr__Java__71 (rtkPosOf $1) $2 } |
-       tok_TypeDeclRest_dummy_98 TypeDeclRest tok_TypeDeclRest_dummy_98 { Ctr__Java__72 (rtkPosOf $1) $2 } |
-       tok_TypeDeclaration_dummy_97 TypeDeclaration tok_TypeDeclaration_dummy_97 { Ctr__Java__73 (rtkPosOf $1) $2 } |
-       tok_TypeParameter_dummy_96 TypeParameter tok_TypeParameter_dummy_96 { Ctr__Java__74 (rtkPosOf $1) $2 } |
-       tok_TypeParameters_dummy_95 TypeParameters tok_TypeParameters_dummy_95 { Ctr__Java__75 (rtkPosOf $1) $2 } |
-       tok_TypeSpecifier_dummy_94 TypeSpecifier tok_TypeSpecifier_dummy_94 { Ctr__Java__76 (rtkPosOf $1) $2 } |
-       tok_VariableDeclaration_dummy_93 VariableDeclaration tok_VariableDeclaration_dummy_93 { Ctr__Java__77 (rtkPosOf $1) $2 } |
-       tok_VariableDeclarator_dummy_92 VariableDeclarator tok_VariableDeclarator_dummy_92 { Ctr__Java__78 (rtkPosOf $1) $2 } |
-       tok_VariableDeclaratorList_dummy_91 VariableDeclaratorList tok_VariableDeclaratorList_dummy_91 { Ctr__Java__79 (rtkPosOf $1) $2 } |
-       tok_VariableInitializer_dummy_90 VariableInitializer tok_VariableInitializer_dummy_90 { Ctr__Java__80 (rtkPosOf $1) $2 } |
-       tok_VariableInitializerList_dummy_89 VariableInitializerList tok_VariableInitializerList_dummy_89 { Ctr__Java__81 (rtkPosOf $1) $2 } |
-       tok_WhileStatement_dummy_88 WhileStatement tok_WhileStatement_dummy_88 { Ctr__Java__82 (rtkPosOf $1) $2 } |
-       tok_WildcardType_dummy_87 WildcardType tok_WildcardType_dummy_87 { Ctr__Java__83 (rtkPosOf $1) $2 }
+Java : tok_Java_dummy_177 Java tok_Java_dummy_177 { Ctr__Java__0 (rtkPosOf $1) $2 } |
+       tok_AdditiveOp_dummy_176 AdditiveOp tok_AdditiveOp_dummy_176 { Ctr__Java__1 (rtkPosOf $1) $2 } |
+       tok_Annotation_dummy_175 Annotation tok_Annotation_dummy_175 { Ctr__Java__2 (rtkPosOf $1) $2 } |
+       tok_AnnotationArguments_dummy_174 AnnotationArguments tok_AnnotationArguments_dummy_174 { Ctr__Java__3 (rtkPosOf $1) $2 } |
+       tok_AnnotationDeclaration_dummy_173 AnnotationDeclaration tok_AnnotationDeclaration_dummy_173 { Ctr__Java__4 (rtkPosOf $1) $2 } |
+       tok_AnnotationElement_dummy_172 AnnotationElement tok_AnnotationElement_dummy_172 { Ctr__Java__5 (rtkPosOf $1) $2 } |
+       tok_AnnotationList_dummy_171 AnnotationList tok_AnnotationList_dummy_171 { Ctr__Java__6 (rtkPosOf $1) (reverse $2) } |
+       tok_AnnotationTypeElement_dummy_170 AnnotationTypeElement tok_AnnotationTypeElement_dummy_170 { Ctr__Java__7 (rtkPosOf $1) $2 } |
+       tok_AnnotationTypeElementList_dummy_169 AnnotationTypeElementList tok_AnnotationTypeElementList_dummy_169 { Ctr__Java__8 (rtkPosOf $1) (reverse $2) } |
+       tok_Arglist_dummy_168 Arglist tok_Arglist_dummy_168 { Ctr__Java__9 (rtkPosOf $1) $2 } |
+       tok_AssignmentOp_dummy_167 AssignmentOp tok_AssignmentOp_dummy_167 { Ctr__Java__10 (rtkPosOf $1) $2 } |
+       tok_CatchList_dummy_166 CatchList tok_CatchList_dummy_166 { Ctr__Java__11 (rtkPosOf $1) (reverse $2) } |
+       tok_ClassDeclaration_dummy_165 ClassDeclaration tok_ClassDeclaration_dummy_165 { Ctr__Java__12 (rtkPosOf $1) $2 } |
+       tok_CompilationUnit_dummy_164 CompilationUnit tok_CompilationUnit_dummy_164 { Ctr__Java__13 (rtkPosOf $1) $2 } |
+       tok_CompoundName_dummy_163 CompoundName tok_CompoundName_dummy_163 { Ctr__Java__14 (rtkPosOf $1) $2 } |
+       tok_CreationExpression_dummy_162 CreationExpression tok_CreationExpression_dummy_162 { Ctr__Java__15 (rtkPosOf $1) $2 } |
+       tok_DimExprs_dummy_161 DimExprs tok_DimExprs_dummy_161 { Ctr__Java__16 (rtkPosOf $1) (reverse $2) } |
+       tok_Dims_dummy_160 Dims tok_Dims_dummy_160 { Ctr__Java__17 (rtkPosOf $1) (reverse $2) } |
+       tok_DoStatement_dummy_159 DoStatement tok_DoStatement_dummy_159 { Ctr__Java__18 (rtkPosOf $1) $2 } |
+       tok_DocComment_dummy_158 DocComment tok_DocComment_dummy_158 { Ctr__Java__19 (rtkPosOf $1) $2 } |
+       tok_EnumConstant_dummy_157 EnumConstant tok_EnumConstant_dummy_157 { Ctr__Java__20 (rtkPosOf $1) $2 } |
+       tok_EnumConstantList_dummy_156 EnumConstantList tok_EnumConstantList_dummy_156 { Ctr__Java__21 (rtkPosOf $1) $2 } |
+       tok_EnumDeclaration_dummy_155 EnumDeclaration tok_EnumDeclaration_dummy_155 { Ctr__Java__22 (rtkPosOf $1) $2 } |
+       tok_EqualityOp_dummy_154 EqualityOp tok_EqualityOp_dummy_154 { Ctr__Java__23 (rtkPosOf $1) $2 } |
+       tok_Expression_dummy_153 Expression tok_Expression_dummy_153 { Ctr__Java__24 (rtkPosOf $1) $2 } |
+       tok_ExtendsList_dummy_152 ExtendsList tok_ExtendsList_dummy_152 { Ctr__Java__25 (rtkPosOf $1) $2 } |
+       tok_FieldDeclaration_dummy_151 FieldDeclaration tok_FieldDeclaration_dummy_151 { Ctr__Java__26 (rtkPosOf $1) $2 } |
+       tok_FieldDeclarationList_dummy_150 FieldDeclarationList tok_FieldDeclarationList_dummy_150 { Ctr__Java__27 (rtkPosOf $1) (reverse $2) } |
+       tok_ForStatement_dummy_149 ForStatement tok_ForStatement_dummy_149 { Ctr__Java__28 (rtkPosOf $1) $2 } |
+       tok_IfStatement_dummy_148 IfStatement tok_IfStatement_dummy_148 { Ctr__Java__29 (rtkPosOf $1) $2 } |
+       tok_ImplementsList_dummy_147 ImplementsList tok_ImplementsList_dummy_147 { Ctr__Java__30 (rtkPosOf $1) $2 } |
+       tok_ImportHead_dummy_146 ImportHead tok_ImportHead_dummy_146 { Ctr__Java__31 (rtkPosOf $1) $2 } |
+       tok_ImportList_dummy_145 ImportList tok_ImportList_dummy_145 { Ctr__Java__32 (rtkPosOf $1) (reverse $2) } |
+       tok_ImportName_dummy_144 ImportName tok_ImportName_dummy_144 { Ctr__Java__33 (rtkPosOf $1) $2 } |
+       tok_ImportStatement_dummy_143 ImportStatement tok_ImportStatement_dummy_143 { Ctr__Java__34 (rtkPosOf $1) $2 } |
+       tok_InterfaceDeclaration_dummy_142 InterfaceDeclaration tok_InterfaceDeclaration_dummy_142 { Ctr__Java__35 (rtkPosOf $1) $2 } |
+       tok_Literal_dummy_141 Literal tok_Literal_dummy_141 { Ctr__Java__36 (rtkPosOf $1) $2 } |
+       tok_LocalModifierList1_dummy_140 LocalModifierList1 tok_LocalModifierList1_dummy_140 { Ctr__Java__37 (rtkPosOf $1) (reverse $2) } |
+       tok_MemberAfterFirstId_dummy_139 MemberAfterFirstId tok_MemberAfterFirstId_dummy_139 { Ctr__Java__38 (rtkPosOf $1) $2 } |
+       tok_MemberDeclaration_dummy_138 MemberDeclaration tok_MemberDeclaration_dummy_138 { Ctr__Java__39 (rtkPosOf $1) $2 } |
+       tok_MemberRest_dummy_137 MemberRest tok_MemberRest_dummy_137 { Ctr__Java__40 (rtkPosOf $1) $2 } |
+       tok_Modifier_dummy_136 Modifier tok_Modifier_dummy_136 { Ctr__Java__41 (rtkPosOf $1) $2 } |
+       tok_ModifierList_dummy_135 ModifierList tok_ModifierList_dummy_135 { Ctr__Java__42 (rtkPosOf $1) (reverse $2) } |
+       tok_MoreTypeSpecifier_dummy_134 MoreTypeSpecifier tok_MoreTypeSpecifier_dummy_134 { Ctr__Java__43 (rtkPosOf $1) $2 } |
+       tok_MoreVariableDeclarators_dummy_133 MoreVariableDeclarators tok_MoreVariableDeclarators_dummy_133 { Ctr__Java__44 (rtkPosOf $1) (reverse $2) } |
+       tok_MultiplicativeOp_dummy_132 MultiplicativeOp tok_MultiplicativeOp_dummy_132 { Ctr__Java__45 (rtkPosOf $1) $2 } |
+       tok_NonEmptyDims_dummy_131 NonEmptyDims tok_NonEmptyDims_dummy_131 { Ctr__Java__46 (rtkPosOf $1) (reverse $2) } |
+       tok_NonEmptyTypeArguments_dummy_130 NonEmptyTypeArguments tok_NonEmptyTypeArguments_dummy_130 { Ctr__Java__47 (rtkPosOf $1) $2 } |
+       tok_OptDocComment_dummy_129 OptDocComment tok_OptDocComment_dummy_129 { Ctr__Java__48 (rtkPosOf $1) $2 } |
+       tok_OptElsePart_dummy_128 OptElsePart tok_OptElsePart_dummy_128 { Ctr__Java__49 (rtkPosOf $1) $2 } |
+       tok_OptExpression_dummy_127 OptExpression tok_OptExpression_dummy_127 { Ctr__Java__50 (rtkPosOf $1) $2 } |
+       tok_OptFinally_dummy_126 OptFinally tok_OptFinally_dummy_126 { Ctr__Java__51 (rtkPosOf $1) $2 } |
+       tok_OptId_dummy_125 OptId tok_OptId_dummy_125 { Ctr__Java__52 (rtkPosOf $1) $2 } |
+       tok_OptVariableInitializer_dummy_124 OptVariableInitializer tok_OptVariableInitializer_dummy_124 { Ctr__Java__53 (rtkPosOf $1) $2 } |
+       tok_Package_dummy_123 Package tok_Package_dummy_123 { Ctr__Java__54 (rtkPosOf $1) $2 } |
+       tok_ParamModifierList_dummy_122 ParamModifierList tok_ParamModifierList_dummy_122 { Ctr__Java__55 (rtkPosOf $1) (reverse $2) } |
+       tok_Parameter_dummy_121 Parameter tok_Parameter_dummy_121 { Ctr__Java__56 (rtkPosOf $1) $2 } |
+       tok_ParameterList_dummy_120 ParameterList tok_ParameterList_dummy_120 { Ctr__Java__57 (rtkPosOf $1) $2 } |
+       tok_PostfixOp_dummy_119 PostfixOp tok_PostfixOp_dummy_119 { Ctr__Java__58 (rtkPosOf $1) $2 } |
+       tok_PrefixOp_dummy_118 PrefixOp tok_PrefixOp_dummy_118 { Ctr__Java__59 (rtkPosOf $1) $2 } |
+       tok_PrimitiveTypeKeyword_dummy_117 PrimitiveTypeKeyword tok_PrimitiveTypeKeyword_dummy_117 { Ctr__Java__60 (rtkPosOf $1) $2 } |
+       tok_RelationalOp_dummy_116 RelationalOp tok_RelationalOp_dummy_116 { Ctr__Java__61 (rtkPosOf $1) $2 } |
+       tok_ShiftOp_dummy_115 ShiftOp tok_ShiftOp_dummy_115 { Ctr__Java__62 (rtkPosOf $1) $2 } |
+       tok_Statement_dummy_114 Statement tok_Statement_dummy_114 { Ctr__Java__63 (rtkPosOf $1) $2 } |
+       tok_StatementBlock_dummy_113 StatementBlock tok_StatementBlock_dummy_113 { Ctr__Java__64 (rtkPosOf $1) $2 } |
+       tok_StatementList_dummy_112 StatementList tok_StatementList_dummy_112 { Ctr__Java__65 (rtkPosOf $1) (reverse $2) } |
+       tok_StaticInitializer_dummy_111 StaticInitializer tok_StaticInitializer_dummy_111 { Ctr__Java__66 (rtkPosOf $1) $2 } |
+       tok_SwitchCaseList_dummy_110 SwitchCaseList tok_SwitchCaseList_dummy_110 { Ctr__Java__67 (rtkPosOf $1) (reverse $2) } |
+       tok_SwitchStatement_dummy_109 SwitchStatement tok_SwitchStatement_dummy_109 { Ctr__Java__68 (rtkPosOf $1) $2 } |
+       tok_ThrowsClause_dummy_108 ThrowsClause tok_ThrowsClause_dummy_108 { Ctr__Java__69 (rtkPosOf $1) $2 } |
+       tok_TryStatement_dummy_107 TryStatement tok_TryStatement_dummy_107 { Ctr__Java__70 (rtkPosOf $1) $2 } |
+       tok_Type_dummy_106 Type tok_Type_dummy_106 { Ctr__Java__71 (rtkPosOf $1) $2 } |
+       tok_TypeArgument_dummy_105 TypeArgument tok_TypeArgument_dummy_105 { Ctr__Java__72 (rtkPosOf $1) $2 } |
+       tok_TypeArguments_dummy_104 TypeArguments tok_TypeArguments_dummy_104 { Ctr__Java__73 (rtkPosOf $1) $2 } |
+       tok_TypeDeclRest_dummy_103 TypeDeclRest tok_TypeDeclRest_dummy_103 { Ctr__Java__74 (rtkPosOf $1) $2 } |
+       tok_TypeDeclaration_dummy_102 TypeDeclaration tok_TypeDeclaration_dummy_102 { Ctr__Java__75 (rtkPosOf $1) $2 } |
+       tok_TypeParameter_dummy_101 TypeParameter tok_TypeParameter_dummy_101 { Ctr__Java__76 (rtkPosOf $1) $2 } |
+       tok_TypeParameters_dummy_100 TypeParameters tok_TypeParameters_dummy_100 { Ctr__Java__77 (rtkPosOf $1) $2 } |
+       tok_TypeSpecifier_dummy_99 TypeSpecifier tok_TypeSpecifier_dummy_99 { Ctr__Java__78 (rtkPosOf $1) $2 } |
+       tok_VariableDeclaration_dummy_98 VariableDeclaration tok_VariableDeclaration_dummy_98 { Ctr__Java__79 (rtkPosOf $1) $2 } |
+       tok_VariableDeclarator_dummy_97 VariableDeclarator tok_VariableDeclarator_dummy_97 { Ctr__Java__80 (rtkPosOf $1) $2 } |
+       tok_VariableDeclaratorList_dummy_96 VariableDeclaratorList tok_VariableDeclaratorList_dummy_96 { Ctr__Java__81 (rtkPosOf $1) $2 } |
+       tok_VariableInitializer_dummy_95 VariableInitializer tok_VariableInitializer_dummy_95 { Ctr__Java__82 (rtkPosOf $1) $2 } |
+       tok_VariableInitializerList_dummy_94 VariableInitializerList tok_VariableInitializerList_dummy_94 { Ctr__Java__83 (rtkPosOf $1) $2 } |
+       tok_WhileStatement_dummy_93 WhileStatement tok_WhileStatement_dummy_93 { Ctr__Java__84 (rtkPosOf $1) $2 } |
+       tok_WildcardType_dummy_92 WildcardType tok_WildcardType_dummy_92 { Ctr__Java__85 (rtkPosOf $1) $2 }
 
 Java : qq_Java { Anti_Java (tkVal_qq_Java $1) } |
-       CompilationUnit { Ctr__Java__84 (rtkPosOf $1) $1 }
+       CompilationUnit { Ctr__Java__86 (rtkPosOf $1) $1 }
 
 AdditiveOp : qq_AdditiveOp { Anti_AdditiveOp (tkVal_qq_AdditiveOp $1) } |
-             tok__plus__74 { Ctr__AdditiveOp__0 (rtkPosOf $1) } |
-             tok__minus__75 { Ctr__AdditiveOp__1 (rtkPosOf $1) }
+             tok__plus__76 { Ctr__AdditiveOp__0 (rtkPosOf $1) } |
+             tok__minus__77 { Ctr__AdditiveOp__1 (rtkPosOf $1) }
 
 ListElem_AnnotationList9 : qq_AnnotationList { Anti_Annotation (tkVal_qq_AnnotationList $1) } |
                            Annotation { $1 }
@@ -412,24 +419,24 @@ AnnotationTypeElementList : {- empty -} { [] } |
 
 Arglist : qq_Arglist { Anti_Arglist (tkVal_qq_Arglist $1) } |
           { Ctr__Arglist__0 rtkNoPos } |
-          Rule_73 { Ctr__Arglist__1 (rtkPosOf $1) $1 }
+          Rule_78 { Ctr__Arglist__1 (rtkPosOf $1) $1 }
 
 AssignmentOp : qq_AssignmentOp { Anti_AssignmentOp (tkVal_qq_AssignmentOp $1) } |
                tok__eql__10 { Ctr__AssignmentOp__0 (rtkPosOf $1) } |
-               tok__plus__eql__47 { Ctr__AssignmentOp__1 (rtkPosOf $1) } |
-               tok__minus__eql__48 { Ctr__AssignmentOp__2 (rtkPosOf $1) } |
-               tok__star__eql__49 { Ctr__AssignmentOp__3 (rtkPosOf $1) } |
-               tok__symbol__eql__50 { Ctr__AssignmentOp__4 (rtkPosOf $1) } |
-               tok__pipe__eql__51 { Ctr__AssignmentOp__5 (rtkPosOf $1) } |
-               tok__symbol__eql__52 { Ctr__AssignmentOp__6 (rtkPosOf $1) } |
-               tok__symbol__eql__53 { Ctr__AssignmentOp__7 (rtkPosOf $1) } |
-               tok__symbol__eql__54 { Ctr__AssignmentOp__8 (rtkPosOf $1) } |
-               tok__symbol__symbol__eql__55 { Ctr__AssignmentOp__9 (rtkPosOf $1) } |
-               tok__symbol__symbol__eql__56 { Ctr__AssignmentOp__10 (rtkPosOf $1) } |
-               tok__symbol__symbol__symbol__eql__57 { Ctr__AssignmentOp__11 (rtkPosOf $1) }
+               tok__plus__eql__49 { Ctr__AssignmentOp__1 (rtkPosOf $1) } |
+               tok__minus__eql__50 { Ctr__AssignmentOp__2 (rtkPosOf $1) } |
+               tok__star__eql__51 { Ctr__AssignmentOp__3 (rtkPosOf $1) } |
+               tok__symbol__eql__52 { Ctr__AssignmentOp__4 (rtkPosOf $1) } |
+               tok__pipe__eql__53 { Ctr__AssignmentOp__5 (rtkPosOf $1) } |
+               tok__symbol__eql__54 { Ctr__AssignmentOp__6 (rtkPosOf $1) } |
+               tok__symbol__eql__55 { Ctr__AssignmentOp__7 (rtkPosOf $1) } |
+               tok__symbol__eql__56 { Ctr__AssignmentOp__8 (rtkPosOf $1) } |
+               tok__symbol__symbol__eql__57 { Ctr__AssignmentOp__9 (rtkPosOf $1) } |
+               tok__symbol__symbol__eql__58 { Ctr__AssignmentOp__10 (rtkPosOf $1) } |
+               tok__symbol__symbol__symbol__eql__59 { Ctr__AssignmentOp__11 (rtkPosOf $1) }
 
 CatchList : {- empty -} { [] } |
-            CatchList ListElem_CatchList59 { $2 : $1 }
+            CatchList ListElem_CatchList64 { $2 : $1 }
 
 ClassDeclaration : qq_ClassDeclaration { Anti_ClassDeclaration (tkVal_qq_ClassDeclaration $1) } |
                    tok_class_13 id TypeParameters Rule_16 Rule_17 tok__symbol__14 FieldDeclarationList tok__symbol__15 { Ctr__ClassDeclaration__0 (rtkPosOf $1) (tkVal_id $2) $3 $4 $5 (reverse $7) }
@@ -438,19 +445,19 @@ CompilationUnit : qq_CompilationUnit { Anti_CompilationUnit (tkVal_qq_Compilatio
                   Rule_1 ImportList Rule_2 { Ctr__CompilationUnit__0 (rtkPosOf $1) $1 (reverse $2) $3 }
 
 CompoundName : qq_CompoundName { Anti_CompoundName (tkVal_qq_CompoundName $1) } |
-               id Rule_85 { Ctr__CompoundName__0 (rtkPosOf $1) (tkVal_id $1) (reverse $2) }
+               id Rule_90 { Ctr__CompoundName__0 (rtkPosOf $1) (tkVal_id $1) (reverse $2) }
 
 CreationExpression : qq_CreationExpression { Anti_CreationExpression (tkVal_qq_CreationExpression $1) } |
-                     tok_new_84 TypeSpecifier Rule_69 { Ctr__CreationExpression__0 (rtkPosOf $1) $2 $3 }
+                     tok_new_86 TypeSpecifier Rule_74 { Ctr__CreationExpression__0 (rtkPosOf $1) $2 $3 }
 
-DimExprs : ListElem_DimExprs72 { [$1] } |
-           DimExprs ListElem_DimExprs72 { $2 : $1 }
+DimExprs : ListElem_DimExprs77 { [$1] } |
+           DimExprs ListElem_DimExprs77 { $2 : $1 }
 
 Dims : {- empty -} { [] } |
        Dims ListElem_Dims32 { $2 : $1 }
 
 DoStatement : qq_DoStatement { Anti_DoStatement (tkVal_qq_DoStatement $1) } |
-              tok_do_39 Statement tok_while_40 tok__lparen__7 Expression tok__rparen__8 tok__semi__1 { Ctr__DoStatement__0 (rtkPosOf $1) $2 $5 }
+              tok_do_41 Statement tok_while_42 tok__lparen__7 Expression tok__rparen__8 tok__semi__1 { Ctr__DoStatement__0 (rtkPosOf $1) $2 $5 }
 
 DocComment : qq_DocComment { Anti_DocComment (tkVal_qq_DocComment $1) } |
              doccomment { Ctr__DocComment__0 (rtkPosOf $1) (tkVal_doccomment $1) }
@@ -465,17 +472,17 @@ EnumDeclaration : qq_EnumDeclaration { Anti_EnumDeclaration (tkVal_qq_EnumDeclar
                   tok_enum_17 id Rule_27 tok__symbol__14 EnumConstantList Rule_28 tok__symbol__15 { Ctr__EnumDeclaration__0 (rtkPosOf $1) (tkVal_id $2) $3 $5 $6 }
 
 EqualityOp : qq_EqualityOp { Anti_EqualityOp (tkVal_qq_EqualityOp $1) } |
-             tok__eql__eql__64 { Ctr__EqualityOp__0 (rtkPosOf $1) } |
-             tok__exclamation__eql__65 { Ctr__EqualityOp__1 (rtkPosOf $1) }
+             tok__eql__eql__66 { Ctr__EqualityOp__0 (rtkPosOf $1) } |
+             tok__exclamation__eql__67 { Ctr__EqualityOp__1 (rtkPosOf $1) }
 
 PrimaryNoPostfix : qq_Expression { Anti_Expression (tkVal_qq_Expression $1) } |
                    Literal { Ctr__Expression__0 (rtkPosOf $1) $1 } |
-                   tok_this_82 { Ctr__Expression__1 (rtkPosOf $1) } |
+                   tok_this_84 { Ctr__Expression__1 (rtkPosOf $1) } |
                    tok__lparen__7 Expression tok__rparen__8 { Ctr__Expression__2 (rtkPosOf $1) $2 } |
                    CreationExpression { Ctr__Expression__3 (rtkPosOf $1) $1 } |
-                   CompoundName Rule_65 { Ctr__Expression__4 (rtkPosOf $1) $1 $2 } |
+                   CompoundName Rule_70 { Ctr__Expression__4 (rtkPosOf $1) $1 $2 } |
                    CompoundName tok__sq_bkt_l__18 Expression tok__sq_bkt_r__19 { Ctr__Expression__5 (rtkPosOf $1) $1 $3 } |
-                   tok_super_83 tok__dot__4 id Rule_67 { Ctr__Expression__6 (rtkPosOf $1) (tkVal_id $3) $4 }
+                   tok_super_85 tok__dot__4 id Rule_72 { Ctr__Expression__6 (rtkPosOf $1) (tkVal_id $3) $4 }
 
 PostfixExpression : PrimaryNoPostfix { Ctr__Expression__7 (rtkPosOf $1) $1 } |
                     PostfixExpression PostfixOp { Ctr__Expression__8 (rtkPosOf $1) $1 $2 } |
@@ -484,8 +491,8 @@ PostfixExpression : PrimaryNoPostfix { Ctr__Expression__7 (rtkPosOf $1) $1 } |
                     PostfixExpression tok__sq_bkt_l__18 Expression tok__sq_bkt_r__19 { Ctr__Expression__11 (rtkPosOf $1) $1 $3 }
 
 UnaryExpressionNotPlusMinus : PostfixExpression { Ctr__Expression__12 (rtkPosOf $1) $1 } |
-                              tok__tilde__80 UnaryExpression { Ctr__Expression__13 (rtkPosOf $1) $2 } |
-                              tok__exclamation__81 UnaryExpression { Ctr__Expression__14 (rtkPosOf $1) $2 } |
+                              tok__tilde__82 UnaryExpression { Ctr__Expression__13 (rtkPosOf $1) $2 } |
+                              tok__exclamation__83 UnaryExpression { Ctr__Expression__14 (rtkPosOf $1) $2 } |
                               CastExpression { Ctr__Expression__15 (rtkPosOf $1) $1 }
 
 UnaryExpression : PrefixOp UnaryExpression { Ctr__Expression__16 (rtkPosOf $1) $1 $2 } |
@@ -507,30 +514,30 @@ ShiftExpression : AdditiveExpression { Ctr__Expression__26 (rtkPosOf $1) $1 } |
 
 RelationalExpression : ShiftExpression { Ctr__Expression__28 (rtkPosOf $1) $1 } |
                        RelationalExpression RelationalOp ShiftExpression { Ctr__Expression__29 (rtkPosOf $1) $1 $2 $3 } |
-                       RelationalExpression tok_instanceof_70 Type { Ctr__Expression__30 (rtkPosOf $1) $1 $3 }
+                       RelationalExpression tok_instanceof_72 Type { Ctr__Expression__30 (rtkPosOf $1) $1 $3 }
 
 EqualityExpression : RelationalExpression { Ctr__Expression__31 (rtkPosOf $1) $1 } |
                      EqualityExpression EqualityOp RelationalExpression { Ctr__Expression__32 (rtkPosOf $1) $1 $2 $3 }
 
 AndExpression : EqualityExpression { Ctr__Expression__33 (rtkPosOf $1) $1 } |
-                AndExpression tok__symbol__63 EqualityExpression { Ctr__Expression__34 (rtkPosOf $1) $1 $3 }
+                AndExpression tok__symbol__65 EqualityExpression { Ctr__Expression__34 (rtkPosOf $1) $1 $3 }
 
 ExclusiveOrExpression : AndExpression { Ctr__Expression__35 (rtkPosOf $1) $1 } |
-                        ExclusiveOrExpression tok__symbol__62 AndExpression { Ctr__Expression__36 (rtkPosOf $1) $1 $3 }
+                        ExclusiveOrExpression tok__symbol__64 AndExpression { Ctr__Expression__36 (rtkPosOf $1) $1 $3 }
 
 InclusiveOrEpression : ExclusiveOrExpression { Ctr__Expression__37 (rtkPosOf $1) $1 } |
-                       InclusiveOrEpression tok__pipe__61 ExclusiveOrExpression { Ctr__Expression__38 (rtkPosOf $1) $1 $3 }
+                       InclusiveOrEpression tok__pipe__63 ExclusiveOrExpression { Ctr__Expression__38 (rtkPosOf $1) $1 $3 }
 
 ConditionalAndExpression : InclusiveOrEpression { Ctr__Expression__39 (rtkPosOf $1) $1 } |
-                           ConditionalAndExpression tok__symbol__symbol__60 InclusiveOrEpression { Ctr__Expression__40 (rtkPosOf $1) $1 $3 }
+                           ConditionalAndExpression tok__symbol__symbol__62 InclusiveOrEpression { Ctr__Expression__40 (rtkPosOf $1) $1 $3 }
 
 ConditionalOrExpression : ConditionalAndExpression { Ctr__Expression__41 (rtkPosOf $1) $1 } |
-                          ConditionalOrExpression tok__pipe__pipe__59 ConditionalAndExpression { Ctr__Expression__42 (rtkPosOf $1) $1 $3 }
+                          ConditionalOrExpression tok__pipe__pipe__61 ConditionalAndExpression { Ctr__Expression__42 (rtkPosOf $1) $1 $3 }
 
 ConditionalExpression : ConditionalOrExpression { Ctr__Expression__43 (rtkPosOf $1) $1 } |
-                        ConditionalOrExpression tok__symbol__58 Expression tok__colon__34 ConditionalExpression { Ctr__Expression__44 (rtkPosOf $1) $1 $3 $5 }
+                        ConditionalOrExpression tok__symbol__60 Expression tok__colon__36 ConditionalExpression { Ctr__Expression__44 (rtkPosOf $1) $1 $3 $5 }
 
-AssignmentExpression : ConditionalExpression Rule_63 { Ctr__Expression__45 (rtkPosOf $1) $1 $2 }
+AssignmentExpression : ConditionalExpression Rule_68 { Ctr__Expression__45 (rtkPosOf $1) $1 $2 }
 
 Expression : AssignmentExpression { Ctr__Expression__46 (rtkPosOf $1) $1 }
 
@@ -548,10 +555,10 @@ FieldDeclarationList : {- empty -} { [] } |
                        FieldDeclarationList ListElem_FieldDeclarationList15 { $2 : $1 }
 
 ForStatement : qq_ForStatement { Anti_ForStatement (tkVal_qq_ForStatement $1) } |
-               tok_for_41 tok__lparen__7 Rule_57 OptExpression tok__semi__1 OptExpression tok__rparen__8 Statement { Ctr__ForStatement__0 (rtkPosOf $1) $3 $4 $6 $8 }
+               tok_for_43 tok__lparen__7 Rule_62 OptExpression tok__semi__1 OptExpression tok__rparen__8 Statement { Ctr__ForStatement__0 (rtkPosOf $1) $3 $4 $6 $8 }
 
 IfStatement : qq_IfStatement { Anti_IfStatement (tkVal_qq_IfStatement $1) } |
-              tok_if_38 tok__lparen__7 Expression tok__rparen__8 Statement OptElsePart { Ctr__IfStatement__0 (rtkPosOf $1) $3 $5 $6 }
+              tok_if_40 tok__lparen__7 Expression tok__rparen__8 Statement OptElsePart { Ctr__IfStatement__0 (rtkPosOf $1) $3 $5 $6 }
 
 ImplementsList : qq_ImplementsList { Anti_ImplementsList (tkVal_qq_ImplementsList $1) } |
                  tok_implements_12 Rule_14 { Ctr__ImplementsList__0 (rtkPosOf $1) (reverse $2) }
@@ -579,11 +586,14 @@ InterfaceDeclaration : qq_InterfaceDeclaration { Anti_InterfaceDeclaration (tkVa
 Literal : qq_Literal { Anti_Literal (tkVal_qq_Literal $1) } |
           integerLiteral { Ctr__Literal__0 (rtkPosOf $1) (tkVal_integerLiteral $1) } |
           floatLiteral { Ctr__Literal__1 (rtkPosOf $1) (tkVal_floatLiteral $1) } |
-          tok_true_85 { Ctr__Literal__2 (rtkPosOf $1) } |
-          tok_false_86 { Ctr__Literal__3 (rtkPosOf $1) } |
+          tok_true_87 { Ctr__Literal__2 (rtkPosOf $1) } |
+          tok_false_88 { Ctr__Literal__3 (rtkPosOf $1) } |
           char { Ctr__Literal__4 (rtkPosOf $1) (tkVal_char $1) } |
           string { Ctr__Literal__5 (rtkPosOf $1) (tkVal_string $1) } |
-          tok_null_87 { Ctr__Literal__6 (rtkPosOf $1) }
+          tok_null_89 { Ctr__Literal__6 (rtkPosOf $1) }
+
+LocalModifierList1 : ListElem_LocalModifierList149 { [$1] } |
+                     LocalModifierList1 ListElem_LocalModifierList149 { $2 : $1 }
 
 MemberAfterFirstId : qq_MemberAfterFirstId { Anti_MemberAfterFirstId (tkVal_qq_MemberAfterFirstId $1) } |
                      tok__lparen__7 Rule_35 tok__rparen__8 Rule_36 StatementBlock { Ctr__MemberAfterFirstId__0 (rtkPosOf $1) $2 $4 $5 } |
@@ -599,16 +609,16 @@ MemberRest : qq_MemberRest { Anti_MemberRest (tkVal_qq_MemberRest $1) } |
              Dims OptVariableInitializer MoreVariableDeclarators tok__semi__1 { Ctr__MemberRest__1 (rtkPosOf (reverse $1)) (reverse $1) $2 (reverse $3) }
 
 Modifier : qq_Modifier { Anti_Modifier (tkVal_qq_Modifier $1) } |
-           tok_public_88 { Ctr__Modifier__0 (rtkPosOf $1) } |
-           tok_private_89 { Ctr__Modifier__1 (rtkPosOf $1) } |
-           tok_protected_90 { Ctr__Modifier__2 (rtkPosOf $1) } |
+           tok_public_90 { Ctr__Modifier__0 (rtkPosOf $1) } |
+           tok_private_91 { Ctr__Modifier__1 (rtkPosOf $1) } |
+           tok_protected_92 { Ctr__Modifier__2 (rtkPosOf $1) } |
            tok_static_3 { Ctr__Modifier__3 (rtkPosOf $1) } |
-           tok_final_91 { Ctr__Modifier__4 (rtkPosOf $1) } |
-           tok_native_92 { Ctr__Modifier__5 (rtkPosOf $1) } |
-           tok_synchronized_32 { Ctr__Modifier__6 (rtkPosOf $1) } |
-           tok_abstract_93 { Ctr__Modifier__7 (rtkPosOf $1) } |
-           tok_threadsafe_94 { Ctr__Modifier__8 (rtkPosOf $1) } |
-           tok_transient_95 { Ctr__Modifier__9 (rtkPosOf $1) }
+           tok_final_31 { Ctr__Modifier__4 (rtkPosOf $1) } |
+           tok_native_93 { Ctr__Modifier__5 (rtkPosOf $1) } |
+           tok_synchronized_34 { Ctr__Modifier__6 (rtkPosOf $1) } |
+           tok_abstract_94 { Ctr__Modifier__7 (rtkPosOf $1) } |
+           tok_threadsafe_95 { Ctr__Modifier__8 (rtkPosOf $1) } |
+           tok_transient_96 { Ctr__Modifier__9 (rtkPosOf $1) }
 
 ModifierList : {- empty -} { [] } |
                ModifierList ListElem_ModifierList11 { $2 : $1 }
@@ -622,14 +632,14 @@ MoreVariableDeclarators : {- empty -} { [] } |
 
 MultiplicativeOp : qq_MultiplicativeOp { Anti_MultiplicativeOp (tkVal_qq_MultiplicativeOp $1) } |
                    tok__star__5 { Ctr__MultiplicativeOp__0 (rtkPosOf $1) } |
-                   tok__symbol__76 { Ctr__MultiplicativeOp__1 (rtkPosOf $1) } |
-                   tok__symbol__77 { Ctr__MultiplicativeOp__2 (rtkPosOf $1) }
+                   tok__symbol__78 { Ctr__MultiplicativeOp__1 (rtkPosOf $1) } |
+                   tok__symbol__79 { Ctr__MultiplicativeOp__2 (rtkPosOf $1) }
 
 NonEmptyDims : ListElem_NonEmptyDims34 { [$1] } |
                NonEmptyDims ListElem_NonEmptyDims34 { $2 : $1 }
 
 NonEmptyTypeArguments : qq_NonEmptyTypeArguments { Anti_NonEmptyTypeArguments (tkVal_qq_NonEmptyTypeArguments $1) } |
-                        tok__symbol__66 TypeArgument Rule_76 tok__symbol__67 { Ctr__NonEmptyTypeArguments__0 (rtkPosOf $1) $2 (reverse $3) }
+                        tok__symbol__68 TypeArgument Rule_81 tok__symbol__69 { Ctr__NonEmptyTypeArguments__0 (rtkPosOf $1) $2 (reverse $3) }
 
 OptDocComment : qq_OptDocComment { Anti_OptDocComment (tkVal_qq_OptDocComment $1) } |
                 { Ctr__OptDocComment__0 rtkNoPos } |
@@ -637,7 +647,7 @@ OptDocComment : qq_OptDocComment { Anti_OptDocComment (tkVal_qq_OptDocComment $1
 
 OptElsePart : qq_OptElsePart { Anti_OptElsePart (tkVal_qq_OptElsePart $1) } |
               { Ctr__OptElsePart__0 rtkNoPos } |
-              Rule_56 { Ctr__OptElsePart__1 (rtkPosOf $1) $1 }
+              Rule_61 { Ctr__OptElsePart__1 (rtkPosOf $1) $1 }
 
 OptExpression : qq_OptExpression { Anti_OptExpression (tkVal_qq_OptExpression $1) } |
                 { Ctr__OptExpression__0 rtkNoPos } |
@@ -645,7 +655,7 @@ OptExpression : qq_OptExpression { Anti_OptExpression (tkVal_qq_OptExpression $1
 
 OptFinally : qq_OptFinally { Anti_OptFinally (tkVal_qq_OptFinally $1) } |
              { Ctr__OptFinally__0 rtkNoPos } |
-             Rule_60 { Ctr__OptFinally__1 (rtkPosOf $1) $1 }
+             Rule_65 { Ctr__OptFinally__1 (rtkPosOf $1) $1 }
 
 OptId : qq_OptId { Anti_OptId (tkVal_qq_OptId $1) } |
         { Ctr__OptId__0 rtkNoPos } |
@@ -653,26 +663,29 @@ OptId : qq_OptId { Anti_OptId (tkVal_qq_OptId $1) } |
 
 OptVariableInitializer : qq_OptVariableInitializer { Anti_OptVariableInitializer (tkVal_qq_OptVariableInitializer $1) } |
                          { Ctr__OptVariableInitializer__0 rtkNoPos } |
-                         Rule_48 { Ctr__OptVariableInitializer__1 (rtkPosOf $1) $1 }
+                         Rule_50 { Ctr__OptVariableInitializer__1 (rtkPosOf $1) $1 }
 
 Package : qq_Package { Anti_Package (tkVal_qq_Package $1) } |
           tok_package_0 CompoundName tok__semi__1 { Ctr__Package__0 (rtkPosOf $1) $2 }
 
+ParamModifierList : {- empty -} { [] } |
+                    ParamModifierList ListElem_ParamModifierList58 { $2 : $1 }
+
 Parameter : qq_Parameter { Anti_Parameter (tkVal_qq_Parameter $1) } |
-            Type id Dims { Ctr__Parameter__0 (rtkPosOf $1) $1 (tkVal_id $2) (reverse $3) }
+            ParamModifierList Type Rule_59 id Dims { Ctr__Parameter__0 (rtkPosOf (reverse $1)) (reverse $1) $2 $3 (tkVal_id $4) (reverse $5) }
 
 ParameterList : qq_ParameterList { Anti_ParameterList (tkVal_qq_ParameterList $1) } |
-                Parameter Rule_53 { Ctr__ParameterList__0 (rtkPosOf $1) $1 (reverse $2) }
+                Parameter Rule_55 { Ctr__ParameterList__0 (rtkPosOf $1) $1 (reverse $2) }
 
 PostfixOp : qq_PostfixOp { Anti_PostfixOp (tkVal_qq_PostfixOp $1) } |
-            tok__plus__plus__78 { Ctr__PostfixOp__0 (rtkPosOf $1) } |
-            tok__minus__minus__79 { Ctr__PostfixOp__1 (rtkPosOf $1) }
+            tok__plus__plus__80 { Ctr__PostfixOp__0 (rtkPosOf $1) } |
+            tok__minus__minus__81 { Ctr__PostfixOp__1 (rtkPosOf $1) }
 
 PrefixOp : qq_PrefixOp { Anti_PrefixOp (tkVal_qq_PrefixOp $1) } |
-           tok__plus__plus__78 { Ctr__PrefixOp__0 (rtkPosOf $1) } |
-           tok__minus__minus__79 { Ctr__PrefixOp__1 (rtkPosOf $1) } |
-           tok__plus__74 { Ctr__PrefixOp__2 (rtkPosOf $1) } |
-           tok__minus__75 { Ctr__PrefixOp__3 (rtkPosOf $1) }
+           tok__plus__plus__80 { Ctr__PrefixOp__0 (rtkPosOf $1) } |
+           tok__minus__minus__81 { Ctr__PrefixOp__1 (rtkPosOf $1) } |
+           tok__plus__76 { Ctr__PrefixOp__2 (rtkPosOf $1) } |
+           tok__minus__77 { Ctr__PrefixOp__3 (rtkPosOf $1) }
 
 PrimitiveTypeKeyword : qq_PrimitiveTypeKeyword { Anti_PrimitiveTypeKeyword (tkVal_qq_PrimitiveTypeKeyword $1) } |
                        tok_boolean_20 { Ctr__PrimitiveTypeKeyword__0 (rtkPosOf $1) } |
@@ -686,10 +699,10 @@ PrimitiveTypeKeyword : qq_PrimitiveTypeKeyword { Anti_PrimitiveTypeKeyword (tkVa
                        tok_void_28 { Ctr__PrimitiveTypeKeyword__8 (rtkPosOf $1) }
 
 RelationalOp : qq_RelationalOp { Anti_RelationalOp (tkVal_qq_RelationalOp $1) } |
-               tok__symbol__66 { Ctr__RelationalOp__0 (rtkPosOf $1) } |
-               tok__symbol__67 { Ctr__RelationalOp__1 (rtkPosOf $1) } |
-               tok__symbol__eql__68 { Ctr__RelationalOp__2 (rtkPosOf $1) } |
-               tok__symbol__eql__69 { Ctr__RelationalOp__3 (rtkPosOf $1) }
+               tok__symbol__68 { Ctr__RelationalOp__0 (rtkPosOf $1) } |
+               tok__symbol__69 { Ctr__RelationalOp__1 (rtkPosOf $1) } |
+               tok__symbol__eql__70 { Ctr__RelationalOp__2 (rtkPosOf $1) } |
+               tok__symbol__eql__71 { Ctr__RelationalOp__3 (rtkPosOf $1) }
 
 Rule_1 : { Ctr__Rule_1__0 rtkNoPos } |
          Package { Ctr__Rule_1__1 (rtkPosOf $1) $1 }
@@ -801,121 +814,136 @@ Rule_46 : {- empty -} { [] } |
 
 Rule_47 : tok__coma__9 VariableDeclarator { Ctr__Rule_47__0 (rtkPosOf $1) $2 }
 
-Rule_48 : tok__eql__10 VariableInitializer { Ctr__Rule_48__0 (rtkPosOf $1) $2 }
+ListElem_LocalModifierList149 : qq_LocalModifierList1 { Anti_Rule_48 (tkVal_qq_LocalModifierList1 $1) } |
+                                Rule_48 { $1 }
 
-Rule_49 : VariableInitializer Rule_50 Rule_52 { Ctr__Rule_49__0 (rtkPosOf $1) $1 (reverse $2) $3 }
+Rule_48 : tok_final_31 { Ctr__Rule_48__1 (rtkPosOf $1) } |
+          Annotation { Ctr__Rule_48__2 (rtkPosOf $1) $1 }
 
 Rule_5 : tok__lparen__7 Rule_6 tok__rparen__8 { Ctr__Rule_5__0 (rtkPosOf $1) $2 }
 
-Rule_50 : {- empty -} { [] } |
-          Rule_50 Rule_51 { $2 : $1 }
+Rule_50 : tok__eql__10 VariableInitializer { Ctr__Rule_50__0 (rtkPosOf $1) $2 }
 
-Rule_51 : tok__coma__9 VariableInitializer { Ctr__Rule_51__0 (rtkPosOf $1) $2 }
+Rule_51 : VariableInitializer Rule_52 Rule_54 { Ctr__Rule_51__0 (rtkPosOf $1) $1 (reverse $2) $3 }
 
-Rule_52 : { Ctr__Rule_52__0 rtkNoPos } |
-          tok__coma__9 { Ctr__Rule_52__1 (rtkPosOf $1) }
+Rule_52 : {- empty -} { [] } |
+          Rule_52 Rule_53 { $2 : $1 }
 
-Rule_53 : {- empty -} { [] } |
-          Rule_53 Rule_54 { $2 : $1 }
+Rule_53 : tok__coma__9 VariableInitializer { Ctr__Rule_53__0 (rtkPosOf $1) $2 }
 
-Rule_54 : tok__coma__9 Parameter { Ctr__Rule_54__0 (rtkPosOf $1) $2 }
+Rule_54 : { Ctr__Rule_54__0 rtkNoPos } |
+          tok__coma__9 { Ctr__Rule_54__1 (rtkPosOf $1) }
 
-Rule_56 : tok_else_37 Statement { Ctr__Rule_56__0 (rtkPosOf $1) $2 }
+Rule_55 : {- empty -} { [] } |
+          Rule_55 Rule_56 { $2 : $1 }
 
-Rule_57 : VariableDeclaration { Ctr__Rule_57__0 (rtkPosOf $1) $1 } |
-          Expression tok__semi__1 { Ctr__Rule_57__1 (rtkPosOf $1) $1 } |
-          tok__semi__1 { Ctr__Rule_57__2 (rtkPosOf $1) }
+Rule_56 : tok__coma__9 Parameter { Ctr__Rule_56__0 (rtkPosOf $1) $2 }
 
-ListElem_CatchList59 : qq_CatchList { Anti_Rule_58 (tkVal_qq_CatchList $1) } |
-                       Rule_58 { $1 }
+ListElem_ParamModifierList58 : qq_ParamModifierList { Anti_Rule_57 (tkVal_qq_ParamModifierList $1) } |
+                               Rule_57 { $1 }
 
-Rule_58 : tok_catch_42 tok__lparen__7 Parameter tok__rparen__8 Statement { Ctr__Rule_58__1 (rtkPosOf $1) $3 $5 }
+Rule_57 : tok_final_31 { Ctr__Rule_57__1 (rtkPosOf $1) } |
+          Annotation { Ctr__Rule_57__2 (rtkPosOf $1) $1 }
+
+Rule_59 : { Ctr__Rule_59__0 rtkNoPos } |
+          tok__dot__dot__dot__32 { Ctr__Rule_59__1 (rtkPosOf $1) }
 
 Rule_6 : { Ctr__Rule_6__0 rtkNoPos } |
          AnnotationArguments { Ctr__Rule_6__1 (rtkPosOf $1) $1 }
 
-Rule_60 : tok_finally_43 Statement { Ctr__Rule_60__0 (rtkPosOf $1) $2 }
+Rule_61 : tok_else_39 Statement { Ctr__Rule_61__0 (rtkPosOf $1) $2 }
 
-ListElem_SwitchCaseList62 : qq_SwitchCaseList { Anti_Rule_61 (tkVal_qq_SwitchCaseList $1) } |
-                            Rule_61 { $1 }
+Rule_62 : VariableDeclaration { Ctr__Rule_62__0 (rtkPosOf $1) $1 } |
+          Expression tok__semi__1 { Ctr__Rule_62__1 (rtkPosOf $1) $1 } |
+          tok__semi__1 { Ctr__Rule_62__2 (rtkPosOf $1) }
 
-Rule_61 : tok_case_45 Expression tok__colon__34 { Ctr__Rule_61__1 (rtkPosOf $1) $2 } |
-          tok_default_30 tok__colon__34 { Ctr__Rule_61__2 (rtkPosOf $1) } |
-          Statement { Ctr__Rule_61__3 (rtkPosOf $1) $1 }
+ListElem_CatchList64 : qq_CatchList { Anti_Rule_63 (tkVal_qq_CatchList $1) } |
+                       Rule_63 { $1 }
 
-Rule_63 : { Ctr__Rule_63__0 rtkNoPos } |
-          Rule_64 { Ctr__Rule_63__1 (rtkPosOf $1) $1 }
+Rule_63 : tok_catch_44 tok__lparen__7 Parameter tok__rparen__8 Statement { Ctr__Rule_63__1 (rtkPosOf $1) $3 $5 }
 
-Rule_64 : AssignmentOp AssignmentExpression { Ctr__Rule_64__0 (rtkPosOf $1) $1 $2 }
+Rule_65 : tok_finally_45 Statement { Ctr__Rule_65__0 (rtkPosOf $1) $2 }
 
-Rule_65 : { Ctr__Rule_65__0 rtkNoPos } |
-          Rule_66 { Ctr__Rule_65__1 (rtkPosOf $1) $1 }
+ListElem_SwitchCaseList67 : qq_SwitchCaseList { Anti_Rule_66 (tkVal_qq_SwitchCaseList $1) } |
+                            Rule_66 { $1 }
 
-Rule_66 : tok__lparen__7 Arglist tok__rparen__8 { Ctr__Rule_66__0 (rtkPosOf $1) $2 }
+Rule_66 : tok_case_47 Expression tok__colon__36 { Ctr__Rule_66__1 (rtkPosOf $1) $2 } |
+          tok_default_30 tok__colon__36 { Ctr__Rule_66__2 (rtkPosOf $1) } |
+          Statement { Ctr__Rule_66__3 (rtkPosOf $1) $1 }
 
-Rule_67 : { Ctr__Rule_67__0 rtkNoPos } |
-          Rule_68 { Ctr__Rule_67__1 (rtkPosOf $1) $1 }
+Rule_68 : { Ctr__Rule_68__0 rtkNoPos } |
+          Rule_69 { Ctr__Rule_68__1 (rtkPosOf $1) $1 }
 
-Rule_68 : tok__lparen__7 Arglist tok__rparen__8 { Ctr__Rule_68__0 (rtkPosOf $1) $2 }
-
-Rule_69 : tok__lparen__7 Arglist tok__rparen__8 { Ctr__Rule_69__0 (rtkPosOf $1) $2 } |
-          DimExprs Rule_70 { Ctr__Rule_69__1 (rtkPosOf (reverse $1)) (reverse $1) $2 }
+Rule_69 : AssignmentOp AssignmentExpression { Ctr__Rule_69__0 (rtkPosOf $1) $1 $2 }
 
 Rule_7 : {- empty -} { [] } |
          Rule_7 Rule_8 { $2 : $1 }
 
 Rule_70 : { Ctr__Rule_70__0 rtkNoPos } |
-          NonEmptyDims { Ctr__Rule_70__1 (rtkPosOf (reverse $1)) (reverse $1) }
+          Rule_71 { Ctr__Rule_70__1 (rtkPosOf $1) $1 }
 
-ListElem_DimExprs72 : qq_DimExprs { Anti_Rule_71 (tkVal_qq_DimExprs $1) } |
-                      Rule_71 { $1 }
+Rule_71 : tok__lparen__7 Arglist tok__rparen__8 { Ctr__Rule_71__0 (rtkPosOf $1) $2 }
 
-Rule_71 : tok__sq_bkt_l__18 Expression tok__sq_bkt_r__19 { Ctr__Rule_71__1 (rtkPosOf $1) $2 }
+Rule_72 : { Ctr__Rule_72__0 rtkNoPos } |
+          Rule_73 { Ctr__Rule_72__1 (rtkPosOf $1) $1 }
 
-Rule_73 : Expression Rule_74 { Ctr__Rule_73__0 (rtkPosOf $1) $1 (reverse $2) }
+Rule_73 : tok__lparen__7 Arglist tok__rparen__8 { Ctr__Rule_73__0 (rtkPosOf $1) $2 }
 
-Rule_74 : {- empty -} { [] } |
-          Rule_74 Rule_75 { $2 : $1 }
+Rule_74 : tok__lparen__7 Arglist tok__rparen__8 { Ctr__Rule_74__0 (rtkPosOf $1) $2 } |
+          DimExprs Rule_75 { Ctr__Rule_74__1 (rtkPosOf (reverse $1)) (reverse $1) $2 }
 
-Rule_75 : tok__coma__9 Expression { Ctr__Rule_75__0 (rtkPosOf $1) $2 }
+Rule_75 : { Ctr__Rule_75__0 rtkNoPos } |
+          NonEmptyDims { Ctr__Rule_75__1 (rtkPosOf (reverse $1)) (reverse $1) }
 
-Rule_76 : {- empty -} { [] } |
-          Rule_76 Rule_77 { $2 : $1 }
+ListElem_DimExprs77 : qq_DimExprs { Anti_Rule_76 (tkVal_qq_DimExprs $1) } |
+                      Rule_76 { $1 }
 
-Rule_77 : tok__coma__9 TypeArgument { Ctr__Rule_77__0 (rtkPosOf $1) $2 }
+Rule_76 : tok__sq_bkt_l__18 Expression tok__sq_bkt_r__19 { Ctr__Rule_76__1 (rtkPosOf $1) $2 }
 
-Rule_78 : tok__symbol__66 TypeParameter Rule_79 tok__symbol__67 { Ctr__Rule_78__0 (rtkPosOf $1) $2 (reverse $3) }
+Rule_78 : Expression Rule_79 { Ctr__Rule_78__0 (rtkPosOf $1) $1 (reverse $2) }
 
 Rule_79 : {- empty -} { [] } |
           Rule_79 Rule_80 { $2 : $1 }
 
 Rule_8 : tok__coma__9 AnnotationElement { Ctr__Rule_8__0 (rtkPosOf $1) $2 }
 
-Rule_80 : tok__coma__9 TypeParameter { Ctr__Rule_80__0 (rtkPosOf $1) $2 }
+Rule_80 : tok__coma__9 Expression { Ctr__Rule_80__0 (rtkPosOf $1) $2 }
 
-Rule_81 : { Ctr__Rule_81__0 rtkNoPos } |
-          Rule_82 { Ctr__Rule_81__1 (rtkPosOf $1) $1 }
+Rule_81 : {- empty -} { [] } |
+          Rule_81 Rule_82 { $2 : $1 }
 
-Rule_82 : tok_extends_11 Type Rule_83 { Ctr__Rule_82__0 (rtkPosOf $1) $2 (reverse $3) }
+Rule_82 : tok__coma__9 TypeArgument { Ctr__Rule_82__0 (rtkPosOf $1) $2 }
 
-Rule_83 : {- empty -} { [] } |
-          Rule_83 Rule_84 { $2 : $1 }
+Rule_83 : tok__symbol__68 TypeParameter Rule_84 tok__symbol__69 { Ctr__Rule_83__0 (rtkPosOf $1) $2 (reverse $3) }
 
-Rule_84 : tok__symbol__63 Type { Ctr__Rule_84__0 (rtkPosOf $1) $2 }
+Rule_84 : {- empty -} { [] } |
+          Rule_84 Rule_85 { $2 : $1 }
 
-Rule_85 : {- empty -} { [] } |
-          Rule_85 Rule_86 { $2 : $1 }
+Rule_85 : tok__coma__9 TypeParameter { Ctr__Rule_85__0 (rtkPosOf $1) $2 }
 
-Rule_86 : tok__dot__4 id { Ctr__Rule_86__0 (rtkPosOf $1) (tkVal_id $2) }
+Rule_86 : { Ctr__Rule_86__0 rtkNoPos } |
+          Rule_87 { Ctr__Rule_86__1 (rtkPosOf $1) $1 }
+
+Rule_87 : tok_extends_11 Type Rule_88 { Ctr__Rule_87__0 (rtkPosOf $1) $2 (reverse $3) }
+
+Rule_88 : {- empty -} { [] } |
+          Rule_88 Rule_89 { $2 : $1 }
+
+Rule_89 : tok__symbol__65 Type { Ctr__Rule_89__0 (rtkPosOf $1) $2 }
+
+Rule_90 : {- empty -} { [] } |
+          Rule_90 Rule_91 { $2 : $1 }
+
+Rule_91 : tok__dot__4 id { Ctr__Rule_91__0 (rtkPosOf $1) (tkVal_id $2) }
 
 ShiftOp : qq_ShiftOp { Anti_ShiftOp (tkVal_qq_ShiftOp $1) } |
-          tok__symbol__symbol__71 { Ctr__ShiftOp__0 (rtkPosOf $1) } |
-          tok__symbol__symbol__72 { Ctr__ShiftOp__1 (rtkPosOf $1) } |
-          tok__symbol__symbol__symbol__73 { Ctr__ShiftOp__2 (rtkPosOf $1) }
+          tok__symbol__symbol__73 { Ctr__ShiftOp__0 (rtkPosOf $1) } |
+          tok__symbol__symbol__74 { Ctr__ShiftOp__1 (rtkPosOf $1) } |
+          tok__symbol__symbol__symbol__75 { Ctr__ShiftOp__2 (rtkPosOf $1) }
 
 Statement : qq_Statement { Anti_Statement (tkVal_qq_Statement $1) } |
             VariableDeclaration { Ctr__Statement__0 (rtkPosOf $1) $1 } |
-            tok_return_31 OptExpression tok__semi__1 { Ctr__Statement__1 (rtkPosOf $1) $2 } |
+            tok_return_33 OptExpression tok__semi__1 { Ctr__Statement__1 (rtkPosOf $1) $2 } |
             Expression tok__semi__1 { Ctr__Statement__2 (rtkPosOf $1) $1 } |
             StatementBlock { Ctr__Statement__3 (rtkPosOf $1) $1 } |
             IfStatement { Ctr__Statement__4 (rtkPosOf $1) $1 } |
@@ -924,36 +952,36 @@ Statement : qq_Statement { Anti_Statement (tkVal_qq_Statement $1) } |
             ForStatement { Ctr__Statement__7 (rtkPosOf $1) $1 } |
             TryStatement { Ctr__Statement__8 (rtkPosOf $1) $1 } |
             SwitchStatement { Ctr__Statement__9 (rtkPosOf $1) $1 } |
-            tok_synchronized_32 tok__lparen__7 Expression tok__rparen__8 Statement { Ctr__Statement__10 (rtkPosOf $1) $3 $5 } |
-            tok_throw_33 Expression tok__semi__1 { Ctr__Statement__11 (rtkPosOf $1) $2 } |
-            id tok__colon__34 Statement { Ctr__Statement__12 (rtkPosOf $1) (tkVal_id $1) $3 } |
-            tok_break_35 OptId tok__semi__1 { Ctr__Statement__13 (rtkPosOf $1) $2 } |
-            tok_continue_36 OptId tok__semi__1 { Ctr__Statement__14 (rtkPosOf $1) $2 } |
+            tok_synchronized_34 tok__lparen__7 Expression tok__rparen__8 Statement { Ctr__Statement__10 (rtkPosOf $1) $3 $5 } |
+            tok_throw_35 Expression tok__semi__1 { Ctr__Statement__11 (rtkPosOf $1) $2 } |
+            id tok__colon__36 Statement { Ctr__Statement__12 (rtkPosOf $1) (tkVal_id $1) $3 } |
+            tok_break_37 OptId tok__semi__1 { Ctr__Statement__13 (rtkPosOf $1) $2 } |
+            tok_continue_38 OptId tok__semi__1 { Ctr__Statement__14 (rtkPosOf $1) $2 } |
             tok__semi__1 { Ctr__Statement__15 (rtkPosOf $1) }
 
-ListElem_StatementList55 : qq_StatementList { Anti_Statement (tkVal_qq_StatementList $1) } |
+ListElem_StatementList60 : qq_StatementList { Anti_Statement (tkVal_qq_StatementList $1) } |
                            Statement { $1 }
 
 StatementBlock : qq_StatementBlock { Anti_StatementBlock (tkVal_qq_StatementBlock $1) } |
                  tok__symbol__14 StatementList tok__symbol__15 { Ctr__StatementBlock__0 (rtkPosOf $1) (reverse $2) }
 
 StatementList : {- empty -} { [] } |
-                StatementList ListElem_StatementList55 { $2 : $1 }
+                StatementList ListElem_StatementList60 { $2 : $1 }
 
 StaticInitializer : qq_StaticInitializer { Anti_StaticInitializer (tkVal_qq_StaticInitializer $1) } |
                     StatementBlock { Ctr__StaticInitializer__0 (rtkPosOf $1) $1 }
 
 SwitchCaseList : {- empty -} { [] } |
-                 SwitchCaseList ListElem_SwitchCaseList62 { $2 : $1 }
+                 SwitchCaseList ListElem_SwitchCaseList67 { $2 : $1 }
 
 SwitchStatement : qq_SwitchStatement { Anti_SwitchStatement (tkVal_qq_SwitchStatement $1) } |
-                  tok_switch_46 tok__lparen__7 Expression tok__rparen__8 tok__symbol__14 SwitchCaseList tok__symbol__15 { Ctr__SwitchStatement__0 (rtkPosOf $1) $3 (reverse $6) }
+                  tok_switch_48 tok__lparen__7 Expression tok__rparen__8 tok__symbol__14 SwitchCaseList tok__symbol__15 { Ctr__SwitchStatement__0 (rtkPosOf $1) $3 (reverse $6) }
 
 ThrowsClause : qq_ThrowsClause { Anti_ThrowsClause (tkVal_qq_ThrowsClause $1) } |
                tok_throws_29 CompoundName Rule_37 { Ctr__ThrowsClause__0 (rtkPosOf $1) $2 (reverse $3) }
 
 TryStatement : qq_TryStatement { Anti_TryStatement (tkVal_qq_TryStatement $1) } |
-               tok_try_44 Statement CatchList OptFinally { Ctr__TryStatement__0 (rtkPosOf $1) $2 (reverse $3) $4 }
+               tok_try_46 Statement CatchList OptFinally { Ctr__TryStatement__0 (rtkPosOf $1) $2 (reverse $3) $4 }
 
 Type : qq_Type { Anti_Type (tkVal_qq_Type $1) } |
        PrimitiveTypeKeyword Dims { Ctr__Type__0 (rtkPosOf $1) $1 (reverse $2) } |
@@ -979,11 +1007,11 @@ TypeDeclaration : qq_TypeDeclaration { Anti_TypeDeclaration (tkVal_qq_TypeDeclar
                   OptDocComment ModifierList TypeDeclRest { Ctr__TypeDeclaration__0 (rtkPosOf $1) $1 (reverse $2) $3 }
 
 TypeParameter : qq_TypeParameter { Anti_TypeParameter (tkVal_qq_TypeParameter $1) } |
-                id Rule_81 { Ctr__TypeParameter__0 (rtkPosOf $1) (tkVal_id $1) $2 }
+                id Rule_86 { Ctr__TypeParameter__0 (rtkPosOf $1) (tkVal_id $1) $2 }
 
 TypeParameters : qq_TypeParameters { Anti_TypeParameters (tkVal_qq_TypeParameters $1) } |
                  { Ctr__TypeParameters__0 rtkNoPos } |
-                 Rule_78 { Ctr__TypeParameters__1 (rtkPosOf $1) $1 }
+                 Rule_83 { Ctr__TypeParameters__1 (rtkPosOf $1) $1 }
 
 TypeSpecifier : qq_TypeSpecifier { Anti_TypeSpecifier (tkVal_qq_TypeSpecifier $1) } |
                 tok_boolean_20 { Ctr__TypeSpecifier__0 (rtkPosOf $1) } |
@@ -998,7 +1026,8 @@ TypeSpecifier : qq_TypeSpecifier { Anti_TypeSpecifier (tkVal_qq_TypeSpecifier $1
                 CompoundName TypeArguments { Ctr__TypeSpecifier__9 (rtkPosOf $1) $1 $2 }
 
 VariableDeclaration : qq_VariableDeclaration { Anti_VariableDeclaration (tkVal_qq_VariableDeclaration $1) } |
-                      Type VariableDeclaratorList tok__semi__1 { Ctr__VariableDeclaration__0 (rtkPosOf $1) $1 $2 }
+                      Type VariableDeclaratorList tok__semi__1 { Ctr__VariableDeclaration__0 (rtkPosOf $1) $1 $2 } |
+                      LocalModifierList1 Type VariableDeclaratorList tok__semi__1 { Ctr__VariableDeclaration__1 (rtkPosOf (reverse $1)) (reverse $1) $2 $3 }
 
 VariableDeclarator : qq_VariableDeclarator { Anti_VariableDeclarator (tkVal_qq_VariableDeclarator $1) } |
                      id Dims OptVariableInitializer { Ctr__VariableDeclarator__0 (rtkPosOf $1) (tkVal_id $1) (reverse $2) $3 }
@@ -1012,15 +1041,15 @@ VariableInitializer : qq_VariableInitializer { Anti_VariableInitializer (tkVal_q
 
 VariableInitializerList : qq_VariableInitializerList { Anti_VariableInitializerList (tkVal_qq_VariableInitializerList $1) } |
                           { Ctr__VariableInitializerList__0 rtkNoPos } |
-                          Rule_49 { Ctr__VariableInitializerList__1 (rtkPosOf $1) $1 }
+                          Rule_51 { Ctr__VariableInitializerList__1 (rtkPosOf $1) $1 }
 
 WhileStatement : qq_WhileStatement { Anti_WhileStatement (tkVal_qq_WhileStatement $1) } |
-                 tok_while_40 tok__lparen__7 Expression tok__rparen__8 Statement { Ctr__WhileStatement__0 (rtkPosOf $1) $3 $5 }
+                 tok_while_42 tok__lparen__7 Expression tok__rparen__8 Statement { Ctr__WhileStatement__0 (rtkPosOf $1) $3 $5 }
 
 WildcardType : qq_WildcardType { Anti_WildcardType (tkVal_qq_WildcardType $1) } |
-               tok__symbol__58 { Ctr__WildcardType__0 (rtkPosOf $1) } |
-               tok__symbol__58 tok_extends_11 Type { Ctr__WildcardType__1 (rtkPosOf $1) $3 } |
-               tok__symbol__58 tok_super_83 Type { Ctr__WildcardType__2 (rtkPosOf $1) $3 }
+               tok__symbol__60 { Ctr__WildcardType__0 (rtkPosOf $1) } |
+               tok__symbol__60 tok_extends_11 Type { Ctr__WildcardType__1 (rtkPosOf $1) $3 } |
+               tok__symbol__60 tok_super_85 Type { Ctr__WildcardType__2 (rtkPosOf $1) $3 }
 
 
 {
@@ -1032,186 +1061,189 @@ parseError (L.PosToken (L.AlexPn _ line col) tok : _) =
 -- Render a token the way it appears in the source, for error messages
 showRtkToken :: L.Token -> String
 showRtkToken L.EndOfFile = "end of input"
-showRtkToken L.Tk__tok_AdditiveOp_dummy_169 = "'tok_AdditiveOp_dummy_169'"
-showRtkToken L.Tk__tok_Annotation_dummy_168 = "'tok_Annotation_dummy_168'"
-showRtkToken L.Tk__tok_AnnotationArguments_dummy_167 = "'tok_AnnotationArguments_dummy_167'"
-showRtkToken L.Tk__tok_AnnotationDeclaration_dummy_166 = "'tok_AnnotationDeclaration_dummy_166'"
-showRtkToken L.Tk__tok_AnnotationElement_dummy_165 = "'tok_AnnotationElement_dummy_165'"
-showRtkToken L.Tk__tok_AnnotationList_dummy_164 = "'tok_AnnotationList_dummy_164'"
-showRtkToken L.Tk__tok_AnnotationTypeElement_dummy_163 = "'tok_AnnotationTypeElement_dummy_163'"
-showRtkToken L.Tk__tok_AnnotationTypeElementList_dummy_162 = "'tok_AnnotationTypeElementList_dummy_162'"
-showRtkToken L.Tk__tok_Arglist_dummy_161 = "'tok_Arglist_dummy_161'"
-showRtkToken L.Tk__tok_AssignmentOp_dummy_160 = "'tok_AssignmentOp_dummy_160'"
-showRtkToken L.Tk__tok_CatchList_dummy_159 = "'tok_CatchList_dummy_159'"
-showRtkToken L.Tk__tok_ClassDeclaration_dummy_158 = "'tok_ClassDeclaration_dummy_158'"
-showRtkToken L.Tk__tok_CompilationUnit_dummy_157 = "'tok_CompilationUnit_dummy_157'"
-showRtkToken L.Tk__tok_CompoundName_dummy_156 = "'tok_CompoundName_dummy_156'"
-showRtkToken L.Tk__tok_CreationExpression_dummy_155 = "'tok_CreationExpression_dummy_155'"
-showRtkToken L.Tk__tok_DimExprs_dummy_154 = "'tok_DimExprs_dummy_154'"
-showRtkToken L.Tk__tok_Dims_dummy_153 = "'tok_Dims_dummy_153'"
-showRtkToken L.Tk__tok_DoStatement_dummy_152 = "'tok_DoStatement_dummy_152'"
-showRtkToken L.Tk__tok_DocComment_dummy_151 = "'tok_DocComment_dummy_151'"
-showRtkToken L.Tk__tok_EnumConstant_dummy_150 = "'tok_EnumConstant_dummy_150'"
-showRtkToken L.Tk__tok_EnumConstantList_dummy_149 = "'tok_EnumConstantList_dummy_149'"
-showRtkToken L.Tk__tok_EnumDeclaration_dummy_148 = "'tok_EnumDeclaration_dummy_148'"
-showRtkToken L.Tk__tok_EqualityOp_dummy_147 = "'tok_EqualityOp_dummy_147'"
-showRtkToken L.Tk__tok_Expression_dummy_146 = "'tok_Expression_dummy_146'"
-showRtkToken L.Tk__tok_ExtendsList_dummy_145 = "'tok_ExtendsList_dummy_145'"
-showRtkToken L.Tk__tok_FieldDeclaration_dummy_144 = "'tok_FieldDeclaration_dummy_144'"
-showRtkToken L.Tk__tok_FieldDeclarationList_dummy_143 = "'tok_FieldDeclarationList_dummy_143'"
-showRtkToken L.Tk__tok_ForStatement_dummy_142 = "'tok_ForStatement_dummy_142'"
-showRtkToken L.Tk__tok_IfStatement_dummy_141 = "'tok_IfStatement_dummy_141'"
-showRtkToken L.Tk__tok_ImplementsList_dummy_140 = "'tok_ImplementsList_dummy_140'"
-showRtkToken L.Tk__tok_ImportHead_dummy_139 = "'tok_ImportHead_dummy_139'"
-showRtkToken L.Tk__tok_ImportList_dummy_138 = "'tok_ImportList_dummy_138'"
-showRtkToken L.Tk__tok_ImportName_dummy_137 = "'tok_ImportName_dummy_137'"
-showRtkToken L.Tk__tok_ImportStatement_dummy_136 = "'tok_ImportStatement_dummy_136'"
-showRtkToken L.Tk__tok_InterfaceDeclaration_dummy_135 = "'tok_InterfaceDeclaration_dummy_135'"
-showRtkToken L.Tk__tok_Java_dummy_170 = "'tok_Java_dummy_170'"
-showRtkToken L.Tk__tok_Literal_dummy_134 = "'tok_Literal_dummy_134'"
-showRtkToken L.Tk__tok_MemberAfterFirstId_dummy_133 = "'tok_MemberAfterFirstId_dummy_133'"
-showRtkToken L.Tk__tok_MemberDeclaration_dummy_132 = "'tok_MemberDeclaration_dummy_132'"
-showRtkToken L.Tk__tok_MemberRest_dummy_131 = "'tok_MemberRest_dummy_131'"
-showRtkToken L.Tk__tok_Modifier_dummy_130 = "'tok_Modifier_dummy_130'"
-showRtkToken L.Tk__tok_ModifierList_dummy_129 = "'tok_ModifierList_dummy_129'"
-showRtkToken L.Tk__tok_MoreTypeSpecifier_dummy_128 = "'tok_MoreTypeSpecifier_dummy_128'"
-showRtkToken L.Tk__tok_MoreVariableDeclarators_dummy_127 = "'tok_MoreVariableDeclarators_dummy_127'"
-showRtkToken L.Tk__tok_MultiplicativeOp_dummy_126 = "'tok_MultiplicativeOp_dummy_126'"
-showRtkToken L.Tk__tok_NonEmptyDims_dummy_125 = "'tok_NonEmptyDims_dummy_125'"
-showRtkToken L.Tk__tok_NonEmptyTypeArguments_dummy_124 = "'tok_NonEmptyTypeArguments_dummy_124'"
-showRtkToken L.Tk__tok_OptDocComment_dummy_123 = "'tok_OptDocComment_dummy_123'"
-showRtkToken L.Tk__tok_OptElsePart_dummy_122 = "'tok_OptElsePart_dummy_122'"
-showRtkToken L.Tk__tok_OptExpression_dummy_121 = "'tok_OptExpression_dummy_121'"
-showRtkToken L.Tk__tok_OptFinally_dummy_120 = "'tok_OptFinally_dummy_120'"
-showRtkToken L.Tk__tok_OptId_dummy_119 = "'tok_OptId_dummy_119'"
-showRtkToken L.Tk__tok_OptVariableInitializer_dummy_118 = "'tok_OptVariableInitializer_dummy_118'"
-showRtkToken L.Tk__tok_Package_dummy_117 = "'tok_Package_dummy_117'"
-showRtkToken L.Tk__tok_Parameter_dummy_116 = "'tok_Parameter_dummy_116'"
-showRtkToken L.Tk__tok_ParameterList_dummy_115 = "'tok_ParameterList_dummy_115'"
-showRtkToken L.Tk__tok_PostfixOp_dummy_114 = "'tok_PostfixOp_dummy_114'"
-showRtkToken L.Tk__tok_PrefixOp_dummy_113 = "'tok_PrefixOp_dummy_113'"
-showRtkToken L.Tk__tok_PrimitiveTypeKeyword_dummy_112 = "'tok_PrimitiveTypeKeyword_dummy_112'"
-showRtkToken L.Tk__tok_RelationalOp_dummy_111 = "'tok_RelationalOp_dummy_111'"
-showRtkToken L.Tk__tok_ShiftOp_dummy_110 = "'tok_ShiftOp_dummy_110'"
-showRtkToken L.Tk__tok_Statement_dummy_109 = "'tok_Statement_dummy_109'"
-showRtkToken L.Tk__tok_StatementBlock_dummy_108 = "'tok_StatementBlock_dummy_108'"
-showRtkToken L.Tk__tok_StatementList_dummy_107 = "'tok_StatementList_dummy_107'"
-showRtkToken L.Tk__tok_StaticInitializer_dummy_106 = "'tok_StaticInitializer_dummy_106'"
-showRtkToken L.Tk__tok_SwitchCaseList_dummy_105 = "'tok_SwitchCaseList_dummy_105'"
-showRtkToken L.Tk__tok_SwitchStatement_dummy_104 = "'tok_SwitchStatement_dummy_104'"
-showRtkToken L.Tk__tok_ThrowsClause_dummy_103 = "'tok_ThrowsClause_dummy_103'"
-showRtkToken L.Tk__tok_TryStatement_dummy_102 = "'tok_TryStatement_dummy_102'"
-showRtkToken L.Tk__tok_Type_dummy_101 = "'tok_Type_dummy_101'"
-showRtkToken L.Tk__tok_TypeArgument_dummy_100 = "'tok_TypeArgument_dummy_100'"
-showRtkToken L.Tk__tok_TypeArguments_dummy_99 = "'tok_TypeArguments_dummy_99'"
-showRtkToken L.Tk__tok_TypeDeclRest_dummy_98 = "'tok_TypeDeclRest_dummy_98'"
-showRtkToken L.Tk__tok_TypeDeclaration_dummy_97 = "'tok_TypeDeclaration_dummy_97'"
-showRtkToken L.Tk__tok_TypeParameter_dummy_96 = "'tok_TypeParameter_dummy_96'"
-showRtkToken L.Tk__tok_TypeParameters_dummy_95 = "'tok_TypeParameters_dummy_95'"
-showRtkToken L.Tk__tok_TypeSpecifier_dummy_94 = "'tok_TypeSpecifier_dummy_94'"
-showRtkToken L.Tk__tok_VariableDeclaration_dummy_93 = "'tok_VariableDeclaration_dummy_93'"
-showRtkToken L.Tk__tok_VariableDeclarator_dummy_92 = "'tok_VariableDeclarator_dummy_92'"
-showRtkToken L.Tk__tok_VariableDeclaratorList_dummy_91 = "'tok_VariableDeclaratorList_dummy_91'"
-showRtkToken L.Tk__tok_VariableInitializer_dummy_90 = "'tok_VariableInitializer_dummy_90'"
-showRtkToken L.Tk__tok_VariableInitializerList_dummy_89 = "'tok_VariableInitializerList_dummy_89'"
-showRtkToken L.Tk__tok_WhileStatement_dummy_88 = "'tok_WhileStatement_dummy_88'"
-showRtkToken L.Tk__tok_WildcardType_dummy_87 = "'tok_WildcardType_dummy_87'"
-showRtkToken L.Tk__tok__tilde__80 = "'~'"
+showRtkToken L.Tk__tok_AdditiveOp_dummy_176 = "'tok_AdditiveOp_dummy_176'"
+showRtkToken L.Tk__tok_Annotation_dummy_175 = "'tok_Annotation_dummy_175'"
+showRtkToken L.Tk__tok_AnnotationArguments_dummy_174 = "'tok_AnnotationArguments_dummy_174'"
+showRtkToken L.Tk__tok_AnnotationDeclaration_dummy_173 = "'tok_AnnotationDeclaration_dummy_173'"
+showRtkToken L.Tk__tok_AnnotationElement_dummy_172 = "'tok_AnnotationElement_dummy_172'"
+showRtkToken L.Tk__tok_AnnotationList_dummy_171 = "'tok_AnnotationList_dummy_171'"
+showRtkToken L.Tk__tok_AnnotationTypeElement_dummy_170 = "'tok_AnnotationTypeElement_dummy_170'"
+showRtkToken L.Tk__tok_AnnotationTypeElementList_dummy_169 = "'tok_AnnotationTypeElementList_dummy_169'"
+showRtkToken L.Tk__tok_Arglist_dummy_168 = "'tok_Arglist_dummy_168'"
+showRtkToken L.Tk__tok_AssignmentOp_dummy_167 = "'tok_AssignmentOp_dummy_167'"
+showRtkToken L.Tk__tok_CatchList_dummy_166 = "'tok_CatchList_dummy_166'"
+showRtkToken L.Tk__tok_ClassDeclaration_dummy_165 = "'tok_ClassDeclaration_dummy_165'"
+showRtkToken L.Tk__tok_CompilationUnit_dummy_164 = "'tok_CompilationUnit_dummy_164'"
+showRtkToken L.Tk__tok_CompoundName_dummy_163 = "'tok_CompoundName_dummy_163'"
+showRtkToken L.Tk__tok_CreationExpression_dummy_162 = "'tok_CreationExpression_dummy_162'"
+showRtkToken L.Tk__tok_DimExprs_dummy_161 = "'tok_DimExprs_dummy_161'"
+showRtkToken L.Tk__tok_Dims_dummy_160 = "'tok_Dims_dummy_160'"
+showRtkToken L.Tk__tok_DoStatement_dummy_159 = "'tok_DoStatement_dummy_159'"
+showRtkToken L.Tk__tok_DocComment_dummy_158 = "'tok_DocComment_dummy_158'"
+showRtkToken L.Tk__tok_EnumConstant_dummy_157 = "'tok_EnumConstant_dummy_157'"
+showRtkToken L.Tk__tok_EnumConstantList_dummy_156 = "'tok_EnumConstantList_dummy_156'"
+showRtkToken L.Tk__tok_EnumDeclaration_dummy_155 = "'tok_EnumDeclaration_dummy_155'"
+showRtkToken L.Tk__tok_EqualityOp_dummy_154 = "'tok_EqualityOp_dummy_154'"
+showRtkToken L.Tk__tok_Expression_dummy_153 = "'tok_Expression_dummy_153'"
+showRtkToken L.Tk__tok_ExtendsList_dummy_152 = "'tok_ExtendsList_dummy_152'"
+showRtkToken L.Tk__tok_FieldDeclaration_dummy_151 = "'tok_FieldDeclaration_dummy_151'"
+showRtkToken L.Tk__tok_FieldDeclarationList_dummy_150 = "'tok_FieldDeclarationList_dummy_150'"
+showRtkToken L.Tk__tok_ForStatement_dummy_149 = "'tok_ForStatement_dummy_149'"
+showRtkToken L.Tk__tok_IfStatement_dummy_148 = "'tok_IfStatement_dummy_148'"
+showRtkToken L.Tk__tok_ImplementsList_dummy_147 = "'tok_ImplementsList_dummy_147'"
+showRtkToken L.Tk__tok_ImportHead_dummy_146 = "'tok_ImportHead_dummy_146'"
+showRtkToken L.Tk__tok_ImportList_dummy_145 = "'tok_ImportList_dummy_145'"
+showRtkToken L.Tk__tok_ImportName_dummy_144 = "'tok_ImportName_dummy_144'"
+showRtkToken L.Tk__tok_ImportStatement_dummy_143 = "'tok_ImportStatement_dummy_143'"
+showRtkToken L.Tk__tok_InterfaceDeclaration_dummy_142 = "'tok_InterfaceDeclaration_dummy_142'"
+showRtkToken L.Tk__tok_Java_dummy_177 = "'tok_Java_dummy_177'"
+showRtkToken L.Tk__tok_Literal_dummy_141 = "'tok_Literal_dummy_141'"
+showRtkToken L.Tk__tok_LocalModifierList1_dummy_140 = "'tok_LocalModifierList1_dummy_140'"
+showRtkToken L.Tk__tok_MemberAfterFirstId_dummy_139 = "'tok_MemberAfterFirstId_dummy_139'"
+showRtkToken L.Tk__tok_MemberDeclaration_dummy_138 = "'tok_MemberDeclaration_dummy_138'"
+showRtkToken L.Tk__tok_MemberRest_dummy_137 = "'tok_MemberRest_dummy_137'"
+showRtkToken L.Tk__tok_Modifier_dummy_136 = "'tok_Modifier_dummy_136'"
+showRtkToken L.Tk__tok_ModifierList_dummy_135 = "'tok_ModifierList_dummy_135'"
+showRtkToken L.Tk__tok_MoreTypeSpecifier_dummy_134 = "'tok_MoreTypeSpecifier_dummy_134'"
+showRtkToken L.Tk__tok_MoreVariableDeclarators_dummy_133 = "'tok_MoreVariableDeclarators_dummy_133'"
+showRtkToken L.Tk__tok_MultiplicativeOp_dummy_132 = "'tok_MultiplicativeOp_dummy_132'"
+showRtkToken L.Tk__tok_NonEmptyDims_dummy_131 = "'tok_NonEmptyDims_dummy_131'"
+showRtkToken L.Tk__tok_NonEmptyTypeArguments_dummy_130 = "'tok_NonEmptyTypeArguments_dummy_130'"
+showRtkToken L.Tk__tok_OptDocComment_dummy_129 = "'tok_OptDocComment_dummy_129'"
+showRtkToken L.Tk__tok_OptElsePart_dummy_128 = "'tok_OptElsePart_dummy_128'"
+showRtkToken L.Tk__tok_OptExpression_dummy_127 = "'tok_OptExpression_dummy_127'"
+showRtkToken L.Tk__tok_OptFinally_dummy_126 = "'tok_OptFinally_dummy_126'"
+showRtkToken L.Tk__tok_OptId_dummy_125 = "'tok_OptId_dummy_125'"
+showRtkToken L.Tk__tok_OptVariableInitializer_dummy_124 = "'tok_OptVariableInitializer_dummy_124'"
+showRtkToken L.Tk__tok_Package_dummy_123 = "'tok_Package_dummy_123'"
+showRtkToken L.Tk__tok_ParamModifierList_dummy_122 = "'tok_ParamModifierList_dummy_122'"
+showRtkToken L.Tk__tok_Parameter_dummy_121 = "'tok_Parameter_dummy_121'"
+showRtkToken L.Tk__tok_ParameterList_dummy_120 = "'tok_ParameterList_dummy_120'"
+showRtkToken L.Tk__tok_PostfixOp_dummy_119 = "'tok_PostfixOp_dummy_119'"
+showRtkToken L.Tk__tok_PrefixOp_dummy_118 = "'tok_PrefixOp_dummy_118'"
+showRtkToken L.Tk__tok_PrimitiveTypeKeyword_dummy_117 = "'tok_PrimitiveTypeKeyword_dummy_117'"
+showRtkToken L.Tk__tok_RelationalOp_dummy_116 = "'tok_RelationalOp_dummy_116'"
+showRtkToken L.Tk__tok_ShiftOp_dummy_115 = "'tok_ShiftOp_dummy_115'"
+showRtkToken L.Tk__tok_Statement_dummy_114 = "'tok_Statement_dummy_114'"
+showRtkToken L.Tk__tok_StatementBlock_dummy_113 = "'tok_StatementBlock_dummy_113'"
+showRtkToken L.Tk__tok_StatementList_dummy_112 = "'tok_StatementList_dummy_112'"
+showRtkToken L.Tk__tok_StaticInitializer_dummy_111 = "'tok_StaticInitializer_dummy_111'"
+showRtkToken L.Tk__tok_SwitchCaseList_dummy_110 = "'tok_SwitchCaseList_dummy_110'"
+showRtkToken L.Tk__tok_SwitchStatement_dummy_109 = "'tok_SwitchStatement_dummy_109'"
+showRtkToken L.Tk__tok_ThrowsClause_dummy_108 = "'tok_ThrowsClause_dummy_108'"
+showRtkToken L.Tk__tok_TryStatement_dummy_107 = "'tok_TryStatement_dummy_107'"
+showRtkToken L.Tk__tok_Type_dummy_106 = "'tok_Type_dummy_106'"
+showRtkToken L.Tk__tok_TypeArgument_dummy_105 = "'tok_TypeArgument_dummy_105'"
+showRtkToken L.Tk__tok_TypeArguments_dummy_104 = "'tok_TypeArguments_dummy_104'"
+showRtkToken L.Tk__tok_TypeDeclRest_dummy_103 = "'tok_TypeDeclRest_dummy_103'"
+showRtkToken L.Tk__tok_TypeDeclaration_dummy_102 = "'tok_TypeDeclaration_dummy_102'"
+showRtkToken L.Tk__tok_TypeParameter_dummy_101 = "'tok_TypeParameter_dummy_101'"
+showRtkToken L.Tk__tok_TypeParameters_dummy_100 = "'tok_TypeParameters_dummy_100'"
+showRtkToken L.Tk__tok_TypeSpecifier_dummy_99 = "'tok_TypeSpecifier_dummy_99'"
+showRtkToken L.Tk__tok_VariableDeclaration_dummy_98 = "'tok_VariableDeclaration_dummy_98'"
+showRtkToken L.Tk__tok_VariableDeclarator_dummy_97 = "'tok_VariableDeclarator_dummy_97'"
+showRtkToken L.Tk__tok_VariableDeclaratorList_dummy_96 = "'tok_VariableDeclaratorList_dummy_96'"
+showRtkToken L.Tk__tok_VariableInitializer_dummy_95 = "'tok_VariableInitializer_dummy_95'"
+showRtkToken L.Tk__tok_VariableInitializerList_dummy_94 = "'tok_VariableInitializerList_dummy_94'"
+showRtkToken L.Tk__tok_WhileStatement_dummy_93 = "'tok_WhileStatement_dummy_93'"
+showRtkToken L.Tk__tok_WildcardType_dummy_92 = "'tok_WildcardType_dummy_92'"
+showRtkToken L.Tk__tok__tilde__82 = "'~'"
 showRtkToken L.Tk__tok__symbol__15 = "'}'"
-showRtkToken L.Tk__tok__pipe__pipe__59 = "'||'"
-showRtkToken L.Tk__tok__pipe__eql__51 = "'|='"
-showRtkToken L.Tk__tok__pipe__61 = "'|'"
+showRtkToken L.Tk__tok__pipe__pipe__61 = "'||'"
+showRtkToken L.Tk__tok__pipe__eql__53 = "'|='"
+showRtkToken L.Tk__tok__pipe__63 = "'|'"
 showRtkToken L.Tk__tok__symbol__14 = "'{'"
-showRtkToken L.Tk__tok_while_40 = "'while'"
+showRtkToken L.Tk__tok_while_42 = "'while'"
 showRtkToken L.Tk__tok_void_28 = "'void'"
-showRtkToken L.Tk__tok_try_44 = "'try'"
-showRtkToken L.Tk__tok_true_85 = "'true'"
-showRtkToken L.Tk__tok_transient_95 = "'transient'"
+showRtkToken L.Tk__tok_try_46 = "'try'"
+showRtkToken L.Tk__tok_true_87 = "'true'"
+showRtkToken L.Tk__tok_transient_96 = "'transient'"
 showRtkToken L.Tk__tok_throws_29 = "'throws'"
-showRtkToken L.Tk__tok_throw_33 = "'throw'"
-showRtkToken L.Tk__tok_threadsafe_94 = "'threadsafe'"
-showRtkToken L.Tk__tok_this_82 = "'this'"
-showRtkToken L.Tk__tok_synchronized_32 = "'synchronized'"
-showRtkToken L.Tk__tok_switch_46 = "'switch'"
-showRtkToken L.Tk__tok_super_83 = "'super'"
+showRtkToken L.Tk__tok_throw_35 = "'throw'"
+showRtkToken L.Tk__tok_threadsafe_95 = "'threadsafe'"
+showRtkToken L.Tk__tok_this_84 = "'this'"
+showRtkToken L.Tk__tok_synchronized_34 = "'synchronized'"
+showRtkToken L.Tk__tok_switch_48 = "'switch'"
+showRtkToken L.Tk__tok_super_85 = "'super'"
 showRtkToken L.Tk__tok_static_3 = "'static'"
 showRtkToken L.Tk__tok_short_23 = "'short'"
-showRtkToken L.Tk__tok_return_31 = "'return'"
-showRtkToken L.Tk__tok_public_88 = "'public'"
-showRtkToken L.Tk__tok_protected_90 = "'protected'"
-showRtkToken L.Tk__tok_private_89 = "'private'"
+showRtkToken L.Tk__tok_return_33 = "'return'"
+showRtkToken L.Tk__tok_public_90 = "'public'"
+showRtkToken L.Tk__tok_protected_92 = "'protected'"
+showRtkToken L.Tk__tok_private_91 = "'private'"
 showRtkToken L.Tk__tok_package_0 = "'package'"
-showRtkToken L.Tk__tok_null_87 = "'null'"
-showRtkToken L.Tk__tok_new_84 = "'new'"
-showRtkToken L.Tk__tok_native_92 = "'native'"
+showRtkToken L.Tk__tok_null_89 = "'null'"
+showRtkToken L.Tk__tok_new_86 = "'new'"
+showRtkToken L.Tk__tok_native_93 = "'native'"
 showRtkToken L.Tk__tok_long_26 = "'long'"
 showRtkToken L.Tk__tok_interface_16 = "'interface'"
 showRtkToken L.Tk__tok_int_24 = "'int'"
-showRtkToken L.Tk__tok_instanceof_70 = "'instanceof'"
+showRtkToken L.Tk__tok_instanceof_72 = "'instanceof'"
 showRtkToken L.Tk__tok_import_2 = "'import'"
 showRtkToken L.Tk__tok_implements_12 = "'implements'"
-showRtkToken L.Tk__tok_if_38 = "'if'"
-showRtkToken L.Tk__tok_for_41 = "'for'"
+showRtkToken L.Tk__tok_if_40 = "'if'"
+showRtkToken L.Tk__tok_for_43 = "'for'"
 showRtkToken L.Tk__tok_float_25 = "'float'"
-showRtkToken L.Tk__tok_finally_43 = "'finally'"
-showRtkToken L.Tk__tok_final_91 = "'final'"
-showRtkToken L.Tk__tok_false_86 = "'false'"
+showRtkToken L.Tk__tok_finally_45 = "'finally'"
+showRtkToken L.Tk__tok_final_31 = "'final'"
+showRtkToken L.Tk__tok_false_88 = "'false'"
 showRtkToken L.Tk__tok_extends_11 = "'extends'"
 showRtkToken L.Tk__tok_enum_17 = "'enum'"
-showRtkToken L.Tk__tok_else_37 = "'else'"
+showRtkToken L.Tk__tok_else_39 = "'else'"
 showRtkToken L.Tk__tok_double_27 = "'double'"
-showRtkToken L.Tk__tok_do_39 = "'do'"
+showRtkToken L.Tk__tok_do_41 = "'do'"
 showRtkToken L.Tk__tok_default_30 = "'default'"
-showRtkToken L.Tk__tok_continue_36 = "'continue'"
+showRtkToken L.Tk__tok_continue_38 = "'continue'"
 showRtkToken L.Tk__tok_class_13 = "'class'"
 showRtkToken L.Tk__tok_char_22 = "'char'"
-showRtkToken L.Tk__tok_catch_42 = "'catch'"
-showRtkToken L.Tk__tok_case_45 = "'case'"
+showRtkToken L.Tk__tok_catch_44 = "'catch'"
+showRtkToken L.Tk__tok_case_47 = "'case'"
 showRtkToken L.Tk__tok_byte_21 = "'byte'"
-showRtkToken L.Tk__tok_break_35 = "'break'"
+showRtkToken L.Tk__tok_break_37 = "'break'"
 showRtkToken L.Tk__tok_boolean_20 = "'boolean'"
-showRtkToken L.Tk__tok_abstract_93 = "'abstract'"
-showRtkToken L.Tk__tok__symbol__eql__53 = "'^='"
-showRtkToken L.Tk__tok__symbol__62 = "'^'"
+showRtkToken L.Tk__tok_abstract_94 = "'abstract'"
+showRtkToken L.Tk__tok__symbol__eql__55 = "'^='"
+showRtkToken L.Tk__tok__symbol__64 = "'^'"
 showRtkToken L.Tk__tok__sq_bkt_r__19 = "']'"
 showRtkToken L.Tk__tok__sq_bkt_l__18 = "'['"
 showRtkToken L.Tk__tok__symbol__6 = "'@'"
-showRtkToken L.Tk__tok__symbol__58 = "'?'"
-showRtkToken L.Tk__tok__symbol__symbol__symbol__eql__57 = "'>>>='"
-showRtkToken L.Tk__tok__symbol__symbol__symbol__73 = "'>>>'"
-showRtkToken L.Tk__tok__symbol__symbol__eql__56 = "'>>='"
-showRtkToken L.Tk__tok__symbol__symbol__71 = "'>>'"
-showRtkToken L.Tk__tok__symbol__eql__69 = "'>='"
-showRtkToken L.Tk__tok__symbol__67 = "'>'"
-showRtkToken L.Tk__tok__eql__eql__64 = "'=='"
+showRtkToken L.Tk__tok__symbol__60 = "'?'"
+showRtkToken L.Tk__tok__symbol__symbol__symbol__eql__59 = "'>>>='"
+showRtkToken L.Tk__tok__symbol__symbol__symbol__75 = "'>>>'"
+showRtkToken L.Tk__tok__symbol__symbol__eql__58 = "'>>='"
+showRtkToken L.Tk__tok__symbol__symbol__73 = "'>>'"
+showRtkToken L.Tk__tok__symbol__eql__71 = "'>='"
+showRtkToken L.Tk__tok__symbol__69 = "'>'"
+showRtkToken L.Tk__tok__eql__eql__66 = "'=='"
 showRtkToken L.Tk__tok__eql__10 = "'='"
-showRtkToken L.Tk__tok__symbol__eql__68 = "'<='"
-showRtkToken L.Tk__tok__symbol__symbol__eql__55 = "'<<='"
-showRtkToken L.Tk__tok__symbol__symbol__72 = "'<<'"
-showRtkToken L.Tk__tok__symbol__66 = "'<'"
+showRtkToken L.Tk__tok__symbol__eql__70 = "'<='"
+showRtkToken L.Tk__tok__symbol__symbol__eql__57 = "'<<='"
+showRtkToken L.Tk__tok__symbol__symbol__74 = "'<<'"
+showRtkToken L.Tk__tok__symbol__68 = "'<'"
 showRtkToken L.Tk__tok__semi__1 = "';'"
-showRtkToken L.Tk__tok__colon__34 = "':'"
-showRtkToken L.Tk__tok__symbol__eql__50 = "'/='"
-showRtkToken L.Tk__tok__symbol__76 = "'/'"
+showRtkToken L.Tk__tok__colon__36 = "':'"
+showRtkToken L.Tk__tok__symbol__eql__52 = "'/='"
+showRtkToken L.Tk__tok__symbol__78 = "'/'"
+showRtkToken L.Tk__tok__dot__dot__dot__32 = "'...'"
 showRtkToken L.Tk__tok__dot__4 = "'.'"
-showRtkToken L.Tk__tok__minus__eql__48 = "'-='"
-showRtkToken L.Tk__tok__minus__minus__79 = "'--'"
-showRtkToken L.Tk__tok__minus__75 = "'-'"
+showRtkToken L.Tk__tok__minus__eql__50 = "'-='"
+showRtkToken L.Tk__tok__minus__minus__81 = "'--'"
+showRtkToken L.Tk__tok__minus__77 = "'-'"
 showRtkToken L.Tk__tok__coma__9 = "','"
-showRtkToken L.Tk__tok__plus__eql__47 = "'+='"
-showRtkToken L.Tk__tok__plus__plus__78 = "'++'"
-showRtkToken L.Tk__tok__plus__74 = "'+'"
-showRtkToken L.Tk__tok__star__eql__49 = "'*='"
+showRtkToken L.Tk__tok__plus__eql__49 = "'+='"
+showRtkToken L.Tk__tok__plus__plus__80 = "'++'"
+showRtkToken L.Tk__tok__plus__76 = "'+'"
+showRtkToken L.Tk__tok__star__eql__51 = "'*='"
 showRtkToken L.Tk__tok__star__5 = "'*'"
 showRtkToken L.Tk__tok__rparen__8 = "')'"
 showRtkToken L.Tk__tok__lparen__7 = "'('"
-showRtkToken L.Tk__tok__symbol__eql__52 = "'&='"
-showRtkToken L.Tk__tok__symbol__symbol__60 = "'&&'"
-showRtkToken L.Tk__tok__symbol__63 = "'&'"
-showRtkToken L.Tk__tok__symbol__eql__54 = "'%='"
-showRtkToken L.Tk__tok__symbol__77 = "'%'"
-showRtkToken L.Tk__tok__exclamation__eql__65 = "'!='"
-showRtkToken L.Tk__tok__exclamation__81 = "'!'"
+showRtkToken L.Tk__tok__symbol__eql__54 = "'&='"
+showRtkToken L.Tk__tok__symbol__symbol__62 = "'&&'"
+showRtkToken L.Tk__tok__symbol__65 = "'&'"
+showRtkToken L.Tk__tok__symbol__eql__56 = "'%='"
+showRtkToken L.Tk__tok__symbol__79 = "'%'"
+showRtkToken L.Tk__tok__exclamation__eql__67 = "'!='"
+showRtkToken L.Tk__tok__exclamation__83 = "'!'"
 showRtkToken (L.Tk__doccomment v) = "doccomment " ++ show v
 showRtkToken (L.Tk__id v) = "id " ++ show v
 showRtkToken (L.Tk__string v) = "string " ++ show v
@@ -1258,12 +1290,14 @@ showRtkToken (L.Tk__qq_OptId v) = "qq_OptId " ++ show v
 showRtkToken (L.Tk__qq_OptExpression v) = "qq_OptExpression " ++ show v
 showRtkToken (L.Tk__qq_StatementList v) = "qq_StatementList " ++ show v
 showRtkToken (L.Tk__qq_Parameter v) = "qq_Parameter " ++ show v
+showRtkToken (L.Tk__qq_ParamModifierList v) = "qq_ParamModifierList " ++ show v
 showRtkToken (L.Tk__qq_ParameterList v) = "qq_ParameterList " ++ show v
 showRtkToken (L.Tk__qq_StaticInitializer v) = "qq_StaticInitializer " ++ show v
 showRtkToken (L.Tk__qq_VariableInitializer v) = "qq_VariableInitializer " ++ show v
 showRtkToken (L.Tk__qq_VariableInitializerList v) = "qq_VariableInitializerList " ++ show v
 showRtkToken (L.Tk__qq_VariableDeclarator v) = "qq_VariableDeclarator " ++ show v
 showRtkToken (L.Tk__qq_OptVariableInitializer v) = "qq_OptVariableInitializer " ++ show v
+showRtkToken (L.Tk__qq_LocalModifierList1 v) = "qq_LocalModifierList1 " ++ show v
 showRtkToken (L.Tk__qq_VariableDeclaration v) = "qq_VariableDeclaration " ++ show v
 showRtkToken (L.Tk__qq_VariableDeclaratorList v) = "qq_VariableDeclaratorList " ++ show v
 showRtkToken (L.Tk__qq_StatementBlock v) = "qq_StatementBlock " ++ show v
@@ -1473,6 +1507,9 @@ tkVal_qq_StatementList t = error ("rtk internal error: token qq_StatementList ex
 tkVal_qq_Parameter :: L.PosToken -> String
 tkVal_qq_Parameter (L.PosToken _ (L.Tk__qq_Parameter v)) = v
 tkVal_qq_Parameter t = error ("rtk internal error: token qq_Parameter expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_ParamModifierList :: L.PosToken -> String
+tkVal_qq_ParamModifierList (L.PosToken _ (L.Tk__qq_ParamModifierList v)) = v
+tkVal_qq_ParamModifierList t = error ("rtk internal error: token qq_ParamModifierList expected, got " ++ showRtkToken (L.ptToken t))
 tkVal_qq_ParameterList :: L.PosToken -> String
 tkVal_qq_ParameterList (L.PosToken _ (L.Tk__qq_ParameterList v)) = v
 tkVal_qq_ParameterList t = error ("rtk internal error: token qq_ParameterList expected, got " ++ showRtkToken (L.ptToken t))
@@ -1491,6 +1528,9 @@ tkVal_qq_VariableDeclarator t = error ("rtk internal error: token qq_VariableDec
 tkVal_qq_OptVariableInitializer :: L.PosToken -> String
 tkVal_qq_OptVariableInitializer (L.PosToken _ (L.Tk__qq_OptVariableInitializer v)) = v
 tkVal_qq_OptVariableInitializer t = error ("rtk internal error: token qq_OptVariableInitializer expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_LocalModifierList1 :: L.PosToken -> String
+tkVal_qq_LocalModifierList1 (L.PosToken _ (L.Tk__qq_LocalModifierList1 v)) = v
+tkVal_qq_LocalModifierList1 t = error ("rtk internal error: token qq_LocalModifierList1 expected, got " ++ showRtkToken (L.ptToken t))
 tkVal_qq_VariableDeclaration :: L.PosToken -> String
 tkVal_qq_VariableDeclaration (L.PosToken _ (L.Tk__qq_VariableDeclaration v)) = v
 tkVal_qq_VariableDeclaration t = error ("rtk internal error: token qq_VariableDeclaration expected, got " ++ showRtkToken (L.ptToken t))
@@ -1649,55 +1689,57 @@ data Java = Ctr__Java__0 RtkPos Java |
             Ctr__Java__34 RtkPos ImportStatement |
             Ctr__Java__35 RtkPos InterfaceDeclaration |
             Ctr__Java__36 RtkPos Literal |
-            Ctr__Java__37 RtkPos MemberAfterFirstId |
-            Ctr__Java__38 RtkPos MemberDeclaration |
-            Ctr__Java__39 RtkPos MemberRest |
-            Ctr__Java__40 RtkPos Modifier |
-            Ctr__Java__41 RtkPos ModifierList |
-            Ctr__Java__42 RtkPos MoreTypeSpecifier |
-            Ctr__Java__43 RtkPos MoreVariableDeclarators |
-            Ctr__Java__44 RtkPos MultiplicativeOp |
-            Ctr__Java__45 RtkPos NonEmptyDims |
-            Ctr__Java__46 RtkPos NonEmptyTypeArguments |
-            Ctr__Java__47 RtkPos OptDocComment |
-            Ctr__Java__48 RtkPos OptElsePart |
-            Ctr__Java__49 RtkPos OptExpression |
-            Ctr__Java__50 RtkPos OptFinally |
-            Ctr__Java__51 RtkPos OptId |
-            Ctr__Java__52 RtkPos OptVariableInitializer |
-            Ctr__Java__53 RtkPos Package |
-            Ctr__Java__54 RtkPos Parameter |
-            Ctr__Java__55 RtkPos ParameterList |
-            Ctr__Java__56 RtkPos PostfixOp |
-            Ctr__Java__57 RtkPos PrefixOp |
-            Ctr__Java__58 RtkPos PrimitiveTypeKeyword |
-            Ctr__Java__59 RtkPos RelationalOp |
-            Ctr__Java__60 RtkPos ShiftOp |
-            Ctr__Java__61 RtkPos Statement |
-            Ctr__Java__62 RtkPos StatementBlock |
-            Ctr__Java__63 RtkPos StatementList |
-            Ctr__Java__64 RtkPos StaticInitializer |
-            Ctr__Java__65 RtkPos SwitchCaseList |
-            Ctr__Java__66 RtkPos SwitchStatement |
-            Ctr__Java__67 RtkPos ThrowsClause |
-            Ctr__Java__68 RtkPos TryStatement |
-            Ctr__Java__69 RtkPos Type |
-            Ctr__Java__70 RtkPos TypeArgument |
-            Ctr__Java__71 RtkPos TypeArguments |
-            Ctr__Java__72 RtkPos TypeDeclRest |
-            Ctr__Java__73 RtkPos TypeDeclaration |
-            Ctr__Java__74 RtkPos TypeParameter |
-            Ctr__Java__75 RtkPos TypeParameters |
-            Ctr__Java__76 RtkPos TypeSpecifier |
-            Ctr__Java__77 RtkPos VariableDeclaration |
-            Ctr__Java__78 RtkPos VariableDeclarator |
-            Ctr__Java__79 RtkPos VariableDeclaratorList |
-            Ctr__Java__80 RtkPos VariableInitializer |
-            Ctr__Java__81 RtkPos VariableInitializerList |
-            Ctr__Java__82 RtkPos WhileStatement |
-            Ctr__Java__83 RtkPos WildcardType |
+            Ctr__Java__37 RtkPos LocalModifierList1 |
+            Ctr__Java__38 RtkPos MemberAfterFirstId |
+            Ctr__Java__39 RtkPos MemberDeclaration |
+            Ctr__Java__40 RtkPos MemberRest |
+            Ctr__Java__41 RtkPos Modifier |
+            Ctr__Java__42 RtkPos ModifierList |
+            Ctr__Java__43 RtkPos MoreTypeSpecifier |
+            Ctr__Java__44 RtkPos MoreVariableDeclarators |
+            Ctr__Java__45 RtkPos MultiplicativeOp |
+            Ctr__Java__46 RtkPos NonEmptyDims |
+            Ctr__Java__47 RtkPos NonEmptyTypeArguments |
+            Ctr__Java__48 RtkPos OptDocComment |
+            Ctr__Java__49 RtkPos OptElsePart |
+            Ctr__Java__50 RtkPos OptExpression |
+            Ctr__Java__51 RtkPos OptFinally |
+            Ctr__Java__52 RtkPos OptId |
+            Ctr__Java__53 RtkPos OptVariableInitializer |
+            Ctr__Java__54 RtkPos Package |
+            Ctr__Java__55 RtkPos ParamModifierList |
+            Ctr__Java__56 RtkPos Parameter |
+            Ctr__Java__57 RtkPos ParameterList |
+            Ctr__Java__58 RtkPos PostfixOp |
+            Ctr__Java__59 RtkPos PrefixOp |
+            Ctr__Java__60 RtkPos PrimitiveTypeKeyword |
+            Ctr__Java__61 RtkPos RelationalOp |
+            Ctr__Java__62 RtkPos ShiftOp |
+            Ctr__Java__63 RtkPos Statement |
+            Ctr__Java__64 RtkPos StatementBlock |
+            Ctr__Java__65 RtkPos StatementList |
+            Ctr__Java__66 RtkPos StaticInitializer |
+            Ctr__Java__67 RtkPos SwitchCaseList |
+            Ctr__Java__68 RtkPos SwitchStatement |
+            Ctr__Java__69 RtkPos ThrowsClause |
+            Ctr__Java__70 RtkPos TryStatement |
+            Ctr__Java__71 RtkPos Type |
+            Ctr__Java__72 RtkPos TypeArgument |
+            Ctr__Java__73 RtkPos TypeArguments |
+            Ctr__Java__74 RtkPos TypeDeclRest |
+            Ctr__Java__75 RtkPos TypeDeclaration |
+            Ctr__Java__76 RtkPos TypeParameter |
+            Ctr__Java__77 RtkPos TypeParameters |
+            Ctr__Java__78 RtkPos TypeSpecifier |
+            Ctr__Java__79 RtkPos VariableDeclaration |
+            Ctr__Java__80 RtkPos VariableDeclarator |
+            Ctr__Java__81 RtkPos VariableDeclaratorList |
+            Ctr__Java__82 RtkPos VariableInitializer |
+            Ctr__Java__83 RtkPos VariableInitializerList |
+            Ctr__Java__84 RtkPos WhileStatement |
+            Ctr__Java__85 RtkPos WildcardType |
             Anti_Java String |
-            Ctr__Java__84 RtkPos CompilationUnit
+            Ctr__Java__86 RtkPos CompilationUnit
             deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Java where
     rtkPosOf (Ctr__Java__0 p _) = p
@@ -1784,8 +1826,10 @@ instance RtkPosOf Java where
     rtkPosOf (Ctr__Java__81 p _) = p
     rtkPosOf (Ctr__Java__82 p _) = p
     rtkPosOf (Ctr__Java__83 p _) = p
-    rtkPosOf (Anti_Java _) = rtkNoPos
     rtkPosOf (Ctr__Java__84 p _) = p
+    rtkPosOf (Ctr__Java__85 p _) = p
+    rtkPosOf (Anti_Java _) = rtkNoPos
+    rtkPosOf (Ctr__Java__86 p _) = p
 data AdditiveOp = Anti_AdditiveOp String |
                   Ctr__AdditiveOp__0 RtkPos |
                   Ctr__AdditiveOp__1 RtkPos
@@ -1830,7 +1874,7 @@ instance RtkPosOf AnnotationTypeElement where
 type AnnotationTypeElementList = [AnnotationTypeElement]
 data Arglist = Anti_Arglist String |
                Ctr__Arglist__0 RtkPos |
-               Ctr__Arglist__1 RtkPos Rule_73
+               Ctr__Arglist__1 RtkPos Rule_78
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Arglist where
     rtkPosOf (Anti_Arglist _) = rtkNoPos
@@ -1864,7 +1908,7 @@ instance RtkPosOf AssignmentOp where
     rtkPosOf (Ctr__AssignmentOp__9 p) = p
     rtkPosOf (Ctr__AssignmentOp__10 p) = p
     rtkPosOf (Ctr__AssignmentOp__11 p) = p
-type CatchList = [Rule_58]
+type CatchList = [Rule_63]
 data ClassDeclaration = Anti_ClassDeclaration String |
                         Ctr__ClassDeclaration__0 RtkPos String TypeParameters Rule_16 Rule_17 FieldDeclarationList
                         deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
@@ -1878,18 +1922,18 @@ instance RtkPosOf CompilationUnit where
     rtkPosOf (Anti_CompilationUnit _) = rtkNoPos
     rtkPosOf (Ctr__CompilationUnit__0 p _ _ _) = p
 data CompoundName = Anti_CompoundName String |
-                    Ctr__CompoundName__0 RtkPos String Rule_85
+                    Ctr__CompoundName__0 RtkPos String Rule_90
                     deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf CompoundName where
     rtkPosOf (Anti_CompoundName _) = rtkNoPos
     rtkPosOf (Ctr__CompoundName__0 p _ _) = p
 data CreationExpression = Anti_CreationExpression String |
-                          Ctr__CreationExpression__0 RtkPos TypeSpecifier Rule_69
+                          Ctr__CreationExpression__0 RtkPos TypeSpecifier Rule_74
                           deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf CreationExpression where
     rtkPosOf (Anti_CreationExpression _) = rtkNoPos
     rtkPosOf (Ctr__CreationExpression__0 p _ _) = p
-type DimExprs = [Rule_71]
+type DimExprs = [Rule_76]
 type Dims = [Rule_31]
 data DoStatement = Anti_DoStatement String |
                    Ctr__DoStatement__0 RtkPos Statement Expression
@@ -1934,9 +1978,9 @@ data Expression = Anti_Expression String |
                   Ctr__Expression__1 RtkPos |
                   Ctr__Expression__2 RtkPos Expression |
                   Ctr__Expression__3 RtkPos CreationExpression |
-                  Ctr__Expression__4 RtkPos CompoundName Rule_65 |
+                  Ctr__Expression__4 RtkPos CompoundName Rule_70 |
                   Ctr__Expression__5 RtkPos CompoundName Expression |
-                  Ctr__Expression__6 RtkPos String Rule_67 |
+                  Ctr__Expression__6 RtkPos String Rule_72 |
                   Ctr__Expression__7 RtkPos Expression |
                   Ctr__Expression__8 RtkPos Expression PostfixOp |
                   Ctr__Expression__9 RtkPos Expression String |
@@ -1975,7 +2019,7 @@ data Expression = Anti_Expression String |
                   Ctr__Expression__42 RtkPos Expression Expression |
                   Ctr__Expression__43 RtkPos Expression |
                   Ctr__Expression__44 RtkPos Expression Expression Expression |
-                  Ctr__Expression__45 RtkPos Expression Rule_63 |
+                  Ctr__Expression__45 RtkPos Expression Rule_68 |
                   Ctr__Expression__46 RtkPos Expression
                   deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Expression where
@@ -2043,7 +2087,7 @@ instance RtkPosOf FieldDeclaration where
     rtkPosOf (Ctr__FieldDeclaration__1 p) = p
 type FieldDeclarationList = [FieldDeclaration]
 data ForStatement = Anti_ForStatement String |
-                    Ctr__ForStatement__0 RtkPos Rule_57 OptExpression OptExpression Statement
+                    Ctr__ForStatement__0 RtkPos Rule_62 OptExpression OptExpression Statement
                     deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf ForStatement where
     rtkPosOf (Anti_ForStatement _) = rtkNoPos
@@ -2107,6 +2151,7 @@ instance RtkPosOf Literal where
     rtkPosOf (Ctr__Literal__4 p _) = p
     rtkPosOf (Ctr__Literal__5 p _) = p
     rtkPosOf (Ctr__Literal__6 p) = p
+type LocalModifierList1 = [Rule_48]
 data MemberAfterFirstId = Anti_MemberAfterFirstId String |
                           Ctr__MemberAfterFirstId__0 RtkPos Rule_35 Rule_36 StatementBlock |
                           Ctr__MemberAfterFirstId__1 RtkPos MoreTypeSpecifier String MemberRest
@@ -2179,7 +2224,7 @@ instance RtkPosOf MultiplicativeOp where
     rtkPosOf (Ctr__MultiplicativeOp__2 p) = p
 type NonEmptyDims = [Rule_33]
 data NonEmptyTypeArguments = Anti_NonEmptyTypeArguments String |
-                             Ctr__NonEmptyTypeArguments__0 RtkPos TypeArgument Rule_76
+                             Ctr__NonEmptyTypeArguments__0 RtkPos TypeArgument Rule_81
                              deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf NonEmptyTypeArguments where
     rtkPosOf (Anti_NonEmptyTypeArguments _) = rtkNoPos
@@ -2194,7 +2239,7 @@ instance RtkPosOf OptDocComment where
     rtkPosOf (Ctr__OptDocComment__1 p _) = p
 data OptElsePart = Anti_OptElsePart String |
                    Ctr__OptElsePart__0 RtkPos |
-                   Ctr__OptElsePart__1 RtkPos Rule_56
+                   Ctr__OptElsePart__1 RtkPos Rule_61
                    deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf OptElsePart where
     rtkPosOf (Anti_OptElsePart _) = rtkNoPos
@@ -2210,7 +2255,7 @@ instance RtkPosOf OptExpression where
     rtkPosOf (Ctr__OptExpression__1 p _) = p
 data OptFinally = Anti_OptFinally String |
                   Ctr__OptFinally__0 RtkPos |
-                  Ctr__OptFinally__1 RtkPos Rule_60
+                  Ctr__OptFinally__1 RtkPos Rule_65
                   deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf OptFinally where
     rtkPosOf (Anti_OptFinally _) = rtkNoPos
@@ -2226,7 +2271,7 @@ instance RtkPosOf OptId where
     rtkPosOf (Ctr__OptId__1 p _) = p
 data OptVariableInitializer = Anti_OptVariableInitializer String |
                               Ctr__OptVariableInitializer__0 RtkPos |
-                              Ctr__OptVariableInitializer__1 RtkPos Rule_48
+                              Ctr__OptVariableInitializer__1 RtkPos Rule_50
                               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf OptVariableInitializer where
     rtkPosOf (Anti_OptVariableInitializer _) = rtkNoPos
@@ -2238,14 +2283,15 @@ data Package = Anti_Package String |
 instance RtkPosOf Package where
     rtkPosOf (Anti_Package _) = rtkNoPos
     rtkPosOf (Ctr__Package__0 p _) = p
+type ParamModifierList = [Rule_57]
 data Parameter = Anti_Parameter String |
-                 Ctr__Parameter__0 RtkPos Type String Dims
+                 Ctr__Parameter__0 RtkPos ParamModifierList Type Rule_59 String Dims
                  deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Parameter where
     rtkPosOf (Anti_Parameter _) = rtkNoPos
-    rtkPosOf (Ctr__Parameter__0 p _ _ _) = p
+    rtkPosOf (Ctr__Parameter__0 p _ _ _ _ _) = p
 data ParameterList = Anti_ParameterList String |
-                     Ctr__ParameterList__0 RtkPos Parameter Rule_53
+                     Ctr__ParameterList__0 RtkPos Parameter Rule_55
                      deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf ParameterList where
     rtkPosOf (Anti_ParameterList _) = rtkNoPos
@@ -2483,136 +2529,144 @@ data Rule_47 = Ctr__Rule_47__0 RtkPos VariableDeclarator
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_47 where
     rtkPosOf (Ctr__Rule_47__0 p _) = p
-data Rule_48 = Ctr__Rule_48__0 RtkPos VariableInitializer
+data Rule_48 = Anti_Rule_48 String |
+               Ctr__Rule_48__1 RtkPos |
+               Ctr__Rule_48__2 RtkPos Annotation
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_48 where
-    rtkPosOf (Ctr__Rule_48__0 p _) = p
-data Rule_49 = Ctr__Rule_49__0 RtkPos VariableInitializer Rule_50 Rule_52
-               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-instance RtkPosOf Rule_49 where
-    rtkPosOf (Ctr__Rule_49__0 p _ _ _) = p
+    rtkPosOf (Anti_Rule_48 _) = rtkNoPos
+    rtkPosOf (Ctr__Rule_48__1 p) = p
+    rtkPosOf (Ctr__Rule_48__2 p _) = p
 data Rule_5 = Ctr__Rule_5__0 RtkPos Rule_6
               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_5 where
     rtkPosOf (Ctr__Rule_5__0 p _) = p
-type Rule_50 = [Rule_51]
-data Rule_51 = Ctr__Rule_51__0 RtkPos VariableInitializer
+data Rule_50 = Ctr__Rule_50__0 RtkPos VariableInitializer
+               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_50 where
+    rtkPosOf (Ctr__Rule_50__0 p _) = p
+data Rule_51 = Ctr__Rule_51__0 RtkPos VariableInitializer Rule_52 Rule_54
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_51 where
-    rtkPosOf (Ctr__Rule_51__0 p _) = p
-data Rule_52 = Ctr__Rule_52__0 RtkPos |
-               Ctr__Rule_52__1 RtkPos
+    rtkPosOf (Ctr__Rule_51__0 p _ _ _) = p
+type Rule_52 = [Rule_53]
+data Rule_53 = Ctr__Rule_53__0 RtkPos VariableInitializer
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-instance RtkPosOf Rule_52 where
-    rtkPosOf (Ctr__Rule_52__0 p) = p
-    rtkPosOf (Ctr__Rule_52__1 p) = p
-type Rule_53 = [Rule_54]
-data Rule_54 = Ctr__Rule_54__0 RtkPos Parameter
+instance RtkPosOf Rule_53 where
+    rtkPosOf (Ctr__Rule_53__0 p _) = p
+data Rule_54 = Ctr__Rule_54__0 RtkPos |
+               Ctr__Rule_54__1 RtkPos
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_54 where
-    rtkPosOf (Ctr__Rule_54__0 p _) = p
-data Rule_56 = Ctr__Rule_56__0 RtkPos Statement
+    rtkPosOf (Ctr__Rule_54__0 p) = p
+    rtkPosOf (Ctr__Rule_54__1 p) = p
+type Rule_55 = [Rule_56]
+data Rule_56 = Ctr__Rule_56__0 RtkPos Parameter
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_56 where
     rtkPosOf (Ctr__Rule_56__0 p _) = p
-data Rule_57 = Ctr__Rule_57__0 RtkPos VariableDeclaration |
-               Ctr__Rule_57__1 RtkPos Expression |
-               Ctr__Rule_57__2 RtkPos
+data Rule_57 = Anti_Rule_57 String |
+               Ctr__Rule_57__1 RtkPos |
+               Ctr__Rule_57__2 RtkPos Annotation
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_57 where
-    rtkPosOf (Ctr__Rule_57__0 p _) = p
-    rtkPosOf (Ctr__Rule_57__1 p _) = p
-    rtkPosOf (Ctr__Rule_57__2 p) = p
-data Rule_58 = Anti_Rule_58 String |
-               Ctr__Rule_58__1 RtkPos Parameter Statement
+    rtkPosOf (Anti_Rule_57 _) = rtkNoPos
+    rtkPosOf (Ctr__Rule_57__1 p) = p
+    rtkPosOf (Ctr__Rule_57__2 p _) = p
+data Rule_59 = Ctr__Rule_59__0 RtkPos |
+               Ctr__Rule_59__1 RtkPos
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-instance RtkPosOf Rule_58 where
-    rtkPosOf (Anti_Rule_58 _) = rtkNoPos
-    rtkPosOf (Ctr__Rule_58__1 p _ _) = p
+instance RtkPosOf Rule_59 where
+    rtkPosOf (Ctr__Rule_59__0 p) = p
+    rtkPosOf (Ctr__Rule_59__1 p) = p
 data Rule_6 = Ctr__Rule_6__0 RtkPos |
               Ctr__Rule_6__1 RtkPos AnnotationArguments
               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_6 where
     rtkPosOf (Ctr__Rule_6__0 p) = p
     rtkPosOf (Ctr__Rule_6__1 p _) = p
-data Rule_60 = Ctr__Rule_60__0 RtkPos Statement
-               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-instance RtkPosOf Rule_60 where
-    rtkPosOf (Ctr__Rule_60__0 p _) = p
-data Rule_61 = Anti_Rule_61 String |
-               Ctr__Rule_61__1 RtkPos Expression |
-               Ctr__Rule_61__2 RtkPos |
-               Ctr__Rule_61__3 RtkPos Statement
+data Rule_61 = Ctr__Rule_61__0 RtkPos Statement
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_61 where
-    rtkPosOf (Anti_Rule_61 _) = rtkNoPos
-    rtkPosOf (Ctr__Rule_61__1 p _) = p
-    rtkPosOf (Ctr__Rule_61__2 p) = p
-    rtkPosOf (Ctr__Rule_61__3 p _) = p
-data Rule_63 = Ctr__Rule_63__0 RtkPos |
-               Ctr__Rule_63__1 RtkPos Rule_64
+    rtkPosOf (Ctr__Rule_61__0 p _) = p
+data Rule_62 = Ctr__Rule_62__0 RtkPos VariableDeclaration |
+               Ctr__Rule_62__1 RtkPos Expression |
+               Ctr__Rule_62__2 RtkPos
+               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_62 where
+    rtkPosOf (Ctr__Rule_62__0 p _) = p
+    rtkPosOf (Ctr__Rule_62__1 p _) = p
+    rtkPosOf (Ctr__Rule_62__2 p) = p
+data Rule_63 = Anti_Rule_63 String |
+               Ctr__Rule_63__1 RtkPos Parameter Statement
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_63 where
-    rtkPosOf (Ctr__Rule_63__0 p) = p
-    rtkPosOf (Ctr__Rule_63__1 p _) = p
-data Rule_64 = Ctr__Rule_64__0 RtkPos AssignmentOp Expression
-               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-instance RtkPosOf Rule_64 where
-    rtkPosOf (Ctr__Rule_64__0 p _ _) = p
-data Rule_65 = Ctr__Rule_65__0 RtkPos |
-               Ctr__Rule_65__1 RtkPos Rule_66
+    rtkPosOf (Anti_Rule_63 _) = rtkNoPos
+    rtkPosOf (Ctr__Rule_63__1 p _ _) = p
+data Rule_65 = Ctr__Rule_65__0 RtkPos Statement
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_65 where
-    rtkPosOf (Ctr__Rule_65__0 p) = p
-    rtkPosOf (Ctr__Rule_65__1 p _) = p
-data Rule_66 = Ctr__Rule_66__0 RtkPos Arglist
+    rtkPosOf (Ctr__Rule_65__0 p _) = p
+data Rule_66 = Anti_Rule_66 String |
+               Ctr__Rule_66__1 RtkPos Expression |
+               Ctr__Rule_66__2 RtkPos |
+               Ctr__Rule_66__3 RtkPos Statement
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_66 where
-    rtkPosOf (Ctr__Rule_66__0 p _) = p
-data Rule_67 = Ctr__Rule_67__0 RtkPos |
-               Ctr__Rule_67__1 RtkPos Rule_68
-               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-instance RtkPosOf Rule_67 where
-    rtkPosOf (Ctr__Rule_67__0 p) = p
-    rtkPosOf (Ctr__Rule_67__1 p _) = p
-data Rule_68 = Ctr__Rule_68__0 RtkPos Arglist
+    rtkPosOf (Anti_Rule_66 _) = rtkNoPos
+    rtkPosOf (Ctr__Rule_66__1 p _) = p
+    rtkPosOf (Ctr__Rule_66__2 p) = p
+    rtkPosOf (Ctr__Rule_66__3 p _) = p
+data Rule_68 = Ctr__Rule_68__0 RtkPos |
+               Ctr__Rule_68__1 RtkPos Rule_69
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_68 where
-    rtkPosOf (Ctr__Rule_68__0 p _) = p
-data Rule_69 = Ctr__Rule_69__0 RtkPos Arglist |
-               Ctr__Rule_69__1 RtkPos DimExprs Rule_70
+    rtkPosOf (Ctr__Rule_68__0 p) = p
+    rtkPosOf (Ctr__Rule_68__1 p _) = p
+data Rule_69 = Ctr__Rule_69__0 RtkPos AssignmentOp Expression
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_69 where
-    rtkPosOf (Ctr__Rule_69__0 p _) = p
-    rtkPosOf (Ctr__Rule_69__1 p _ _) = p
+    rtkPosOf (Ctr__Rule_69__0 p _ _) = p
 type Rule_7 = [Rule_8]
 data Rule_70 = Ctr__Rule_70__0 RtkPos |
-               Ctr__Rule_70__1 RtkPos NonEmptyDims
+               Ctr__Rule_70__1 RtkPos Rule_71
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_70 where
     rtkPosOf (Ctr__Rule_70__0 p) = p
     rtkPosOf (Ctr__Rule_70__1 p _) = p
-data Rule_71 = Anti_Rule_71 String |
-               Ctr__Rule_71__1 RtkPos Expression
+data Rule_71 = Ctr__Rule_71__0 RtkPos Arglist
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_71 where
-    rtkPosOf (Anti_Rule_71 _) = rtkNoPos
-    rtkPosOf (Ctr__Rule_71__1 p _) = p
-data Rule_73 = Ctr__Rule_73__0 RtkPos Expression Rule_74
+    rtkPosOf (Ctr__Rule_71__0 p _) = p
+data Rule_72 = Ctr__Rule_72__0 RtkPos |
+               Ctr__Rule_72__1 RtkPos Rule_73
+               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_72 where
+    rtkPosOf (Ctr__Rule_72__0 p) = p
+    rtkPosOf (Ctr__Rule_72__1 p _) = p
+data Rule_73 = Ctr__Rule_73__0 RtkPos Arglist
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_73 where
-    rtkPosOf (Ctr__Rule_73__0 p _ _) = p
-type Rule_74 = [Rule_75]
-data Rule_75 = Ctr__Rule_75__0 RtkPos Expression
+    rtkPosOf (Ctr__Rule_73__0 p _) = p
+data Rule_74 = Ctr__Rule_74__0 RtkPos Arglist |
+               Ctr__Rule_74__1 RtkPos DimExprs Rule_75
+               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_74 where
+    rtkPosOf (Ctr__Rule_74__0 p _) = p
+    rtkPosOf (Ctr__Rule_74__1 p _ _) = p
+data Rule_75 = Ctr__Rule_75__0 RtkPos |
+               Ctr__Rule_75__1 RtkPos NonEmptyDims
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_75 where
-    rtkPosOf (Ctr__Rule_75__0 p _) = p
-type Rule_76 = [Rule_77]
-data Rule_77 = Ctr__Rule_77__0 RtkPos TypeArgument
+    rtkPosOf (Ctr__Rule_75__0 p) = p
+    rtkPosOf (Ctr__Rule_75__1 p _) = p
+data Rule_76 = Anti_Rule_76 String |
+               Ctr__Rule_76__1 RtkPos Expression
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-instance RtkPosOf Rule_77 where
-    rtkPosOf (Ctr__Rule_77__0 p _) = p
-data Rule_78 = Ctr__Rule_78__0 RtkPos TypeParameter Rule_79
+instance RtkPosOf Rule_76 where
+    rtkPosOf (Anti_Rule_76 _) = rtkNoPos
+    rtkPosOf (Ctr__Rule_76__1 p _) = p
+data Rule_78 = Ctr__Rule_78__0 RtkPos Expression Rule_79
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_78 where
     rtkPosOf (Ctr__Rule_78__0 p _ _) = p
@@ -2621,30 +2675,44 @@ data Rule_8 = Ctr__Rule_8__0 RtkPos AnnotationElement
               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_8 where
     rtkPosOf (Ctr__Rule_8__0 p _) = p
-data Rule_80 = Ctr__Rule_80__0 RtkPos TypeParameter
+data Rule_80 = Ctr__Rule_80__0 RtkPos Expression
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_80 where
     rtkPosOf (Ctr__Rule_80__0 p _) = p
-data Rule_81 = Ctr__Rule_81__0 RtkPos |
-               Ctr__Rule_81__1 RtkPos Rule_82
-               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-instance RtkPosOf Rule_81 where
-    rtkPosOf (Ctr__Rule_81__0 p) = p
-    rtkPosOf (Ctr__Rule_81__1 p _) = p
-data Rule_82 = Ctr__Rule_82__0 RtkPos Type Rule_83
+type Rule_81 = [Rule_82]
+data Rule_82 = Ctr__Rule_82__0 RtkPos TypeArgument
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_82 where
-    rtkPosOf (Ctr__Rule_82__0 p _ _) = p
-type Rule_83 = [Rule_84]
-data Rule_84 = Ctr__Rule_84__0 RtkPos Type
+    rtkPosOf (Ctr__Rule_82__0 p _) = p
+data Rule_83 = Ctr__Rule_83__0 RtkPos TypeParameter Rule_84
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-instance RtkPosOf Rule_84 where
-    rtkPosOf (Ctr__Rule_84__0 p _) = p
-type Rule_85 = [Rule_86]
-data Rule_86 = Ctr__Rule_86__0 RtkPos String
+instance RtkPosOf Rule_83 where
+    rtkPosOf (Ctr__Rule_83__0 p _ _) = p
+type Rule_84 = [Rule_85]
+data Rule_85 = Ctr__Rule_85__0 RtkPos TypeParameter
+               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_85 where
+    rtkPosOf (Ctr__Rule_85__0 p _) = p
+data Rule_86 = Ctr__Rule_86__0 RtkPos |
+               Ctr__Rule_86__1 RtkPos Rule_87
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_86 where
-    rtkPosOf (Ctr__Rule_86__0 p _) = p
+    rtkPosOf (Ctr__Rule_86__0 p) = p
+    rtkPosOf (Ctr__Rule_86__1 p _) = p
+data Rule_87 = Ctr__Rule_87__0 RtkPos Type Rule_88
+               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_87 where
+    rtkPosOf (Ctr__Rule_87__0 p _ _) = p
+type Rule_88 = [Rule_89]
+data Rule_89 = Ctr__Rule_89__0 RtkPos Type
+               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_89 where
+    rtkPosOf (Ctr__Rule_89__0 p _) = p
+type Rule_90 = [Rule_91]
+data Rule_91 = Ctr__Rule_91__0 RtkPos String
+               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_91 where
+    rtkPosOf (Ctr__Rule_91__0 p _) = p
 data ShiftOp = Anti_ShiftOp String |
                Ctr__ShiftOp__0 RtkPos |
                Ctr__ShiftOp__1 RtkPos |
@@ -2704,7 +2772,7 @@ data StaticInitializer = Anti_StaticInitializer String |
 instance RtkPosOf StaticInitializer where
     rtkPosOf (Anti_StaticInitializer _) = rtkNoPos
     rtkPosOf (Ctr__StaticInitializer__0 p _) = p
-type SwitchCaseList = [Rule_61]
+type SwitchCaseList = [Rule_66]
 data SwitchStatement = Anti_SwitchStatement String |
                        Ctr__SwitchStatement__0 RtkPos Expression SwitchCaseList
                        deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
@@ -2770,14 +2838,14 @@ instance RtkPosOf TypeDeclaration where
     rtkPosOf (Anti_TypeDeclaration _) = rtkNoPos
     rtkPosOf (Ctr__TypeDeclaration__0 p _ _ _) = p
 data TypeParameter = Anti_TypeParameter String |
-                     Ctr__TypeParameter__0 RtkPos String Rule_81
+                     Ctr__TypeParameter__0 RtkPos String Rule_86
                      deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf TypeParameter where
     rtkPosOf (Anti_TypeParameter _) = rtkNoPos
     rtkPosOf (Ctr__TypeParameter__0 p _ _) = p
 data TypeParameters = Anti_TypeParameters String |
                       Ctr__TypeParameters__0 RtkPos |
-                      Ctr__TypeParameters__1 RtkPos Rule_78
+                      Ctr__TypeParameters__1 RtkPos Rule_83
                       deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf TypeParameters where
     rtkPosOf (Anti_TypeParameters _) = rtkNoPos
@@ -2808,11 +2876,13 @@ instance RtkPosOf TypeSpecifier where
     rtkPosOf (Ctr__TypeSpecifier__8 p) = p
     rtkPosOf (Ctr__TypeSpecifier__9 p _ _) = p
 data VariableDeclaration = Anti_VariableDeclaration String |
-                           Ctr__VariableDeclaration__0 RtkPos Type VariableDeclaratorList
+                           Ctr__VariableDeclaration__0 RtkPos Type VariableDeclaratorList |
+                           Ctr__VariableDeclaration__1 RtkPos LocalModifierList1 Type VariableDeclaratorList
                            deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf VariableDeclaration where
     rtkPosOf (Anti_VariableDeclaration _) = rtkNoPos
     rtkPosOf (Ctr__VariableDeclaration__0 p _ _) = p
+    rtkPosOf (Ctr__VariableDeclaration__1 p _ _ _) = p
 data VariableDeclarator = Anti_VariableDeclarator String |
                           Ctr__VariableDeclarator__0 RtkPos String Dims OptVariableInitializer
                           deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
@@ -2835,7 +2905,7 @@ instance RtkPosOf VariableInitializer where
     rtkPosOf (Ctr__VariableInitializer__1 p _) = p
 data VariableInitializerList = Anti_VariableInitializerList String |
                                Ctr__VariableInitializerList__0 RtkPos |
-                               Ctr__VariableInitializerList__1 RtkPos Rule_49
+                               Ctr__VariableInitializerList__1 RtkPos Rule_51
                                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf VariableInitializerList where
     rtkPosOf (Anti_VariableInitializerList _) = rtkNoPos

--- a/test/golden/java/JavaQQ.hs
+++ b/test/golden/java/JavaQQ.hs
@@ -63,7 +63,7 @@ rtkRenderError err =
                 _ -> err
         _ -> err
 
-qqShortcuts = M.fromList [ ("java","Java"),("additiveOp","AdditiveOp"),("annotation","Annotation"),("annotationArguments","AnnotationArguments"),("annotationDeclaration","AnnotationDeclaration"),("annotationElement","AnnotationElement"),("annotationList","AnnotationList"),("annotationTypeElement","AnnotationTypeElement"),("annotationTypeElementList","AnnotationTypeElementList"),("arglist","Arglist"),("assignmentOp","AssignmentOp"),("catchList","CatchList"),("classDeclaration","ClassDeclaration"),("compilationUnit","CompilationUnit"),("compoundName","CompoundName"),("creationExpression","CreationExpression"),("dimExprs","DimExprs"),("dims","Dims"),("doStatement","DoStatement"),("docComment","DocComment"),("enumConstant","EnumConstant"),("enumConstantList","EnumConstantList"),("enumDeclaration","EnumDeclaration"),("equalityOp","EqualityOp"),("expression","Expression"),("extendsList","ExtendsList"),("fieldDeclaration","FieldDeclaration"),("fieldDeclarationList","FieldDeclarationList"),("forStatement","ForStatement"),("ifStatement","IfStatement"),("implementsList","ImplementsList"),("importHead","ImportHead"),("importList","ImportList"),("importName","ImportName"),("importStatement","ImportStatement"),("interfaceDeclaration","InterfaceDeclaration"),("literal","Literal"),("memberAfterFirstId","MemberAfterFirstId"),("memberDeclaration","MemberDeclaration"),("memberRest","MemberRest"),("modifier","Modifier"),("modifierList","ModifierList"),("moreTypeSpecifier","MoreTypeSpecifier"),("moreVariableDeclarators","MoreVariableDeclarators"),("multiplicativeOp","MultiplicativeOp"),("nonEmptyDims","NonEmptyDims"),("nonEmptyTypeArguments","NonEmptyTypeArguments"),("optDocComment","OptDocComment"),("optElsePart","OptElsePart"),("optExpression","OptExpression"),("optFinally","OptFinally"),("optId","OptId"),("optVariableInitializer","OptVariableInitializer"),("package","Package"),("parameter","Parameter"),("parameterList","ParameterList"),("postfixOp","PostfixOp"),("prefixOp","PrefixOp"),("primitiveTypeKeyword","PrimitiveTypeKeyword"),("relationalOp","RelationalOp"),("shiftOp","ShiftOp"),("statement","Statement"),("statementBlock","StatementBlock"),("statementList","StatementList"),("staticInitializer","StaticInitializer"),("switchCaseList","SwitchCaseList"),("switchStatement","SwitchStatement"),("throwsClause","ThrowsClause"),("tryStatement","TryStatement"),("type","Type"),("typeArgument","TypeArgument"),("typeArguments","TypeArguments"),("typeDeclRest","TypeDeclRest"),("typeDeclaration","TypeDeclaration"),("typeParameter","TypeParameter"),("typeParameters","TypeParameters"),("typeSpecifier","TypeSpecifier"),("variableDeclaration","VariableDeclaration"),("variableDeclarator","VariableDeclarator"),("variableDeclaratorList","VariableDeclaratorList"),("variableInitializer","VariableInitializer"),("variableInitializerList","VariableInitializerList"),("whileStatement","WhileStatement"),("wildcardType","WildcardType")]
+qqShortcuts = M.fromList [ ("java","Java"),("additiveOp","AdditiveOp"),("annotation","Annotation"),("annotationArguments","AnnotationArguments"),("annotationDeclaration","AnnotationDeclaration"),("annotationElement","AnnotationElement"),("annotationList","AnnotationList"),("annotationTypeElement","AnnotationTypeElement"),("annotationTypeElementList","AnnotationTypeElementList"),("arglist","Arglist"),("assignmentOp","AssignmentOp"),("catchList","CatchList"),("classDeclaration","ClassDeclaration"),("compilationUnit","CompilationUnit"),("compoundName","CompoundName"),("creationExpression","CreationExpression"),("dimExprs","DimExprs"),("dims","Dims"),("doStatement","DoStatement"),("docComment","DocComment"),("enumConstant","EnumConstant"),("enumConstantList","EnumConstantList"),("enumDeclaration","EnumDeclaration"),("equalityOp","EqualityOp"),("expression","Expression"),("extendsList","ExtendsList"),("fieldDeclaration","FieldDeclaration"),("fieldDeclarationList","FieldDeclarationList"),("forStatement","ForStatement"),("ifStatement","IfStatement"),("implementsList","ImplementsList"),("importHead","ImportHead"),("importList","ImportList"),("importName","ImportName"),("importStatement","ImportStatement"),("interfaceDeclaration","InterfaceDeclaration"),("literal","Literal"),("localModifierList1","LocalModifierList1"),("memberAfterFirstId","MemberAfterFirstId"),("memberDeclaration","MemberDeclaration"),("memberRest","MemberRest"),("modifier","Modifier"),("modifierList","ModifierList"),("moreTypeSpecifier","MoreTypeSpecifier"),("moreVariableDeclarators","MoreVariableDeclarators"),("multiplicativeOp","MultiplicativeOp"),("nonEmptyDims","NonEmptyDims"),("nonEmptyTypeArguments","NonEmptyTypeArguments"),("optDocComment","OptDocComment"),("optElsePart","OptElsePart"),("optExpression","OptExpression"),("optFinally","OptFinally"),("optId","OptId"),("optVariableInitializer","OptVariableInitializer"),("package","Package"),("paramModifierList","ParamModifierList"),("parameter","Parameter"),("parameterList","ParameterList"),("postfixOp","PostfixOp"),("prefixOp","PrefixOp"),("primitiveTypeKeyword","PrimitiveTypeKeyword"),("relationalOp","RelationalOp"),("shiftOp","ShiftOp"),("statement","Statement"),("statementBlock","StatementBlock"),("statementList","StatementList"),("staticInitializer","StaticInitializer"),("switchCaseList","SwitchCaseList"),("switchStatement","SwitchStatement"),("throwsClause","ThrowsClause"),("tryStatement","TryStatement"),("type","Type"),("typeArgument","TypeArgument"),("typeArguments","TypeArguments"),("typeDeclRest","TypeDeclRest"),("typeDeclaration","TypeDeclaration"),("typeParameter","TypeParameter"),("typeParameters","TypeParameters"),("typeSpecifier","TypeSpecifier"),("variableDeclaration","VariableDeclaration"),("variableDeclarator","VariableDeclarator"),("variableDeclaratorList","VariableDeclaratorList"),("variableInitializer","VariableInitializer"),("variableInitializerList","VariableInitializerList"),("whileStatement","WhileStatement"),("wildcardType","WildcardType")]
 
 -- A quasi-quote pattern must match an AST parsed from anywhere in a source
 -- file, while the pattern itself was parsed from the quote body - so every
@@ -80,7 +80,7 @@ quoteJavaExp dummy func s = do
            Left err -> fail (rtkRenderError err)
            Right a -> return a
   let expr = func ast
-  dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_58Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_61Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_71Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) expr
+  dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_63Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_66Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_76Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) expr
 quoteJavaPat :: Data.Data a => String -> (Java -> a) -> String -> TH.PatQ
 quoteJavaPat dummy func s = do
   s1 <- either fail return (replaceAllPatterns s)
@@ -88,7 +88,7 @@ quoteJavaPat dummy func s = do
            Left err -> fail (rtkRenderError err)
            Right a -> return a
   let expr = func ast
-  dataToPatQ (const Nothing `Generics.extQ` rtkPosWildPat `Generics.extQ` antiJavaPat `Generics.extQ` antiOptDocCommentPat `Generics.extQ` antiTypeDeclarationPat `Generics.extQ` antiImportStatementPat `Generics.extQ` antiCompilationUnitPat `Generics.extQ` antiPackagePat `Generics.extQ` antiImportNamePat `Generics.extQ` antiImportHeadPat `Generics.extQ` antiDocCommentPat `Generics.extQ` antiAnnotationPat `Generics.extQ` antiAnnotationArgumentsPat `Generics.extQ` antiAnnotationElementPat `Generics.extQ` antiRule_10Pat `Generics.extQ` antiExtendsListPat `Generics.extQ` antiImplementsListPat `Generics.extQ` antiFieldDeclarationPat `Generics.extQ` antiClassDeclarationPat `Generics.extQ` antiInterfaceDeclarationPat `Generics.extQ` antiAnnotationDeclarationPat `Generics.extQ` antiAnnotationTypeElementPat `Generics.extQ` antiEnumConstantPat `Generics.extQ` antiEnumConstantListPat `Generics.extQ` antiEnumDeclarationPat `Generics.extQ` antiTypeDeclRestPat `Generics.extQ` antiRule_31Pat `Generics.extQ` antiRule_33Pat `Generics.extQ` antiMemberDeclarationPat `Generics.extQ` antiPrimitiveTypeKeywordPat `Generics.extQ` antiMemberAfterFirstIdPat `Generics.extQ` antiMoreTypeSpecifierPat `Generics.extQ` antiThrowsClausePat `Generics.extQ` antiMemberRestPat `Generics.extQ` antiRule_44Pat `Generics.extQ` antiStatementBlockPat `Generics.extQ` antiVariableDeclaratorListPat `Generics.extQ` antiVariableDeclarationPat `Generics.extQ` antiOptVariableInitializerPat `Generics.extQ` antiVariableDeclaratorPat `Generics.extQ` antiVariableInitializerListPat `Generics.extQ` antiVariableInitializerPat `Generics.extQ` antiStaticInitializerPat `Generics.extQ` antiParameterListPat `Generics.extQ` antiParameterPat `Generics.extQ` antiStatementPat `Generics.extQ` antiOptExpressionPat `Generics.extQ` antiOptIdPat `Generics.extQ` antiOptElsePartPat `Generics.extQ` antiIfStatementPat `Generics.extQ` antiDoStatementPat `Generics.extQ` antiWhileStatementPat `Generics.extQ` antiForStatementPat `Generics.extQ` antiRule_58Pat `Generics.extQ` antiOptFinallyPat `Generics.extQ` antiTryStatementPat `Generics.extQ` antiRule_61Pat `Generics.extQ` antiSwitchStatementPat `Generics.extQ` antiExpressionPat `Generics.extQ` antiAssignmentOpPat `Generics.extQ` antiEqualityOpPat `Generics.extQ` antiRelationalOpPat `Generics.extQ` antiShiftOpPat `Generics.extQ` antiAdditiveOpPat `Generics.extQ` antiMultiplicativeOpPat `Generics.extQ` antiPrefixOpPat `Generics.extQ` antiPostfixOpPat `Generics.extQ` antiCreationExpressionPat `Generics.extQ` antiRule_71Pat `Generics.extQ` antiLiteralPat `Generics.extQ` antiArglistPat `Generics.extQ` antiTypeArgumentsPat `Generics.extQ` antiNonEmptyTypeArgumentsPat `Generics.extQ` antiTypeArgumentPat `Generics.extQ` antiWildcardTypePat `Generics.extQ` antiTypeParametersPat `Generics.extQ` antiTypeParameterPat `Generics.extQ` antiTypePat `Generics.extQ` antiTypeSpecifierPat `Generics.extQ` antiModifierPat `Generics.extQ` antiCompoundNamePat) expr
+  dataToPatQ (const Nothing `Generics.extQ` rtkPosWildPat `Generics.extQ` antiJavaPat `Generics.extQ` antiOptDocCommentPat `Generics.extQ` antiTypeDeclarationPat `Generics.extQ` antiImportStatementPat `Generics.extQ` antiCompilationUnitPat `Generics.extQ` antiPackagePat `Generics.extQ` antiImportNamePat `Generics.extQ` antiImportHeadPat `Generics.extQ` antiDocCommentPat `Generics.extQ` antiAnnotationPat `Generics.extQ` antiAnnotationArgumentsPat `Generics.extQ` antiAnnotationElementPat `Generics.extQ` antiRule_10Pat `Generics.extQ` antiExtendsListPat `Generics.extQ` antiImplementsListPat `Generics.extQ` antiFieldDeclarationPat `Generics.extQ` antiClassDeclarationPat `Generics.extQ` antiInterfaceDeclarationPat `Generics.extQ` antiAnnotationDeclarationPat `Generics.extQ` antiAnnotationTypeElementPat `Generics.extQ` antiEnumConstantPat `Generics.extQ` antiEnumConstantListPat `Generics.extQ` antiEnumDeclarationPat `Generics.extQ` antiTypeDeclRestPat `Generics.extQ` antiRule_31Pat `Generics.extQ` antiRule_33Pat `Generics.extQ` antiMemberDeclarationPat `Generics.extQ` antiPrimitiveTypeKeywordPat `Generics.extQ` antiMemberAfterFirstIdPat `Generics.extQ` antiMoreTypeSpecifierPat `Generics.extQ` antiThrowsClausePat `Generics.extQ` antiMemberRestPat `Generics.extQ` antiRule_44Pat `Generics.extQ` antiStatementBlockPat `Generics.extQ` antiVariableDeclaratorListPat `Generics.extQ` antiVariableDeclarationPat `Generics.extQ` antiRule_48Pat `Generics.extQ` antiOptVariableInitializerPat `Generics.extQ` antiVariableDeclaratorPat `Generics.extQ` antiVariableInitializerListPat `Generics.extQ` antiVariableInitializerPat `Generics.extQ` antiStaticInitializerPat `Generics.extQ` antiParameterListPat `Generics.extQ` antiRule_57Pat `Generics.extQ` antiParameterPat `Generics.extQ` antiStatementPat `Generics.extQ` antiOptExpressionPat `Generics.extQ` antiOptIdPat `Generics.extQ` antiOptElsePartPat `Generics.extQ` antiIfStatementPat `Generics.extQ` antiDoStatementPat `Generics.extQ` antiWhileStatementPat `Generics.extQ` antiForStatementPat `Generics.extQ` antiRule_63Pat `Generics.extQ` antiOptFinallyPat `Generics.extQ` antiTryStatementPat `Generics.extQ` antiRule_66Pat `Generics.extQ` antiSwitchStatementPat `Generics.extQ` antiExpressionPat `Generics.extQ` antiAssignmentOpPat `Generics.extQ` antiEqualityOpPat `Generics.extQ` antiRelationalOpPat `Generics.extQ` antiShiftOpPat `Generics.extQ` antiAdditiveOpPat `Generics.extQ` antiMultiplicativeOpPat `Generics.extQ` antiPrefixOpPat `Generics.extQ` antiPostfixOpPat `Generics.extQ` antiCreationExpressionPat `Generics.extQ` antiRule_76Pat `Generics.extQ` antiLiteralPat `Generics.extQ` antiArglistPat `Generics.extQ` antiTypeArgumentsPat `Generics.extQ` antiNonEmptyTypeArgumentsPat `Generics.extQ` antiTypeArgumentPat `Generics.extQ` antiWildcardTypePat `Generics.extQ` antiTypeParametersPat `Generics.extQ` antiTypeParameterPat `Generics.extQ` antiTypePat `Generics.extQ` antiTypeSpecifierPat `Generics.extQ` antiModifierPat `Generics.extQ` antiCompoundNamePat) expr
 
 antiCompoundNameExp :: CompoundName -> Maybe (TH.Q TH.Exp )
 antiCompoundNameExp ( Anti_CompoundName v) = Just $ TH.varE (TH.mkName v)
@@ -150,12 +150,12 @@ antiLiteralExp ( Anti_Literal v) = Just $ TH.varE (TH.mkName v)
 antiLiteralExp _ = Nothing
 
 
-antiRule_71Exp :: [ Rule_71 ] -> Maybe (TH.Q TH.Exp)
-antiRule_71Exp ((Anti_Rule_71 v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_58Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_61Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_71Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
+antiRule_76Exp :: [ Rule_76 ] -> Maybe (TH.Q TH.Exp)
+antiRule_76Exp ((Anti_Rule_76 v):rest) =
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_63Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_66Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_76Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
-antiRule_71Exp _ = Nothing
+antiRule_76Exp _ = Nothing
 
 
 antiCreationExpressionExp :: CreationExpression -> Maybe (TH.Q TH.Exp )
@@ -213,12 +213,12 @@ antiSwitchStatementExp ( Anti_SwitchStatement v) = Just $ TH.varE (TH.mkName v)
 antiSwitchStatementExp _ = Nothing
 
 
-antiRule_61Exp :: [ Rule_61 ] -> Maybe (TH.Q TH.Exp)
-antiRule_61Exp ((Anti_Rule_61 v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_58Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_61Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_71Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
+antiRule_66Exp :: [ Rule_66 ] -> Maybe (TH.Q TH.Exp)
+antiRule_66Exp ((Anti_Rule_66 v):rest) =
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_63Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_66Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_76Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
-antiRule_61Exp _ = Nothing
+antiRule_66Exp _ = Nothing
 
 
 antiTryStatementExp :: TryStatement -> Maybe (TH.Q TH.Exp )
@@ -231,12 +231,12 @@ antiOptFinallyExp ( Anti_OptFinally v) = Just $ TH.varE (TH.mkName v)
 antiOptFinallyExp _ = Nothing
 
 
-antiRule_58Exp :: [ Rule_58 ] -> Maybe (TH.Q TH.Exp)
-antiRule_58Exp ((Anti_Rule_58 v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_58Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_61Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_71Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
+antiRule_63Exp :: [ Rule_63 ] -> Maybe (TH.Q TH.Exp)
+antiRule_63Exp ((Anti_Rule_63 v):rest) =
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_63Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_66Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_76Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
-antiRule_58Exp _ = Nothing
+antiRule_63Exp _ = Nothing
 
 
 antiForStatementExp :: ForStatement -> Maybe (TH.Q TH.Exp )
@@ -276,7 +276,7 @@ antiOptExpressionExp _ = Nothing
 
 antiStatementExp :: [ Statement ] -> Maybe (TH.Q TH.Exp)
 antiStatementExp ((Anti_Statement v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_58Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_61Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_71Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_63Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_66Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_76Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
 antiStatementExp _ = Nothing
@@ -285,6 +285,14 @@ antiStatementExp _ = Nothing
 antiParameterExp :: Parameter -> Maybe (TH.Q TH.Exp )
 antiParameterExp ( Anti_Parameter v) = Just $ TH.varE (TH.mkName v)
 antiParameterExp _ = Nothing
+
+
+antiRule_57Exp :: [ Rule_57 ] -> Maybe (TH.Q TH.Exp)
+antiRule_57Exp ((Anti_Rule_57 v):rest) =
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_63Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_66Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_76Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
+     lvar = TH.varE $ TH.mkName v
+   in Just [| $lvar ++ $restExp |]
+antiRule_57Exp _ = Nothing
 
 
 antiParameterListExp :: ParameterList -> Maybe (TH.Q TH.Exp )
@@ -317,6 +325,14 @@ antiOptVariableInitializerExp ( Anti_OptVariableInitializer v) = Just $ TH.varE 
 antiOptVariableInitializerExp _ = Nothing
 
 
+antiRule_48Exp :: [ Rule_48 ] -> Maybe (TH.Q TH.Exp)
+antiRule_48Exp ((Anti_Rule_48 v):rest) =
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_63Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_66Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_76Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
+     lvar = TH.varE $ TH.mkName v
+   in Just [| $lvar ++ $restExp |]
+antiRule_48Exp _ = Nothing
+
+
 antiVariableDeclarationExp :: VariableDeclaration -> Maybe (TH.Q TH.Exp )
 antiVariableDeclarationExp ( Anti_VariableDeclaration v) = Just $ TH.varE (TH.mkName v)
 antiVariableDeclarationExp _ = Nothing
@@ -334,7 +350,7 @@ antiStatementBlockExp _ = Nothing
 
 antiRule_44Exp :: [ Rule_44 ] -> Maybe (TH.Q TH.Exp)
 antiRule_44Exp ((Anti_Rule_44 v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_58Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_61Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_71Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_63Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_66Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_76Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
 antiRule_44Exp _ = Nothing
@@ -372,7 +388,7 @@ antiMemberDeclarationExp _ = Nothing
 
 antiRule_33Exp :: [ Rule_33 ] -> Maybe (TH.Q TH.Exp)
 antiRule_33Exp ((Anti_Rule_33 v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_58Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_61Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_71Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_63Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_66Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_76Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
 antiRule_33Exp _ = Nothing
@@ -380,7 +396,7 @@ antiRule_33Exp _ = Nothing
 
 antiRule_31Exp :: [ Rule_31 ] -> Maybe (TH.Q TH.Exp)
 antiRule_31Exp ((Anti_Rule_31 v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_58Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_61Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_71Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_63Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_66Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_76Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
 antiRule_31Exp _ = Nothing
@@ -408,7 +424,7 @@ antiEnumConstantExp _ = Nothing
 
 antiAnnotationTypeElementExp :: [ AnnotationTypeElement ] -> Maybe (TH.Q TH.Exp)
 antiAnnotationTypeElementExp ((Anti_AnnotationTypeElement v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_58Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_61Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_71Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_63Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_66Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_76Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
 antiAnnotationTypeElementExp _ = Nothing
@@ -431,7 +447,7 @@ antiClassDeclarationExp _ = Nothing
 
 antiFieldDeclarationExp :: [ FieldDeclaration ] -> Maybe (TH.Q TH.Exp)
 antiFieldDeclarationExp ((Anti_FieldDeclaration v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_58Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_61Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_71Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_63Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_66Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_76Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
 antiFieldDeclarationExp _ = Nothing
@@ -449,7 +465,7 @@ antiExtendsListExp _ = Nothing
 
 antiRule_10Exp :: [ Rule_10 ] -> Maybe (TH.Q TH.Exp)
 antiRule_10Exp ((Anti_Rule_10 v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_58Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_61Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_71Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_63Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_66Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_76Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
 antiRule_10Exp _ = Nothing
@@ -497,7 +513,7 @@ antiCompilationUnitExp _ = Nothing
 
 antiImportStatementExp :: [ ImportStatement ] -> Maybe (TH.Q TH.Exp)
 antiImportStatementExp ((Anti_ImportStatement v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_58Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_61Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_71Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_63Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_66Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_76Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
 antiImportStatementExp _ = Nothing
@@ -579,9 +595,9 @@ antiLiteralPat ( Anti_Literal v) = Just $ TH.varP (TH.mkName v)
 antiLiteralPat _ = Nothing
 
 
-antiRule_71Pat :: [ Rule_71 ] -> Maybe (TH.Q TH.Pat)
-antiRule_71Pat [Anti_Rule_71 v] = Just $ TH.varP (TH.mkName v)
-antiRule_71Pat _ = Nothing
+antiRule_76Pat :: [ Rule_76 ] -> Maybe (TH.Q TH.Pat)
+antiRule_76Pat [Anti_Rule_76 v] = Just $ TH.varP (TH.mkName v)
+antiRule_76Pat _ = Nothing
 
 
 antiCreationExpressionPat :: CreationExpression -> Maybe (TH.Q TH.Pat )
@@ -639,9 +655,9 @@ antiSwitchStatementPat ( Anti_SwitchStatement v) = Just $ TH.varP (TH.mkName v)
 antiSwitchStatementPat _ = Nothing
 
 
-antiRule_61Pat :: [ Rule_61 ] -> Maybe (TH.Q TH.Pat)
-antiRule_61Pat [Anti_Rule_61 v] = Just $ TH.varP (TH.mkName v)
-antiRule_61Pat _ = Nothing
+antiRule_66Pat :: [ Rule_66 ] -> Maybe (TH.Q TH.Pat)
+antiRule_66Pat [Anti_Rule_66 v] = Just $ TH.varP (TH.mkName v)
+antiRule_66Pat _ = Nothing
 
 
 antiTryStatementPat :: TryStatement -> Maybe (TH.Q TH.Pat )
@@ -654,9 +670,9 @@ antiOptFinallyPat ( Anti_OptFinally v) = Just $ TH.varP (TH.mkName v)
 antiOptFinallyPat _ = Nothing
 
 
-antiRule_58Pat :: [ Rule_58 ] -> Maybe (TH.Q TH.Pat)
-antiRule_58Pat [Anti_Rule_58 v] = Just $ TH.varP (TH.mkName v)
-antiRule_58Pat _ = Nothing
+antiRule_63Pat :: [ Rule_63 ] -> Maybe (TH.Q TH.Pat)
+antiRule_63Pat [Anti_Rule_63 v] = Just $ TH.varP (TH.mkName v)
+antiRule_63Pat _ = Nothing
 
 
 antiForStatementPat :: ForStatement -> Maybe (TH.Q TH.Pat )
@@ -704,6 +720,11 @@ antiParameterPat ( Anti_Parameter v) = Just $ TH.varP (TH.mkName v)
 antiParameterPat _ = Nothing
 
 
+antiRule_57Pat :: [ Rule_57 ] -> Maybe (TH.Q TH.Pat)
+antiRule_57Pat [Anti_Rule_57 v] = Just $ TH.varP (TH.mkName v)
+antiRule_57Pat _ = Nothing
+
+
 antiParameterListPat :: ParameterList -> Maybe (TH.Q TH.Pat )
 antiParameterListPat ( Anti_ParameterList v) = Just $ TH.varP (TH.mkName v)
 antiParameterListPat _ = Nothing
@@ -732,6 +753,11 @@ antiVariableDeclaratorPat _ = Nothing
 antiOptVariableInitializerPat :: OptVariableInitializer -> Maybe (TH.Q TH.Pat )
 antiOptVariableInitializerPat ( Anti_OptVariableInitializer v) = Just $ TH.varP (TH.mkName v)
 antiOptVariableInitializerPat _ = Nothing
+
+
+antiRule_48Pat :: [ Rule_48 ] -> Maybe (TH.Q TH.Pat)
+antiRule_48Pat [Anti_Rule_48 v] = Just $ TH.varP (TH.mkName v)
+antiRule_48Pat _ = Nothing
 
 
 antiVariableDeclarationPat :: VariableDeclaration -> Maybe (TH.Q TH.Pat )
@@ -921,420 +947,430 @@ quoteJavaDecs s = return []
 getJava ( Ctr__Java__0 _ s) = s
 
 java :: QuasiQuoter
-java = QuasiQuoter (quoteJavaExp "tok_Java_dummy_170" getJava ) (quoteJavaPat "tok_Java_dummy_170" getJava ) quoteJavaType quoteJavaDecs
+java = QuasiQuoter (quoteJavaExp "tok_Java_dummy_177" getJava ) (quoteJavaPat "tok_Java_dummy_177" getJava ) quoteJavaType quoteJavaDecs
 
 getAdditiveOp ( Ctr__Java__1 _ s) = s
 
 additiveOp :: QuasiQuoter
-additiveOp = QuasiQuoter (quoteJavaExp "tok_AdditiveOp_dummy_169" getAdditiveOp ) (quoteJavaPat "tok_AdditiveOp_dummy_169" getAdditiveOp ) quoteJavaType quoteJavaDecs
+additiveOp = QuasiQuoter (quoteJavaExp "tok_AdditiveOp_dummy_176" getAdditiveOp ) (quoteJavaPat "tok_AdditiveOp_dummy_176" getAdditiveOp ) quoteJavaType quoteJavaDecs
 
 getAnnotation ( Ctr__Java__2 _ s) = s
 
 annotation :: QuasiQuoter
-annotation = QuasiQuoter (quoteJavaExp "tok_Annotation_dummy_168" getAnnotation ) (quoteJavaPat "tok_Annotation_dummy_168" getAnnotation ) quoteJavaType quoteJavaDecs
+annotation = QuasiQuoter (quoteJavaExp "tok_Annotation_dummy_175" getAnnotation ) (quoteJavaPat "tok_Annotation_dummy_175" getAnnotation ) quoteJavaType quoteJavaDecs
 
 getAnnotationArguments ( Ctr__Java__3 _ s) = s
 
 annotationArguments :: QuasiQuoter
-annotationArguments = QuasiQuoter (quoteJavaExp "tok_AnnotationArguments_dummy_167" getAnnotationArguments ) (quoteJavaPat "tok_AnnotationArguments_dummy_167" getAnnotationArguments ) quoteJavaType quoteJavaDecs
+annotationArguments = QuasiQuoter (quoteJavaExp "tok_AnnotationArguments_dummy_174" getAnnotationArguments ) (quoteJavaPat "tok_AnnotationArguments_dummy_174" getAnnotationArguments ) quoteJavaType quoteJavaDecs
 
 getAnnotationDeclaration ( Ctr__Java__4 _ s) = s
 
 annotationDeclaration :: QuasiQuoter
-annotationDeclaration = QuasiQuoter (quoteJavaExp "tok_AnnotationDeclaration_dummy_166" getAnnotationDeclaration ) (quoteJavaPat "tok_AnnotationDeclaration_dummy_166" getAnnotationDeclaration ) quoteJavaType quoteJavaDecs
+annotationDeclaration = QuasiQuoter (quoteJavaExp "tok_AnnotationDeclaration_dummy_173" getAnnotationDeclaration ) (quoteJavaPat "tok_AnnotationDeclaration_dummy_173" getAnnotationDeclaration ) quoteJavaType quoteJavaDecs
 
 getAnnotationElement ( Ctr__Java__5 _ s) = s
 
 annotationElement :: QuasiQuoter
-annotationElement = QuasiQuoter (quoteJavaExp "tok_AnnotationElement_dummy_165" getAnnotationElement ) (quoteJavaPat "tok_AnnotationElement_dummy_165" getAnnotationElement ) quoteJavaType quoteJavaDecs
+annotationElement = QuasiQuoter (quoteJavaExp "tok_AnnotationElement_dummy_172" getAnnotationElement ) (quoteJavaPat "tok_AnnotationElement_dummy_172" getAnnotationElement ) quoteJavaType quoteJavaDecs
 
 getAnnotationList ( Ctr__Java__6 _ s) = s
 
 annotationList :: QuasiQuoter
-annotationList = QuasiQuoter (quoteJavaExp "tok_AnnotationList_dummy_164" getAnnotationList ) (quoteJavaPat "tok_AnnotationList_dummy_164" getAnnotationList ) quoteJavaType quoteJavaDecs
+annotationList = QuasiQuoter (quoteJavaExp "tok_AnnotationList_dummy_171" getAnnotationList ) (quoteJavaPat "tok_AnnotationList_dummy_171" getAnnotationList ) quoteJavaType quoteJavaDecs
 
 getAnnotationTypeElement ( Ctr__Java__7 _ s) = s
 
 annotationTypeElement :: QuasiQuoter
-annotationTypeElement = QuasiQuoter (quoteJavaExp "tok_AnnotationTypeElement_dummy_163" getAnnotationTypeElement ) (quoteJavaPat "tok_AnnotationTypeElement_dummy_163" getAnnotationTypeElement ) quoteJavaType quoteJavaDecs
+annotationTypeElement = QuasiQuoter (quoteJavaExp "tok_AnnotationTypeElement_dummy_170" getAnnotationTypeElement ) (quoteJavaPat "tok_AnnotationTypeElement_dummy_170" getAnnotationTypeElement ) quoteJavaType quoteJavaDecs
 
 getAnnotationTypeElementList ( Ctr__Java__8 _ s) = s
 
 annotationTypeElementList :: QuasiQuoter
-annotationTypeElementList = QuasiQuoter (quoteJavaExp "tok_AnnotationTypeElementList_dummy_162" getAnnotationTypeElementList ) (quoteJavaPat "tok_AnnotationTypeElementList_dummy_162" getAnnotationTypeElementList ) quoteJavaType quoteJavaDecs
+annotationTypeElementList = QuasiQuoter (quoteJavaExp "tok_AnnotationTypeElementList_dummy_169" getAnnotationTypeElementList ) (quoteJavaPat "tok_AnnotationTypeElementList_dummy_169" getAnnotationTypeElementList ) quoteJavaType quoteJavaDecs
 
 getArglist ( Ctr__Java__9 _ s) = s
 
 arglist :: QuasiQuoter
-arglist = QuasiQuoter (quoteJavaExp "tok_Arglist_dummy_161" getArglist ) (quoteJavaPat "tok_Arglist_dummy_161" getArglist ) quoteJavaType quoteJavaDecs
+arglist = QuasiQuoter (quoteJavaExp "tok_Arglist_dummy_168" getArglist ) (quoteJavaPat "tok_Arglist_dummy_168" getArglist ) quoteJavaType quoteJavaDecs
 
 getAssignmentOp ( Ctr__Java__10 _ s) = s
 
 assignmentOp :: QuasiQuoter
-assignmentOp = QuasiQuoter (quoteJavaExp "tok_AssignmentOp_dummy_160" getAssignmentOp ) (quoteJavaPat "tok_AssignmentOp_dummy_160" getAssignmentOp ) quoteJavaType quoteJavaDecs
+assignmentOp = QuasiQuoter (quoteJavaExp "tok_AssignmentOp_dummy_167" getAssignmentOp ) (quoteJavaPat "tok_AssignmentOp_dummy_167" getAssignmentOp ) quoteJavaType quoteJavaDecs
 
 getCatchList ( Ctr__Java__11 _ s) = s
 
 catchList :: QuasiQuoter
-catchList = QuasiQuoter (quoteJavaExp "tok_CatchList_dummy_159" getCatchList ) (quoteJavaPat "tok_CatchList_dummy_159" getCatchList ) quoteJavaType quoteJavaDecs
+catchList = QuasiQuoter (quoteJavaExp "tok_CatchList_dummy_166" getCatchList ) (quoteJavaPat "tok_CatchList_dummy_166" getCatchList ) quoteJavaType quoteJavaDecs
 
 getClassDeclaration ( Ctr__Java__12 _ s) = s
 
 classDeclaration :: QuasiQuoter
-classDeclaration = QuasiQuoter (quoteJavaExp "tok_ClassDeclaration_dummy_158" getClassDeclaration ) (quoteJavaPat "tok_ClassDeclaration_dummy_158" getClassDeclaration ) quoteJavaType quoteJavaDecs
+classDeclaration = QuasiQuoter (quoteJavaExp "tok_ClassDeclaration_dummy_165" getClassDeclaration ) (quoteJavaPat "tok_ClassDeclaration_dummy_165" getClassDeclaration ) quoteJavaType quoteJavaDecs
 
 getCompilationUnit ( Ctr__Java__13 _ s) = s
 
 compilationUnit :: QuasiQuoter
-compilationUnit = QuasiQuoter (quoteJavaExp "tok_CompilationUnit_dummy_157" getCompilationUnit ) (quoteJavaPat "tok_CompilationUnit_dummy_157" getCompilationUnit ) quoteJavaType quoteJavaDecs
+compilationUnit = QuasiQuoter (quoteJavaExp "tok_CompilationUnit_dummy_164" getCompilationUnit ) (quoteJavaPat "tok_CompilationUnit_dummy_164" getCompilationUnit ) quoteJavaType quoteJavaDecs
 
 getCompoundName ( Ctr__Java__14 _ s) = s
 
 compoundName :: QuasiQuoter
-compoundName = QuasiQuoter (quoteJavaExp "tok_CompoundName_dummy_156" getCompoundName ) (quoteJavaPat "tok_CompoundName_dummy_156" getCompoundName ) quoteJavaType quoteJavaDecs
+compoundName = QuasiQuoter (quoteJavaExp "tok_CompoundName_dummy_163" getCompoundName ) (quoteJavaPat "tok_CompoundName_dummy_163" getCompoundName ) quoteJavaType quoteJavaDecs
 
 getCreationExpression ( Ctr__Java__15 _ s) = s
 
 creationExpression :: QuasiQuoter
-creationExpression = QuasiQuoter (quoteJavaExp "tok_CreationExpression_dummy_155" getCreationExpression ) (quoteJavaPat "tok_CreationExpression_dummy_155" getCreationExpression ) quoteJavaType quoteJavaDecs
+creationExpression = QuasiQuoter (quoteJavaExp "tok_CreationExpression_dummy_162" getCreationExpression ) (quoteJavaPat "tok_CreationExpression_dummy_162" getCreationExpression ) quoteJavaType quoteJavaDecs
 
 getDimExprs ( Ctr__Java__16 _ s) = s
 
 dimExprs :: QuasiQuoter
-dimExprs = QuasiQuoter (quoteJavaExp "tok_DimExprs_dummy_154" getDimExprs ) (quoteJavaPat "tok_DimExprs_dummy_154" getDimExprs ) quoteJavaType quoteJavaDecs
+dimExprs = QuasiQuoter (quoteJavaExp "tok_DimExprs_dummy_161" getDimExprs ) (quoteJavaPat "tok_DimExprs_dummy_161" getDimExprs ) quoteJavaType quoteJavaDecs
 
 getDims ( Ctr__Java__17 _ s) = s
 
 dims :: QuasiQuoter
-dims = QuasiQuoter (quoteJavaExp "tok_Dims_dummy_153" getDims ) (quoteJavaPat "tok_Dims_dummy_153" getDims ) quoteJavaType quoteJavaDecs
+dims = QuasiQuoter (quoteJavaExp "tok_Dims_dummy_160" getDims ) (quoteJavaPat "tok_Dims_dummy_160" getDims ) quoteJavaType quoteJavaDecs
 
 getDoStatement ( Ctr__Java__18 _ s) = s
 
 doStatement :: QuasiQuoter
-doStatement = QuasiQuoter (quoteJavaExp "tok_DoStatement_dummy_152" getDoStatement ) (quoteJavaPat "tok_DoStatement_dummy_152" getDoStatement ) quoteJavaType quoteJavaDecs
+doStatement = QuasiQuoter (quoteJavaExp "tok_DoStatement_dummy_159" getDoStatement ) (quoteJavaPat "tok_DoStatement_dummy_159" getDoStatement ) quoteJavaType quoteJavaDecs
 
 getDocComment ( Ctr__Java__19 _ s) = s
 
 docComment :: QuasiQuoter
-docComment = QuasiQuoter (quoteJavaExp "tok_DocComment_dummy_151" getDocComment ) (quoteJavaPat "tok_DocComment_dummy_151" getDocComment ) quoteJavaType quoteJavaDecs
+docComment = QuasiQuoter (quoteJavaExp "tok_DocComment_dummy_158" getDocComment ) (quoteJavaPat "tok_DocComment_dummy_158" getDocComment ) quoteJavaType quoteJavaDecs
 
 getEnumConstant ( Ctr__Java__20 _ s) = s
 
 enumConstant :: QuasiQuoter
-enumConstant = QuasiQuoter (quoteJavaExp "tok_EnumConstant_dummy_150" getEnumConstant ) (quoteJavaPat "tok_EnumConstant_dummy_150" getEnumConstant ) quoteJavaType quoteJavaDecs
+enumConstant = QuasiQuoter (quoteJavaExp "tok_EnumConstant_dummy_157" getEnumConstant ) (quoteJavaPat "tok_EnumConstant_dummy_157" getEnumConstant ) quoteJavaType quoteJavaDecs
 
 getEnumConstantList ( Ctr__Java__21 _ s) = s
 
 enumConstantList :: QuasiQuoter
-enumConstantList = QuasiQuoter (quoteJavaExp "tok_EnumConstantList_dummy_149" getEnumConstantList ) (quoteJavaPat "tok_EnumConstantList_dummy_149" getEnumConstantList ) quoteJavaType quoteJavaDecs
+enumConstantList = QuasiQuoter (quoteJavaExp "tok_EnumConstantList_dummy_156" getEnumConstantList ) (quoteJavaPat "tok_EnumConstantList_dummy_156" getEnumConstantList ) quoteJavaType quoteJavaDecs
 
 getEnumDeclaration ( Ctr__Java__22 _ s) = s
 
 enumDeclaration :: QuasiQuoter
-enumDeclaration = QuasiQuoter (quoteJavaExp "tok_EnumDeclaration_dummy_148" getEnumDeclaration ) (quoteJavaPat "tok_EnumDeclaration_dummy_148" getEnumDeclaration ) quoteJavaType quoteJavaDecs
+enumDeclaration = QuasiQuoter (quoteJavaExp "tok_EnumDeclaration_dummy_155" getEnumDeclaration ) (quoteJavaPat "tok_EnumDeclaration_dummy_155" getEnumDeclaration ) quoteJavaType quoteJavaDecs
 
 getEqualityOp ( Ctr__Java__23 _ s) = s
 
 equalityOp :: QuasiQuoter
-equalityOp = QuasiQuoter (quoteJavaExp "tok_EqualityOp_dummy_147" getEqualityOp ) (quoteJavaPat "tok_EqualityOp_dummy_147" getEqualityOp ) quoteJavaType quoteJavaDecs
+equalityOp = QuasiQuoter (quoteJavaExp "tok_EqualityOp_dummy_154" getEqualityOp ) (quoteJavaPat "tok_EqualityOp_dummy_154" getEqualityOp ) quoteJavaType quoteJavaDecs
 
 getExpression ( Ctr__Java__24 _ s) = s
 
 expression :: QuasiQuoter
-expression = QuasiQuoter (quoteJavaExp "tok_Expression_dummy_146" getExpression ) (quoteJavaPat "tok_Expression_dummy_146" getExpression ) quoteJavaType quoteJavaDecs
+expression = QuasiQuoter (quoteJavaExp "tok_Expression_dummy_153" getExpression ) (quoteJavaPat "tok_Expression_dummy_153" getExpression ) quoteJavaType quoteJavaDecs
 
 getExtendsList ( Ctr__Java__25 _ s) = s
 
 extendsList :: QuasiQuoter
-extendsList = QuasiQuoter (quoteJavaExp "tok_ExtendsList_dummy_145" getExtendsList ) (quoteJavaPat "tok_ExtendsList_dummy_145" getExtendsList ) quoteJavaType quoteJavaDecs
+extendsList = QuasiQuoter (quoteJavaExp "tok_ExtendsList_dummy_152" getExtendsList ) (quoteJavaPat "tok_ExtendsList_dummy_152" getExtendsList ) quoteJavaType quoteJavaDecs
 
 getFieldDeclaration ( Ctr__Java__26 _ s) = s
 
 fieldDeclaration :: QuasiQuoter
-fieldDeclaration = QuasiQuoter (quoteJavaExp "tok_FieldDeclaration_dummy_144" getFieldDeclaration ) (quoteJavaPat "tok_FieldDeclaration_dummy_144" getFieldDeclaration ) quoteJavaType quoteJavaDecs
+fieldDeclaration = QuasiQuoter (quoteJavaExp "tok_FieldDeclaration_dummy_151" getFieldDeclaration ) (quoteJavaPat "tok_FieldDeclaration_dummy_151" getFieldDeclaration ) quoteJavaType quoteJavaDecs
 
 getFieldDeclarationList ( Ctr__Java__27 _ s) = s
 
 fieldDeclarationList :: QuasiQuoter
-fieldDeclarationList = QuasiQuoter (quoteJavaExp "tok_FieldDeclarationList_dummy_143" getFieldDeclarationList ) (quoteJavaPat "tok_FieldDeclarationList_dummy_143" getFieldDeclarationList ) quoteJavaType quoteJavaDecs
+fieldDeclarationList = QuasiQuoter (quoteJavaExp "tok_FieldDeclarationList_dummy_150" getFieldDeclarationList ) (quoteJavaPat "tok_FieldDeclarationList_dummy_150" getFieldDeclarationList ) quoteJavaType quoteJavaDecs
 
 getForStatement ( Ctr__Java__28 _ s) = s
 
 forStatement :: QuasiQuoter
-forStatement = QuasiQuoter (quoteJavaExp "tok_ForStatement_dummy_142" getForStatement ) (quoteJavaPat "tok_ForStatement_dummy_142" getForStatement ) quoteJavaType quoteJavaDecs
+forStatement = QuasiQuoter (quoteJavaExp "tok_ForStatement_dummy_149" getForStatement ) (quoteJavaPat "tok_ForStatement_dummy_149" getForStatement ) quoteJavaType quoteJavaDecs
 
 getIfStatement ( Ctr__Java__29 _ s) = s
 
 ifStatement :: QuasiQuoter
-ifStatement = QuasiQuoter (quoteJavaExp "tok_IfStatement_dummy_141" getIfStatement ) (quoteJavaPat "tok_IfStatement_dummy_141" getIfStatement ) quoteJavaType quoteJavaDecs
+ifStatement = QuasiQuoter (quoteJavaExp "tok_IfStatement_dummy_148" getIfStatement ) (quoteJavaPat "tok_IfStatement_dummy_148" getIfStatement ) quoteJavaType quoteJavaDecs
 
 getImplementsList ( Ctr__Java__30 _ s) = s
 
 implementsList :: QuasiQuoter
-implementsList = QuasiQuoter (quoteJavaExp "tok_ImplementsList_dummy_140" getImplementsList ) (quoteJavaPat "tok_ImplementsList_dummy_140" getImplementsList ) quoteJavaType quoteJavaDecs
+implementsList = QuasiQuoter (quoteJavaExp "tok_ImplementsList_dummy_147" getImplementsList ) (quoteJavaPat "tok_ImplementsList_dummy_147" getImplementsList ) quoteJavaType quoteJavaDecs
 
 getImportHead ( Ctr__Java__31 _ s) = s
 
 importHead :: QuasiQuoter
-importHead = QuasiQuoter (quoteJavaExp "tok_ImportHead_dummy_139" getImportHead ) (quoteJavaPat "tok_ImportHead_dummy_139" getImportHead ) quoteJavaType quoteJavaDecs
+importHead = QuasiQuoter (quoteJavaExp "tok_ImportHead_dummy_146" getImportHead ) (quoteJavaPat "tok_ImportHead_dummy_146" getImportHead ) quoteJavaType quoteJavaDecs
 
 getImportList ( Ctr__Java__32 _ s) = s
 
 importList :: QuasiQuoter
-importList = QuasiQuoter (quoteJavaExp "tok_ImportList_dummy_138" getImportList ) (quoteJavaPat "tok_ImportList_dummy_138" getImportList ) quoteJavaType quoteJavaDecs
+importList = QuasiQuoter (quoteJavaExp "tok_ImportList_dummy_145" getImportList ) (quoteJavaPat "tok_ImportList_dummy_145" getImportList ) quoteJavaType quoteJavaDecs
 
 getImportName ( Ctr__Java__33 _ s) = s
 
 importName :: QuasiQuoter
-importName = QuasiQuoter (quoteJavaExp "tok_ImportName_dummy_137" getImportName ) (quoteJavaPat "tok_ImportName_dummy_137" getImportName ) quoteJavaType quoteJavaDecs
+importName = QuasiQuoter (quoteJavaExp "tok_ImportName_dummy_144" getImportName ) (quoteJavaPat "tok_ImportName_dummy_144" getImportName ) quoteJavaType quoteJavaDecs
 
 getImportStatement ( Ctr__Java__34 _ s) = s
 
 importStatement :: QuasiQuoter
-importStatement = QuasiQuoter (quoteJavaExp "tok_ImportStatement_dummy_136" getImportStatement ) (quoteJavaPat "tok_ImportStatement_dummy_136" getImportStatement ) quoteJavaType quoteJavaDecs
+importStatement = QuasiQuoter (quoteJavaExp "tok_ImportStatement_dummy_143" getImportStatement ) (quoteJavaPat "tok_ImportStatement_dummy_143" getImportStatement ) quoteJavaType quoteJavaDecs
 
 getInterfaceDeclaration ( Ctr__Java__35 _ s) = s
 
 interfaceDeclaration :: QuasiQuoter
-interfaceDeclaration = QuasiQuoter (quoteJavaExp "tok_InterfaceDeclaration_dummy_135" getInterfaceDeclaration ) (quoteJavaPat "tok_InterfaceDeclaration_dummy_135" getInterfaceDeclaration ) quoteJavaType quoteJavaDecs
+interfaceDeclaration = QuasiQuoter (quoteJavaExp "tok_InterfaceDeclaration_dummy_142" getInterfaceDeclaration ) (quoteJavaPat "tok_InterfaceDeclaration_dummy_142" getInterfaceDeclaration ) quoteJavaType quoteJavaDecs
 
 getLiteral ( Ctr__Java__36 _ s) = s
 
 literal :: QuasiQuoter
-literal = QuasiQuoter (quoteJavaExp "tok_Literal_dummy_134" getLiteral ) (quoteJavaPat "tok_Literal_dummy_134" getLiteral ) quoteJavaType quoteJavaDecs
+literal = QuasiQuoter (quoteJavaExp "tok_Literal_dummy_141" getLiteral ) (quoteJavaPat "tok_Literal_dummy_141" getLiteral ) quoteJavaType quoteJavaDecs
 
-getMemberAfterFirstId ( Ctr__Java__37 _ s) = s
+getLocalModifierList1 ( Ctr__Java__37 _ s) = s
+
+localModifierList1 :: QuasiQuoter
+localModifierList1 = QuasiQuoter (quoteJavaExp "tok_LocalModifierList1_dummy_140" getLocalModifierList1 ) (quoteJavaPat "tok_LocalModifierList1_dummy_140" getLocalModifierList1 ) quoteJavaType quoteJavaDecs
+
+getMemberAfterFirstId ( Ctr__Java__38 _ s) = s
 
 memberAfterFirstId :: QuasiQuoter
-memberAfterFirstId = QuasiQuoter (quoteJavaExp "tok_MemberAfterFirstId_dummy_133" getMemberAfterFirstId ) (quoteJavaPat "tok_MemberAfterFirstId_dummy_133" getMemberAfterFirstId ) quoteJavaType quoteJavaDecs
+memberAfterFirstId = QuasiQuoter (quoteJavaExp "tok_MemberAfterFirstId_dummy_139" getMemberAfterFirstId ) (quoteJavaPat "tok_MemberAfterFirstId_dummy_139" getMemberAfterFirstId ) quoteJavaType quoteJavaDecs
 
-getMemberDeclaration ( Ctr__Java__38 _ s) = s
+getMemberDeclaration ( Ctr__Java__39 _ s) = s
 
 memberDeclaration :: QuasiQuoter
-memberDeclaration = QuasiQuoter (quoteJavaExp "tok_MemberDeclaration_dummy_132" getMemberDeclaration ) (quoteJavaPat "tok_MemberDeclaration_dummy_132" getMemberDeclaration ) quoteJavaType quoteJavaDecs
+memberDeclaration = QuasiQuoter (quoteJavaExp "tok_MemberDeclaration_dummy_138" getMemberDeclaration ) (quoteJavaPat "tok_MemberDeclaration_dummy_138" getMemberDeclaration ) quoteJavaType quoteJavaDecs
 
-getMemberRest ( Ctr__Java__39 _ s) = s
+getMemberRest ( Ctr__Java__40 _ s) = s
 
 memberRest :: QuasiQuoter
-memberRest = QuasiQuoter (quoteJavaExp "tok_MemberRest_dummy_131" getMemberRest ) (quoteJavaPat "tok_MemberRest_dummy_131" getMemberRest ) quoteJavaType quoteJavaDecs
+memberRest = QuasiQuoter (quoteJavaExp "tok_MemberRest_dummy_137" getMemberRest ) (quoteJavaPat "tok_MemberRest_dummy_137" getMemberRest ) quoteJavaType quoteJavaDecs
 
-getModifier ( Ctr__Java__40 _ s) = s
+getModifier ( Ctr__Java__41 _ s) = s
 
 modifier :: QuasiQuoter
-modifier = QuasiQuoter (quoteJavaExp "tok_Modifier_dummy_130" getModifier ) (quoteJavaPat "tok_Modifier_dummy_130" getModifier ) quoteJavaType quoteJavaDecs
+modifier = QuasiQuoter (quoteJavaExp "tok_Modifier_dummy_136" getModifier ) (quoteJavaPat "tok_Modifier_dummy_136" getModifier ) quoteJavaType quoteJavaDecs
 
-getModifierList ( Ctr__Java__41 _ s) = s
+getModifierList ( Ctr__Java__42 _ s) = s
 
 modifierList :: QuasiQuoter
-modifierList = QuasiQuoter (quoteJavaExp "tok_ModifierList_dummy_129" getModifierList ) (quoteJavaPat "tok_ModifierList_dummy_129" getModifierList ) quoteJavaType quoteJavaDecs
+modifierList = QuasiQuoter (quoteJavaExp "tok_ModifierList_dummy_135" getModifierList ) (quoteJavaPat "tok_ModifierList_dummy_135" getModifierList ) quoteJavaType quoteJavaDecs
 
-getMoreTypeSpecifier ( Ctr__Java__42 _ s) = s
+getMoreTypeSpecifier ( Ctr__Java__43 _ s) = s
 
 moreTypeSpecifier :: QuasiQuoter
-moreTypeSpecifier = QuasiQuoter (quoteJavaExp "tok_MoreTypeSpecifier_dummy_128" getMoreTypeSpecifier ) (quoteJavaPat "tok_MoreTypeSpecifier_dummy_128" getMoreTypeSpecifier ) quoteJavaType quoteJavaDecs
+moreTypeSpecifier = QuasiQuoter (quoteJavaExp "tok_MoreTypeSpecifier_dummy_134" getMoreTypeSpecifier ) (quoteJavaPat "tok_MoreTypeSpecifier_dummy_134" getMoreTypeSpecifier ) quoteJavaType quoteJavaDecs
 
-getMoreVariableDeclarators ( Ctr__Java__43 _ s) = s
+getMoreVariableDeclarators ( Ctr__Java__44 _ s) = s
 
 moreVariableDeclarators :: QuasiQuoter
-moreVariableDeclarators = QuasiQuoter (quoteJavaExp "tok_MoreVariableDeclarators_dummy_127" getMoreVariableDeclarators ) (quoteJavaPat "tok_MoreVariableDeclarators_dummy_127" getMoreVariableDeclarators ) quoteJavaType quoteJavaDecs
+moreVariableDeclarators = QuasiQuoter (quoteJavaExp "tok_MoreVariableDeclarators_dummy_133" getMoreVariableDeclarators ) (quoteJavaPat "tok_MoreVariableDeclarators_dummy_133" getMoreVariableDeclarators ) quoteJavaType quoteJavaDecs
 
-getMultiplicativeOp ( Ctr__Java__44 _ s) = s
+getMultiplicativeOp ( Ctr__Java__45 _ s) = s
 
 multiplicativeOp :: QuasiQuoter
-multiplicativeOp = QuasiQuoter (quoteJavaExp "tok_MultiplicativeOp_dummy_126" getMultiplicativeOp ) (quoteJavaPat "tok_MultiplicativeOp_dummy_126" getMultiplicativeOp ) quoteJavaType quoteJavaDecs
+multiplicativeOp = QuasiQuoter (quoteJavaExp "tok_MultiplicativeOp_dummy_132" getMultiplicativeOp ) (quoteJavaPat "tok_MultiplicativeOp_dummy_132" getMultiplicativeOp ) quoteJavaType quoteJavaDecs
 
-getNonEmptyDims ( Ctr__Java__45 _ s) = s
+getNonEmptyDims ( Ctr__Java__46 _ s) = s
 
 nonEmptyDims :: QuasiQuoter
-nonEmptyDims = QuasiQuoter (quoteJavaExp "tok_NonEmptyDims_dummy_125" getNonEmptyDims ) (quoteJavaPat "tok_NonEmptyDims_dummy_125" getNonEmptyDims ) quoteJavaType quoteJavaDecs
+nonEmptyDims = QuasiQuoter (quoteJavaExp "tok_NonEmptyDims_dummy_131" getNonEmptyDims ) (quoteJavaPat "tok_NonEmptyDims_dummy_131" getNonEmptyDims ) quoteJavaType quoteJavaDecs
 
-getNonEmptyTypeArguments ( Ctr__Java__46 _ s) = s
+getNonEmptyTypeArguments ( Ctr__Java__47 _ s) = s
 
 nonEmptyTypeArguments :: QuasiQuoter
-nonEmptyTypeArguments = QuasiQuoter (quoteJavaExp "tok_NonEmptyTypeArguments_dummy_124" getNonEmptyTypeArguments ) (quoteJavaPat "tok_NonEmptyTypeArguments_dummy_124" getNonEmptyTypeArguments ) quoteJavaType quoteJavaDecs
+nonEmptyTypeArguments = QuasiQuoter (quoteJavaExp "tok_NonEmptyTypeArguments_dummy_130" getNonEmptyTypeArguments ) (quoteJavaPat "tok_NonEmptyTypeArguments_dummy_130" getNonEmptyTypeArguments ) quoteJavaType quoteJavaDecs
 
-getOptDocComment ( Ctr__Java__47 _ s) = s
+getOptDocComment ( Ctr__Java__48 _ s) = s
 
 optDocComment :: QuasiQuoter
-optDocComment = QuasiQuoter (quoteJavaExp "tok_OptDocComment_dummy_123" getOptDocComment ) (quoteJavaPat "tok_OptDocComment_dummy_123" getOptDocComment ) quoteJavaType quoteJavaDecs
+optDocComment = QuasiQuoter (quoteJavaExp "tok_OptDocComment_dummy_129" getOptDocComment ) (quoteJavaPat "tok_OptDocComment_dummy_129" getOptDocComment ) quoteJavaType quoteJavaDecs
 
-getOptElsePart ( Ctr__Java__48 _ s) = s
+getOptElsePart ( Ctr__Java__49 _ s) = s
 
 optElsePart :: QuasiQuoter
-optElsePart = QuasiQuoter (quoteJavaExp "tok_OptElsePart_dummy_122" getOptElsePart ) (quoteJavaPat "tok_OptElsePart_dummy_122" getOptElsePart ) quoteJavaType quoteJavaDecs
+optElsePart = QuasiQuoter (quoteJavaExp "tok_OptElsePart_dummy_128" getOptElsePart ) (quoteJavaPat "tok_OptElsePart_dummy_128" getOptElsePart ) quoteJavaType quoteJavaDecs
 
-getOptExpression ( Ctr__Java__49 _ s) = s
+getOptExpression ( Ctr__Java__50 _ s) = s
 
 optExpression :: QuasiQuoter
-optExpression = QuasiQuoter (quoteJavaExp "tok_OptExpression_dummy_121" getOptExpression ) (quoteJavaPat "tok_OptExpression_dummy_121" getOptExpression ) quoteJavaType quoteJavaDecs
+optExpression = QuasiQuoter (quoteJavaExp "tok_OptExpression_dummy_127" getOptExpression ) (quoteJavaPat "tok_OptExpression_dummy_127" getOptExpression ) quoteJavaType quoteJavaDecs
 
-getOptFinally ( Ctr__Java__50 _ s) = s
+getOptFinally ( Ctr__Java__51 _ s) = s
 
 optFinally :: QuasiQuoter
-optFinally = QuasiQuoter (quoteJavaExp "tok_OptFinally_dummy_120" getOptFinally ) (quoteJavaPat "tok_OptFinally_dummy_120" getOptFinally ) quoteJavaType quoteJavaDecs
+optFinally = QuasiQuoter (quoteJavaExp "tok_OptFinally_dummy_126" getOptFinally ) (quoteJavaPat "tok_OptFinally_dummy_126" getOptFinally ) quoteJavaType quoteJavaDecs
 
-getOptId ( Ctr__Java__51 _ s) = s
+getOptId ( Ctr__Java__52 _ s) = s
 
 optId :: QuasiQuoter
-optId = QuasiQuoter (quoteJavaExp "tok_OptId_dummy_119" getOptId ) (quoteJavaPat "tok_OptId_dummy_119" getOptId ) quoteJavaType quoteJavaDecs
+optId = QuasiQuoter (quoteJavaExp "tok_OptId_dummy_125" getOptId ) (quoteJavaPat "tok_OptId_dummy_125" getOptId ) quoteJavaType quoteJavaDecs
 
-getOptVariableInitializer ( Ctr__Java__52 _ s) = s
+getOptVariableInitializer ( Ctr__Java__53 _ s) = s
 
 optVariableInitializer :: QuasiQuoter
-optVariableInitializer = QuasiQuoter (quoteJavaExp "tok_OptVariableInitializer_dummy_118" getOptVariableInitializer ) (quoteJavaPat "tok_OptVariableInitializer_dummy_118" getOptVariableInitializer ) quoteJavaType quoteJavaDecs
+optVariableInitializer = QuasiQuoter (quoteJavaExp "tok_OptVariableInitializer_dummy_124" getOptVariableInitializer ) (quoteJavaPat "tok_OptVariableInitializer_dummy_124" getOptVariableInitializer ) quoteJavaType quoteJavaDecs
 
-getPackage ( Ctr__Java__53 _ s) = s
+getPackage ( Ctr__Java__54 _ s) = s
 
 package :: QuasiQuoter
-package = QuasiQuoter (quoteJavaExp "tok_Package_dummy_117" getPackage ) (quoteJavaPat "tok_Package_dummy_117" getPackage ) quoteJavaType quoteJavaDecs
+package = QuasiQuoter (quoteJavaExp "tok_Package_dummy_123" getPackage ) (quoteJavaPat "tok_Package_dummy_123" getPackage ) quoteJavaType quoteJavaDecs
 
-getParameter ( Ctr__Java__54 _ s) = s
+getParamModifierList ( Ctr__Java__55 _ s) = s
+
+paramModifierList :: QuasiQuoter
+paramModifierList = QuasiQuoter (quoteJavaExp "tok_ParamModifierList_dummy_122" getParamModifierList ) (quoteJavaPat "tok_ParamModifierList_dummy_122" getParamModifierList ) quoteJavaType quoteJavaDecs
+
+getParameter ( Ctr__Java__56 _ s) = s
 
 parameter :: QuasiQuoter
-parameter = QuasiQuoter (quoteJavaExp "tok_Parameter_dummy_116" getParameter ) (quoteJavaPat "tok_Parameter_dummy_116" getParameter ) quoteJavaType quoteJavaDecs
+parameter = QuasiQuoter (quoteJavaExp "tok_Parameter_dummy_121" getParameter ) (quoteJavaPat "tok_Parameter_dummy_121" getParameter ) quoteJavaType quoteJavaDecs
 
-getParameterList ( Ctr__Java__55 _ s) = s
+getParameterList ( Ctr__Java__57 _ s) = s
 
 parameterList :: QuasiQuoter
-parameterList = QuasiQuoter (quoteJavaExp "tok_ParameterList_dummy_115" getParameterList ) (quoteJavaPat "tok_ParameterList_dummy_115" getParameterList ) quoteJavaType quoteJavaDecs
+parameterList = QuasiQuoter (quoteJavaExp "tok_ParameterList_dummy_120" getParameterList ) (quoteJavaPat "tok_ParameterList_dummy_120" getParameterList ) quoteJavaType quoteJavaDecs
 
-getPostfixOp ( Ctr__Java__56 _ s) = s
+getPostfixOp ( Ctr__Java__58 _ s) = s
 
 postfixOp :: QuasiQuoter
-postfixOp = QuasiQuoter (quoteJavaExp "tok_PostfixOp_dummy_114" getPostfixOp ) (quoteJavaPat "tok_PostfixOp_dummy_114" getPostfixOp ) quoteJavaType quoteJavaDecs
+postfixOp = QuasiQuoter (quoteJavaExp "tok_PostfixOp_dummy_119" getPostfixOp ) (quoteJavaPat "tok_PostfixOp_dummy_119" getPostfixOp ) quoteJavaType quoteJavaDecs
 
-getPrefixOp ( Ctr__Java__57 _ s) = s
+getPrefixOp ( Ctr__Java__59 _ s) = s
 
 prefixOp :: QuasiQuoter
-prefixOp = QuasiQuoter (quoteJavaExp "tok_PrefixOp_dummy_113" getPrefixOp ) (quoteJavaPat "tok_PrefixOp_dummy_113" getPrefixOp ) quoteJavaType quoteJavaDecs
+prefixOp = QuasiQuoter (quoteJavaExp "tok_PrefixOp_dummy_118" getPrefixOp ) (quoteJavaPat "tok_PrefixOp_dummy_118" getPrefixOp ) quoteJavaType quoteJavaDecs
 
-getPrimitiveTypeKeyword ( Ctr__Java__58 _ s) = s
+getPrimitiveTypeKeyword ( Ctr__Java__60 _ s) = s
 
 primitiveTypeKeyword :: QuasiQuoter
-primitiveTypeKeyword = QuasiQuoter (quoteJavaExp "tok_PrimitiveTypeKeyword_dummy_112" getPrimitiveTypeKeyword ) (quoteJavaPat "tok_PrimitiveTypeKeyword_dummy_112" getPrimitiveTypeKeyword ) quoteJavaType quoteJavaDecs
+primitiveTypeKeyword = QuasiQuoter (quoteJavaExp "tok_PrimitiveTypeKeyword_dummy_117" getPrimitiveTypeKeyword ) (quoteJavaPat "tok_PrimitiveTypeKeyword_dummy_117" getPrimitiveTypeKeyword ) quoteJavaType quoteJavaDecs
 
-getRelationalOp ( Ctr__Java__59 _ s) = s
+getRelationalOp ( Ctr__Java__61 _ s) = s
 
 relationalOp :: QuasiQuoter
-relationalOp = QuasiQuoter (quoteJavaExp "tok_RelationalOp_dummy_111" getRelationalOp ) (quoteJavaPat "tok_RelationalOp_dummy_111" getRelationalOp ) quoteJavaType quoteJavaDecs
+relationalOp = QuasiQuoter (quoteJavaExp "tok_RelationalOp_dummy_116" getRelationalOp ) (quoteJavaPat "tok_RelationalOp_dummy_116" getRelationalOp ) quoteJavaType quoteJavaDecs
 
-getShiftOp ( Ctr__Java__60 _ s) = s
+getShiftOp ( Ctr__Java__62 _ s) = s
 
 shiftOp :: QuasiQuoter
-shiftOp = QuasiQuoter (quoteJavaExp "tok_ShiftOp_dummy_110" getShiftOp ) (quoteJavaPat "tok_ShiftOp_dummy_110" getShiftOp ) quoteJavaType quoteJavaDecs
+shiftOp = QuasiQuoter (quoteJavaExp "tok_ShiftOp_dummy_115" getShiftOp ) (quoteJavaPat "tok_ShiftOp_dummy_115" getShiftOp ) quoteJavaType quoteJavaDecs
 
-getStatement ( Ctr__Java__61 _ s) = s
+getStatement ( Ctr__Java__63 _ s) = s
 
 statement :: QuasiQuoter
-statement = QuasiQuoter (quoteJavaExp "tok_Statement_dummy_109" getStatement ) (quoteJavaPat "tok_Statement_dummy_109" getStatement ) quoteJavaType quoteJavaDecs
+statement = QuasiQuoter (quoteJavaExp "tok_Statement_dummy_114" getStatement ) (quoteJavaPat "tok_Statement_dummy_114" getStatement ) quoteJavaType quoteJavaDecs
 
-getStatementBlock ( Ctr__Java__62 _ s) = s
+getStatementBlock ( Ctr__Java__64 _ s) = s
 
 statementBlock :: QuasiQuoter
-statementBlock = QuasiQuoter (quoteJavaExp "tok_StatementBlock_dummy_108" getStatementBlock ) (quoteJavaPat "tok_StatementBlock_dummy_108" getStatementBlock ) quoteJavaType quoteJavaDecs
+statementBlock = QuasiQuoter (quoteJavaExp "tok_StatementBlock_dummy_113" getStatementBlock ) (quoteJavaPat "tok_StatementBlock_dummy_113" getStatementBlock ) quoteJavaType quoteJavaDecs
 
-getStatementList ( Ctr__Java__63 _ s) = s
+getStatementList ( Ctr__Java__65 _ s) = s
 
 statementList :: QuasiQuoter
-statementList = QuasiQuoter (quoteJavaExp "tok_StatementList_dummy_107" getStatementList ) (quoteJavaPat "tok_StatementList_dummy_107" getStatementList ) quoteJavaType quoteJavaDecs
+statementList = QuasiQuoter (quoteJavaExp "tok_StatementList_dummy_112" getStatementList ) (quoteJavaPat "tok_StatementList_dummy_112" getStatementList ) quoteJavaType quoteJavaDecs
 
-getStaticInitializer ( Ctr__Java__64 _ s) = s
+getStaticInitializer ( Ctr__Java__66 _ s) = s
 
 staticInitializer :: QuasiQuoter
-staticInitializer = QuasiQuoter (quoteJavaExp "tok_StaticInitializer_dummy_106" getStaticInitializer ) (quoteJavaPat "tok_StaticInitializer_dummy_106" getStaticInitializer ) quoteJavaType quoteJavaDecs
+staticInitializer = QuasiQuoter (quoteJavaExp "tok_StaticInitializer_dummy_111" getStaticInitializer ) (quoteJavaPat "tok_StaticInitializer_dummy_111" getStaticInitializer ) quoteJavaType quoteJavaDecs
 
-getSwitchCaseList ( Ctr__Java__65 _ s) = s
+getSwitchCaseList ( Ctr__Java__67 _ s) = s
 
 switchCaseList :: QuasiQuoter
-switchCaseList = QuasiQuoter (quoteJavaExp "tok_SwitchCaseList_dummy_105" getSwitchCaseList ) (quoteJavaPat "tok_SwitchCaseList_dummy_105" getSwitchCaseList ) quoteJavaType quoteJavaDecs
+switchCaseList = QuasiQuoter (quoteJavaExp "tok_SwitchCaseList_dummy_110" getSwitchCaseList ) (quoteJavaPat "tok_SwitchCaseList_dummy_110" getSwitchCaseList ) quoteJavaType quoteJavaDecs
 
-getSwitchStatement ( Ctr__Java__66 _ s) = s
+getSwitchStatement ( Ctr__Java__68 _ s) = s
 
 switchStatement :: QuasiQuoter
-switchStatement = QuasiQuoter (quoteJavaExp "tok_SwitchStatement_dummy_104" getSwitchStatement ) (quoteJavaPat "tok_SwitchStatement_dummy_104" getSwitchStatement ) quoteJavaType quoteJavaDecs
+switchStatement = QuasiQuoter (quoteJavaExp "tok_SwitchStatement_dummy_109" getSwitchStatement ) (quoteJavaPat "tok_SwitchStatement_dummy_109" getSwitchStatement ) quoteJavaType quoteJavaDecs
 
-getThrowsClause ( Ctr__Java__67 _ s) = s
+getThrowsClause ( Ctr__Java__69 _ s) = s
 
 throwsClause :: QuasiQuoter
-throwsClause = QuasiQuoter (quoteJavaExp "tok_ThrowsClause_dummy_103" getThrowsClause ) (quoteJavaPat "tok_ThrowsClause_dummy_103" getThrowsClause ) quoteJavaType quoteJavaDecs
+throwsClause = QuasiQuoter (quoteJavaExp "tok_ThrowsClause_dummy_108" getThrowsClause ) (quoteJavaPat "tok_ThrowsClause_dummy_108" getThrowsClause ) quoteJavaType quoteJavaDecs
 
-getTryStatement ( Ctr__Java__68 _ s) = s
+getTryStatement ( Ctr__Java__70 _ s) = s
 
 tryStatement :: QuasiQuoter
-tryStatement = QuasiQuoter (quoteJavaExp "tok_TryStatement_dummy_102" getTryStatement ) (quoteJavaPat "tok_TryStatement_dummy_102" getTryStatement ) quoteJavaType quoteJavaDecs
+tryStatement = QuasiQuoter (quoteJavaExp "tok_TryStatement_dummy_107" getTryStatement ) (quoteJavaPat "tok_TryStatement_dummy_107" getTryStatement ) quoteJavaType quoteJavaDecs
 
-getType ( Ctr__Java__69 _ s) = s
+getType ( Ctr__Java__71 _ s) = s
 
 __type :: QuasiQuoter
-__type = QuasiQuoter (quoteJavaExp "tok_Type_dummy_101" getType ) (quoteJavaPat "tok_Type_dummy_101" getType ) quoteJavaType quoteJavaDecs
+__type = QuasiQuoter (quoteJavaExp "tok_Type_dummy_106" getType ) (quoteJavaPat "tok_Type_dummy_106" getType ) quoteJavaType quoteJavaDecs
 
-getTypeArgument ( Ctr__Java__70 _ s) = s
+getTypeArgument ( Ctr__Java__72 _ s) = s
 
 typeArgument :: QuasiQuoter
-typeArgument = QuasiQuoter (quoteJavaExp "tok_TypeArgument_dummy_100" getTypeArgument ) (quoteJavaPat "tok_TypeArgument_dummy_100" getTypeArgument ) quoteJavaType quoteJavaDecs
+typeArgument = QuasiQuoter (quoteJavaExp "tok_TypeArgument_dummy_105" getTypeArgument ) (quoteJavaPat "tok_TypeArgument_dummy_105" getTypeArgument ) quoteJavaType quoteJavaDecs
 
-getTypeArguments ( Ctr__Java__71 _ s) = s
+getTypeArguments ( Ctr__Java__73 _ s) = s
 
 typeArguments :: QuasiQuoter
-typeArguments = QuasiQuoter (quoteJavaExp "tok_TypeArguments_dummy_99" getTypeArguments ) (quoteJavaPat "tok_TypeArguments_dummy_99" getTypeArguments ) quoteJavaType quoteJavaDecs
+typeArguments = QuasiQuoter (quoteJavaExp "tok_TypeArguments_dummy_104" getTypeArguments ) (quoteJavaPat "tok_TypeArguments_dummy_104" getTypeArguments ) quoteJavaType quoteJavaDecs
 
-getTypeDeclRest ( Ctr__Java__72 _ s) = s
+getTypeDeclRest ( Ctr__Java__74 _ s) = s
 
 typeDeclRest :: QuasiQuoter
-typeDeclRest = QuasiQuoter (quoteJavaExp "tok_TypeDeclRest_dummy_98" getTypeDeclRest ) (quoteJavaPat "tok_TypeDeclRest_dummy_98" getTypeDeclRest ) quoteJavaType quoteJavaDecs
+typeDeclRest = QuasiQuoter (quoteJavaExp "tok_TypeDeclRest_dummy_103" getTypeDeclRest ) (quoteJavaPat "tok_TypeDeclRest_dummy_103" getTypeDeclRest ) quoteJavaType quoteJavaDecs
 
-getTypeDeclaration ( Ctr__Java__73 _ s) = s
+getTypeDeclaration ( Ctr__Java__75 _ s) = s
 
 typeDeclaration :: QuasiQuoter
-typeDeclaration = QuasiQuoter (quoteJavaExp "tok_TypeDeclaration_dummy_97" getTypeDeclaration ) (quoteJavaPat "tok_TypeDeclaration_dummy_97" getTypeDeclaration ) quoteJavaType quoteJavaDecs
+typeDeclaration = QuasiQuoter (quoteJavaExp "tok_TypeDeclaration_dummy_102" getTypeDeclaration ) (quoteJavaPat "tok_TypeDeclaration_dummy_102" getTypeDeclaration ) quoteJavaType quoteJavaDecs
 
-getTypeParameter ( Ctr__Java__74 _ s) = s
+getTypeParameter ( Ctr__Java__76 _ s) = s
 
 typeParameter :: QuasiQuoter
-typeParameter = QuasiQuoter (quoteJavaExp "tok_TypeParameter_dummy_96" getTypeParameter ) (quoteJavaPat "tok_TypeParameter_dummy_96" getTypeParameter ) quoteJavaType quoteJavaDecs
+typeParameter = QuasiQuoter (quoteJavaExp "tok_TypeParameter_dummy_101" getTypeParameter ) (quoteJavaPat "tok_TypeParameter_dummy_101" getTypeParameter ) quoteJavaType quoteJavaDecs
 
-getTypeParameters ( Ctr__Java__75 _ s) = s
+getTypeParameters ( Ctr__Java__77 _ s) = s
 
 typeParameters :: QuasiQuoter
-typeParameters = QuasiQuoter (quoteJavaExp "tok_TypeParameters_dummy_95" getTypeParameters ) (quoteJavaPat "tok_TypeParameters_dummy_95" getTypeParameters ) quoteJavaType quoteJavaDecs
+typeParameters = QuasiQuoter (quoteJavaExp "tok_TypeParameters_dummy_100" getTypeParameters ) (quoteJavaPat "tok_TypeParameters_dummy_100" getTypeParameters ) quoteJavaType quoteJavaDecs
 
-getTypeSpecifier ( Ctr__Java__76 _ s) = s
+getTypeSpecifier ( Ctr__Java__78 _ s) = s
 
 typeSpecifier :: QuasiQuoter
-typeSpecifier = QuasiQuoter (quoteJavaExp "tok_TypeSpecifier_dummy_94" getTypeSpecifier ) (quoteJavaPat "tok_TypeSpecifier_dummy_94" getTypeSpecifier ) quoteJavaType quoteJavaDecs
+typeSpecifier = QuasiQuoter (quoteJavaExp "tok_TypeSpecifier_dummy_99" getTypeSpecifier ) (quoteJavaPat "tok_TypeSpecifier_dummy_99" getTypeSpecifier ) quoteJavaType quoteJavaDecs
 
-getVariableDeclaration ( Ctr__Java__77 _ s) = s
+getVariableDeclaration ( Ctr__Java__79 _ s) = s
 
 variableDeclaration :: QuasiQuoter
-variableDeclaration = QuasiQuoter (quoteJavaExp "tok_VariableDeclaration_dummy_93" getVariableDeclaration ) (quoteJavaPat "tok_VariableDeclaration_dummy_93" getVariableDeclaration ) quoteJavaType quoteJavaDecs
+variableDeclaration = QuasiQuoter (quoteJavaExp "tok_VariableDeclaration_dummy_98" getVariableDeclaration ) (quoteJavaPat "tok_VariableDeclaration_dummy_98" getVariableDeclaration ) quoteJavaType quoteJavaDecs
 
-getVariableDeclarator ( Ctr__Java__78 _ s) = s
+getVariableDeclarator ( Ctr__Java__80 _ s) = s
 
 variableDeclarator :: QuasiQuoter
-variableDeclarator = QuasiQuoter (quoteJavaExp "tok_VariableDeclarator_dummy_92" getVariableDeclarator ) (quoteJavaPat "tok_VariableDeclarator_dummy_92" getVariableDeclarator ) quoteJavaType quoteJavaDecs
+variableDeclarator = QuasiQuoter (quoteJavaExp "tok_VariableDeclarator_dummy_97" getVariableDeclarator ) (quoteJavaPat "tok_VariableDeclarator_dummy_97" getVariableDeclarator ) quoteJavaType quoteJavaDecs
 
-getVariableDeclaratorList ( Ctr__Java__79 _ s) = s
+getVariableDeclaratorList ( Ctr__Java__81 _ s) = s
 
 variableDeclaratorList :: QuasiQuoter
-variableDeclaratorList = QuasiQuoter (quoteJavaExp "tok_VariableDeclaratorList_dummy_91" getVariableDeclaratorList ) (quoteJavaPat "tok_VariableDeclaratorList_dummy_91" getVariableDeclaratorList ) quoteJavaType quoteJavaDecs
+variableDeclaratorList = QuasiQuoter (quoteJavaExp "tok_VariableDeclaratorList_dummy_96" getVariableDeclaratorList ) (quoteJavaPat "tok_VariableDeclaratorList_dummy_96" getVariableDeclaratorList ) quoteJavaType quoteJavaDecs
 
-getVariableInitializer ( Ctr__Java__80 _ s) = s
+getVariableInitializer ( Ctr__Java__82 _ s) = s
 
 variableInitializer :: QuasiQuoter
-variableInitializer = QuasiQuoter (quoteJavaExp "tok_VariableInitializer_dummy_90" getVariableInitializer ) (quoteJavaPat "tok_VariableInitializer_dummy_90" getVariableInitializer ) quoteJavaType quoteJavaDecs
+variableInitializer = QuasiQuoter (quoteJavaExp "tok_VariableInitializer_dummy_95" getVariableInitializer ) (quoteJavaPat "tok_VariableInitializer_dummy_95" getVariableInitializer ) quoteJavaType quoteJavaDecs
 
-getVariableInitializerList ( Ctr__Java__81 _ s) = s
+getVariableInitializerList ( Ctr__Java__83 _ s) = s
 
 variableInitializerList :: QuasiQuoter
-variableInitializerList = QuasiQuoter (quoteJavaExp "tok_VariableInitializerList_dummy_89" getVariableInitializerList ) (quoteJavaPat "tok_VariableInitializerList_dummy_89" getVariableInitializerList ) quoteJavaType quoteJavaDecs
+variableInitializerList = QuasiQuoter (quoteJavaExp "tok_VariableInitializerList_dummy_94" getVariableInitializerList ) (quoteJavaPat "tok_VariableInitializerList_dummy_94" getVariableInitializerList ) quoteJavaType quoteJavaDecs
 
-getWhileStatement ( Ctr__Java__82 _ s) = s
+getWhileStatement ( Ctr__Java__84 _ s) = s
 
 whileStatement :: QuasiQuoter
-whileStatement = QuasiQuoter (quoteJavaExp "tok_WhileStatement_dummy_88" getWhileStatement ) (quoteJavaPat "tok_WhileStatement_dummy_88" getWhileStatement ) quoteJavaType quoteJavaDecs
+whileStatement = QuasiQuoter (quoteJavaExp "tok_WhileStatement_dummy_93" getWhileStatement ) (quoteJavaPat "tok_WhileStatement_dummy_93" getWhileStatement ) quoteJavaType quoteJavaDecs
 
-getWildcardType ( Ctr__Java__83 _ s) = s
+getWildcardType ( Ctr__Java__85 _ s) = s
 
 wildcardType :: QuasiQuoter
-wildcardType = QuasiQuoter (quoteJavaExp "tok_WildcardType_dummy_87" getWildcardType ) (quoteJavaPat "tok_WildcardType_dummy_87" getWildcardType ) quoteJavaType quoteJavaDecs
+wildcardType = QuasiQuoter (quoteJavaExp "tok_WildcardType_dummy_92" getWildcardType ) (quoteJavaPat "tok_WildcardType_dummy_92" getWildcardType ) quoteJavaType quoteJavaDecs
 


### PR DESCRIPTION
Parameter is now ParamModifierList Type ('...')? id Dims with
ParamModifierList = ('final' | Annotation)* (JLS 8.4.1 VariableModifier).
Parameter positions (after '(' or ',' in parameter lists, and in
'catch (...)') have no competing expression interpretation, so the nullable
modifier prefix is safe there: the epsilon-reduce on a type-start token is
the state's only action. catch reuses Parameter, so
'catch (final Exception e)' is fixed by the same stroke. '...' becomes a
new single lexer literal (Alex's maximal munch prefers it over '.').

Local declarations get a second, keyword-anchored alternative instead:
VariableDeclaration = Type VariableDeclaratorList ';'
                    | LocalModifierList1 Type VariableDeclaratorList ';'
with LocalModifierList1 = ('final' | Annotation)+. At statement start the
parser already weighs "Type vs Expression" after an identifier; a nullable
prefix there would force an epsilon-reduce decision before that identifier
is shifted, sending 'Foo x;' down the expression path. 'final' and '@'
cannot start an expression, so the non-empty list adds plain shifts and the
unmodified alternative keeps today's exact automaton. The for statement's
init reuses VariableDeclaration, so 'for (final int i = 0; ...)' comes for
free (probed). Conflict inventory unchanged: 18 shift/reduce across 12
states with the same per-state distribution and families, 0 reduce/reduce.

Goldens refreshed (test/golden/java/; operators.tokens' generated token
names renumbered - the stream itself is unchanged). commons-lang corpus:
main 27 -> 53, tests 29 -> 62 passing, no regressions - the largest
main-tree improvement of any phase, matching final-on-parameter being the
most common first error. The 59 newly passing files leave the parser
blacklists; the headers now name the current top blockers (generics in
expressions, class literals/lambdas/method references/anonymous classes/
enhanced for, doc comment before 'package', array initializers in 'new').

https://claude.ai/code/session_01DaK3RzLNan4FzcdBJmd5bu