### PR TITLE
Add ClassOrInterfaceType rule and resolve shift/reduce conflict

### DIFF
--- a/test-grammars/java.pg
+++ b/test-grammars/java.pg
@@ -1,7 +1,7 @@
 grammar 'Java';
 
 # ============================================================================
-# LALR conflict inventory (happy: 18 shift/reduce, 0 reduce/reduce)
+# LALR conflict inventory (happy: 17 shift/reduce, 0 reduce/reduce)
 # ============================================================================
 # Every remaining conflict is a shift/reduce whose default resolution (shift)
 # is the correct Java reading. They fall into seven families; the items
@@ -57,15 +57,22 @@ grammar 'Java';
 #    access/sizing) or greedily extends the dims list; no input is lost.
 #    See the NOTEs at Dims and PrimaryNoPostfix.
 #
-# 6. '<' commits to type arguments - 3 states, 1 conflict each on '<':
+# 6. '<' commits to type arguments - 2 states, 1 conflict each on '<':
 #    after CompoundName at statement start and in a cast head (reduce: bare-
-#    name primary, as in family 5), and in a pure type position (reduce:
-#    Type -> CompoundName, whose only following '<' would be
-#    'x instanceof T < y'). Standard for LALR Java parsers; see the NOTE at
-#    TypeArguments. Only the cast-head state loses real input ('(a < b)' as
-#    a parenthesized primary, see KNOWN LIMITATION at CastExpression); the
-#    other two reject only semantically invalid Java ('a < b;' as a bare
-#    statement-expression, 'x instanceof T < y').
+#    name primary, as in family 5). Standard for LALR Java parsers; see the
+#    NOTE at TypeArguments. Only the cast-head state loses real input
+#    ('(a < b)' as a parenthesized primary, see KNOWN LIMITATION at
+#    CastExpression); the other rejects only semantically invalid Java
+#    ('a < b;' as a bare statement-expression). The family's third state -
+#    pure type position, reduce Type -> CompoundName, whose lookahead held
+#    '<' only through 'x instanceof T < y' - vanished when
+#    RelationalExpression became non-associative: '<' no longer follows a
+#    complete relational operand. The same restructure lets ShiftOp be
+#    composed from single '>' tokens with NO conflict at all: RelationalOp
+#    '>' and ShiftOp '>' '>' share the shift of the first '>', and the next
+#    token splits them deterministically (another '>' extends the shift
+#    operator, an operand start reduces RelationalOp). See the NOTEs at
+#    RelationalExpression and ShiftOp.
 #
 # 7. QQ bootstrap dummy bracket - 1 state, 1 conflict. The quasi-quoter
 #    wraps a quote body in a per-rule dummy-token pair, and the whole-file
@@ -139,8 +146,18 @@ AnnotationList = Annotation* ;
 # left the inner one always empty.
 ModifierList = (Modifier | Annotation)* ;
 
-ExtendsList = 'extends' CompoundName (',' CompoundName)* ;
-ImplementsList = 'implements' CompoundName + ~',';
+# A supertype reference (JLS ClassOrInterfaceType): a possibly qualified
+# name with optional type arguments - Comparable<A>, java.util.List<String>.
+# The nullable TypeArguments directly after CompoundName is safe here: in
+# extends/implements position no expression interpretation competes, so the
+# epsilon-reduce of the empty TypeArguments (on ',', '{' or 'implements') is
+# the state's only action on those tokens and '<' is a plain shift into
+# NonEmptyTypeArguments. (Contrast with Type, which must spell out its
+# NonEmptyTypeArguments alternative; see the NOTE there.)
+ClassOrInterfaceType = CompoundName TypeArguments ;
+
+ExtendsList = 'extends' ClassOrInterfaceType (',' ClassOrInterfaceType)* ;
+ImplementsList = 'implements' ClassOrInterfaceType + ~',';
 FieldDeclarationList = FieldDeclaration *;
 
 ClassDeclaration  =
@@ -451,9 +468,34 @@ Expression : EqualityExpression = RelationalExpression | EqualityExpression Equa
 
 RelationalOp = '<' | '>' | '<=' | '>=' ;
 
-Expression : RelationalExpression = ShiftExpression | RelationalExpression RelationalOp ShiftExpression | RelationalExpression 'instanceof' Type ;
+# Non-associative on purpose: both operands are ShiftExpressions, not the
+# JLS's left-recursive RelationalExpression. This is what lets ShiftOp below
+# be composed from single '>' tokens: RelationalOp and ShiftOp are then
+# expected from the SAME automaton state, so a lone '>' is shifted without
+# committing and the NEXT token decides - a second '>' extends a shift
+# operator, an operand start reduces RelationalOp '>'. With a left-recursive
+# first operand that decision would instead be a reduce-vs-shift at the
+# FIRST '>' (reduce to RelationalExpression to compare vs shift into
+# ShiftOp), and happy's shift preference would make every plain 'a > b'
+# unparseable. Cost: a chained relational ('a < b < c') is now a parse
+# error instead of a semantic error - no loss for valid Java, where a
+# relational result (boolean) admits no further relational operator.
+# 'instanceof' keeps its left-recursive operand: the keyword follows a
+# COMPLETE relational expression, so shifting it needs no early commitment.
+Expression : RelationalExpression = ShiftExpression | ShiftExpression RelationalOp ShiftExpression | RelationalExpression 'instanceof' Type ;
 
-ShiftOp = '>>' | '<<' | '>>>' ;
+# There are NO '>>'/'>>>' tokens: shift operators are composed in the parser
+# from adjacent '>' tokens. RTK collects lexer literals from the rule text,
+# so once no rule spells '>>'/'>>>', the input '>>' lexes as two '>' tokens:
+# in 'Map<String, List<String>>' each '>' closes one TypeArguments level,
+# while in 'a >> b' the parser assembles the operator from the two tokens
+# (see the RelationalExpression NOTE above for why that is decidable).
+# '>>=' and '>>>=' STAY single tokens in AssignmentOp: in valid Java those
+# character sequences are always the assignment operator (a type-argument
+# closer is never followed directly by '='). Trade-off: token adjacency is
+# not checked, so a spaced 'a > > b' is (wrongly but harmlessly) accepted
+# as 'a >> b'.
+ShiftOp = '<<' | '>' '>' | '>' '>' '>' ;
 
 Expression : ShiftExpression = AdditiveExpression | ShiftExpression ShiftOp AdditiveExpression ;
 
@@ -555,8 +597,8 @@ Arglist = (Expression (',' Expression)*)? ;
 # NOTE: '<' is both the type-argument opener (List<String>) and the
 # comparison operator (x < y). Wherever a CompoundName can be followed by
 # either, the parser shifts '<' into NonEmptyTypeArguments (standard for
-# Java parsers); see the shift/reduce inventory at CastExpression for the
-# three states where this surfaces.
+# Java parsers); see family 6 of the conflict inventory at the top of this
+# file for the two states where this surfaces.
 TypeArguments = NonEmptyTypeArguments? ;
 
 # Non-optional variant: Type and CastExpression need the '<' to be a plain

--- a/test-grammars/java/lexical/operators.tokens
+++ b/test-grammars/java/lexical/operators.tokens
@@ -10,15 +10,15 @@ Tk__tok_int_24
 Tk__id "a"
 Tk__tok__eql__10
 Tk__integerLiteral "1"
-Tk__tok__plus__76
+Tk__tok__plus__74
 Tk__integerLiteral "2"
-Tk__tok__minus__77
+Tk__tok__minus__75
 Tk__integerLiteral "3"
 Tk__tok__star__5
 Tk__integerLiteral "4"
-Tk__tok__symbol__78
+Tk__tok__symbol__76
 Tk__integerLiteral "5"
-Tk__tok__symbol__79
+Tk__tok__symbol__77
 Tk__integerLiteral "6"
 Tk__tok__semi__1
 Tk__id "a"
@@ -69,18 +69,21 @@ Tk__tok_int_24
 Tk__id "b"
 Tk__tok__eql__10
 Tk__id "a"
-Tk__tok__symbol__symbol__74
+Tk__tok__symbol__symbol__73
 Tk__integerLiteral "1"
 Tk__tok__pipe__63
 Tk__id "a"
-Tk__tok__symbol__symbol__73
+Tk__tok__symbol__69
+Tk__tok__symbol__69
 Tk__integerLiteral "2"
 Tk__tok__symbol__65
 Tk__id "a"
-Tk__tok__symbol__symbol__symbol__75
+Tk__tok__symbol__69
+Tk__tok__symbol__69
+Tk__tok__symbol__69
 Tk__integerLiteral "3"
 Tk__tok__symbol__64
-Tk__tok__tilde__82
+Tk__tok__tilde__80
 Tk__id "a"
 Tk__tok__semi__1
 Tk__tok_boolean_20
@@ -113,19 +116,19 @@ Tk__tok__semi__1
 Tk__tok_boolean_20
 Tk__id "d"
 Tk__tok__eql__10
-Tk__tok__exclamation__83
+Tk__tok__exclamation__81
 Tk__id "c"
 Tk__tok__semi__1
 Tk__id "a"
-Tk__tok__plus__plus__80
+Tk__tok__plus__plus__78
 Tk__tok__semi__1
 Tk__id "a"
-Tk__tok__minus__minus__81
+Tk__tok__minus__minus__79
 Tk__tok__semi__1
-Tk__tok__plus__plus__80
+Tk__tok__plus__plus__78
 Tk__id "a"
 Tk__tok__semi__1
-Tk__tok__minus__minus__81
+Tk__tok__minus__minus__79
 Tk__id "a"
 Tk__tok__semi__1
 Tk__tok_int_24

--- a/test-suites/commons-lang-parser-blacklist-tests.txt
+++ b/test-suites/commons-lang-parser-blacklist-tests.txt
@@ -1,11 +1,13 @@
 # Blacklist for full parsing tests (test sources)
 # These files use features not yet supported by the grammar, chiefly:
-# - generic method calls / nested generics in expressions
-# - class literals (Foo.class), lambda expressions (->), method
-#   references (::), anonymous inner classes, enhanced for (:)
+# - lambda expressions (->), method references (::), class literals
+#   (Foo.class), anonymous inner classes, enhanced for (:)
 # - array initializers in 'new' (new int[] {...})
+# - the diamond operator (new HashMap<>())
+# - explicit constructor invocations (super(...) / this(...))
+# - generic method calls (Collections.<String>emptyList())
 #
-# Total: 205 files blacklisted, 62 files passing
+# Total: 200 files blacklisted, 67 files passing
 # As grammar support is added, remove files from this list
 
 org/apache/commons/lang3/AnnotationUtilsTest.java
@@ -109,8 +111,6 @@ org/apache/commons/lang3/concurrent/FutureTasksTest.java
 org/apache/commons/lang3/concurrent/LazyInitializerAnonClassTest.java
 org/apache/commons/lang3/concurrent/LazyInitializerCloserTest.java
 org/apache/commons/lang3/concurrent/LazyInitializerFailableCloserTest.java
-org/apache/commons/lang3/concurrent/LazyInitializerSimpleTest.java
-org/apache/commons/lang3/concurrent/LazyInitializerSingleInstanceTest.java
 org/apache/commons/lang3/concurrent/LazyInitializerSupplierTest.java
 org/apache/commons/lang3/concurrent/MemoizerComputableTest.java
 org/apache/commons/lang3/concurrent/MemoizerFunctionTest.java
@@ -127,7 +127,6 @@ org/apache/commons/lang3/exception/ContextedExceptionTest.java
 org/apache/commons/lang3/exception/ContextedRuntimeExceptionTest.java
 org/apache/commons/lang3/exception/CustomCheckedException.java
 org/apache/commons/lang3/exception/CustomUncheckedException.java
-org/apache/commons/lang3/exception/DefaultExceptionContextTest.java
 org/apache/commons/lang3/exception/ExceptionUtilsTest.java
 org/apache/commons/lang3/function/AnnotationTestFixture.java
 org/apache/commons/lang3/function/BooleanConsumerTest.java
@@ -171,9 +170,7 @@ org/apache/commons/lang3/reflect/MethodUtilsTest.java
 org/apache/commons/lang3/reflect/TypeLiteralTest.java
 org/apache/commons/lang3/reflect/TypeUtilsTest.java
 org/apache/commons/lang3/reflect/testbed/Annotated.java
-org/apache/commons/lang3/reflect/testbed/GenericParent.java
 org/apache/commons/lang3/reflect/testbed/PrivatelyShadowedChild.java
-org/apache/commons/lang3/reflect/testbed/StringParameterizedChild.java
 org/apache/commons/lang3/stream/FailableStreamTest.java
 org/apache/commons/lang3/stream/IntStreamsTest.java
 org/apache/commons/lang3/stream/LangCollectorsTest.java

--- a/test-suites/commons-lang-parser-blacklist.txt
+++ b/test-suites/commons-lang-parser-blacklist.txt
@@ -1,11 +1,13 @@
 # Blacklist for full parsing tests (main sources)
 # These files use features not yet supported by the grammar, chiefly:
-# - generic method calls / nested generics in expressions
-# - class literals (Foo.class), lambda expressions (->), method
-#   references (::), anonymous inner classes, enhanced for (:)
+# - lambda expressions (->), method references (::), class literals
+#   (Foo.class), anonymous inner classes, enhanced for (:)
+# - explicit constructor invocations (super(...) / this(...))
+# - the diamond operator (new HashMap<>())
 # - a doc comment directly before 'package' (package-info.java)
+# - generic methods with a void/primitive return type (<T> void m(...))
 #
-# Total: 206 files blacklisted, 53 files passing
+# Total: 186 files blacklisted, 73 files passing
 # As grammar support is added, remove files from this list
 
 org/apache/commons/lang3/AnnotationUtils.java
@@ -14,7 +16,6 @@ org/apache/commons/lang3/ArchUtils.java
 org/apache/commons/lang3/ArrayUtils.java
 org/apache/commons/lang3/BooleanUtils.java
 org/apache/commons/lang3/CachedRandomBits.java
-org/apache/commons/lang3/CharRange.java
 org/apache/commons/lang3/CharSequenceUtils.java
 org/apache/commons/lang3/CharSet.java
 org/apache/commons/lang3/CharSetUtils.java
@@ -47,8 +48,6 @@ org/apache/commons/lang3/ThreadUtils.java
 org/apache/commons/lang3/Validate.java
 org/apache/commons/lang3/arch/Processor.java
 org/apache/commons/lang3/arch/package-info.java
-org/apache/commons/lang3/builder/AbstractSupplier.java
-org/apache/commons/lang3/builder/CompareToBuilder.java
 org/apache/commons/lang3/builder/Diff.java
 org/apache/commons/lang3/builder/DiffBuilder.java
 org/apache/commons/lang3/builder/DiffResult.java
@@ -62,28 +61,22 @@ org/apache/commons/lang3/builder/ToStringBuilder.java
 org/apache/commons/lang3/builder/ToStringStyle.java
 org/apache/commons/lang3/builder/package-info.java
 org/apache/commons/lang3/compare/ComparableUtils.java
-org/apache/commons/lang3/compare/ObjectToStringComparator.java
 org/apache/commons/lang3/compare/package-info.java
 org/apache/commons/lang3/concurrent/AbstractCircuitBreaker.java
 org/apache/commons/lang3/concurrent/AbstractConcurrentInitializer.java
-org/apache/commons/lang3/concurrent/AbstractFutureProxy.java
 org/apache/commons/lang3/concurrent/AtomicInitializer.java
 org/apache/commons/lang3/concurrent/AtomicSafeInitializer.java
 org/apache/commons/lang3/concurrent/BackgroundInitializer.java
-org/apache/commons/lang3/concurrent/BasicThreadFactory.java
 org/apache/commons/lang3/concurrent/CallableBackgroundInitializer.java
 org/apache/commons/lang3/concurrent/CircuitBreakingException.java
 org/apache/commons/lang3/concurrent/ConcurrentException.java
-org/apache/commons/lang3/concurrent/ConcurrentInitializer.java
 org/apache/commons/lang3/concurrent/ConcurrentRuntimeException.java
 org/apache/commons/lang3/concurrent/ConcurrentUtils.java
-org/apache/commons/lang3/concurrent/ConstantInitializer.java
 org/apache/commons/lang3/concurrent/EventCountCircuitBreaker.java
 org/apache/commons/lang3/concurrent/FutureTasks.java
 org/apache/commons/lang3/concurrent/LazyInitializer.java
 org/apache/commons/lang3/concurrent/Memoizer.java
 org/apache/commons/lang3/concurrent/MultiBackgroundInitializer.java
-org/apache/commons/lang3/concurrent/ThresholdCircuitBreaker.java
 org/apache/commons/lang3/concurrent/TimedSemaphore.java
 org/apache/commons/lang3/concurrent/UncheckedExecutionException.java
 org/apache/commons/lang3/concurrent/UncheckedFuture.java
@@ -99,7 +92,6 @@ org/apache/commons/lang3/exception/CloneFailedException.java
 org/apache/commons/lang3/exception/ContextedException.java
 org/apache/commons/lang3/exception/ContextedRuntimeException.java
 org/apache/commons/lang3/exception/DefaultExceptionContext.java
-org/apache/commons/lang3/exception/ExceptionContext.java
 org/apache/commons/lang3/exception/ExceptionUtils.java
 org/apache/commons/lang3/exception/UncheckedException.java
 org/apache/commons/lang3/exception/UncheckedIllegalAccessException.java
@@ -153,18 +145,9 @@ org/apache/commons/lang3/function/Suppliers.java
 org/apache/commons/lang3/function/TriConsumer.java
 org/apache/commons/lang3/function/TriFunction.java
 org/apache/commons/lang3/function/package-info.java
-org/apache/commons/lang3/math/Fraction.java
 org/apache/commons/lang3/math/NumberUtils.java
 org/apache/commons/lang3/math/package-info.java
 org/apache/commons/lang3/mutable/Mutable.java
-org/apache/commons/lang3/mutable/MutableBoolean.java
-org/apache/commons/lang3/mutable/MutableByte.java
-org/apache/commons/lang3/mutable/MutableDouble.java
-org/apache/commons/lang3/mutable/MutableFloat.java
-org/apache/commons/lang3/mutable/MutableInt.java
-org/apache/commons/lang3/mutable/MutableLong.java
-org/apache/commons/lang3/mutable/MutableObject.java
-org/apache/commons/lang3/mutable/MutableShort.java
 org/apache/commons/lang3/mutable/package-info.java
 org/apache/commons/lang3/package-info.java
 org/apache/commons/lang3/reflect/ConstructorUtils.java
@@ -209,7 +192,6 @@ org/apache/commons/lang3/tuple/ImmutableTriple.java
 org/apache/commons/lang3/tuple/MutablePair.java
 org/apache/commons/lang3/tuple/MutableTriple.java
 org/apache/commons/lang3/tuple/Pair.java
-org/apache/commons/lang3/tuple/Triple.java
 org/apache/commons/lang3/tuple/package-info.java
 org/apache/commons/lang3/util/FluentBitSet.java
 org/apache/commons/lang3/util/IterableStringTokenizer.java

--- a/test/golden/java/JavaLexer.x
+++ b/test/golden/java/JavaLexer.x
@@ -10,18 +10,19 @@ import Data.Data (Data)
 @exponentPart = ([eE]  ("+"| "-") ?  [0-9]  ([0-9_]*  [0-9]) ?)
 @floatTypeSuffix = ([fFdD])
 
-tokens :- "tok_AdditiveOp_dummy_176" { simple Tk__tok_AdditiveOp_dummy_176 }
-          "tok_Annotation_dummy_175" { simple Tk__tok_Annotation_dummy_175 }
-          "tok_AnnotationArguments_dummy_174" { simple Tk__tok_AnnotationArguments_dummy_174 }
-          "tok_AnnotationDeclaration_dummy_173" { simple Tk__tok_AnnotationDeclaration_dummy_173 }
-          "tok_AnnotationElement_dummy_172" { simple Tk__tok_AnnotationElement_dummy_172 }
-          "tok_AnnotationList_dummy_171" { simple Tk__tok_AnnotationList_dummy_171 }
-          "tok_AnnotationTypeElement_dummy_170" { simple Tk__tok_AnnotationTypeElement_dummy_170 }
-          "tok_AnnotationTypeElementList_dummy_169" { simple Tk__tok_AnnotationTypeElementList_dummy_169 }
-          "tok_Arglist_dummy_168" { simple Tk__tok_Arglist_dummy_168 }
-          "tok_AssignmentOp_dummy_167" { simple Tk__tok_AssignmentOp_dummy_167 }
-          "tok_CatchList_dummy_166" { simple Tk__tok_CatchList_dummy_166 }
-          "tok_ClassDeclaration_dummy_165" { simple Tk__tok_ClassDeclaration_dummy_165 }
+tokens :- "tok_AdditiveOp_dummy_177" { simple Tk__tok_AdditiveOp_dummy_177 }
+          "tok_Annotation_dummy_176" { simple Tk__tok_Annotation_dummy_176 }
+          "tok_AnnotationArguments_dummy_175" { simple Tk__tok_AnnotationArguments_dummy_175 }
+          "tok_AnnotationDeclaration_dummy_174" { simple Tk__tok_AnnotationDeclaration_dummy_174 }
+          "tok_AnnotationElement_dummy_173" { simple Tk__tok_AnnotationElement_dummy_173 }
+          "tok_AnnotationList_dummy_172" { simple Tk__tok_AnnotationList_dummy_172 }
+          "tok_AnnotationTypeElement_dummy_171" { simple Tk__tok_AnnotationTypeElement_dummy_171 }
+          "tok_AnnotationTypeElementList_dummy_170" { simple Tk__tok_AnnotationTypeElementList_dummy_170 }
+          "tok_Arglist_dummy_169" { simple Tk__tok_Arglist_dummy_169 }
+          "tok_AssignmentOp_dummy_168" { simple Tk__tok_AssignmentOp_dummy_168 }
+          "tok_CatchList_dummy_167" { simple Tk__tok_CatchList_dummy_167 }
+          "tok_ClassDeclaration_dummy_166" { simple Tk__tok_ClassDeclaration_dummy_166 }
+          "tok_ClassOrInterfaceType_dummy_165" { simple Tk__tok_ClassOrInterfaceType_dummy_165 }
           "tok_CompilationUnit_dummy_164" { simple Tk__tok_CompilationUnit_dummy_164 }
           "tok_CompoundName_dummy_163" { simple Tk__tok_CompoundName_dummy_163 }
           "tok_CreationExpression_dummy_162" { simple Tk__tok_CreationExpression_dummy_162 }
@@ -45,7 +46,7 @@ tokens :- "tok_AdditiveOp_dummy_176" { simple Tk__tok_AdditiveOp_dummy_176 }
           "tok_ImportName_dummy_144" { simple Tk__tok_ImportName_dummy_144 }
           "tok_ImportStatement_dummy_143" { simple Tk__tok_ImportStatement_dummy_143 }
           "tok_InterfaceDeclaration_dummy_142" { simple Tk__tok_InterfaceDeclaration_dummy_142 }
-          "tok_Java_dummy_177" { simple Tk__tok_Java_dummy_177 }
+          "tok_Java_dummy_178" { simple Tk__tok_Java_dummy_178 }
           "tok_Literal_dummy_141" { simple Tk__tok_Literal_dummy_141 }
           "tok_LocalModifierList1_dummy_140" { simple Tk__tok_LocalModifierList1_dummy_140 }
           "tok_MemberAfterFirstId_dummy_139" { simple Tk__tok_MemberAfterFirstId_dummy_139 }
@@ -96,7 +97,7 @@ tokens :- "tok_AdditiveOp_dummy_176" { simple Tk__tok_AdditiveOp_dummy_176 }
           "tok_VariableInitializerList_dummy_94" { simple Tk__tok_VariableInitializerList_dummy_94 }
           "tok_WhileStatement_dummy_93" { simple Tk__tok_WhileStatement_dummy_93 }
           "tok_WildcardType_dummy_92" { simple Tk__tok_WildcardType_dummy_92 }
-          "~" { simple Tk__tok__tilde__82 }
+          "~" { simple Tk__tok__tilde__80 }
           "}" { simple Tk__tok__symbol__15 }
           "||" { simple Tk__tok__pipe__pipe__61 }
           "|=" { simple Tk__tok__pipe__eql__53 }
@@ -105,25 +106,25 @@ tokens :- "tok_AdditiveOp_dummy_176" { simple Tk__tok_AdditiveOp_dummy_176 }
           "while" { simple Tk__tok_while_42 }
           "void" { simple Tk__tok_void_28 }
           "try" { simple Tk__tok_try_46 }
-          "true" { simple Tk__tok_true_87 }
-          "transient" { simple Tk__tok_transient_96 }
+          "true" { simple Tk__tok_true_85 }
+          "transient" { simple Tk__tok_transient_94 }
           "throws" { simple Tk__tok_throws_29 }
           "throw" { simple Tk__tok_throw_35 }
-          "threadsafe" { simple Tk__tok_threadsafe_95 }
-          "this" { simple Tk__tok_this_84 }
+          "threadsafe" { simple Tk__tok_threadsafe_93 }
+          "this" { simple Tk__tok_this_82 }
           "synchronized" { simple Tk__tok_synchronized_34 }
           "switch" { simple Tk__tok_switch_48 }
-          "super" { simple Tk__tok_super_85 }
+          "super" { simple Tk__tok_super_83 }
           "static" { simple Tk__tok_static_3 }
           "short" { simple Tk__tok_short_23 }
           "return" { simple Tk__tok_return_33 }
-          "public" { simple Tk__tok_public_90 }
-          "protected" { simple Tk__tok_protected_92 }
-          "private" { simple Tk__tok_private_91 }
+          "public" { simple Tk__tok_public_88 }
+          "protected" { simple Tk__tok_protected_90 }
+          "private" { simple Tk__tok_private_89 }
           "package" { simple Tk__tok_package_0 }
-          "null" { simple Tk__tok_null_89 }
-          "new" { simple Tk__tok_new_86 }
-          "native" { simple Tk__tok_native_93 }
+          "null" { simple Tk__tok_null_87 }
+          "new" { simple Tk__tok_new_84 }
+          "native" { simple Tk__tok_native_91 }
           "long" { simple Tk__tok_long_26 }
           "interface" { simple Tk__tok_interface_16 }
           "int" { simple Tk__tok_int_24 }
@@ -135,7 +136,7 @@ tokens :- "tok_AdditiveOp_dummy_176" { simple Tk__tok_AdditiveOp_dummy_176 }
           "float" { simple Tk__tok_float_25 }
           "finally" { simple Tk__tok_finally_45 }
           "final" { simple Tk__tok_final_31 }
-          "false" { simple Tk__tok_false_88 }
+          "false" { simple Tk__tok_false_86 }
           "extends" { simple Tk__tok_extends_11 }
           "enum" { simple Tk__tok_enum_17 }
           "else" { simple Tk__tok_else_39 }
@@ -150,7 +151,7 @@ tokens :- "tok_AdditiveOp_dummy_176" { simple Tk__tok_AdditiveOp_dummy_176 }
           "byte" { simple Tk__tok_byte_21 }
           "break" { simple Tk__tok_break_37 }
           "boolean" { simple Tk__tok_boolean_20 }
-          "abstract" { simple Tk__tok_abstract_94 }
+          "abstract" { simple Tk__tok_abstract_92 }
           "^=" { simple Tk__tok__symbol__eql__55 }
           "^" { simple Tk__tok__symbol__64 }
           "]" { simple Tk__tok__sq_bkt_r__19 }
@@ -158,30 +159,28 @@ tokens :- "tok_AdditiveOp_dummy_176" { simple Tk__tok_AdditiveOp_dummy_176 }
           "@" { simple Tk__tok__symbol__6 }
           "?" { simple Tk__tok__symbol__60 }
           ">>>=" { simple Tk__tok__symbol__symbol__symbol__eql__59 }
-          ">>>" { simple Tk__tok__symbol__symbol__symbol__75 }
           ">>=" { simple Tk__tok__symbol__symbol__eql__58 }
-          ">>" { simple Tk__tok__symbol__symbol__73 }
           ">=" { simple Tk__tok__symbol__eql__71 }
           ">" { simple Tk__tok__symbol__69 }
           "==" { simple Tk__tok__eql__eql__66 }
           "=" { simple Tk__tok__eql__10 }
           "<=" { simple Tk__tok__symbol__eql__70 }
           "<<=" { simple Tk__tok__symbol__symbol__eql__57 }
-          "<<" { simple Tk__tok__symbol__symbol__74 }
+          "<<" { simple Tk__tok__symbol__symbol__73 }
           "<" { simple Tk__tok__symbol__68 }
           ";" { simple Tk__tok__semi__1 }
           ":" { simple Tk__tok__colon__36 }
           "/=" { simple Tk__tok__symbol__eql__52 }
-          "/" { simple Tk__tok__symbol__78 }
+          "/" { simple Tk__tok__symbol__76 }
           "..." { simple Tk__tok__dot__dot__dot__32 }
           "." { simple Tk__tok__dot__4 }
           "-=" { simple Tk__tok__minus__eql__50 }
-          "--" { simple Tk__tok__minus__minus__81 }
-          "-" { simple Tk__tok__minus__77 }
+          "--" { simple Tk__tok__minus__minus__79 }
+          "-" { simple Tk__tok__minus__75 }
           "," { simple Tk__tok__coma__9 }
           "+=" { simple Tk__tok__plus__eql__49 }
-          "++" { simple Tk__tok__plus__plus__80 }
-          "+" { simple Tk__tok__plus__76 }
+          "++" { simple Tk__tok__plus__plus__78 }
+          "+" { simple Tk__tok__plus__74 }
           "*=" { simple Tk__tok__star__eql__51 }
           "*" { simple Tk__tok__star__5 }
           ")" { simple Tk__tok__rparen__8 }
@@ -190,9 +189,9 @@ tokens :- "tok_AdditiveOp_dummy_176" { simple Tk__tok_AdditiveOp_dummy_176 }
           "&&" { simple Tk__tok__symbol__symbol__62 }
           "&" { simple Tk__tok__symbol__65 }
           "%=" { simple Tk__tok__symbol__eql__56 }
-          "%" { simple Tk__tok__symbol__79 }
+          "%" { simple Tk__tok__symbol__77 }
           "!=" { simple Tk__tok__exclamation__eql__67 }
-          "!" { simple Tk__tok__exclamation__83 }
+          "!" { simple Tk__tok__exclamation__81 }
           ("/*"  ([^\*\n]| [\n])  ([\n]| [^\*\n]| [\*]  [^\/\n]| [\*]  [\n])*  "*/") ;
           ("//"  [^\n]*  \n) ;
           ([\ \t\n\r]+) ;
@@ -275,6 +274,7 @@ tokens :- "tok_AdditiveOp_dummy_176" { simple Tk__tok_AdditiveOp_dummy_176 }
           ("$"  "FieldDeclarationList"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_FieldDeclarationList . ((tail . dropWhile (/= ':'))) }
           ("$"  "ImplementsList"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_ImplementsList . ((tail . dropWhile (/= ':'))) }
           ("$"  "ExtendsList"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_ExtendsList . ((tail . dropWhile (/= ':'))) }
+          ("$"  "ClassOrInterfaceType"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_ClassOrInterfaceType . ((tail . dropWhile (/= ':'))) }
           ("$"  "ModifierList"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_ModifierList . ((tail . dropWhile (/= ':'))) }
           ("$"  "AnnotationList"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_AnnotationList . ((tail . dropWhile (/= ':'))) }
           ("$"  "AnnotationElement"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_AnnotationElement . ((tail . dropWhile (/= ':'))) }
@@ -294,18 +294,19 @@ tokens :- "tok_AdditiveOp_dummy_176" { simple Tk__tok_AdditiveOp_dummy_176 }
 
 {
 data Token = EndOfFile |
-             Tk__tok_AdditiveOp_dummy_176 |
-             Tk__tok_Annotation_dummy_175 |
-             Tk__tok_AnnotationArguments_dummy_174 |
-             Tk__tok_AnnotationDeclaration_dummy_173 |
-             Tk__tok_AnnotationElement_dummy_172 |
-             Tk__tok_AnnotationList_dummy_171 |
-             Tk__tok_AnnotationTypeElement_dummy_170 |
-             Tk__tok_AnnotationTypeElementList_dummy_169 |
-             Tk__tok_Arglist_dummy_168 |
-             Tk__tok_AssignmentOp_dummy_167 |
-             Tk__tok_CatchList_dummy_166 |
-             Tk__tok_ClassDeclaration_dummy_165 |
+             Tk__tok_AdditiveOp_dummy_177 |
+             Tk__tok_Annotation_dummy_176 |
+             Tk__tok_AnnotationArguments_dummy_175 |
+             Tk__tok_AnnotationDeclaration_dummy_174 |
+             Tk__tok_AnnotationElement_dummy_173 |
+             Tk__tok_AnnotationList_dummy_172 |
+             Tk__tok_AnnotationTypeElement_dummy_171 |
+             Tk__tok_AnnotationTypeElementList_dummy_170 |
+             Tk__tok_Arglist_dummy_169 |
+             Tk__tok_AssignmentOp_dummy_168 |
+             Tk__tok_CatchList_dummy_167 |
+             Tk__tok_ClassDeclaration_dummy_166 |
+             Tk__tok_ClassOrInterfaceType_dummy_165 |
              Tk__tok_CompilationUnit_dummy_164 |
              Tk__tok_CompoundName_dummy_163 |
              Tk__tok_CreationExpression_dummy_162 |
@@ -329,7 +330,7 @@ data Token = EndOfFile |
              Tk__tok_ImportName_dummy_144 |
              Tk__tok_ImportStatement_dummy_143 |
              Tk__tok_InterfaceDeclaration_dummy_142 |
-             Tk__tok_Java_dummy_177 |
+             Tk__tok_Java_dummy_178 |
              Tk__tok_Literal_dummy_141 |
              Tk__tok_LocalModifierList1_dummy_140 |
              Tk__tok_MemberAfterFirstId_dummy_139 |
@@ -380,7 +381,7 @@ data Token = EndOfFile |
              Tk__tok_VariableInitializerList_dummy_94 |
              Tk__tok_WhileStatement_dummy_93 |
              Tk__tok_WildcardType_dummy_92 |
-             Tk__tok__tilde__82 |
+             Tk__tok__tilde__80 |
              Tk__tok__symbol__15 |
              Tk__tok__pipe__pipe__61 |
              Tk__tok__pipe__eql__53 |
@@ -389,25 +390,25 @@ data Token = EndOfFile |
              Tk__tok_while_42 |
              Tk__tok_void_28 |
              Tk__tok_try_46 |
-             Tk__tok_true_87 |
-             Tk__tok_transient_96 |
+             Tk__tok_true_85 |
+             Tk__tok_transient_94 |
              Tk__tok_throws_29 |
              Tk__tok_throw_35 |
-             Tk__tok_threadsafe_95 |
-             Tk__tok_this_84 |
+             Tk__tok_threadsafe_93 |
+             Tk__tok_this_82 |
              Tk__tok_synchronized_34 |
              Tk__tok_switch_48 |
-             Tk__tok_super_85 |
+             Tk__tok_super_83 |
              Tk__tok_static_3 |
              Tk__tok_short_23 |
              Tk__tok_return_33 |
-             Tk__tok_public_90 |
-             Tk__tok_protected_92 |
-             Tk__tok_private_91 |
+             Tk__tok_public_88 |
+             Tk__tok_protected_90 |
+             Tk__tok_private_89 |
              Tk__tok_package_0 |
-             Tk__tok_null_89 |
-             Tk__tok_new_86 |
-             Tk__tok_native_93 |
+             Tk__tok_null_87 |
+             Tk__tok_new_84 |
+             Tk__tok_native_91 |
              Tk__tok_long_26 |
              Tk__tok_interface_16 |
              Tk__tok_int_24 |
@@ -419,7 +420,7 @@ data Token = EndOfFile |
              Tk__tok_float_25 |
              Tk__tok_finally_45 |
              Tk__tok_final_31 |
-             Tk__tok_false_88 |
+             Tk__tok_false_86 |
              Tk__tok_extends_11 |
              Tk__tok_enum_17 |
              Tk__tok_else_39 |
@@ -434,7 +435,7 @@ data Token = EndOfFile |
              Tk__tok_byte_21 |
              Tk__tok_break_37 |
              Tk__tok_boolean_20 |
-             Tk__tok_abstract_94 |
+             Tk__tok_abstract_92 |
              Tk__tok__symbol__eql__55 |
              Tk__tok__symbol__64 |
              Tk__tok__sq_bkt_r__19 |
@@ -442,30 +443,28 @@ data Token = EndOfFile |
              Tk__tok__symbol__6 |
              Tk__tok__symbol__60 |
              Tk__tok__symbol__symbol__symbol__eql__59 |
-             Tk__tok__symbol__symbol__symbol__75 |
              Tk__tok__symbol__symbol__eql__58 |
-             Tk__tok__symbol__symbol__73 |
              Tk__tok__symbol__eql__71 |
              Tk__tok__symbol__69 |
              Tk__tok__eql__eql__66 |
              Tk__tok__eql__10 |
              Tk__tok__symbol__eql__70 |
              Tk__tok__symbol__symbol__eql__57 |
-             Tk__tok__symbol__symbol__74 |
+             Tk__tok__symbol__symbol__73 |
              Tk__tok__symbol__68 |
              Tk__tok__semi__1 |
              Tk__tok__colon__36 |
              Tk__tok__symbol__eql__52 |
-             Tk__tok__symbol__78 |
+             Tk__tok__symbol__76 |
              Tk__tok__dot__dot__dot__32 |
              Tk__tok__dot__4 |
              Tk__tok__minus__eql__50 |
-             Tk__tok__minus__minus__81 |
-             Tk__tok__minus__77 |
+             Tk__tok__minus__minus__79 |
+             Tk__tok__minus__75 |
              Tk__tok__coma__9 |
              Tk__tok__plus__eql__49 |
-             Tk__tok__plus__plus__80 |
-             Tk__tok__plus__76 |
+             Tk__tok__plus__plus__78 |
+             Tk__tok__plus__74 |
              Tk__tok__star__eql__51 |
              Tk__tok__star__5 |
              Tk__tok__rparen__8 |
@@ -474,9 +473,9 @@ data Token = EndOfFile |
              Tk__tok__symbol__symbol__62 |
              Tk__tok__symbol__65 |
              Tk__tok__symbol__eql__56 |
-             Tk__tok__symbol__79 |
+             Tk__tok__symbol__77 |
              Tk__tok__exclamation__eql__67 |
-             Tk__tok__exclamation__83 |
+             Tk__tok__exclamation__81 |
              Tk__doccomment String |
              Tk__id String |
              Tk__string String |
@@ -556,6 +555,7 @@ data Token = EndOfFile |
              Tk__qq_FieldDeclarationList String |
              Tk__qq_ImplementsList String |
              Tk__qq_ExtendsList String |
+             Tk__qq_ClassOrInterfaceType String |
              Tk__qq_ModifierList String |
              Tk__qq_AnnotationList String |
              Tk__qq_AnnotationElement String |

--- a/test/golden/java/JavaParser.y
+++ b/test/golden/java/JavaParser.y
@@ -13,18 +13,19 @@ import qualified JavaLexer as L (Token(..), PosToken(..), AlexPosn(..), alexScan
 %token
 
 rtk__eof { L.PosToken _ L.EndOfFile }
-tok_AdditiveOp_dummy_176 { L.PosToken _ L.Tk__tok_AdditiveOp_dummy_176 }
-tok_Annotation_dummy_175 { L.PosToken _ L.Tk__tok_Annotation_dummy_175 }
-tok_AnnotationArguments_dummy_174 { L.PosToken _ L.Tk__tok_AnnotationArguments_dummy_174 }
-tok_AnnotationDeclaration_dummy_173 { L.PosToken _ L.Tk__tok_AnnotationDeclaration_dummy_173 }
-tok_AnnotationElement_dummy_172 { L.PosToken _ L.Tk__tok_AnnotationElement_dummy_172 }
-tok_AnnotationList_dummy_171 { L.PosToken _ L.Tk__tok_AnnotationList_dummy_171 }
-tok_AnnotationTypeElement_dummy_170 { L.PosToken _ L.Tk__tok_AnnotationTypeElement_dummy_170 }
-tok_AnnotationTypeElementList_dummy_169 { L.PosToken _ L.Tk__tok_AnnotationTypeElementList_dummy_169 }
-tok_Arglist_dummy_168 { L.PosToken _ L.Tk__tok_Arglist_dummy_168 }
-tok_AssignmentOp_dummy_167 { L.PosToken _ L.Tk__tok_AssignmentOp_dummy_167 }
-tok_CatchList_dummy_166 { L.PosToken _ L.Tk__tok_CatchList_dummy_166 }
-tok_ClassDeclaration_dummy_165 { L.PosToken _ L.Tk__tok_ClassDeclaration_dummy_165 }
+tok_AdditiveOp_dummy_177 { L.PosToken _ L.Tk__tok_AdditiveOp_dummy_177 }
+tok_Annotation_dummy_176 { L.PosToken _ L.Tk__tok_Annotation_dummy_176 }
+tok_AnnotationArguments_dummy_175 { L.PosToken _ L.Tk__tok_AnnotationArguments_dummy_175 }
+tok_AnnotationDeclaration_dummy_174 { L.PosToken _ L.Tk__tok_AnnotationDeclaration_dummy_174 }
+tok_AnnotationElement_dummy_173 { L.PosToken _ L.Tk__tok_AnnotationElement_dummy_173 }
+tok_AnnotationList_dummy_172 { L.PosToken _ L.Tk__tok_AnnotationList_dummy_172 }
+tok_AnnotationTypeElement_dummy_171 { L.PosToken _ L.Tk__tok_AnnotationTypeElement_dummy_171 }
+tok_AnnotationTypeElementList_dummy_170 { L.PosToken _ L.Tk__tok_AnnotationTypeElementList_dummy_170 }
+tok_Arglist_dummy_169 { L.PosToken _ L.Tk__tok_Arglist_dummy_169 }
+tok_AssignmentOp_dummy_168 { L.PosToken _ L.Tk__tok_AssignmentOp_dummy_168 }
+tok_CatchList_dummy_167 { L.PosToken _ L.Tk__tok_CatchList_dummy_167 }
+tok_ClassDeclaration_dummy_166 { L.PosToken _ L.Tk__tok_ClassDeclaration_dummy_166 }
+tok_ClassOrInterfaceType_dummy_165 { L.PosToken _ L.Tk__tok_ClassOrInterfaceType_dummy_165 }
 tok_CompilationUnit_dummy_164 { L.PosToken _ L.Tk__tok_CompilationUnit_dummy_164 }
 tok_CompoundName_dummy_163 { L.PosToken _ L.Tk__tok_CompoundName_dummy_163 }
 tok_CreationExpression_dummy_162 { L.PosToken _ L.Tk__tok_CreationExpression_dummy_162 }
@@ -48,7 +49,7 @@ tok_ImportList_dummy_145 { L.PosToken _ L.Tk__tok_ImportList_dummy_145 }
 tok_ImportName_dummy_144 { L.PosToken _ L.Tk__tok_ImportName_dummy_144 }
 tok_ImportStatement_dummy_143 { L.PosToken _ L.Tk__tok_ImportStatement_dummy_143 }
 tok_InterfaceDeclaration_dummy_142 { L.PosToken _ L.Tk__tok_InterfaceDeclaration_dummy_142 }
-tok_Java_dummy_177 { L.PosToken _ L.Tk__tok_Java_dummy_177 }
+tok_Java_dummy_178 { L.PosToken _ L.Tk__tok_Java_dummy_178 }
 tok_Literal_dummy_141 { L.PosToken _ L.Tk__tok_Literal_dummy_141 }
 tok_LocalModifierList1_dummy_140 { L.PosToken _ L.Tk__tok_LocalModifierList1_dummy_140 }
 tok_MemberAfterFirstId_dummy_139 { L.PosToken _ L.Tk__tok_MemberAfterFirstId_dummy_139 }
@@ -99,7 +100,7 @@ tok_VariableInitializer_dummy_95 { L.PosToken _ L.Tk__tok_VariableInitializer_du
 tok_VariableInitializerList_dummy_94 { L.PosToken _ L.Tk__tok_VariableInitializerList_dummy_94 }
 tok_WhileStatement_dummy_93 { L.PosToken _ L.Tk__tok_WhileStatement_dummy_93 }
 tok_WildcardType_dummy_92 { L.PosToken _ L.Tk__tok_WildcardType_dummy_92 }
-tok__tilde__82 { L.PosToken _ L.Tk__tok__tilde__82 }
+tok__tilde__80 { L.PosToken _ L.Tk__tok__tilde__80 }
 tok__symbol__15 { L.PosToken _ L.Tk__tok__symbol__15 }
 tok__pipe__pipe__61 { L.PosToken _ L.Tk__tok__pipe__pipe__61 }
 tok__pipe__eql__53 { L.PosToken _ L.Tk__tok__pipe__eql__53 }
@@ -108,25 +109,25 @@ tok__symbol__14 { L.PosToken _ L.Tk__tok__symbol__14 }
 tok_while_42 { L.PosToken _ L.Tk__tok_while_42 }
 tok_void_28 { L.PosToken _ L.Tk__tok_void_28 }
 tok_try_46 { L.PosToken _ L.Tk__tok_try_46 }
-tok_true_87 { L.PosToken _ L.Tk__tok_true_87 }
-tok_transient_96 { L.PosToken _ L.Tk__tok_transient_96 }
+tok_true_85 { L.PosToken _ L.Tk__tok_true_85 }
+tok_transient_94 { L.PosToken _ L.Tk__tok_transient_94 }
 tok_throws_29 { L.PosToken _ L.Tk__tok_throws_29 }
 tok_throw_35 { L.PosToken _ L.Tk__tok_throw_35 }
-tok_threadsafe_95 { L.PosToken _ L.Tk__tok_threadsafe_95 }
-tok_this_84 { L.PosToken _ L.Tk__tok_this_84 }
+tok_threadsafe_93 { L.PosToken _ L.Tk__tok_threadsafe_93 }
+tok_this_82 { L.PosToken _ L.Tk__tok_this_82 }
 tok_synchronized_34 { L.PosToken _ L.Tk__tok_synchronized_34 }
 tok_switch_48 { L.PosToken _ L.Tk__tok_switch_48 }
-tok_super_85 { L.PosToken _ L.Tk__tok_super_85 }
+tok_super_83 { L.PosToken _ L.Tk__tok_super_83 }
 tok_static_3 { L.PosToken _ L.Tk__tok_static_3 }
 tok_short_23 { L.PosToken _ L.Tk__tok_short_23 }
 tok_return_33 { L.PosToken _ L.Tk__tok_return_33 }
-tok_public_90 { L.PosToken _ L.Tk__tok_public_90 }
-tok_protected_92 { L.PosToken _ L.Tk__tok_protected_92 }
-tok_private_91 { L.PosToken _ L.Tk__tok_private_91 }
+tok_public_88 { L.PosToken _ L.Tk__tok_public_88 }
+tok_protected_90 { L.PosToken _ L.Tk__tok_protected_90 }
+tok_private_89 { L.PosToken _ L.Tk__tok_private_89 }
 tok_package_0 { L.PosToken _ L.Tk__tok_package_0 }
-tok_null_89 { L.PosToken _ L.Tk__tok_null_89 }
-tok_new_86 { L.PosToken _ L.Tk__tok_new_86 }
-tok_native_93 { L.PosToken _ L.Tk__tok_native_93 }
+tok_null_87 { L.PosToken _ L.Tk__tok_null_87 }
+tok_new_84 { L.PosToken _ L.Tk__tok_new_84 }
+tok_native_91 { L.PosToken _ L.Tk__tok_native_91 }
 tok_long_26 { L.PosToken _ L.Tk__tok_long_26 }
 tok_interface_16 { L.PosToken _ L.Tk__tok_interface_16 }
 tok_int_24 { L.PosToken _ L.Tk__tok_int_24 }
@@ -138,7 +139,7 @@ tok_for_43 { L.PosToken _ L.Tk__tok_for_43 }
 tok_float_25 { L.PosToken _ L.Tk__tok_float_25 }
 tok_finally_45 { L.PosToken _ L.Tk__tok_finally_45 }
 tok_final_31 { L.PosToken _ L.Tk__tok_final_31 }
-tok_false_88 { L.PosToken _ L.Tk__tok_false_88 }
+tok_false_86 { L.PosToken _ L.Tk__tok_false_86 }
 tok_extends_11 { L.PosToken _ L.Tk__tok_extends_11 }
 tok_enum_17 { L.PosToken _ L.Tk__tok_enum_17 }
 tok_else_39 { L.PosToken _ L.Tk__tok_else_39 }
@@ -153,7 +154,7 @@ tok_case_47 { L.PosToken _ L.Tk__tok_case_47 }
 tok_byte_21 { L.PosToken _ L.Tk__tok_byte_21 }
 tok_break_37 { L.PosToken _ L.Tk__tok_break_37 }
 tok_boolean_20 { L.PosToken _ L.Tk__tok_boolean_20 }
-tok_abstract_94 { L.PosToken _ L.Tk__tok_abstract_94 }
+tok_abstract_92 { L.PosToken _ L.Tk__tok_abstract_92 }
 tok__symbol__eql__55 { L.PosToken _ L.Tk__tok__symbol__eql__55 }
 tok__symbol__64 { L.PosToken _ L.Tk__tok__symbol__64 }
 tok__sq_bkt_r__19 { L.PosToken _ L.Tk__tok__sq_bkt_r__19 }
@@ -161,30 +162,28 @@ tok__sq_bkt_l__18 { L.PosToken _ L.Tk__tok__sq_bkt_l__18 }
 tok__symbol__6 { L.PosToken _ L.Tk__tok__symbol__6 }
 tok__symbol__60 { L.PosToken _ L.Tk__tok__symbol__60 }
 tok__symbol__symbol__symbol__eql__59 { L.PosToken _ L.Tk__tok__symbol__symbol__symbol__eql__59 }
-tok__symbol__symbol__symbol__75 { L.PosToken _ L.Tk__tok__symbol__symbol__symbol__75 }
 tok__symbol__symbol__eql__58 { L.PosToken _ L.Tk__tok__symbol__symbol__eql__58 }
-tok__symbol__symbol__73 { L.PosToken _ L.Tk__tok__symbol__symbol__73 }
 tok__symbol__eql__71 { L.PosToken _ L.Tk__tok__symbol__eql__71 }
 tok__symbol__69 { L.PosToken _ L.Tk__tok__symbol__69 }
 tok__eql__eql__66 { L.PosToken _ L.Tk__tok__eql__eql__66 }
 tok__eql__10 { L.PosToken _ L.Tk__tok__eql__10 }
 tok__symbol__eql__70 { L.PosToken _ L.Tk__tok__symbol__eql__70 }
 tok__symbol__symbol__eql__57 { L.PosToken _ L.Tk__tok__symbol__symbol__eql__57 }
-tok__symbol__symbol__74 { L.PosToken _ L.Tk__tok__symbol__symbol__74 }
+tok__symbol__symbol__73 { L.PosToken _ L.Tk__tok__symbol__symbol__73 }
 tok__symbol__68 { L.PosToken _ L.Tk__tok__symbol__68 }
 tok__semi__1 { L.PosToken _ L.Tk__tok__semi__1 }
 tok__colon__36 { L.PosToken _ L.Tk__tok__colon__36 }
 tok__symbol__eql__52 { L.PosToken _ L.Tk__tok__symbol__eql__52 }
-tok__symbol__78 { L.PosToken _ L.Tk__tok__symbol__78 }
+tok__symbol__76 { L.PosToken _ L.Tk__tok__symbol__76 }
 tok__dot__dot__dot__32 { L.PosToken _ L.Tk__tok__dot__dot__dot__32 }
 tok__dot__4 { L.PosToken _ L.Tk__tok__dot__4 }
 tok__minus__eql__50 { L.PosToken _ L.Tk__tok__minus__eql__50 }
-tok__minus__minus__81 { L.PosToken _ L.Tk__tok__minus__minus__81 }
-tok__minus__77 { L.PosToken _ L.Tk__tok__minus__77 }
+tok__minus__minus__79 { L.PosToken _ L.Tk__tok__minus__minus__79 }
+tok__minus__75 { L.PosToken _ L.Tk__tok__minus__75 }
 tok__coma__9 { L.PosToken _ L.Tk__tok__coma__9 }
 tok__plus__eql__49 { L.PosToken _ L.Tk__tok__plus__eql__49 }
-tok__plus__plus__80 { L.PosToken _ L.Tk__tok__plus__plus__80 }
-tok__plus__76 { L.PosToken _ L.Tk__tok__plus__76 }
+tok__plus__plus__78 { L.PosToken _ L.Tk__tok__plus__plus__78 }
+tok__plus__74 { L.PosToken _ L.Tk__tok__plus__74 }
 tok__star__eql__51 { L.PosToken _ L.Tk__tok__star__eql__51 }
 tok__star__5 { L.PosToken _ L.Tk__tok__star__5 }
 tok__rparen__8 { L.PosToken _ L.Tk__tok__rparen__8 }
@@ -193,9 +192,9 @@ tok__symbol__eql__54 { L.PosToken _ L.Tk__tok__symbol__eql__54 }
 tok__symbol__symbol__62 { L.PosToken _ L.Tk__tok__symbol__symbol__62 }
 tok__symbol__65 { L.PosToken _ L.Tk__tok__symbol__65 }
 tok__symbol__eql__56 { L.PosToken _ L.Tk__tok__symbol__eql__56 }
-tok__symbol__79 { L.PosToken _ L.Tk__tok__symbol__79 }
+tok__symbol__77 { L.PosToken _ L.Tk__tok__symbol__77 }
 tok__exclamation__eql__67 { L.PosToken _ L.Tk__tok__exclamation__eql__67 }
-tok__exclamation__83 { L.PosToken _ L.Tk__tok__exclamation__83 }
+tok__exclamation__81 { L.PosToken _ L.Tk__tok__exclamation__81 }
 doccomment { L.PosToken _ (L.Tk__doccomment _) }
 id { L.PosToken _ (L.Tk__id _) }
 string { L.PosToken _ (L.Tk__string _) }
@@ -275,6 +274,7 @@ qq_ClassDeclaration { L.PosToken _ (L.Tk__qq_ClassDeclaration _) }
 qq_FieldDeclarationList { L.PosToken _ (L.Tk__qq_FieldDeclarationList _) }
 qq_ImplementsList { L.PosToken _ (L.Tk__qq_ImplementsList _) }
 qq_ExtendsList { L.PosToken _ (L.Tk__qq_ExtendsList _) }
+qq_ClassOrInterfaceType { L.PosToken _ (L.Tk__qq_ClassOrInterfaceType _) }
 qq_ModifierList { L.PosToken _ (L.Tk__qq_ModifierList _) }
 qq_AnnotationList { L.PosToken _ (L.Tk__qq_AnnotationList _) }
 qq_AnnotationElement { L.PosToken _ (L.Tk__qq_AnnotationElement _) }
@@ -295,99 +295,100 @@ qq_Java { L.PosToken _ (L.Tk__qq_Java _) }
 
 Java__top : Java rtk__eof { $1 }
 
-Java : tok_Java_dummy_177 Java tok_Java_dummy_177 { Ctr__Java__0 (rtkPosOf $1) $2 } |
-       tok_AdditiveOp_dummy_176 AdditiveOp tok_AdditiveOp_dummy_176 { Ctr__Java__1 (rtkPosOf $1) $2 } |
-       tok_Annotation_dummy_175 Annotation tok_Annotation_dummy_175 { Ctr__Java__2 (rtkPosOf $1) $2 } |
-       tok_AnnotationArguments_dummy_174 AnnotationArguments tok_AnnotationArguments_dummy_174 { Ctr__Java__3 (rtkPosOf $1) $2 } |
-       tok_AnnotationDeclaration_dummy_173 AnnotationDeclaration tok_AnnotationDeclaration_dummy_173 { Ctr__Java__4 (rtkPosOf $1) $2 } |
-       tok_AnnotationElement_dummy_172 AnnotationElement tok_AnnotationElement_dummy_172 { Ctr__Java__5 (rtkPosOf $1) $2 } |
-       tok_AnnotationList_dummy_171 AnnotationList tok_AnnotationList_dummy_171 { Ctr__Java__6 (rtkPosOf $1) (reverse $2) } |
-       tok_AnnotationTypeElement_dummy_170 AnnotationTypeElement tok_AnnotationTypeElement_dummy_170 { Ctr__Java__7 (rtkPosOf $1) $2 } |
-       tok_AnnotationTypeElementList_dummy_169 AnnotationTypeElementList tok_AnnotationTypeElementList_dummy_169 { Ctr__Java__8 (rtkPosOf $1) (reverse $2) } |
-       tok_Arglist_dummy_168 Arglist tok_Arglist_dummy_168 { Ctr__Java__9 (rtkPosOf $1) $2 } |
-       tok_AssignmentOp_dummy_167 AssignmentOp tok_AssignmentOp_dummy_167 { Ctr__Java__10 (rtkPosOf $1) $2 } |
-       tok_CatchList_dummy_166 CatchList tok_CatchList_dummy_166 { Ctr__Java__11 (rtkPosOf $1) (reverse $2) } |
-       tok_ClassDeclaration_dummy_165 ClassDeclaration tok_ClassDeclaration_dummy_165 { Ctr__Java__12 (rtkPosOf $1) $2 } |
-       tok_CompilationUnit_dummy_164 CompilationUnit tok_CompilationUnit_dummy_164 { Ctr__Java__13 (rtkPosOf $1) $2 } |
-       tok_CompoundName_dummy_163 CompoundName tok_CompoundName_dummy_163 { Ctr__Java__14 (rtkPosOf $1) $2 } |
-       tok_CreationExpression_dummy_162 CreationExpression tok_CreationExpression_dummy_162 { Ctr__Java__15 (rtkPosOf $1) $2 } |
-       tok_DimExprs_dummy_161 DimExprs tok_DimExprs_dummy_161 { Ctr__Java__16 (rtkPosOf $1) (reverse $2) } |
-       tok_Dims_dummy_160 Dims tok_Dims_dummy_160 { Ctr__Java__17 (rtkPosOf $1) (reverse $2) } |
-       tok_DoStatement_dummy_159 DoStatement tok_DoStatement_dummy_159 { Ctr__Java__18 (rtkPosOf $1) $2 } |
-       tok_DocComment_dummy_158 DocComment tok_DocComment_dummy_158 { Ctr__Java__19 (rtkPosOf $1) $2 } |
-       tok_EnumConstant_dummy_157 EnumConstant tok_EnumConstant_dummy_157 { Ctr__Java__20 (rtkPosOf $1) $2 } |
-       tok_EnumConstantList_dummy_156 EnumConstantList tok_EnumConstantList_dummy_156 { Ctr__Java__21 (rtkPosOf $1) $2 } |
-       tok_EnumDeclaration_dummy_155 EnumDeclaration tok_EnumDeclaration_dummy_155 { Ctr__Java__22 (rtkPosOf $1) $2 } |
-       tok_EqualityOp_dummy_154 EqualityOp tok_EqualityOp_dummy_154 { Ctr__Java__23 (rtkPosOf $1) $2 } |
-       tok_Expression_dummy_153 Expression tok_Expression_dummy_153 { Ctr__Java__24 (rtkPosOf $1) $2 } |
-       tok_ExtendsList_dummy_152 ExtendsList tok_ExtendsList_dummy_152 { Ctr__Java__25 (rtkPosOf $1) $2 } |
-       tok_FieldDeclaration_dummy_151 FieldDeclaration tok_FieldDeclaration_dummy_151 { Ctr__Java__26 (rtkPosOf $1) $2 } |
-       tok_FieldDeclarationList_dummy_150 FieldDeclarationList tok_FieldDeclarationList_dummy_150 { Ctr__Java__27 (rtkPosOf $1) (reverse $2) } |
-       tok_ForStatement_dummy_149 ForStatement tok_ForStatement_dummy_149 { Ctr__Java__28 (rtkPosOf $1) $2 } |
-       tok_IfStatement_dummy_148 IfStatement tok_IfStatement_dummy_148 { Ctr__Java__29 (rtkPosOf $1) $2 } |
-       tok_ImplementsList_dummy_147 ImplementsList tok_ImplementsList_dummy_147 { Ctr__Java__30 (rtkPosOf $1) $2 } |
-       tok_ImportHead_dummy_146 ImportHead tok_ImportHead_dummy_146 { Ctr__Java__31 (rtkPosOf $1) $2 } |
-       tok_ImportList_dummy_145 ImportList tok_ImportList_dummy_145 { Ctr__Java__32 (rtkPosOf $1) (reverse $2) } |
-       tok_ImportName_dummy_144 ImportName tok_ImportName_dummy_144 { Ctr__Java__33 (rtkPosOf $1) $2 } |
-       tok_ImportStatement_dummy_143 ImportStatement tok_ImportStatement_dummy_143 { Ctr__Java__34 (rtkPosOf $1) $2 } |
-       tok_InterfaceDeclaration_dummy_142 InterfaceDeclaration tok_InterfaceDeclaration_dummy_142 { Ctr__Java__35 (rtkPosOf $1) $2 } |
-       tok_Literal_dummy_141 Literal tok_Literal_dummy_141 { Ctr__Java__36 (rtkPosOf $1) $2 } |
-       tok_LocalModifierList1_dummy_140 LocalModifierList1 tok_LocalModifierList1_dummy_140 { Ctr__Java__37 (rtkPosOf $1) (reverse $2) } |
-       tok_MemberAfterFirstId_dummy_139 MemberAfterFirstId tok_MemberAfterFirstId_dummy_139 { Ctr__Java__38 (rtkPosOf $1) $2 } |
-       tok_MemberDeclaration_dummy_138 MemberDeclaration tok_MemberDeclaration_dummy_138 { Ctr__Java__39 (rtkPosOf $1) $2 } |
-       tok_MemberRest_dummy_137 MemberRest tok_MemberRest_dummy_137 { Ctr__Java__40 (rtkPosOf $1) $2 } |
-       tok_Modifier_dummy_136 Modifier tok_Modifier_dummy_136 { Ctr__Java__41 (rtkPosOf $1) $2 } |
-       tok_ModifierList_dummy_135 ModifierList tok_ModifierList_dummy_135 { Ctr__Java__42 (rtkPosOf $1) (reverse $2) } |
-       tok_MoreTypeSpecifier_dummy_134 MoreTypeSpecifier tok_MoreTypeSpecifier_dummy_134 { Ctr__Java__43 (rtkPosOf $1) $2 } |
-       tok_MoreVariableDeclarators_dummy_133 MoreVariableDeclarators tok_MoreVariableDeclarators_dummy_133 { Ctr__Java__44 (rtkPosOf $1) (reverse $2) } |
-       tok_MultiplicativeOp_dummy_132 MultiplicativeOp tok_MultiplicativeOp_dummy_132 { Ctr__Java__45 (rtkPosOf $1) $2 } |
-       tok_NonEmptyDims_dummy_131 NonEmptyDims tok_NonEmptyDims_dummy_131 { Ctr__Java__46 (rtkPosOf $1) (reverse $2) } |
-       tok_NonEmptyTypeArguments_dummy_130 NonEmptyTypeArguments tok_NonEmptyTypeArguments_dummy_130 { Ctr__Java__47 (rtkPosOf $1) $2 } |
-       tok_OptDocComment_dummy_129 OptDocComment tok_OptDocComment_dummy_129 { Ctr__Java__48 (rtkPosOf $1) $2 } |
-       tok_OptElsePart_dummy_128 OptElsePart tok_OptElsePart_dummy_128 { Ctr__Java__49 (rtkPosOf $1) $2 } |
-       tok_OptExpression_dummy_127 OptExpression tok_OptExpression_dummy_127 { Ctr__Java__50 (rtkPosOf $1) $2 } |
-       tok_OptFinally_dummy_126 OptFinally tok_OptFinally_dummy_126 { Ctr__Java__51 (rtkPosOf $1) $2 } |
-       tok_OptId_dummy_125 OptId tok_OptId_dummy_125 { Ctr__Java__52 (rtkPosOf $1) $2 } |
-       tok_OptVariableInitializer_dummy_124 OptVariableInitializer tok_OptVariableInitializer_dummy_124 { Ctr__Java__53 (rtkPosOf $1) $2 } |
-       tok_Package_dummy_123 Package tok_Package_dummy_123 { Ctr__Java__54 (rtkPosOf $1) $2 } |
-       tok_ParamModifierList_dummy_122 ParamModifierList tok_ParamModifierList_dummy_122 { Ctr__Java__55 (rtkPosOf $1) (reverse $2) } |
-       tok_Parameter_dummy_121 Parameter tok_Parameter_dummy_121 { Ctr__Java__56 (rtkPosOf $1) $2 } |
-       tok_ParameterList_dummy_120 ParameterList tok_ParameterList_dummy_120 { Ctr__Java__57 (rtkPosOf $1) $2 } |
-       tok_PostfixOp_dummy_119 PostfixOp tok_PostfixOp_dummy_119 { Ctr__Java__58 (rtkPosOf $1) $2 } |
-       tok_PrefixOp_dummy_118 PrefixOp tok_PrefixOp_dummy_118 { Ctr__Java__59 (rtkPosOf $1) $2 } |
-       tok_PrimitiveTypeKeyword_dummy_117 PrimitiveTypeKeyword tok_PrimitiveTypeKeyword_dummy_117 { Ctr__Java__60 (rtkPosOf $1) $2 } |
-       tok_RelationalOp_dummy_116 RelationalOp tok_RelationalOp_dummy_116 { Ctr__Java__61 (rtkPosOf $1) $2 } |
-       tok_ShiftOp_dummy_115 ShiftOp tok_ShiftOp_dummy_115 { Ctr__Java__62 (rtkPosOf $1) $2 } |
-       tok_Statement_dummy_114 Statement tok_Statement_dummy_114 { Ctr__Java__63 (rtkPosOf $1) $2 } |
-       tok_StatementBlock_dummy_113 StatementBlock tok_StatementBlock_dummy_113 { Ctr__Java__64 (rtkPosOf $1) $2 } |
-       tok_StatementList_dummy_112 StatementList tok_StatementList_dummy_112 { Ctr__Java__65 (rtkPosOf $1) (reverse $2) } |
-       tok_StaticInitializer_dummy_111 StaticInitializer tok_StaticInitializer_dummy_111 { Ctr__Java__66 (rtkPosOf $1) $2 } |
-       tok_SwitchCaseList_dummy_110 SwitchCaseList tok_SwitchCaseList_dummy_110 { Ctr__Java__67 (rtkPosOf $1) (reverse $2) } |
-       tok_SwitchStatement_dummy_109 SwitchStatement tok_SwitchStatement_dummy_109 { Ctr__Java__68 (rtkPosOf $1) $2 } |
-       tok_ThrowsClause_dummy_108 ThrowsClause tok_ThrowsClause_dummy_108 { Ctr__Java__69 (rtkPosOf $1) $2 } |
-       tok_TryStatement_dummy_107 TryStatement tok_TryStatement_dummy_107 { Ctr__Java__70 (rtkPosOf $1) $2 } |
-       tok_Type_dummy_106 Type tok_Type_dummy_106 { Ctr__Java__71 (rtkPosOf $1) $2 } |
-       tok_TypeArgument_dummy_105 TypeArgument tok_TypeArgument_dummy_105 { Ctr__Java__72 (rtkPosOf $1) $2 } |
-       tok_TypeArguments_dummy_104 TypeArguments tok_TypeArguments_dummy_104 { Ctr__Java__73 (rtkPosOf $1) $2 } |
-       tok_TypeDeclRest_dummy_103 TypeDeclRest tok_TypeDeclRest_dummy_103 { Ctr__Java__74 (rtkPosOf $1) $2 } |
-       tok_TypeDeclaration_dummy_102 TypeDeclaration tok_TypeDeclaration_dummy_102 { Ctr__Java__75 (rtkPosOf $1) $2 } |
-       tok_TypeParameter_dummy_101 TypeParameter tok_TypeParameter_dummy_101 { Ctr__Java__76 (rtkPosOf $1) $2 } |
-       tok_TypeParameters_dummy_100 TypeParameters tok_TypeParameters_dummy_100 { Ctr__Java__77 (rtkPosOf $1) $2 } |
-       tok_TypeSpecifier_dummy_99 TypeSpecifier tok_TypeSpecifier_dummy_99 { Ctr__Java__78 (rtkPosOf $1) $2 } |
-       tok_VariableDeclaration_dummy_98 VariableDeclaration tok_VariableDeclaration_dummy_98 { Ctr__Java__79 (rtkPosOf $1) $2 } |
-       tok_VariableDeclarator_dummy_97 VariableDeclarator tok_VariableDeclarator_dummy_97 { Ctr__Java__80 (rtkPosOf $1) $2 } |
-       tok_VariableDeclaratorList_dummy_96 VariableDeclaratorList tok_VariableDeclaratorList_dummy_96 { Ctr__Java__81 (rtkPosOf $1) $2 } |
-       tok_VariableInitializer_dummy_95 VariableInitializer tok_VariableInitializer_dummy_95 { Ctr__Java__82 (rtkPosOf $1) $2 } |
-       tok_VariableInitializerList_dummy_94 VariableInitializerList tok_VariableInitializerList_dummy_94 { Ctr__Java__83 (rtkPosOf $1) $2 } |
-       tok_WhileStatement_dummy_93 WhileStatement tok_WhileStatement_dummy_93 { Ctr__Java__84 (rtkPosOf $1) $2 } |
-       tok_WildcardType_dummy_92 WildcardType tok_WildcardType_dummy_92 { Ctr__Java__85 (rtkPosOf $1) $2 }
+Java : tok_Java_dummy_178 Java tok_Java_dummy_178 { Ctr__Java__0 (rtkPosOf $1) $2 } |
+       tok_AdditiveOp_dummy_177 AdditiveOp tok_AdditiveOp_dummy_177 { Ctr__Java__1 (rtkPosOf $1) $2 } |
+       tok_Annotation_dummy_176 Annotation tok_Annotation_dummy_176 { Ctr__Java__2 (rtkPosOf $1) $2 } |
+       tok_AnnotationArguments_dummy_175 AnnotationArguments tok_AnnotationArguments_dummy_175 { Ctr__Java__3 (rtkPosOf $1) $2 } |
+       tok_AnnotationDeclaration_dummy_174 AnnotationDeclaration tok_AnnotationDeclaration_dummy_174 { Ctr__Java__4 (rtkPosOf $1) $2 } |
+       tok_AnnotationElement_dummy_173 AnnotationElement tok_AnnotationElement_dummy_173 { Ctr__Java__5 (rtkPosOf $1) $2 } |
+       tok_AnnotationList_dummy_172 AnnotationList tok_AnnotationList_dummy_172 { Ctr__Java__6 (rtkPosOf $1) (reverse $2) } |
+       tok_AnnotationTypeElement_dummy_171 AnnotationTypeElement tok_AnnotationTypeElement_dummy_171 { Ctr__Java__7 (rtkPosOf $1) $2 } |
+       tok_AnnotationTypeElementList_dummy_170 AnnotationTypeElementList tok_AnnotationTypeElementList_dummy_170 { Ctr__Java__8 (rtkPosOf $1) (reverse $2) } |
+       tok_Arglist_dummy_169 Arglist tok_Arglist_dummy_169 { Ctr__Java__9 (rtkPosOf $1) $2 } |
+       tok_AssignmentOp_dummy_168 AssignmentOp tok_AssignmentOp_dummy_168 { Ctr__Java__10 (rtkPosOf $1) $2 } |
+       tok_CatchList_dummy_167 CatchList tok_CatchList_dummy_167 { Ctr__Java__11 (rtkPosOf $1) (reverse $2) } |
+       tok_ClassDeclaration_dummy_166 ClassDeclaration tok_ClassDeclaration_dummy_166 { Ctr__Java__12 (rtkPosOf $1) $2 } |
+       tok_ClassOrInterfaceType_dummy_165 ClassOrInterfaceType tok_ClassOrInterfaceType_dummy_165 { Ctr__Java__13 (rtkPosOf $1) $2 } |
+       tok_CompilationUnit_dummy_164 CompilationUnit tok_CompilationUnit_dummy_164 { Ctr__Java__14 (rtkPosOf $1) $2 } |
+       tok_CompoundName_dummy_163 CompoundName tok_CompoundName_dummy_163 { Ctr__Java__15 (rtkPosOf $1) $2 } |
+       tok_CreationExpression_dummy_162 CreationExpression tok_CreationExpression_dummy_162 { Ctr__Java__16 (rtkPosOf $1) $2 } |
+       tok_DimExprs_dummy_161 DimExprs tok_DimExprs_dummy_161 { Ctr__Java__17 (rtkPosOf $1) (reverse $2) } |
+       tok_Dims_dummy_160 Dims tok_Dims_dummy_160 { Ctr__Java__18 (rtkPosOf $1) (reverse $2) } |
+       tok_DoStatement_dummy_159 DoStatement tok_DoStatement_dummy_159 { Ctr__Java__19 (rtkPosOf $1) $2 } |
+       tok_DocComment_dummy_158 DocComment tok_DocComment_dummy_158 { Ctr__Java__20 (rtkPosOf $1) $2 } |
+       tok_EnumConstant_dummy_157 EnumConstant tok_EnumConstant_dummy_157 { Ctr__Java__21 (rtkPosOf $1) $2 } |
+       tok_EnumConstantList_dummy_156 EnumConstantList tok_EnumConstantList_dummy_156 { Ctr__Java__22 (rtkPosOf $1) $2 } |
+       tok_EnumDeclaration_dummy_155 EnumDeclaration tok_EnumDeclaration_dummy_155 { Ctr__Java__23 (rtkPosOf $1) $2 } |
+       tok_EqualityOp_dummy_154 EqualityOp tok_EqualityOp_dummy_154 { Ctr__Java__24 (rtkPosOf $1) $2 } |
+       tok_Expression_dummy_153 Expression tok_Expression_dummy_153 { Ctr__Java__25 (rtkPosOf $1) $2 } |
+       tok_ExtendsList_dummy_152 ExtendsList tok_ExtendsList_dummy_152 { Ctr__Java__26 (rtkPosOf $1) $2 } |
+       tok_FieldDeclaration_dummy_151 FieldDeclaration tok_FieldDeclaration_dummy_151 { Ctr__Java__27 (rtkPosOf $1) $2 } |
+       tok_FieldDeclarationList_dummy_150 FieldDeclarationList tok_FieldDeclarationList_dummy_150 { Ctr__Java__28 (rtkPosOf $1) (reverse $2) } |
+       tok_ForStatement_dummy_149 ForStatement tok_ForStatement_dummy_149 { Ctr__Java__29 (rtkPosOf $1) $2 } |
+       tok_IfStatement_dummy_148 IfStatement tok_IfStatement_dummy_148 { Ctr__Java__30 (rtkPosOf $1) $2 } |
+       tok_ImplementsList_dummy_147 ImplementsList tok_ImplementsList_dummy_147 { Ctr__Java__31 (rtkPosOf $1) $2 } |
+       tok_ImportHead_dummy_146 ImportHead tok_ImportHead_dummy_146 { Ctr__Java__32 (rtkPosOf $1) $2 } |
+       tok_ImportList_dummy_145 ImportList tok_ImportList_dummy_145 { Ctr__Java__33 (rtkPosOf $1) (reverse $2) } |
+       tok_ImportName_dummy_144 ImportName tok_ImportName_dummy_144 { Ctr__Java__34 (rtkPosOf $1) $2 } |
+       tok_ImportStatement_dummy_143 ImportStatement tok_ImportStatement_dummy_143 { Ctr__Java__35 (rtkPosOf $1) $2 } |
+       tok_InterfaceDeclaration_dummy_142 InterfaceDeclaration tok_InterfaceDeclaration_dummy_142 { Ctr__Java__36 (rtkPosOf $1) $2 } |
+       tok_Literal_dummy_141 Literal tok_Literal_dummy_141 { Ctr__Java__37 (rtkPosOf $1) $2 } |
+       tok_LocalModifierList1_dummy_140 LocalModifierList1 tok_LocalModifierList1_dummy_140 { Ctr__Java__38 (rtkPosOf $1) (reverse $2) } |
+       tok_MemberAfterFirstId_dummy_139 MemberAfterFirstId tok_MemberAfterFirstId_dummy_139 { Ctr__Java__39 (rtkPosOf $1) $2 } |
+       tok_MemberDeclaration_dummy_138 MemberDeclaration tok_MemberDeclaration_dummy_138 { Ctr__Java__40 (rtkPosOf $1) $2 } |
+       tok_MemberRest_dummy_137 MemberRest tok_MemberRest_dummy_137 { Ctr__Java__41 (rtkPosOf $1) $2 } |
+       tok_Modifier_dummy_136 Modifier tok_Modifier_dummy_136 { Ctr__Java__42 (rtkPosOf $1) $2 } |
+       tok_ModifierList_dummy_135 ModifierList tok_ModifierList_dummy_135 { Ctr__Java__43 (rtkPosOf $1) (reverse $2) } |
+       tok_MoreTypeSpecifier_dummy_134 MoreTypeSpecifier tok_MoreTypeSpecifier_dummy_134 { Ctr__Java__44 (rtkPosOf $1) $2 } |
+       tok_MoreVariableDeclarators_dummy_133 MoreVariableDeclarators tok_MoreVariableDeclarators_dummy_133 { Ctr__Java__45 (rtkPosOf $1) (reverse $2) } |
+       tok_MultiplicativeOp_dummy_132 MultiplicativeOp tok_MultiplicativeOp_dummy_132 { Ctr__Java__46 (rtkPosOf $1) $2 } |
+       tok_NonEmptyDims_dummy_131 NonEmptyDims tok_NonEmptyDims_dummy_131 { Ctr__Java__47 (rtkPosOf $1) (reverse $2) } |
+       tok_NonEmptyTypeArguments_dummy_130 NonEmptyTypeArguments tok_NonEmptyTypeArguments_dummy_130 { Ctr__Java__48 (rtkPosOf $1) $2 } |
+       tok_OptDocComment_dummy_129 OptDocComment tok_OptDocComment_dummy_129 { Ctr__Java__49 (rtkPosOf $1) $2 } |
+       tok_OptElsePart_dummy_128 OptElsePart tok_OptElsePart_dummy_128 { Ctr__Java__50 (rtkPosOf $1) $2 } |
+       tok_OptExpression_dummy_127 OptExpression tok_OptExpression_dummy_127 { Ctr__Java__51 (rtkPosOf $1) $2 } |
+       tok_OptFinally_dummy_126 OptFinally tok_OptFinally_dummy_126 { Ctr__Java__52 (rtkPosOf $1) $2 } |
+       tok_OptId_dummy_125 OptId tok_OptId_dummy_125 { Ctr__Java__53 (rtkPosOf $1) $2 } |
+       tok_OptVariableInitializer_dummy_124 OptVariableInitializer tok_OptVariableInitializer_dummy_124 { Ctr__Java__54 (rtkPosOf $1) $2 } |
+       tok_Package_dummy_123 Package tok_Package_dummy_123 { Ctr__Java__55 (rtkPosOf $1) $2 } |
+       tok_ParamModifierList_dummy_122 ParamModifierList tok_ParamModifierList_dummy_122 { Ctr__Java__56 (rtkPosOf $1) (reverse $2) } |
+       tok_Parameter_dummy_121 Parameter tok_Parameter_dummy_121 { Ctr__Java__57 (rtkPosOf $1) $2 } |
+       tok_ParameterList_dummy_120 ParameterList tok_ParameterList_dummy_120 { Ctr__Java__58 (rtkPosOf $1) $2 } |
+       tok_PostfixOp_dummy_119 PostfixOp tok_PostfixOp_dummy_119 { Ctr__Java__59 (rtkPosOf $1) $2 } |
+       tok_PrefixOp_dummy_118 PrefixOp tok_PrefixOp_dummy_118 { Ctr__Java__60 (rtkPosOf $1) $2 } |
+       tok_PrimitiveTypeKeyword_dummy_117 PrimitiveTypeKeyword tok_PrimitiveTypeKeyword_dummy_117 { Ctr__Java__61 (rtkPosOf $1) $2 } |
+       tok_RelationalOp_dummy_116 RelationalOp tok_RelationalOp_dummy_116 { Ctr__Java__62 (rtkPosOf $1) $2 } |
+       tok_ShiftOp_dummy_115 ShiftOp tok_ShiftOp_dummy_115 { Ctr__Java__63 (rtkPosOf $1) $2 } |
+       tok_Statement_dummy_114 Statement tok_Statement_dummy_114 { Ctr__Java__64 (rtkPosOf $1) $2 } |
+       tok_StatementBlock_dummy_113 StatementBlock tok_StatementBlock_dummy_113 { Ctr__Java__65 (rtkPosOf $1) $2 } |
+       tok_StatementList_dummy_112 StatementList tok_StatementList_dummy_112 { Ctr__Java__66 (rtkPosOf $1) (reverse $2) } |
+       tok_StaticInitializer_dummy_111 StaticInitializer tok_StaticInitializer_dummy_111 { Ctr__Java__67 (rtkPosOf $1) $2 } |
+       tok_SwitchCaseList_dummy_110 SwitchCaseList tok_SwitchCaseList_dummy_110 { Ctr__Java__68 (rtkPosOf $1) (reverse $2) } |
+       tok_SwitchStatement_dummy_109 SwitchStatement tok_SwitchStatement_dummy_109 { Ctr__Java__69 (rtkPosOf $1) $2 } |
+       tok_ThrowsClause_dummy_108 ThrowsClause tok_ThrowsClause_dummy_108 { Ctr__Java__70 (rtkPosOf $1) $2 } |
+       tok_TryStatement_dummy_107 TryStatement tok_TryStatement_dummy_107 { Ctr__Java__71 (rtkPosOf $1) $2 } |
+       tok_Type_dummy_106 Type tok_Type_dummy_106 { Ctr__Java__72 (rtkPosOf $1) $2 } |
+       tok_TypeArgument_dummy_105 TypeArgument tok_TypeArgument_dummy_105 { Ctr__Java__73 (rtkPosOf $1) $2 } |
+       tok_TypeArguments_dummy_104 TypeArguments tok_TypeArguments_dummy_104 { Ctr__Java__74 (rtkPosOf $1) $2 } |
+       tok_TypeDeclRest_dummy_103 TypeDeclRest tok_TypeDeclRest_dummy_103 { Ctr__Java__75 (rtkPosOf $1) $2 } |
+       tok_TypeDeclaration_dummy_102 TypeDeclaration tok_TypeDeclaration_dummy_102 { Ctr__Java__76 (rtkPosOf $1) $2 } |
+       tok_TypeParameter_dummy_101 TypeParameter tok_TypeParameter_dummy_101 { Ctr__Java__77 (rtkPosOf $1) $2 } |
+       tok_TypeParameters_dummy_100 TypeParameters tok_TypeParameters_dummy_100 { Ctr__Java__78 (rtkPosOf $1) $2 } |
+       tok_TypeSpecifier_dummy_99 TypeSpecifier tok_TypeSpecifier_dummy_99 { Ctr__Java__79 (rtkPosOf $1) $2 } |
+       tok_VariableDeclaration_dummy_98 VariableDeclaration tok_VariableDeclaration_dummy_98 { Ctr__Java__80 (rtkPosOf $1) $2 } |
+       tok_VariableDeclarator_dummy_97 VariableDeclarator tok_VariableDeclarator_dummy_97 { Ctr__Java__81 (rtkPosOf $1) $2 } |
+       tok_VariableDeclaratorList_dummy_96 VariableDeclaratorList tok_VariableDeclaratorList_dummy_96 { Ctr__Java__82 (rtkPosOf $1) $2 } |
+       tok_VariableInitializer_dummy_95 VariableInitializer tok_VariableInitializer_dummy_95 { Ctr__Java__83 (rtkPosOf $1) $2 } |
+       tok_VariableInitializerList_dummy_94 VariableInitializerList tok_VariableInitializerList_dummy_94 { Ctr__Java__84 (rtkPosOf $1) $2 } |
+       tok_WhileStatement_dummy_93 WhileStatement tok_WhileStatement_dummy_93 { Ctr__Java__85 (rtkPosOf $1) $2 } |
+       tok_WildcardType_dummy_92 WildcardType tok_WildcardType_dummy_92 { Ctr__Java__86 (rtkPosOf $1) $2 }
 
 Java : qq_Java { Anti_Java (tkVal_qq_Java $1) } |
-       CompilationUnit { Ctr__Java__86 (rtkPosOf $1) $1 }
+       CompilationUnit { Ctr__Java__87 (rtkPosOf $1) $1 }
 
 AdditiveOp : qq_AdditiveOp { Anti_AdditiveOp (tkVal_qq_AdditiveOp $1) } |
-             tok__plus__76 { Ctr__AdditiveOp__0 (rtkPosOf $1) } |
-             tok__minus__77 { Ctr__AdditiveOp__1 (rtkPosOf $1) }
+             tok__plus__74 { Ctr__AdditiveOp__0 (rtkPosOf $1) } |
+             tok__minus__75 { Ctr__AdditiveOp__1 (rtkPosOf $1) }
 
 ListElem_AnnotationList9 : qq_AnnotationList { Anti_Annotation (tkVal_qq_AnnotationList $1) } |
                            Annotation { $1 }
@@ -441,6 +442,9 @@ CatchList : {- empty -} { [] } |
 ClassDeclaration : qq_ClassDeclaration { Anti_ClassDeclaration (tkVal_qq_ClassDeclaration $1) } |
                    tok_class_13 id TypeParameters Rule_16 Rule_17 tok__symbol__14 FieldDeclarationList tok__symbol__15 { Ctr__ClassDeclaration__0 (rtkPosOf $1) (tkVal_id $2) $3 $4 $5 (reverse $7) }
 
+ClassOrInterfaceType : qq_ClassOrInterfaceType { Anti_ClassOrInterfaceType (tkVal_qq_ClassOrInterfaceType $1) } |
+                       CompoundName TypeArguments { Ctr__ClassOrInterfaceType__0 (rtkPosOf $1) $1 $2 }
+
 CompilationUnit : qq_CompilationUnit { Anti_CompilationUnit (tkVal_qq_CompilationUnit $1) } |
                   Rule_1 ImportList Rule_2 { Ctr__CompilationUnit__0 (rtkPosOf $1) $1 (reverse $2) $3 }
 
@@ -448,7 +452,7 @@ CompoundName : qq_CompoundName { Anti_CompoundName (tkVal_qq_CompoundName $1) } 
                id Rule_90 { Ctr__CompoundName__0 (rtkPosOf $1) (tkVal_id $1) (reverse $2) }
 
 CreationExpression : qq_CreationExpression { Anti_CreationExpression (tkVal_qq_CreationExpression $1) } |
-                     tok_new_86 TypeSpecifier Rule_74 { Ctr__CreationExpression__0 (rtkPosOf $1) $2 $3 }
+                     tok_new_84 TypeSpecifier Rule_74 { Ctr__CreationExpression__0 (rtkPosOf $1) $2 $3 }
 
 DimExprs : ListElem_DimExprs77 { [$1] } |
            DimExprs ListElem_DimExprs77 { $2 : $1 }
@@ -477,12 +481,12 @@ EqualityOp : qq_EqualityOp { Anti_EqualityOp (tkVal_qq_EqualityOp $1) } |
 
 PrimaryNoPostfix : qq_Expression { Anti_Expression (tkVal_qq_Expression $1) } |
                    Literal { Ctr__Expression__0 (rtkPosOf $1) $1 } |
-                   tok_this_84 { Ctr__Expression__1 (rtkPosOf $1) } |
+                   tok_this_82 { Ctr__Expression__1 (rtkPosOf $1) } |
                    tok__lparen__7 Expression tok__rparen__8 { Ctr__Expression__2 (rtkPosOf $1) $2 } |
                    CreationExpression { Ctr__Expression__3 (rtkPosOf $1) $1 } |
                    CompoundName Rule_70 { Ctr__Expression__4 (rtkPosOf $1) $1 $2 } |
                    CompoundName tok__sq_bkt_l__18 Expression tok__sq_bkt_r__19 { Ctr__Expression__5 (rtkPosOf $1) $1 $3 } |
-                   tok_super_85 tok__dot__4 id Rule_72 { Ctr__Expression__6 (rtkPosOf $1) (tkVal_id $3) $4 }
+                   tok_super_83 tok__dot__4 id Rule_72 { Ctr__Expression__6 (rtkPosOf $1) (tkVal_id $3) $4 }
 
 PostfixExpression : PrimaryNoPostfix { Ctr__Expression__7 (rtkPosOf $1) $1 } |
                     PostfixExpression PostfixOp { Ctr__Expression__8 (rtkPosOf $1) $1 $2 } |
@@ -491,8 +495,8 @@ PostfixExpression : PrimaryNoPostfix { Ctr__Expression__7 (rtkPosOf $1) $1 } |
                     PostfixExpression tok__sq_bkt_l__18 Expression tok__sq_bkt_r__19 { Ctr__Expression__11 (rtkPosOf $1) $1 $3 }
 
 UnaryExpressionNotPlusMinus : PostfixExpression { Ctr__Expression__12 (rtkPosOf $1) $1 } |
-                              tok__tilde__82 UnaryExpression { Ctr__Expression__13 (rtkPosOf $1) $2 } |
-                              tok__exclamation__83 UnaryExpression { Ctr__Expression__14 (rtkPosOf $1) $2 } |
+                              tok__tilde__80 UnaryExpression { Ctr__Expression__13 (rtkPosOf $1) $2 } |
+                              tok__exclamation__81 UnaryExpression { Ctr__Expression__14 (rtkPosOf $1) $2 } |
                               CastExpression { Ctr__Expression__15 (rtkPosOf $1) $1 }
 
 UnaryExpression : PrefixOp UnaryExpression { Ctr__Expression__16 (rtkPosOf $1) $1 $2 } |
@@ -513,7 +517,7 @@ ShiftExpression : AdditiveExpression { Ctr__Expression__26 (rtkPosOf $1) $1 } |
                   ShiftExpression ShiftOp AdditiveExpression { Ctr__Expression__27 (rtkPosOf $1) $1 $2 $3 }
 
 RelationalExpression : ShiftExpression { Ctr__Expression__28 (rtkPosOf $1) $1 } |
-                       RelationalExpression RelationalOp ShiftExpression { Ctr__Expression__29 (rtkPosOf $1) $1 $2 $3 } |
+                       ShiftExpression RelationalOp ShiftExpression { Ctr__Expression__29 (rtkPosOf $1) $1 $2 $3 } |
                        RelationalExpression tok_instanceof_72 Type { Ctr__Expression__30 (rtkPosOf $1) $1 $3 }
 
 EqualityExpression : RelationalExpression { Ctr__Expression__31 (rtkPosOf $1) $1 } |
@@ -542,7 +546,7 @@ AssignmentExpression : ConditionalExpression Rule_68 { Ctr__Expression__45 (rtkP
 Expression : AssignmentExpression { Ctr__Expression__46 (rtkPosOf $1) $1 }
 
 ExtendsList : qq_ExtendsList { Anti_ExtendsList (tkVal_qq_ExtendsList $1) } |
-              tok_extends_11 CompoundName Rule_12 { Ctr__ExtendsList__0 (rtkPosOf $1) $2 (reverse $3) }
+              tok_extends_11 ClassOrInterfaceType Rule_12 { Ctr__ExtendsList__0 (rtkPosOf $1) $2 (reverse $3) }
 
 FieldDeclaration : qq_FieldDeclaration { Anti_FieldDeclaration (tkVal_qq_FieldDeclaration $1) } |
                    OptDocComment ModifierList Rule_30 { Ctr__FieldDeclaration__0 (rtkPosOf $1) $1 (reverse $2) $3 } |
@@ -586,11 +590,11 @@ InterfaceDeclaration : qq_InterfaceDeclaration { Anti_InterfaceDeclaration (tkVa
 Literal : qq_Literal { Anti_Literal (tkVal_qq_Literal $1) } |
           integerLiteral { Ctr__Literal__0 (rtkPosOf $1) (tkVal_integerLiteral $1) } |
           floatLiteral { Ctr__Literal__1 (rtkPosOf $1) (tkVal_floatLiteral $1) } |
-          tok_true_87 { Ctr__Literal__2 (rtkPosOf $1) } |
-          tok_false_88 { Ctr__Literal__3 (rtkPosOf $1) } |
+          tok_true_85 { Ctr__Literal__2 (rtkPosOf $1) } |
+          tok_false_86 { Ctr__Literal__3 (rtkPosOf $1) } |
           char { Ctr__Literal__4 (rtkPosOf $1) (tkVal_char $1) } |
           string { Ctr__Literal__5 (rtkPosOf $1) (tkVal_string $1) } |
-          tok_null_89 { Ctr__Literal__6 (rtkPosOf $1) }
+          tok_null_87 { Ctr__Literal__6 (rtkPosOf $1) }
 
 LocalModifierList1 : ListElem_LocalModifierList149 { [$1] } |
                      LocalModifierList1 ListElem_LocalModifierList149 { $2 : $1 }
@@ -609,16 +613,16 @@ MemberRest : qq_MemberRest { Anti_MemberRest (tkVal_qq_MemberRest $1) } |
              Dims OptVariableInitializer MoreVariableDeclarators tok__semi__1 { Ctr__MemberRest__1 (rtkPosOf (reverse $1)) (reverse $1) $2 (reverse $3) }
 
 Modifier : qq_Modifier { Anti_Modifier (tkVal_qq_Modifier $1) } |
-           tok_public_90 { Ctr__Modifier__0 (rtkPosOf $1) } |
-           tok_private_91 { Ctr__Modifier__1 (rtkPosOf $1) } |
-           tok_protected_92 { Ctr__Modifier__2 (rtkPosOf $1) } |
+           tok_public_88 { Ctr__Modifier__0 (rtkPosOf $1) } |
+           tok_private_89 { Ctr__Modifier__1 (rtkPosOf $1) } |
+           tok_protected_90 { Ctr__Modifier__2 (rtkPosOf $1) } |
            tok_static_3 { Ctr__Modifier__3 (rtkPosOf $1) } |
            tok_final_31 { Ctr__Modifier__4 (rtkPosOf $1) } |
-           tok_native_93 { Ctr__Modifier__5 (rtkPosOf $1) } |
+           tok_native_91 { Ctr__Modifier__5 (rtkPosOf $1) } |
            tok_synchronized_34 { Ctr__Modifier__6 (rtkPosOf $1) } |
-           tok_abstract_94 { Ctr__Modifier__7 (rtkPosOf $1) } |
-           tok_threadsafe_95 { Ctr__Modifier__8 (rtkPosOf $1) } |
-           tok_transient_96 { Ctr__Modifier__9 (rtkPosOf $1) }
+           tok_abstract_92 { Ctr__Modifier__7 (rtkPosOf $1) } |
+           tok_threadsafe_93 { Ctr__Modifier__8 (rtkPosOf $1) } |
+           tok_transient_94 { Ctr__Modifier__9 (rtkPosOf $1) }
 
 ModifierList : {- empty -} { [] } |
                ModifierList ListElem_ModifierList11 { $2 : $1 }
@@ -632,8 +636,8 @@ MoreVariableDeclarators : {- empty -} { [] } |
 
 MultiplicativeOp : qq_MultiplicativeOp { Anti_MultiplicativeOp (tkVal_qq_MultiplicativeOp $1) } |
                    tok__star__5 { Ctr__MultiplicativeOp__0 (rtkPosOf $1) } |
-                   tok__symbol__78 { Ctr__MultiplicativeOp__1 (rtkPosOf $1) } |
-                   tok__symbol__79 { Ctr__MultiplicativeOp__2 (rtkPosOf $1) }
+                   tok__symbol__76 { Ctr__MultiplicativeOp__1 (rtkPosOf $1) } |
+                   tok__symbol__77 { Ctr__MultiplicativeOp__2 (rtkPosOf $1) }
 
 NonEmptyDims : ListElem_NonEmptyDims34 { [$1] } |
                NonEmptyDims ListElem_NonEmptyDims34 { $2 : $1 }
@@ -678,14 +682,14 @@ ParameterList : qq_ParameterList { Anti_ParameterList (tkVal_qq_ParameterList $1
                 Parameter Rule_55 { Ctr__ParameterList__0 (rtkPosOf $1) $1 (reverse $2) }
 
 PostfixOp : qq_PostfixOp { Anti_PostfixOp (tkVal_qq_PostfixOp $1) } |
-            tok__plus__plus__80 { Ctr__PostfixOp__0 (rtkPosOf $1) } |
-            tok__minus__minus__81 { Ctr__PostfixOp__1 (rtkPosOf $1) }
+            tok__plus__plus__78 { Ctr__PostfixOp__0 (rtkPosOf $1) } |
+            tok__minus__minus__79 { Ctr__PostfixOp__1 (rtkPosOf $1) }
 
 PrefixOp : qq_PrefixOp { Anti_PrefixOp (tkVal_qq_PrefixOp $1) } |
-           tok__plus__plus__80 { Ctr__PrefixOp__0 (rtkPosOf $1) } |
-           tok__minus__minus__81 { Ctr__PrefixOp__1 (rtkPosOf $1) } |
-           tok__plus__76 { Ctr__PrefixOp__2 (rtkPosOf $1) } |
-           tok__minus__77 { Ctr__PrefixOp__3 (rtkPosOf $1) }
+           tok__plus__plus__78 { Ctr__PrefixOp__0 (rtkPosOf $1) } |
+           tok__minus__minus__79 { Ctr__PrefixOp__1 (rtkPosOf $1) } |
+           tok__plus__74 { Ctr__PrefixOp__2 (rtkPosOf $1) } |
+           tok__minus__75 { Ctr__PrefixOp__3 (rtkPosOf $1) }
 
 PrimitiveTypeKeyword : qq_PrimitiveTypeKeyword { Anti_PrimitiveTypeKeyword (tkVal_qq_PrimitiveTypeKeyword $1) } |
                        tok_boolean_20 { Ctr__PrimitiveTypeKeyword__0 (rtkPosOf $1) } |
@@ -716,10 +720,10 @@ Rule_10 : Modifier { Ctr__Rule_10__1 (rtkPosOf $1) $1 } |
 Rule_12 : {- empty -} { [] } |
           Rule_12 Rule_13 { $2 : $1 }
 
-Rule_13 : tok__coma__9 CompoundName { Ctr__Rule_13__0 (rtkPosOf $1) $2 }
+Rule_13 : tok__coma__9 ClassOrInterfaceType { Ctr__Rule_13__0 (rtkPosOf $1) $2 }
 
-Rule_14 : CompoundName { [$1] } |
-          Rule_14 tok__coma__9 CompoundName { $3 : $1 }
+Rule_14 : ClassOrInterfaceType { [$1] } |
+          Rule_14 tok__coma__9 ClassOrInterfaceType { $3 : $1 }
 
 Rule_16 : { Ctr__Rule_16__0 rtkNoPos } |
           ExtendsList { Ctr__Rule_16__1 (rtkPosOf $1) $1 }
@@ -938,8 +942,8 @@ Rule_91 : tok__dot__4 id { Ctr__Rule_91__0 (rtkPosOf $1) (tkVal_id $2) }
 
 ShiftOp : qq_ShiftOp { Anti_ShiftOp (tkVal_qq_ShiftOp $1) } |
           tok__symbol__symbol__73 { Ctr__ShiftOp__0 (rtkPosOf $1) } |
-          tok__symbol__symbol__74 { Ctr__ShiftOp__1 (rtkPosOf $1) } |
-          tok__symbol__symbol__symbol__75 { Ctr__ShiftOp__2 (rtkPosOf $1) }
+          tok__symbol__69 tok__symbol__69 { Ctr__ShiftOp__1 (rtkPosOf $1) } |
+          tok__symbol__69 tok__symbol__69 tok__symbol__69 { Ctr__ShiftOp__2 (rtkPosOf $1) }
 
 Statement : qq_Statement { Anti_Statement (tkVal_qq_Statement $1) } |
             VariableDeclaration { Ctr__Statement__0 (rtkPosOf $1) $1 } |
@@ -1049,7 +1053,7 @@ WhileStatement : qq_WhileStatement { Anti_WhileStatement (tkVal_qq_WhileStatemen
 WildcardType : qq_WildcardType { Anti_WildcardType (tkVal_qq_WildcardType $1) } |
                tok__symbol__60 { Ctr__WildcardType__0 (rtkPosOf $1) } |
                tok__symbol__60 tok_extends_11 Type { Ctr__WildcardType__1 (rtkPosOf $1) $3 } |
-               tok__symbol__60 tok_super_85 Type { Ctr__WildcardType__2 (rtkPosOf $1) $3 }
+               tok__symbol__60 tok_super_83 Type { Ctr__WildcardType__2 (rtkPosOf $1) $3 }
 
 
 {
@@ -1061,18 +1065,19 @@ parseError (L.PosToken (L.AlexPn _ line col) tok : _) =
 -- Render a token the way it appears in the source, for error messages
 showRtkToken :: L.Token -> String
 showRtkToken L.EndOfFile = "end of input"
-showRtkToken L.Tk__tok_AdditiveOp_dummy_176 = "'tok_AdditiveOp_dummy_176'"
-showRtkToken L.Tk__tok_Annotation_dummy_175 = "'tok_Annotation_dummy_175'"
-showRtkToken L.Tk__tok_AnnotationArguments_dummy_174 = "'tok_AnnotationArguments_dummy_174'"
-showRtkToken L.Tk__tok_AnnotationDeclaration_dummy_173 = "'tok_AnnotationDeclaration_dummy_173'"
-showRtkToken L.Tk__tok_AnnotationElement_dummy_172 = "'tok_AnnotationElement_dummy_172'"
-showRtkToken L.Tk__tok_AnnotationList_dummy_171 = "'tok_AnnotationList_dummy_171'"
-showRtkToken L.Tk__tok_AnnotationTypeElement_dummy_170 = "'tok_AnnotationTypeElement_dummy_170'"
-showRtkToken L.Tk__tok_AnnotationTypeElementList_dummy_169 = "'tok_AnnotationTypeElementList_dummy_169'"
-showRtkToken L.Tk__tok_Arglist_dummy_168 = "'tok_Arglist_dummy_168'"
-showRtkToken L.Tk__tok_AssignmentOp_dummy_167 = "'tok_AssignmentOp_dummy_167'"
-showRtkToken L.Tk__tok_CatchList_dummy_166 = "'tok_CatchList_dummy_166'"
-showRtkToken L.Tk__tok_ClassDeclaration_dummy_165 = "'tok_ClassDeclaration_dummy_165'"
+showRtkToken L.Tk__tok_AdditiveOp_dummy_177 = "'tok_AdditiveOp_dummy_177'"
+showRtkToken L.Tk__tok_Annotation_dummy_176 = "'tok_Annotation_dummy_176'"
+showRtkToken L.Tk__tok_AnnotationArguments_dummy_175 = "'tok_AnnotationArguments_dummy_175'"
+showRtkToken L.Tk__tok_AnnotationDeclaration_dummy_174 = "'tok_AnnotationDeclaration_dummy_174'"
+showRtkToken L.Tk__tok_AnnotationElement_dummy_173 = "'tok_AnnotationElement_dummy_173'"
+showRtkToken L.Tk__tok_AnnotationList_dummy_172 = "'tok_AnnotationList_dummy_172'"
+showRtkToken L.Tk__tok_AnnotationTypeElement_dummy_171 = "'tok_AnnotationTypeElement_dummy_171'"
+showRtkToken L.Tk__tok_AnnotationTypeElementList_dummy_170 = "'tok_AnnotationTypeElementList_dummy_170'"
+showRtkToken L.Tk__tok_Arglist_dummy_169 = "'tok_Arglist_dummy_169'"
+showRtkToken L.Tk__tok_AssignmentOp_dummy_168 = "'tok_AssignmentOp_dummy_168'"
+showRtkToken L.Tk__tok_CatchList_dummy_167 = "'tok_CatchList_dummy_167'"
+showRtkToken L.Tk__tok_ClassDeclaration_dummy_166 = "'tok_ClassDeclaration_dummy_166'"
+showRtkToken L.Tk__tok_ClassOrInterfaceType_dummy_165 = "'tok_ClassOrInterfaceType_dummy_165'"
 showRtkToken L.Tk__tok_CompilationUnit_dummy_164 = "'tok_CompilationUnit_dummy_164'"
 showRtkToken L.Tk__tok_CompoundName_dummy_163 = "'tok_CompoundName_dummy_163'"
 showRtkToken L.Tk__tok_CreationExpression_dummy_162 = "'tok_CreationExpression_dummy_162'"
@@ -1096,7 +1101,7 @@ showRtkToken L.Tk__tok_ImportList_dummy_145 = "'tok_ImportList_dummy_145'"
 showRtkToken L.Tk__tok_ImportName_dummy_144 = "'tok_ImportName_dummy_144'"
 showRtkToken L.Tk__tok_ImportStatement_dummy_143 = "'tok_ImportStatement_dummy_143'"
 showRtkToken L.Tk__tok_InterfaceDeclaration_dummy_142 = "'tok_InterfaceDeclaration_dummy_142'"
-showRtkToken L.Tk__tok_Java_dummy_177 = "'tok_Java_dummy_177'"
+showRtkToken L.Tk__tok_Java_dummy_178 = "'tok_Java_dummy_178'"
 showRtkToken L.Tk__tok_Literal_dummy_141 = "'tok_Literal_dummy_141'"
 showRtkToken L.Tk__tok_LocalModifierList1_dummy_140 = "'tok_LocalModifierList1_dummy_140'"
 showRtkToken L.Tk__tok_MemberAfterFirstId_dummy_139 = "'tok_MemberAfterFirstId_dummy_139'"
@@ -1147,7 +1152,7 @@ showRtkToken L.Tk__tok_VariableInitializer_dummy_95 = "'tok_VariableInitializer_
 showRtkToken L.Tk__tok_VariableInitializerList_dummy_94 = "'tok_VariableInitializerList_dummy_94'"
 showRtkToken L.Tk__tok_WhileStatement_dummy_93 = "'tok_WhileStatement_dummy_93'"
 showRtkToken L.Tk__tok_WildcardType_dummy_92 = "'tok_WildcardType_dummy_92'"
-showRtkToken L.Tk__tok__tilde__82 = "'~'"
+showRtkToken L.Tk__tok__tilde__80 = "'~'"
 showRtkToken L.Tk__tok__symbol__15 = "'}'"
 showRtkToken L.Tk__tok__pipe__pipe__61 = "'||'"
 showRtkToken L.Tk__tok__pipe__eql__53 = "'|='"
@@ -1156,25 +1161,25 @@ showRtkToken L.Tk__tok__symbol__14 = "'{'"
 showRtkToken L.Tk__tok_while_42 = "'while'"
 showRtkToken L.Tk__tok_void_28 = "'void'"
 showRtkToken L.Tk__tok_try_46 = "'try'"
-showRtkToken L.Tk__tok_true_87 = "'true'"
-showRtkToken L.Tk__tok_transient_96 = "'transient'"
+showRtkToken L.Tk__tok_true_85 = "'true'"
+showRtkToken L.Tk__tok_transient_94 = "'transient'"
 showRtkToken L.Tk__tok_throws_29 = "'throws'"
 showRtkToken L.Tk__tok_throw_35 = "'throw'"
-showRtkToken L.Tk__tok_threadsafe_95 = "'threadsafe'"
-showRtkToken L.Tk__tok_this_84 = "'this'"
+showRtkToken L.Tk__tok_threadsafe_93 = "'threadsafe'"
+showRtkToken L.Tk__tok_this_82 = "'this'"
 showRtkToken L.Tk__tok_synchronized_34 = "'synchronized'"
 showRtkToken L.Tk__tok_switch_48 = "'switch'"
-showRtkToken L.Tk__tok_super_85 = "'super'"
+showRtkToken L.Tk__tok_super_83 = "'super'"
 showRtkToken L.Tk__tok_static_3 = "'static'"
 showRtkToken L.Tk__tok_short_23 = "'short'"
 showRtkToken L.Tk__tok_return_33 = "'return'"
-showRtkToken L.Tk__tok_public_90 = "'public'"
-showRtkToken L.Tk__tok_protected_92 = "'protected'"
-showRtkToken L.Tk__tok_private_91 = "'private'"
+showRtkToken L.Tk__tok_public_88 = "'public'"
+showRtkToken L.Tk__tok_protected_90 = "'protected'"
+showRtkToken L.Tk__tok_private_89 = "'private'"
 showRtkToken L.Tk__tok_package_0 = "'package'"
-showRtkToken L.Tk__tok_null_89 = "'null'"
-showRtkToken L.Tk__tok_new_86 = "'new'"
-showRtkToken L.Tk__tok_native_93 = "'native'"
+showRtkToken L.Tk__tok_null_87 = "'null'"
+showRtkToken L.Tk__tok_new_84 = "'new'"
+showRtkToken L.Tk__tok_native_91 = "'native'"
 showRtkToken L.Tk__tok_long_26 = "'long'"
 showRtkToken L.Tk__tok_interface_16 = "'interface'"
 showRtkToken L.Tk__tok_int_24 = "'int'"
@@ -1186,7 +1191,7 @@ showRtkToken L.Tk__tok_for_43 = "'for'"
 showRtkToken L.Tk__tok_float_25 = "'float'"
 showRtkToken L.Tk__tok_finally_45 = "'finally'"
 showRtkToken L.Tk__tok_final_31 = "'final'"
-showRtkToken L.Tk__tok_false_88 = "'false'"
+showRtkToken L.Tk__tok_false_86 = "'false'"
 showRtkToken L.Tk__tok_extends_11 = "'extends'"
 showRtkToken L.Tk__tok_enum_17 = "'enum'"
 showRtkToken L.Tk__tok_else_39 = "'else'"
@@ -1201,7 +1206,7 @@ showRtkToken L.Tk__tok_case_47 = "'case'"
 showRtkToken L.Tk__tok_byte_21 = "'byte'"
 showRtkToken L.Tk__tok_break_37 = "'break'"
 showRtkToken L.Tk__tok_boolean_20 = "'boolean'"
-showRtkToken L.Tk__tok_abstract_94 = "'abstract'"
+showRtkToken L.Tk__tok_abstract_92 = "'abstract'"
 showRtkToken L.Tk__tok__symbol__eql__55 = "'^='"
 showRtkToken L.Tk__tok__symbol__64 = "'^'"
 showRtkToken L.Tk__tok__sq_bkt_r__19 = "']'"
@@ -1209,30 +1214,28 @@ showRtkToken L.Tk__tok__sq_bkt_l__18 = "'['"
 showRtkToken L.Tk__tok__symbol__6 = "'@'"
 showRtkToken L.Tk__tok__symbol__60 = "'?'"
 showRtkToken L.Tk__tok__symbol__symbol__symbol__eql__59 = "'>>>='"
-showRtkToken L.Tk__tok__symbol__symbol__symbol__75 = "'>>>'"
 showRtkToken L.Tk__tok__symbol__symbol__eql__58 = "'>>='"
-showRtkToken L.Tk__tok__symbol__symbol__73 = "'>>'"
 showRtkToken L.Tk__tok__symbol__eql__71 = "'>='"
 showRtkToken L.Tk__tok__symbol__69 = "'>'"
 showRtkToken L.Tk__tok__eql__eql__66 = "'=='"
 showRtkToken L.Tk__tok__eql__10 = "'='"
 showRtkToken L.Tk__tok__symbol__eql__70 = "'<='"
 showRtkToken L.Tk__tok__symbol__symbol__eql__57 = "'<<='"
-showRtkToken L.Tk__tok__symbol__symbol__74 = "'<<'"
+showRtkToken L.Tk__tok__symbol__symbol__73 = "'<<'"
 showRtkToken L.Tk__tok__symbol__68 = "'<'"
 showRtkToken L.Tk__tok__semi__1 = "';'"
 showRtkToken L.Tk__tok__colon__36 = "':'"
 showRtkToken L.Tk__tok__symbol__eql__52 = "'/='"
-showRtkToken L.Tk__tok__symbol__78 = "'/'"
+showRtkToken L.Tk__tok__symbol__76 = "'/'"
 showRtkToken L.Tk__tok__dot__dot__dot__32 = "'...'"
 showRtkToken L.Tk__tok__dot__4 = "'.'"
 showRtkToken L.Tk__tok__minus__eql__50 = "'-='"
-showRtkToken L.Tk__tok__minus__minus__81 = "'--'"
-showRtkToken L.Tk__tok__minus__77 = "'-'"
+showRtkToken L.Tk__tok__minus__minus__79 = "'--'"
+showRtkToken L.Tk__tok__minus__75 = "'-'"
 showRtkToken L.Tk__tok__coma__9 = "','"
 showRtkToken L.Tk__tok__plus__eql__49 = "'+='"
-showRtkToken L.Tk__tok__plus__plus__80 = "'++'"
-showRtkToken L.Tk__tok__plus__76 = "'+'"
+showRtkToken L.Tk__tok__plus__plus__78 = "'++'"
+showRtkToken L.Tk__tok__plus__74 = "'+'"
 showRtkToken L.Tk__tok__star__eql__51 = "'*='"
 showRtkToken L.Tk__tok__star__5 = "'*'"
 showRtkToken L.Tk__tok__rparen__8 = "')'"
@@ -1241,9 +1244,9 @@ showRtkToken L.Tk__tok__symbol__eql__54 = "'&='"
 showRtkToken L.Tk__tok__symbol__symbol__62 = "'&&'"
 showRtkToken L.Tk__tok__symbol__65 = "'&'"
 showRtkToken L.Tk__tok__symbol__eql__56 = "'%='"
-showRtkToken L.Tk__tok__symbol__79 = "'%'"
+showRtkToken L.Tk__tok__symbol__77 = "'%'"
 showRtkToken L.Tk__tok__exclamation__eql__67 = "'!='"
-showRtkToken L.Tk__tok__exclamation__83 = "'!'"
+showRtkToken L.Tk__tok__exclamation__81 = "'!'"
 showRtkToken (L.Tk__doccomment v) = "doccomment " ++ show v
 showRtkToken (L.Tk__id v) = "id " ++ show v
 showRtkToken (L.Tk__string v) = "string " ++ show v
@@ -1323,6 +1326,7 @@ showRtkToken (L.Tk__qq_ClassDeclaration v) = "qq_ClassDeclaration " ++ show v
 showRtkToken (L.Tk__qq_FieldDeclarationList v) = "qq_FieldDeclarationList " ++ show v
 showRtkToken (L.Tk__qq_ImplementsList v) = "qq_ImplementsList " ++ show v
 showRtkToken (L.Tk__qq_ExtendsList v) = "qq_ExtendsList " ++ show v
+showRtkToken (L.Tk__qq_ClassOrInterfaceType v) = "qq_ClassOrInterfaceType " ++ show v
 showRtkToken (L.Tk__qq_ModifierList v) = "qq_ModifierList " ++ show v
 showRtkToken (L.Tk__qq_AnnotationList v) = "qq_AnnotationList " ++ show v
 showRtkToken (L.Tk__qq_AnnotationElement v) = "qq_AnnotationElement " ++ show v
@@ -1606,6 +1610,9 @@ tkVal_qq_ImplementsList t = error ("rtk internal error: token qq_ImplementsList 
 tkVal_qq_ExtendsList :: L.PosToken -> String
 tkVal_qq_ExtendsList (L.PosToken _ (L.Tk__qq_ExtendsList v)) = v
 tkVal_qq_ExtendsList t = error ("rtk internal error: token qq_ExtendsList expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_ClassOrInterfaceType :: L.PosToken -> String
+tkVal_qq_ClassOrInterfaceType (L.PosToken _ (L.Tk__qq_ClassOrInterfaceType v)) = v
+tkVal_qq_ClassOrInterfaceType t = error ("rtk internal error: token qq_ClassOrInterfaceType expected, got " ++ showRtkToken (L.ptToken t))
 tkVal_qq_ModifierList :: L.PosToken -> String
 tkVal_qq_ModifierList (L.PosToken _ (L.Tk__qq_ModifierList v)) = v
 tkVal_qq_ModifierList t = error ("rtk internal error: token qq_ModifierList expected, got " ++ showRtkToken (L.ptToken t))
@@ -1665,81 +1672,82 @@ data Java = Ctr__Java__0 RtkPos Java |
             Ctr__Java__10 RtkPos AssignmentOp |
             Ctr__Java__11 RtkPos CatchList |
             Ctr__Java__12 RtkPos ClassDeclaration |
-            Ctr__Java__13 RtkPos CompilationUnit |
-            Ctr__Java__14 RtkPos CompoundName |
-            Ctr__Java__15 RtkPos CreationExpression |
-            Ctr__Java__16 RtkPos DimExprs |
-            Ctr__Java__17 RtkPos Dims |
-            Ctr__Java__18 RtkPos DoStatement |
-            Ctr__Java__19 RtkPos DocComment |
-            Ctr__Java__20 RtkPos EnumConstant |
-            Ctr__Java__21 RtkPos EnumConstantList |
-            Ctr__Java__22 RtkPos EnumDeclaration |
-            Ctr__Java__23 RtkPos EqualityOp |
-            Ctr__Java__24 RtkPos Expression |
-            Ctr__Java__25 RtkPos ExtendsList |
-            Ctr__Java__26 RtkPos FieldDeclaration |
-            Ctr__Java__27 RtkPos FieldDeclarationList |
-            Ctr__Java__28 RtkPos ForStatement |
-            Ctr__Java__29 RtkPos IfStatement |
-            Ctr__Java__30 RtkPos ImplementsList |
-            Ctr__Java__31 RtkPos ImportHead |
-            Ctr__Java__32 RtkPos ImportList |
-            Ctr__Java__33 RtkPos ImportName |
-            Ctr__Java__34 RtkPos ImportStatement |
-            Ctr__Java__35 RtkPos InterfaceDeclaration |
-            Ctr__Java__36 RtkPos Literal |
-            Ctr__Java__37 RtkPos LocalModifierList1 |
-            Ctr__Java__38 RtkPos MemberAfterFirstId |
-            Ctr__Java__39 RtkPos MemberDeclaration |
-            Ctr__Java__40 RtkPos MemberRest |
-            Ctr__Java__41 RtkPos Modifier |
-            Ctr__Java__42 RtkPos ModifierList |
-            Ctr__Java__43 RtkPos MoreTypeSpecifier |
-            Ctr__Java__44 RtkPos MoreVariableDeclarators |
-            Ctr__Java__45 RtkPos MultiplicativeOp |
-            Ctr__Java__46 RtkPos NonEmptyDims |
-            Ctr__Java__47 RtkPos NonEmptyTypeArguments |
-            Ctr__Java__48 RtkPos OptDocComment |
-            Ctr__Java__49 RtkPos OptElsePart |
-            Ctr__Java__50 RtkPos OptExpression |
-            Ctr__Java__51 RtkPos OptFinally |
-            Ctr__Java__52 RtkPos OptId |
-            Ctr__Java__53 RtkPos OptVariableInitializer |
-            Ctr__Java__54 RtkPos Package |
-            Ctr__Java__55 RtkPos ParamModifierList |
-            Ctr__Java__56 RtkPos Parameter |
-            Ctr__Java__57 RtkPos ParameterList |
-            Ctr__Java__58 RtkPos PostfixOp |
-            Ctr__Java__59 RtkPos PrefixOp |
-            Ctr__Java__60 RtkPos PrimitiveTypeKeyword |
-            Ctr__Java__61 RtkPos RelationalOp |
-            Ctr__Java__62 RtkPos ShiftOp |
-            Ctr__Java__63 RtkPos Statement |
-            Ctr__Java__64 RtkPos StatementBlock |
-            Ctr__Java__65 RtkPos StatementList |
-            Ctr__Java__66 RtkPos StaticInitializer |
-            Ctr__Java__67 RtkPos SwitchCaseList |
-            Ctr__Java__68 RtkPos SwitchStatement |
-            Ctr__Java__69 RtkPos ThrowsClause |
-            Ctr__Java__70 RtkPos TryStatement |
-            Ctr__Java__71 RtkPos Type |
-            Ctr__Java__72 RtkPos TypeArgument |
-            Ctr__Java__73 RtkPos TypeArguments |
-            Ctr__Java__74 RtkPos TypeDeclRest |
-            Ctr__Java__75 RtkPos TypeDeclaration |
-            Ctr__Java__76 RtkPos TypeParameter |
-            Ctr__Java__77 RtkPos TypeParameters |
-            Ctr__Java__78 RtkPos TypeSpecifier |
-            Ctr__Java__79 RtkPos VariableDeclaration |
-            Ctr__Java__80 RtkPos VariableDeclarator |
-            Ctr__Java__81 RtkPos VariableDeclaratorList |
-            Ctr__Java__82 RtkPos VariableInitializer |
-            Ctr__Java__83 RtkPos VariableInitializerList |
-            Ctr__Java__84 RtkPos WhileStatement |
-            Ctr__Java__85 RtkPos WildcardType |
+            Ctr__Java__13 RtkPos ClassOrInterfaceType |
+            Ctr__Java__14 RtkPos CompilationUnit |
+            Ctr__Java__15 RtkPos CompoundName |
+            Ctr__Java__16 RtkPos CreationExpression |
+            Ctr__Java__17 RtkPos DimExprs |
+            Ctr__Java__18 RtkPos Dims |
+            Ctr__Java__19 RtkPos DoStatement |
+            Ctr__Java__20 RtkPos DocComment |
+            Ctr__Java__21 RtkPos EnumConstant |
+            Ctr__Java__22 RtkPos EnumConstantList |
+            Ctr__Java__23 RtkPos EnumDeclaration |
+            Ctr__Java__24 RtkPos EqualityOp |
+            Ctr__Java__25 RtkPos Expression |
+            Ctr__Java__26 RtkPos ExtendsList |
+            Ctr__Java__27 RtkPos FieldDeclaration |
+            Ctr__Java__28 RtkPos FieldDeclarationList |
+            Ctr__Java__29 RtkPos ForStatement |
+            Ctr__Java__30 RtkPos IfStatement |
+            Ctr__Java__31 RtkPos ImplementsList |
+            Ctr__Java__32 RtkPos ImportHead |
+            Ctr__Java__33 RtkPos ImportList |
+            Ctr__Java__34 RtkPos ImportName |
+            Ctr__Java__35 RtkPos ImportStatement |
+            Ctr__Java__36 RtkPos InterfaceDeclaration |
+            Ctr__Java__37 RtkPos Literal |
+            Ctr__Java__38 RtkPos LocalModifierList1 |
+            Ctr__Java__39 RtkPos MemberAfterFirstId |
+            Ctr__Java__40 RtkPos MemberDeclaration |
+            Ctr__Java__41 RtkPos MemberRest |
+            Ctr__Java__42 RtkPos Modifier |
+            Ctr__Java__43 RtkPos ModifierList |
+            Ctr__Java__44 RtkPos MoreTypeSpecifier |
+            Ctr__Java__45 RtkPos MoreVariableDeclarators |
+            Ctr__Java__46 RtkPos MultiplicativeOp |
+            Ctr__Java__47 RtkPos NonEmptyDims |
+            Ctr__Java__48 RtkPos NonEmptyTypeArguments |
+            Ctr__Java__49 RtkPos OptDocComment |
+            Ctr__Java__50 RtkPos OptElsePart |
+            Ctr__Java__51 RtkPos OptExpression |
+            Ctr__Java__52 RtkPos OptFinally |
+            Ctr__Java__53 RtkPos OptId |
+            Ctr__Java__54 RtkPos OptVariableInitializer |
+            Ctr__Java__55 RtkPos Package |
+            Ctr__Java__56 RtkPos ParamModifierList |
+            Ctr__Java__57 RtkPos Parameter |
+            Ctr__Java__58 RtkPos ParameterList |
+            Ctr__Java__59 RtkPos PostfixOp |
+            Ctr__Java__60 RtkPos PrefixOp |
+            Ctr__Java__61 RtkPos PrimitiveTypeKeyword |
+            Ctr__Java__62 RtkPos RelationalOp |
+            Ctr__Java__63 RtkPos ShiftOp |
+            Ctr__Java__64 RtkPos Statement |
+            Ctr__Java__65 RtkPos StatementBlock |
+            Ctr__Java__66 RtkPos StatementList |
+            Ctr__Java__67 RtkPos StaticInitializer |
+            Ctr__Java__68 RtkPos SwitchCaseList |
+            Ctr__Java__69 RtkPos SwitchStatement |
+            Ctr__Java__70 RtkPos ThrowsClause |
+            Ctr__Java__71 RtkPos TryStatement |
+            Ctr__Java__72 RtkPos Type |
+            Ctr__Java__73 RtkPos TypeArgument |
+            Ctr__Java__74 RtkPos TypeArguments |
+            Ctr__Java__75 RtkPos TypeDeclRest |
+            Ctr__Java__76 RtkPos TypeDeclaration |
+            Ctr__Java__77 RtkPos TypeParameter |
+            Ctr__Java__78 RtkPos TypeParameters |
+            Ctr__Java__79 RtkPos TypeSpecifier |
+            Ctr__Java__80 RtkPos VariableDeclaration |
+            Ctr__Java__81 RtkPos VariableDeclarator |
+            Ctr__Java__82 RtkPos VariableDeclaratorList |
+            Ctr__Java__83 RtkPos VariableInitializer |
+            Ctr__Java__84 RtkPos VariableInitializerList |
+            Ctr__Java__85 RtkPos WhileStatement |
+            Ctr__Java__86 RtkPos WildcardType |
             Anti_Java String |
-            Ctr__Java__86 RtkPos CompilationUnit
+            Ctr__Java__87 RtkPos CompilationUnit
             deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Java where
     rtkPosOf (Ctr__Java__0 p _) = p
@@ -1828,8 +1836,9 @@ instance RtkPosOf Java where
     rtkPosOf (Ctr__Java__83 p _) = p
     rtkPosOf (Ctr__Java__84 p _) = p
     rtkPosOf (Ctr__Java__85 p _) = p
-    rtkPosOf (Anti_Java _) = rtkNoPos
     rtkPosOf (Ctr__Java__86 p _) = p
+    rtkPosOf (Anti_Java _) = rtkNoPos
+    rtkPosOf (Ctr__Java__87 p _) = p
 data AdditiveOp = Anti_AdditiveOp String |
                   Ctr__AdditiveOp__0 RtkPos |
                   Ctr__AdditiveOp__1 RtkPos
@@ -1915,6 +1924,12 @@ data ClassDeclaration = Anti_ClassDeclaration String |
 instance RtkPosOf ClassDeclaration where
     rtkPosOf (Anti_ClassDeclaration _) = rtkNoPos
     rtkPosOf (Ctr__ClassDeclaration__0 p _ _ _ _ _) = p
+data ClassOrInterfaceType = Anti_ClassOrInterfaceType String |
+                            Ctr__ClassOrInterfaceType__0 RtkPos CompoundName TypeArguments
+                            deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf ClassOrInterfaceType where
+    rtkPosOf (Anti_ClassOrInterfaceType _) = rtkNoPos
+    rtkPosOf (Ctr__ClassOrInterfaceType__0 p _ _) = p
 data CompilationUnit = Anti_CompilationUnit String |
                        Ctr__CompilationUnit__0 RtkPos Rule_1 ImportList Rule_2
                        deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
@@ -2072,7 +2087,7 @@ instance RtkPosOf Expression where
     rtkPosOf (Ctr__Expression__45 p _ _) = p
     rtkPosOf (Ctr__Expression__46 p _) = p
 data ExtendsList = Anti_ExtendsList String |
-                   Ctr__ExtendsList__0 RtkPos CompoundName Rule_12
+                   Ctr__ExtendsList__0 RtkPos ClassOrInterfaceType Rule_12
                    deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf ExtendsList where
     rtkPosOf (Anti_ExtendsList _) = rtkNoPos
@@ -2365,11 +2380,11 @@ instance RtkPosOf Rule_10 where
     rtkPosOf (Ctr__Rule_10__1 p _) = p
     rtkPosOf (Ctr__Rule_10__2 p _) = p
 type Rule_12 = [Rule_13]
-data Rule_13 = Ctr__Rule_13__0 RtkPos CompoundName
+data Rule_13 = Ctr__Rule_13__0 RtkPos ClassOrInterfaceType
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_13 where
     rtkPosOf (Ctr__Rule_13__0 p _) = p
-type Rule_14 = [CompoundName]
+type Rule_14 = [ClassOrInterfaceType]
 data Rule_16 = Ctr__Rule_16__0 RtkPos |
                Ctr__Rule_16__1 RtkPos ExtendsList
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)

--- a/test/golden/java/JavaQQ.hs
+++ b/test/golden/java/JavaQQ.hs
@@ -63,7 +63,7 @@ rtkRenderError err =
                 _ -> err
         _ -> err
 
-qqShortcuts = M.fromList [ ("java","Java"),("additiveOp","AdditiveOp"),("annotation","Annotation"),("annotationArguments","AnnotationArguments"),("annotationDeclaration","AnnotationDeclaration"),("annotationElement","AnnotationElement"),("annotationList","AnnotationList"),("annotationTypeElement","AnnotationTypeElement"),("annotationTypeElementList","AnnotationTypeElementList"),("arglist","Arglist"),("assignmentOp","AssignmentOp"),("catchList","CatchList"),("classDeclaration","ClassDeclaration"),("compilationUnit","CompilationUnit"),("compoundName","CompoundName"),("creationExpression","CreationExpression"),("dimExprs","DimExprs"),("dims","Dims"),("doStatement","DoStatement"),("docComment","DocComment"),("enumConstant","EnumConstant"),("enumConstantList","EnumConstantList"),("enumDeclaration","EnumDeclaration"),("equalityOp","EqualityOp"),("expression","Expression"),("extendsList","ExtendsList"),("fieldDeclaration","FieldDeclaration"),("fieldDeclarationList","FieldDeclarationList"),("forStatement","ForStatement"),("ifStatement","IfStatement"),("implementsList","ImplementsList"),("importHead","ImportHead"),("importList","ImportList"),("importName","ImportName"),("importStatement","ImportStatement"),("interfaceDeclaration","InterfaceDeclaration"),("literal","Literal"),("localModifierList1","LocalModifierList1"),("memberAfterFirstId","MemberAfterFirstId"),("memberDeclaration","MemberDeclaration"),("memberRest","MemberRest"),("modifier","Modifier"),("modifierList","ModifierList"),("moreTypeSpecifier","MoreTypeSpecifier"),("moreVariableDeclarators","MoreVariableDeclarators"),("multiplicativeOp","MultiplicativeOp"),("nonEmptyDims","NonEmptyDims"),("nonEmptyTypeArguments","NonEmptyTypeArguments"),("optDocComment","OptDocComment"),("optElsePart","OptElsePart"),("optExpression","OptExpression"),("optFinally","OptFinally"),("optId","OptId"),("optVariableInitializer","OptVariableInitializer"),("package","Package"),("paramModifierList","ParamModifierList"),("parameter","Parameter"),("parameterList","ParameterList"),("postfixOp","PostfixOp"),("prefixOp","PrefixOp"),("primitiveTypeKeyword","PrimitiveTypeKeyword"),("relationalOp","RelationalOp"),("shiftOp","ShiftOp"),("statement","Statement"),("statementBlock","StatementBlock"),("statementList","StatementList"),("staticInitializer","StaticInitializer"),("switchCaseList","SwitchCaseList"),("switchStatement","SwitchStatement"),("throwsClause","ThrowsClause"),("tryStatement","TryStatement"),("type","Type"),("typeArgument","TypeArgument"),("typeArguments","TypeArguments"),("typeDeclRest","TypeDeclRest"),("typeDeclaration","TypeDeclaration"),("typeParameter","TypeParameter"),("typeParameters","TypeParameters"),("typeSpecifier","TypeSpecifier"),("variableDeclaration","VariableDeclaration"),("variableDeclarator","VariableDeclarator"),("variableDeclaratorList","VariableDeclaratorList"),("variableInitializer","VariableInitializer"),("variableInitializerList","VariableInitializerList"),("whileStatement","WhileStatement"),("wildcardType","WildcardType")]
+qqShortcuts = M.fromList [ ("java","Java"),("additiveOp","AdditiveOp"),("annotation","Annotation"),("annotationArguments","AnnotationArguments"),("annotationDeclaration","AnnotationDeclaration"),("annotationElement","AnnotationElement"),("annotationList","AnnotationList"),("annotationTypeElement","AnnotationTypeElement"),("annotationTypeElementList","AnnotationTypeElementList"),("arglist","Arglist"),("assignmentOp","AssignmentOp"),("catchList","CatchList"),("classDeclaration","ClassDeclaration"),("classOrInterfaceType","ClassOrInterfaceType"),("compilationUnit","CompilationUnit"),("compoundName","CompoundName"),("creationExpression","CreationExpression"),("dimExprs","DimExprs"),("dims","Dims"),("doStatement","DoStatement"),("docComment","DocComment"),("enumConstant","EnumConstant"),("enumConstantList","EnumConstantList"),("enumDeclaration","EnumDeclaration"),("equalityOp","EqualityOp"),("expression","Expression"),("extendsList","ExtendsList"),("fieldDeclaration","FieldDeclaration"),("fieldDeclarationList","FieldDeclarationList"),("forStatement","ForStatement"),("ifStatement","IfStatement"),("implementsList","ImplementsList"),("importHead","ImportHead"),("importList","ImportList"),("importName","ImportName"),("importStatement","ImportStatement"),("interfaceDeclaration","InterfaceDeclaration"),("literal","Literal"),("localModifierList1","LocalModifierList1"),("memberAfterFirstId","MemberAfterFirstId"),("memberDeclaration","MemberDeclaration"),("memberRest","MemberRest"),("modifier","Modifier"),("modifierList","ModifierList"),("moreTypeSpecifier","MoreTypeSpecifier"),("moreVariableDeclarators","MoreVariableDeclarators"),("multiplicativeOp","MultiplicativeOp"),("nonEmptyDims","NonEmptyDims"),("nonEmptyTypeArguments","NonEmptyTypeArguments"),("optDocComment","OptDocComment"),("optElsePart","OptElsePart"),("optExpression","OptExpression"),("optFinally","OptFinally"),("optId","OptId"),("optVariableInitializer","OptVariableInitializer"),("package","Package"),("paramModifierList","ParamModifierList"),("parameter","Parameter"),("parameterList","ParameterList"),("postfixOp","PostfixOp"),("prefixOp","PrefixOp"),("primitiveTypeKeyword","PrimitiveTypeKeyword"),("relationalOp","RelationalOp"),("shiftOp","ShiftOp"),("statement","Statement"),("statementBlock","StatementBlock"),("statementList","StatementList"),("staticInitializer","StaticInitializer"),("switchCaseList","SwitchCaseList"),("switchStatement","SwitchStatement"),("throwsClause","ThrowsClause"),("tryStatement","TryStatement"),("type","Type"),("typeArgument","TypeArgument"),("typeArguments","TypeArguments"),("typeDeclRest","TypeDeclRest"),("typeDeclaration","TypeDeclaration"),("typeParameter","TypeParameter"),("typeParameters","TypeParameters"),("typeSpecifier","TypeSpecifier"),("variableDeclaration","VariableDeclaration"),("variableDeclarator","VariableDeclarator"),("variableDeclaratorList","VariableDeclaratorList"),("variableInitializer","VariableInitializer"),("variableInitializerList","VariableInitializerList"),("whileStatement","WhileStatement"),("wildcardType","WildcardType")]
 
 -- A quasi-quote pattern must match an AST parsed from anywhere in a source
 -- file, while the pattern itself was parsed from the quote body - so every
@@ -80,7 +80,7 @@ quoteJavaExp dummy func s = do
            Left err -> fail (rtkRenderError err)
            Right a -> return a
   let expr = func ast
-  dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_63Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_66Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_76Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) expr
+  dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiClassOrInterfaceTypeExp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_63Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_66Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_76Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) expr
 quoteJavaPat :: Data.Data a => String -> (Java -> a) -> String -> TH.PatQ
 quoteJavaPat dummy func s = do
   s1 <- either fail return (replaceAllPatterns s)
@@ -88,7 +88,7 @@ quoteJavaPat dummy func s = do
            Left err -> fail (rtkRenderError err)
            Right a -> return a
   let expr = func ast
-  dataToPatQ (const Nothing `Generics.extQ` rtkPosWildPat `Generics.extQ` antiJavaPat `Generics.extQ` antiOptDocCommentPat `Generics.extQ` antiTypeDeclarationPat `Generics.extQ` antiImportStatementPat `Generics.extQ` antiCompilationUnitPat `Generics.extQ` antiPackagePat `Generics.extQ` antiImportNamePat `Generics.extQ` antiImportHeadPat `Generics.extQ` antiDocCommentPat `Generics.extQ` antiAnnotationPat `Generics.extQ` antiAnnotationArgumentsPat `Generics.extQ` antiAnnotationElementPat `Generics.extQ` antiRule_10Pat `Generics.extQ` antiExtendsListPat `Generics.extQ` antiImplementsListPat `Generics.extQ` antiFieldDeclarationPat `Generics.extQ` antiClassDeclarationPat `Generics.extQ` antiInterfaceDeclarationPat `Generics.extQ` antiAnnotationDeclarationPat `Generics.extQ` antiAnnotationTypeElementPat `Generics.extQ` antiEnumConstantPat `Generics.extQ` antiEnumConstantListPat `Generics.extQ` antiEnumDeclarationPat `Generics.extQ` antiTypeDeclRestPat `Generics.extQ` antiRule_31Pat `Generics.extQ` antiRule_33Pat `Generics.extQ` antiMemberDeclarationPat `Generics.extQ` antiPrimitiveTypeKeywordPat `Generics.extQ` antiMemberAfterFirstIdPat `Generics.extQ` antiMoreTypeSpecifierPat `Generics.extQ` antiThrowsClausePat `Generics.extQ` antiMemberRestPat `Generics.extQ` antiRule_44Pat `Generics.extQ` antiStatementBlockPat `Generics.extQ` antiVariableDeclaratorListPat `Generics.extQ` antiVariableDeclarationPat `Generics.extQ` antiRule_48Pat `Generics.extQ` antiOptVariableInitializerPat `Generics.extQ` antiVariableDeclaratorPat `Generics.extQ` antiVariableInitializerListPat `Generics.extQ` antiVariableInitializerPat `Generics.extQ` antiStaticInitializerPat `Generics.extQ` antiParameterListPat `Generics.extQ` antiRule_57Pat `Generics.extQ` antiParameterPat `Generics.extQ` antiStatementPat `Generics.extQ` antiOptExpressionPat `Generics.extQ` antiOptIdPat `Generics.extQ` antiOptElsePartPat `Generics.extQ` antiIfStatementPat `Generics.extQ` antiDoStatementPat `Generics.extQ` antiWhileStatementPat `Generics.extQ` antiForStatementPat `Generics.extQ` antiRule_63Pat `Generics.extQ` antiOptFinallyPat `Generics.extQ` antiTryStatementPat `Generics.extQ` antiRule_66Pat `Generics.extQ` antiSwitchStatementPat `Generics.extQ` antiExpressionPat `Generics.extQ` antiAssignmentOpPat `Generics.extQ` antiEqualityOpPat `Generics.extQ` antiRelationalOpPat `Generics.extQ` antiShiftOpPat `Generics.extQ` antiAdditiveOpPat `Generics.extQ` antiMultiplicativeOpPat `Generics.extQ` antiPrefixOpPat `Generics.extQ` antiPostfixOpPat `Generics.extQ` antiCreationExpressionPat `Generics.extQ` antiRule_76Pat `Generics.extQ` antiLiteralPat `Generics.extQ` antiArglistPat `Generics.extQ` antiTypeArgumentsPat `Generics.extQ` antiNonEmptyTypeArgumentsPat `Generics.extQ` antiTypeArgumentPat `Generics.extQ` antiWildcardTypePat `Generics.extQ` antiTypeParametersPat `Generics.extQ` antiTypeParameterPat `Generics.extQ` antiTypePat `Generics.extQ` antiTypeSpecifierPat `Generics.extQ` antiModifierPat `Generics.extQ` antiCompoundNamePat) expr
+  dataToPatQ (const Nothing `Generics.extQ` rtkPosWildPat `Generics.extQ` antiJavaPat `Generics.extQ` antiOptDocCommentPat `Generics.extQ` antiTypeDeclarationPat `Generics.extQ` antiImportStatementPat `Generics.extQ` antiCompilationUnitPat `Generics.extQ` antiPackagePat `Generics.extQ` antiImportNamePat `Generics.extQ` antiImportHeadPat `Generics.extQ` antiDocCommentPat `Generics.extQ` antiAnnotationPat `Generics.extQ` antiAnnotationArgumentsPat `Generics.extQ` antiAnnotationElementPat `Generics.extQ` antiRule_10Pat `Generics.extQ` antiClassOrInterfaceTypePat `Generics.extQ` antiExtendsListPat `Generics.extQ` antiImplementsListPat `Generics.extQ` antiFieldDeclarationPat `Generics.extQ` antiClassDeclarationPat `Generics.extQ` antiInterfaceDeclarationPat `Generics.extQ` antiAnnotationDeclarationPat `Generics.extQ` antiAnnotationTypeElementPat `Generics.extQ` antiEnumConstantPat `Generics.extQ` antiEnumConstantListPat `Generics.extQ` antiEnumDeclarationPat `Generics.extQ` antiTypeDeclRestPat `Generics.extQ` antiRule_31Pat `Generics.extQ` antiRule_33Pat `Generics.extQ` antiMemberDeclarationPat `Generics.extQ` antiPrimitiveTypeKeywordPat `Generics.extQ` antiMemberAfterFirstIdPat `Generics.extQ` antiMoreTypeSpecifierPat `Generics.extQ` antiThrowsClausePat `Generics.extQ` antiMemberRestPat `Generics.extQ` antiRule_44Pat `Generics.extQ` antiStatementBlockPat `Generics.extQ` antiVariableDeclaratorListPat `Generics.extQ` antiVariableDeclarationPat `Generics.extQ` antiRule_48Pat `Generics.extQ` antiOptVariableInitializerPat `Generics.extQ` antiVariableDeclaratorPat `Generics.extQ` antiVariableInitializerListPat `Generics.extQ` antiVariableInitializerPat `Generics.extQ` antiStaticInitializerPat `Generics.extQ` antiParameterListPat `Generics.extQ` antiRule_57Pat `Generics.extQ` antiParameterPat `Generics.extQ` antiStatementPat `Generics.extQ` antiOptExpressionPat `Generics.extQ` antiOptIdPat `Generics.extQ` antiOptElsePartPat `Generics.extQ` antiIfStatementPat `Generics.extQ` antiDoStatementPat `Generics.extQ` antiWhileStatementPat `Generics.extQ` antiForStatementPat `Generics.extQ` antiRule_63Pat `Generics.extQ` antiOptFinallyPat `Generics.extQ` antiTryStatementPat `Generics.extQ` antiRule_66Pat `Generics.extQ` antiSwitchStatementPat `Generics.extQ` antiExpressionPat `Generics.extQ` antiAssignmentOpPat `Generics.extQ` antiEqualityOpPat `Generics.extQ` antiRelationalOpPat `Generics.extQ` antiShiftOpPat `Generics.extQ` antiAdditiveOpPat `Generics.extQ` antiMultiplicativeOpPat `Generics.extQ` antiPrefixOpPat `Generics.extQ` antiPostfixOpPat `Generics.extQ` antiCreationExpressionPat `Generics.extQ` antiRule_76Pat `Generics.extQ` antiLiteralPat `Generics.extQ` antiArglistPat `Generics.extQ` antiTypeArgumentsPat `Generics.extQ` antiNonEmptyTypeArgumentsPat `Generics.extQ` antiTypeArgumentPat `Generics.extQ` antiWildcardTypePat `Generics.extQ` antiTypeParametersPat `Generics.extQ` antiTypeParameterPat `Generics.extQ` antiTypePat `Generics.extQ` antiTypeSpecifierPat `Generics.extQ` antiModifierPat `Generics.extQ` antiCompoundNamePat) expr
 
 antiCompoundNameExp :: CompoundName -> Maybe (TH.Q TH.Exp )
 antiCompoundNameExp ( Anti_CompoundName v) = Just $ TH.varE (TH.mkName v)
@@ -152,7 +152,7 @@ antiLiteralExp _ = Nothing
 
 antiRule_76Exp :: [ Rule_76 ] -> Maybe (TH.Q TH.Exp)
 antiRule_76Exp ((Anti_Rule_76 v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_63Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_66Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_76Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiClassOrInterfaceTypeExp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_63Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_66Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_76Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
 antiRule_76Exp _ = Nothing
@@ -215,7 +215,7 @@ antiSwitchStatementExp _ = Nothing
 
 antiRule_66Exp :: [ Rule_66 ] -> Maybe (TH.Q TH.Exp)
 antiRule_66Exp ((Anti_Rule_66 v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_63Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_66Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_76Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiClassOrInterfaceTypeExp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_63Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_66Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_76Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
 antiRule_66Exp _ = Nothing
@@ -233,7 +233,7 @@ antiOptFinallyExp _ = Nothing
 
 antiRule_63Exp :: [ Rule_63 ] -> Maybe (TH.Q TH.Exp)
 antiRule_63Exp ((Anti_Rule_63 v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_63Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_66Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_76Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiClassOrInterfaceTypeExp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_63Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_66Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_76Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
 antiRule_63Exp _ = Nothing
@@ -276,7 +276,7 @@ antiOptExpressionExp _ = Nothing
 
 antiStatementExp :: [ Statement ] -> Maybe (TH.Q TH.Exp)
 antiStatementExp ((Anti_Statement v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_63Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_66Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_76Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiClassOrInterfaceTypeExp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_63Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_66Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_76Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
 antiStatementExp _ = Nothing
@@ -289,7 +289,7 @@ antiParameterExp _ = Nothing
 
 antiRule_57Exp :: [ Rule_57 ] -> Maybe (TH.Q TH.Exp)
 antiRule_57Exp ((Anti_Rule_57 v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_63Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_66Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_76Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiClassOrInterfaceTypeExp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_63Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_66Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_76Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
 antiRule_57Exp _ = Nothing
@@ -327,7 +327,7 @@ antiOptVariableInitializerExp _ = Nothing
 
 antiRule_48Exp :: [ Rule_48 ] -> Maybe (TH.Q TH.Exp)
 antiRule_48Exp ((Anti_Rule_48 v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_63Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_66Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_76Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiClassOrInterfaceTypeExp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_63Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_66Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_76Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
 antiRule_48Exp _ = Nothing
@@ -350,7 +350,7 @@ antiStatementBlockExp _ = Nothing
 
 antiRule_44Exp :: [ Rule_44 ] -> Maybe (TH.Q TH.Exp)
 antiRule_44Exp ((Anti_Rule_44 v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_63Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_66Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_76Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiClassOrInterfaceTypeExp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_63Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_66Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_76Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
 antiRule_44Exp _ = Nothing
@@ -388,7 +388,7 @@ antiMemberDeclarationExp _ = Nothing
 
 antiRule_33Exp :: [ Rule_33 ] -> Maybe (TH.Q TH.Exp)
 antiRule_33Exp ((Anti_Rule_33 v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_63Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_66Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_76Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiClassOrInterfaceTypeExp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_63Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_66Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_76Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
 antiRule_33Exp _ = Nothing
@@ -396,7 +396,7 @@ antiRule_33Exp _ = Nothing
 
 antiRule_31Exp :: [ Rule_31 ] -> Maybe (TH.Q TH.Exp)
 antiRule_31Exp ((Anti_Rule_31 v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_63Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_66Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_76Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiClassOrInterfaceTypeExp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_63Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_66Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_76Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
 antiRule_31Exp _ = Nothing
@@ -424,7 +424,7 @@ antiEnumConstantExp _ = Nothing
 
 antiAnnotationTypeElementExp :: [ AnnotationTypeElement ] -> Maybe (TH.Q TH.Exp)
 antiAnnotationTypeElementExp ((Anti_AnnotationTypeElement v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_63Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_66Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_76Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiClassOrInterfaceTypeExp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_63Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_66Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_76Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
 antiAnnotationTypeElementExp _ = Nothing
@@ -447,7 +447,7 @@ antiClassDeclarationExp _ = Nothing
 
 antiFieldDeclarationExp :: [ FieldDeclaration ] -> Maybe (TH.Q TH.Exp)
 antiFieldDeclarationExp ((Anti_FieldDeclaration v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_63Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_66Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_76Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiClassOrInterfaceTypeExp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_63Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_66Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_76Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
 antiFieldDeclarationExp _ = Nothing
@@ -463,9 +463,14 @@ antiExtendsListExp ( Anti_ExtendsList v) = Just $ TH.varE (TH.mkName v)
 antiExtendsListExp _ = Nothing
 
 
+antiClassOrInterfaceTypeExp :: ClassOrInterfaceType -> Maybe (TH.Q TH.Exp )
+antiClassOrInterfaceTypeExp ( Anti_ClassOrInterfaceType v) = Just $ TH.varE (TH.mkName v)
+antiClassOrInterfaceTypeExp _ = Nothing
+
+
 antiRule_10Exp :: [ Rule_10 ] -> Maybe (TH.Q TH.Exp)
 antiRule_10Exp ((Anti_Rule_10 v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_63Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_66Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_76Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiClassOrInterfaceTypeExp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_63Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_66Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_76Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
 antiRule_10Exp _ = Nothing
@@ -513,7 +518,7 @@ antiCompilationUnitExp _ = Nothing
 
 antiImportStatementExp :: [ ImportStatement ] -> Maybe (TH.Q TH.Exp)
 antiImportStatementExp ((Anti_ImportStatement v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_63Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_66Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_76Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiClassOrInterfaceTypeExp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiRule_63Exp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiRule_66Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_76Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
 antiImportStatementExp _ = Nothing
@@ -875,6 +880,11 @@ antiExtendsListPat ( Anti_ExtendsList v) = Just $ TH.varP (TH.mkName v)
 antiExtendsListPat _ = Nothing
 
 
+antiClassOrInterfaceTypePat :: ClassOrInterfaceType -> Maybe (TH.Q TH.Pat )
+antiClassOrInterfaceTypePat ( Anti_ClassOrInterfaceType v) = Just $ TH.varP (TH.mkName v)
+antiClassOrInterfaceTypePat _ = Nothing
+
+
 antiRule_10Pat :: [ Rule_10 ] -> Maybe (TH.Q TH.Pat)
 antiRule_10Pat [Anti_Rule_10 v] = Just $ TH.varP (TH.mkName v)
 antiRule_10Pat _ = Nothing
@@ -947,429 +957,434 @@ quoteJavaDecs s = return []
 getJava ( Ctr__Java__0 _ s) = s
 
 java :: QuasiQuoter
-java = QuasiQuoter (quoteJavaExp "tok_Java_dummy_177" getJava ) (quoteJavaPat "tok_Java_dummy_177" getJava ) quoteJavaType quoteJavaDecs
+java = QuasiQuoter (quoteJavaExp "tok_Java_dummy_178" getJava ) (quoteJavaPat "tok_Java_dummy_178" getJava ) quoteJavaType quoteJavaDecs
 
 getAdditiveOp ( Ctr__Java__1 _ s) = s
 
 additiveOp :: QuasiQuoter
-additiveOp = QuasiQuoter (quoteJavaExp "tok_AdditiveOp_dummy_176" getAdditiveOp ) (quoteJavaPat "tok_AdditiveOp_dummy_176" getAdditiveOp ) quoteJavaType quoteJavaDecs
+additiveOp = QuasiQuoter (quoteJavaExp "tok_AdditiveOp_dummy_177" getAdditiveOp ) (quoteJavaPat "tok_AdditiveOp_dummy_177" getAdditiveOp ) quoteJavaType quoteJavaDecs
 
 getAnnotation ( Ctr__Java__2 _ s) = s
 
 annotation :: QuasiQuoter
-annotation = QuasiQuoter (quoteJavaExp "tok_Annotation_dummy_175" getAnnotation ) (quoteJavaPat "tok_Annotation_dummy_175" getAnnotation ) quoteJavaType quoteJavaDecs
+annotation = QuasiQuoter (quoteJavaExp "tok_Annotation_dummy_176" getAnnotation ) (quoteJavaPat "tok_Annotation_dummy_176" getAnnotation ) quoteJavaType quoteJavaDecs
 
 getAnnotationArguments ( Ctr__Java__3 _ s) = s
 
 annotationArguments :: QuasiQuoter
-annotationArguments = QuasiQuoter (quoteJavaExp "tok_AnnotationArguments_dummy_174" getAnnotationArguments ) (quoteJavaPat "tok_AnnotationArguments_dummy_174" getAnnotationArguments ) quoteJavaType quoteJavaDecs
+annotationArguments = QuasiQuoter (quoteJavaExp "tok_AnnotationArguments_dummy_175" getAnnotationArguments ) (quoteJavaPat "tok_AnnotationArguments_dummy_175" getAnnotationArguments ) quoteJavaType quoteJavaDecs
 
 getAnnotationDeclaration ( Ctr__Java__4 _ s) = s
 
 annotationDeclaration :: QuasiQuoter
-annotationDeclaration = QuasiQuoter (quoteJavaExp "tok_AnnotationDeclaration_dummy_173" getAnnotationDeclaration ) (quoteJavaPat "tok_AnnotationDeclaration_dummy_173" getAnnotationDeclaration ) quoteJavaType quoteJavaDecs
+annotationDeclaration = QuasiQuoter (quoteJavaExp "tok_AnnotationDeclaration_dummy_174" getAnnotationDeclaration ) (quoteJavaPat "tok_AnnotationDeclaration_dummy_174" getAnnotationDeclaration ) quoteJavaType quoteJavaDecs
 
 getAnnotationElement ( Ctr__Java__5 _ s) = s
 
 annotationElement :: QuasiQuoter
-annotationElement = QuasiQuoter (quoteJavaExp "tok_AnnotationElement_dummy_172" getAnnotationElement ) (quoteJavaPat "tok_AnnotationElement_dummy_172" getAnnotationElement ) quoteJavaType quoteJavaDecs
+annotationElement = QuasiQuoter (quoteJavaExp "tok_AnnotationElement_dummy_173" getAnnotationElement ) (quoteJavaPat "tok_AnnotationElement_dummy_173" getAnnotationElement ) quoteJavaType quoteJavaDecs
 
 getAnnotationList ( Ctr__Java__6 _ s) = s
 
 annotationList :: QuasiQuoter
-annotationList = QuasiQuoter (quoteJavaExp "tok_AnnotationList_dummy_171" getAnnotationList ) (quoteJavaPat "tok_AnnotationList_dummy_171" getAnnotationList ) quoteJavaType quoteJavaDecs
+annotationList = QuasiQuoter (quoteJavaExp "tok_AnnotationList_dummy_172" getAnnotationList ) (quoteJavaPat "tok_AnnotationList_dummy_172" getAnnotationList ) quoteJavaType quoteJavaDecs
 
 getAnnotationTypeElement ( Ctr__Java__7 _ s) = s
 
 annotationTypeElement :: QuasiQuoter
-annotationTypeElement = QuasiQuoter (quoteJavaExp "tok_AnnotationTypeElement_dummy_170" getAnnotationTypeElement ) (quoteJavaPat "tok_AnnotationTypeElement_dummy_170" getAnnotationTypeElement ) quoteJavaType quoteJavaDecs
+annotationTypeElement = QuasiQuoter (quoteJavaExp "tok_AnnotationTypeElement_dummy_171" getAnnotationTypeElement ) (quoteJavaPat "tok_AnnotationTypeElement_dummy_171" getAnnotationTypeElement ) quoteJavaType quoteJavaDecs
 
 getAnnotationTypeElementList ( Ctr__Java__8 _ s) = s
 
 annotationTypeElementList :: QuasiQuoter
-annotationTypeElementList = QuasiQuoter (quoteJavaExp "tok_AnnotationTypeElementList_dummy_169" getAnnotationTypeElementList ) (quoteJavaPat "tok_AnnotationTypeElementList_dummy_169" getAnnotationTypeElementList ) quoteJavaType quoteJavaDecs
+annotationTypeElementList = QuasiQuoter (quoteJavaExp "tok_AnnotationTypeElementList_dummy_170" getAnnotationTypeElementList ) (quoteJavaPat "tok_AnnotationTypeElementList_dummy_170" getAnnotationTypeElementList ) quoteJavaType quoteJavaDecs
 
 getArglist ( Ctr__Java__9 _ s) = s
 
 arglist :: QuasiQuoter
-arglist = QuasiQuoter (quoteJavaExp "tok_Arglist_dummy_168" getArglist ) (quoteJavaPat "tok_Arglist_dummy_168" getArglist ) quoteJavaType quoteJavaDecs
+arglist = QuasiQuoter (quoteJavaExp "tok_Arglist_dummy_169" getArglist ) (quoteJavaPat "tok_Arglist_dummy_169" getArglist ) quoteJavaType quoteJavaDecs
 
 getAssignmentOp ( Ctr__Java__10 _ s) = s
 
 assignmentOp :: QuasiQuoter
-assignmentOp = QuasiQuoter (quoteJavaExp "tok_AssignmentOp_dummy_167" getAssignmentOp ) (quoteJavaPat "tok_AssignmentOp_dummy_167" getAssignmentOp ) quoteJavaType quoteJavaDecs
+assignmentOp = QuasiQuoter (quoteJavaExp "tok_AssignmentOp_dummy_168" getAssignmentOp ) (quoteJavaPat "tok_AssignmentOp_dummy_168" getAssignmentOp ) quoteJavaType quoteJavaDecs
 
 getCatchList ( Ctr__Java__11 _ s) = s
 
 catchList :: QuasiQuoter
-catchList = QuasiQuoter (quoteJavaExp "tok_CatchList_dummy_166" getCatchList ) (quoteJavaPat "tok_CatchList_dummy_166" getCatchList ) quoteJavaType quoteJavaDecs
+catchList = QuasiQuoter (quoteJavaExp "tok_CatchList_dummy_167" getCatchList ) (quoteJavaPat "tok_CatchList_dummy_167" getCatchList ) quoteJavaType quoteJavaDecs
 
 getClassDeclaration ( Ctr__Java__12 _ s) = s
 
 classDeclaration :: QuasiQuoter
-classDeclaration = QuasiQuoter (quoteJavaExp "tok_ClassDeclaration_dummy_165" getClassDeclaration ) (quoteJavaPat "tok_ClassDeclaration_dummy_165" getClassDeclaration ) quoteJavaType quoteJavaDecs
+classDeclaration = QuasiQuoter (quoteJavaExp "tok_ClassDeclaration_dummy_166" getClassDeclaration ) (quoteJavaPat "tok_ClassDeclaration_dummy_166" getClassDeclaration ) quoteJavaType quoteJavaDecs
 
-getCompilationUnit ( Ctr__Java__13 _ s) = s
+getClassOrInterfaceType ( Ctr__Java__13 _ s) = s
+
+classOrInterfaceType :: QuasiQuoter
+classOrInterfaceType = QuasiQuoter (quoteJavaExp "tok_ClassOrInterfaceType_dummy_165" getClassOrInterfaceType ) (quoteJavaPat "tok_ClassOrInterfaceType_dummy_165" getClassOrInterfaceType ) quoteJavaType quoteJavaDecs
+
+getCompilationUnit ( Ctr__Java__14 _ s) = s
 
 compilationUnit :: QuasiQuoter
 compilationUnit = QuasiQuoter (quoteJavaExp "tok_CompilationUnit_dummy_164" getCompilationUnit ) (quoteJavaPat "tok_CompilationUnit_dummy_164" getCompilationUnit ) quoteJavaType quoteJavaDecs
 
-getCompoundName ( Ctr__Java__14 _ s) = s
+getCompoundName ( Ctr__Java__15 _ s) = s
 
 compoundName :: QuasiQuoter
 compoundName = QuasiQuoter (quoteJavaExp "tok_CompoundName_dummy_163" getCompoundName ) (quoteJavaPat "tok_CompoundName_dummy_163" getCompoundName ) quoteJavaType quoteJavaDecs
 
-getCreationExpression ( Ctr__Java__15 _ s) = s
+getCreationExpression ( Ctr__Java__16 _ s) = s
 
 creationExpression :: QuasiQuoter
 creationExpression = QuasiQuoter (quoteJavaExp "tok_CreationExpression_dummy_162" getCreationExpression ) (quoteJavaPat "tok_CreationExpression_dummy_162" getCreationExpression ) quoteJavaType quoteJavaDecs
 
-getDimExprs ( Ctr__Java__16 _ s) = s
+getDimExprs ( Ctr__Java__17 _ s) = s
 
 dimExprs :: QuasiQuoter
 dimExprs = QuasiQuoter (quoteJavaExp "tok_DimExprs_dummy_161" getDimExprs ) (quoteJavaPat "tok_DimExprs_dummy_161" getDimExprs ) quoteJavaType quoteJavaDecs
 
-getDims ( Ctr__Java__17 _ s) = s
+getDims ( Ctr__Java__18 _ s) = s
 
 dims :: QuasiQuoter
 dims = QuasiQuoter (quoteJavaExp "tok_Dims_dummy_160" getDims ) (quoteJavaPat "tok_Dims_dummy_160" getDims ) quoteJavaType quoteJavaDecs
 
-getDoStatement ( Ctr__Java__18 _ s) = s
+getDoStatement ( Ctr__Java__19 _ s) = s
 
 doStatement :: QuasiQuoter
 doStatement = QuasiQuoter (quoteJavaExp "tok_DoStatement_dummy_159" getDoStatement ) (quoteJavaPat "tok_DoStatement_dummy_159" getDoStatement ) quoteJavaType quoteJavaDecs
 
-getDocComment ( Ctr__Java__19 _ s) = s
+getDocComment ( Ctr__Java__20 _ s) = s
 
 docComment :: QuasiQuoter
 docComment = QuasiQuoter (quoteJavaExp "tok_DocComment_dummy_158" getDocComment ) (quoteJavaPat "tok_DocComment_dummy_158" getDocComment ) quoteJavaType quoteJavaDecs
 
-getEnumConstant ( Ctr__Java__20 _ s) = s
+getEnumConstant ( Ctr__Java__21 _ s) = s
 
 enumConstant :: QuasiQuoter
 enumConstant = QuasiQuoter (quoteJavaExp "tok_EnumConstant_dummy_157" getEnumConstant ) (quoteJavaPat "tok_EnumConstant_dummy_157" getEnumConstant ) quoteJavaType quoteJavaDecs
 
-getEnumConstantList ( Ctr__Java__21 _ s) = s
+getEnumConstantList ( Ctr__Java__22 _ s) = s
 
 enumConstantList :: QuasiQuoter
 enumConstantList = QuasiQuoter (quoteJavaExp "tok_EnumConstantList_dummy_156" getEnumConstantList ) (quoteJavaPat "tok_EnumConstantList_dummy_156" getEnumConstantList ) quoteJavaType quoteJavaDecs
 
-getEnumDeclaration ( Ctr__Java__22 _ s) = s
+getEnumDeclaration ( Ctr__Java__23 _ s) = s
 
 enumDeclaration :: QuasiQuoter
 enumDeclaration = QuasiQuoter (quoteJavaExp "tok_EnumDeclaration_dummy_155" getEnumDeclaration ) (quoteJavaPat "tok_EnumDeclaration_dummy_155" getEnumDeclaration ) quoteJavaType quoteJavaDecs
 
-getEqualityOp ( Ctr__Java__23 _ s) = s
+getEqualityOp ( Ctr__Java__24 _ s) = s
 
 equalityOp :: QuasiQuoter
 equalityOp = QuasiQuoter (quoteJavaExp "tok_EqualityOp_dummy_154" getEqualityOp ) (quoteJavaPat "tok_EqualityOp_dummy_154" getEqualityOp ) quoteJavaType quoteJavaDecs
 
-getExpression ( Ctr__Java__24 _ s) = s
+getExpression ( Ctr__Java__25 _ s) = s
 
 expression :: QuasiQuoter
 expression = QuasiQuoter (quoteJavaExp "tok_Expression_dummy_153" getExpression ) (quoteJavaPat "tok_Expression_dummy_153" getExpression ) quoteJavaType quoteJavaDecs
 
-getExtendsList ( Ctr__Java__25 _ s) = s
+getExtendsList ( Ctr__Java__26 _ s) = s
 
 extendsList :: QuasiQuoter
 extendsList = QuasiQuoter (quoteJavaExp "tok_ExtendsList_dummy_152" getExtendsList ) (quoteJavaPat "tok_ExtendsList_dummy_152" getExtendsList ) quoteJavaType quoteJavaDecs
 
-getFieldDeclaration ( Ctr__Java__26 _ s) = s
+getFieldDeclaration ( Ctr__Java__27 _ s) = s
 
 fieldDeclaration :: QuasiQuoter
 fieldDeclaration = QuasiQuoter (quoteJavaExp "tok_FieldDeclaration_dummy_151" getFieldDeclaration ) (quoteJavaPat "tok_FieldDeclaration_dummy_151" getFieldDeclaration ) quoteJavaType quoteJavaDecs
 
-getFieldDeclarationList ( Ctr__Java__27 _ s) = s
+getFieldDeclarationList ( Ctr__Java__28 _ s) = s
 
 fieldDeclarationList :: QuasiQuoter
 fieldDeclarationList = QuasiQuoter (quoteJavaExp "tok_FieldDeclarationList_dummy_150" getFieldDeclarationList ) (quoteJavaPat "tok_FieldDeclarationList_dummy_150" getFieldDeclarationList ) quoteJavaType quoteJavaDecs
 
-getForStatement ( Ctr__Java__28 _ s) = s
+getForStatement ( Ctr__Java__29 _ s) = s
 
 forStatement :: QuasiQuoter
 forStatement = QuasiQuoter (quoteJavaExp "tok_ForStatement_dummy_149" getForStatement ) (quoteJavaPat "tok_ForStatement_dummy_149" getForStatement ) quoteJavaType quoteJavaDecs
 
-getIfStatement ( Ctr__Java__29 _ s) = s
+getIfStatement ( Ctr__Java__30 _ s) = s
 
 ifStatement :: QuasiQuoter
 ifStatement = QuasiQuoter (quoteJavaExp "tok_IfStatement_dummy_148" getIfStatement ) (quoteJavaPat "tok_IfStatement_dummy_148" getIfStatement ) quoteJavaType quoteJavaDecs
 
-getImplementsList ( Ctr__Java__30 _ s) = s
+getImplementsList ( Ctr__Java__31 _ s) = s
 
 implementsList :: QuasiQuoter
 implementsList = QuasiQuoter (quoteJavaExp "tok_ImplementsList_dummy_147" getImplementsList ) (quoteJavaPat "tok_ImplementsList_dummy_147" getImplementsList ) quoteJavaType quoteJavaDecs
 
-getImportHead ( Ctr__Java__31 _ s) = s
+getImportHead ( Ctr__Java__32 _ s) = s
 
 importHead :: QuasiQuoter
 importHead = QuasiQuoter (quoteJavaExp "tok_ImportHead_dummy_146" getImportHead ) (quoteJavaPat "tok_ImportHead_dummy_146" getImportHead ) quoteJavaType quoteJavaDecs
 
-getImportList ( Ctr__Java__32 _ s) = s
+getImportList ( Ctr__Java__33 _ s) = s
 
 importList :: QuasiQuoter
 importList = QuasiQuoter (quoteJavaExp "tok_ImportList_dummy_145" getImportList ) (quoteJavaPat "tok_ImportList_dummy_145" getImportList ) quoteJavaType quoteJavaDecs
 
-getImportName ( Ctr__Java__33 _ s) = s
+getImportName ( Ctr__Java__34 _ s) = s
 
 importName :: QuasiQuoter
 importName = QuasiQuoter (quoteJavaExp "tok_ImportName_dummy_144" getImportName ) (quoteJavaPat "tok_ImportName_dummy_144" getImportName ) quoteJavaType quoteJavaDecs
 
-getImportStatement ( Ctr__Java__34 _ s) = s
+getImportStatement ( Ctr__Java__35 _ s) = s
 
 importStatement :: QuasiQuoter
 importStatement = QuasiQuoter (quoteJavaExp "tok_ImportStatement_dummy_143" getImportStatement ) (quoteJavaPat "tok_ImportStatement_dummy_143" getImportStatement ) quoteJavaType quoteJavaDecs
 
-getInterfaceDeclaration ( Ctr__Java__35 _ s) = s
+getInterfaceDeclaration ( Ctr__Java__36 _ s) = s
 
 interfaceDeclaration :: QuasiQuoter
 interfaceDeclaration = QuasiQuoter (quoteJavaExp "tok_InterfaceDeclaration_dummy_142" getInterfaceDeclaration ) (quoteJavaPat "tok_InterfaceDeclaration_dummy_142" getInterfaceDeclaration ) quoteJavaType quoteJavaDecs
 
-getLiteral ( Ctr__Java__36 _ s) = s
+getLiteral ( Ctr__Java__37 _ s) = s
 
 literal :: QuasiQuoter
 literal = QuasiQuoter (quoteJavaExp "tok_Literal_dummy_141" getLiteral ) (quoteJavaPat "tok_Literal_dummy_141" getLiteral ) quoteJavaType quoteJavaDecs
 
-getLocalModifierList1 ( Ctr__Java__37 _ s) = s
+getLocalModifierList1 ( Ctr__Java__38 _ s) = s
 
 localModifierList1 :: QuasiQuoter
 localModifierList1 = QuasiQuoter (quoteJavaExp "tok_LocalModifierList1_dummy_140" getLocalModifierList1 ) (quoteJavaPat "tok_LocalModifierList1_dummy_140" getLocalModifierList1 ) quoteJavaType quoteJavaDecs
 
-getMemberAfterFirstId ( Ctr__Java__38 _ s) = s
+getMemberAfterFirstId ( Ctr__Java__39 _ s) = s
 
 memberAfterFirstId :: QuasiQuoter
 memberAfterFirstId = QuasiQuoter (quoteJavaExp "tok_MemberAfterFirstId_dummy_139" getMemberAfterFirstId ) (quoteJavaPat "tok_MemberAfterFirstId_dummy_139" getMemberAfterFirstId ) quoteJavaType quoteJavaDecs
 
-getMemberDeclaration ( Ctr__Java__39 _ s) = s
+getMemberDeclaration ( Ctr__Java__40 _ s) = s
 
 memberDeclaration :: QuasiQuoter
 memberDeclaration = QuasiQuoter (quoteJavaExp "tok_MemberDeclaration_dummy_138" getMemberDeclaration ) (quoteJavaPat "tok_MemberDeclaration_dummy_138" getMemberDeclaration ) quoteJavaType quoteJavaDecs
 
-getMemberRest ( Ctr__Java__40 _ s) = s
+getMemberRest ( Ctr__Java__41 _ s) = s
 
 memberRest :: QuasiQuoter
 memberRest = QuasiQuoter (quoteJavaExp "tok_MemberRest_dummy_137" getMemberRest ) (quoteJavaPat "tok_MemberRest_dummy_137" getMemberRest ) quoteJavaType quoteJavaDecs
 
-getModifier ( Ctr__Java__41 _ s) = s
+getModifier ( Ctr__Java__42 _ s) = s
 
 modifier :: QuasiQuoter
 modifier = QuasiQuoter (quoteJavaExp "tok_Modifier_dummy_136" getModifier ) (quoteJavaPat "tok_Modifier_dummy_136" getModifier ) quoteJavaType quoteJavaDecs
 
-getModifierList ( Ctr__Java__42 _ s) = s
+getModifierList ( Ctr__Java__43 _ s) = s
 
 modifierList :: QuasiQuoter
 modifierList = QuasiQuoter (quoteJavaExp "tok_ModifierList_dummy_135" getModifierList ) (quoteJavaPat "tok_ModifierList_dummy_135" getModifierList ) quoteJavaType quoteJavaDecs
 
-getMoreTypeSpecifier ( Ctr__Java__43 _ s) = s
+getMoreTypeSpecifier ( Ctr__Java__44 _ s) = s
 
 moreTypeSpecifier :: QuasiQuoter
 moreTypeSpecifier = QuasiQuoter (quoteJavaExp "tok_MoreTypeSpecifier_dummy_134" getMoreTypeSpecifier ) (quoteJavaPat "tok_MoreTypeSpecifier_dummy_134" getMoreTypeSpecifier ) quoteJavaType quoteJavaDecs
 
-getMoreVariableDeclarators ( Ctr__Java__44 _ s) = s
+getMoreVariableDeclarators ( Ctr__Java__45 _ s) = s
 
 moreVariableDeclarators :: QuasiQuoter
 moreVariableDeclarators = QuasiQuoter (quoteJavaExp "tok_MoreVariableDeclarators_dummy_133" getMoreVariableDeclarators ) (quoteJavaPat "tok_MoreVariableDeclarators_dummy_133" getMoreVariableDeclarators ) quoteJavaType quoteJavaDecs
 
-getMultiplicativeOp ( Ctr__Java__45 _ s) = s
+getMultiplicativeOp ( Ctr__Java__46 _ s) = s
 
 multiplicativeOp :: QuasiQuoter
 multiplicativeOp = QuasiQuoter (quoteJavaExp "tok_MultiplicativeOp_dummy_132" getMultiplicativeOp ) (quoteJavaPat "tok_MultiplicativeOp_dummy_132" getMultiplicativeOp ) quoteJavaType quoteJavaDecs
 
-getNonEmptyDims ( Ctr__Java__46 _ s) = s
+getNonEmptyDims ( Ctr__Java__47 _ s) = s
 
 nonEmptyDims :: QuasiQuoter
 nonEmptyDims = QuasiQuoter (quoteJavaExp "tok_NonEmptyDims_dummy_131" getNonEmptyDims ) (quoteJavaPat "tok_NonEmptyDims_dummy_131" getNonEmptyDims ) quoteJavaType quoteJavaDecs
 
-getNonEmptyTypeArguments ( Ctr__Java__47 _ s) = s
+getNonEmptyTypeArguments ( Ctr__Java__48 _ s) = s
 
 nonEmptyTypeArguments :: QuasiQuoter
 nonEmptyTypeArguments = QuasiQuoter (quoteJavaExp "tok_NonEmptyTypeArguments_dummy_130" getNonEmptyTypeArguments ) (quoteJavaPat "tok_NonEmptyTypeArguments_dummy_130" getNonEmptyTypeArguments ) quoteJavaType quoteJavaDecs
 
-getOptDocComment ( Ctr__Java__48 _ s) = s
+getOptDocComment ( Ctr__Java__49 _ s) = s
 
 optDocComment :: QuasiQuoter
 optDocComment = QuasiQuoter (quoteJavaExp "tok_OptDocComment_dummy_129" getOptDocComment ) (quoteJavaPat "tok_OptDocComment_dummy_129" getOptDocComment ) quoteJavaType quoteJavaDecs
 
-getOptElsePart ( Ctr__Java__49 _ s) = s
+getOptElsePart ( Ctr__Java__50 _ s) = s
 
 optElsePart :: QuasiQuoter
 optElsePart = QuasiQuoter (quoteJavaExp "tok_OptElsePart_dummy_128" getOptElsePart ) (quoteJavaPat "tok_OptElsePart_dummy_128" getOptElsePart ) quoteJavaType quoteJavaDecs
 
-getOptExpression ( Ctr__Java__50 _ s) = s
+getOptExpression ( Ctr__Java__51 _ s) = s
 
 optExpression :: QuasiQuoter
 optExpression = QuasiQuoter (quoteJavaExp "tok_OptExpression_dummy_127" getOptExpression ) (quoteJavaPat "tok_OptExpression_dummy_127" getOptExpression ) quoteJavaType quoteJavaDecs
 
-getOptFinally ( Ctr__Java__51 _ s) = s
+getOptFinally ( Ctr__Java__52 _ s) = s
 
 optFinally :: QuasiQuoter
 optFinally = QuasiQuoter (quoteJavaExp "tok_OptFinally_dummy_126" getOptFinally ) (quoteJavaPat "tok_OptFinally_dummy_126" getOptFinally ) quoteJavaType quoteJavaDecs
 
-getOptId ( Ctr__Java__52 _ s) = s
+getOptId ( Ctr__Java__53 _ s) = s
 
 optId :: QuasiQuoter
 optId = QuasiQuoter (quoteJavaExp "tok_OptId_dummy_125" getOptId ) (quoteJavaPat "tok_OptId_dummy_125" getOptId ) quoteJavaType quoteJavaDecs
 
-getOptVariableInitializer ( Ctr__Java__53 _ s) = s
+getOptVariableInitializer ( Ctr__Java__54 _ s) = s
 
 optVariableInitializer :: QuasiQuoter
 optVariableInitializer = QuasiQuoter (quoteJavaExp "tok_OptVariableInitializer_dummy_124" getOptVariableInitializer ) (quoteJavaPat "tok_OptVariableInitializer_dummy_124" getOptVariableInitializer ) quoteJavaType quoteJavaDecs
 
-getPackage ( Ctr__Java__54 _ s) = s
+getPackage ( Ctr__Java__55 _ s) = s
 
 package :: QuasiQuoter
 package = QuasiQuoter (quoteJavaExp "tok_Package_dummy_123" getPackage ) (quoteJavaPat "tok_Package_dummy_123" getPackage ) quoteJavaType quoteJavaDecs
 
-getParamModifierList ( Ctr__Java__55 _ s) = s
+getParamModifierList ( Ctr__Java__56 _ s) = s
 
 paramModifierList :: QuasiQuoter
 paramModifierList = QuasiQuoter (quoteJavaExp "tok_ParamModifierList_dummy_122" getParamModifierList ) (quoteJavaPat "tok_ParamModifierList_dummy_122" getParamModifierList ) quoteJavaType quoteJavaDecs
 
-getParameter ( Ctr__Java__56 _ s) = s
+getParameter ( Ctr__Java__57 _ s) = s
 
 parameter :: QuasiQuoter
 parameter = QuasiQuoter (quoteJavaExp "tok_Parameter_dummy_121" getParameter ) (quoteJavaPat "tok_Parameter_dummy_121" getParameter ) quoteJavaType quoteJavaDecs
 
-getParameterList ( Ctr__Java__57 _ s) = s
+getParameterList ( Ctr__Java__58 _ s) = s
 
 parameterList :: QuasiQuoter
 parameterList = QuasiQuoter (quoteJavaExp "tok_ParameterList_dummy_120" getParameterList ) (quoteJavaPat "tok_ParameterList_dummy_120" getParameterList ) quoteJavaType quoteJavaDecs
 
-getPostfixOp ( Ctr__Java__58 _ s) = s
+getPostfixOp ( Ctr__Java__59 _ s) = s
 
 postfixOp :: QuasiQuoter
 postfixOp = QuasiQuoter (quoteJavaExp "tok_PostfixOp_dummy_119" getPostfixOp ) (quoteJavaPat "tok_PostfixOp_dummy_119" getPostfixOp ) quoteJavaType quoteJavaDecs
 
-getPrefixOp ( Ctr__Java__59 _ s) = s
+getPrefixOp ( Ctr__Java__60 _ s) = s
 
 prefixOp :: QuasiQuoter
 prefixOp = QuasiQuoter (quoteJavaExp "tok_PrefixOp_dummy_118" getPrefixOp ) (quoteJavaPat "tok_PrefixOp_dummy_118" getPrefixOp ) quoteJavaType quoteJavaDecs
 
-getPrimitiveTypeKeyword ( Ctr__Java__60 _ s) = s
+getPrimitiveTypeKeyword ( Ctr__Java__61 _ s) = s
 
 primitiveTypeKeyword :: QuasiQuoter
 primitiveTypeKeyword = QuasiQuoter (quoteJavaExp "tok_PrimitiveTypeKeyword_dummy_117" getPrimitiveTypeKeyword ) (quoteJavaPat "tok_PrimitiveTypeKeyword_dummy_117" getPrimitiveTypeKeyword ) quoteJavaType quoteJavaDecs
 
-getRelationalOp ( Ctr__Java__61 _ s) = s
+getRelationalOp ( Ctr__Java__62 _ s) = s
 
 relationalOp :: QuasiQuoter
 relationalOp = QuasiQuoter (quoteJavaExp "tok_RelationalOp_dummy_116" getRelationalOp ) (quoteJavaPat "tok_RelationalOp_dummy_116" getRelationalOp ) quoteJavaType quoteJavaDecs
 
-getShiftOp ( Ctr__Java__62 _ s) = s
+getShiftOp ( Ctr__Java__63 _ s) = s
 
 shiftOp :: QuasiQuoter
 shiftOp = QuasiQuoter (quoteJavaExp "tok_ShiftOp_dummy_115" getShiftOp ) (quoteJavaPat "tok_ShiftOp_dummy_115" getShiftOp ) quoteJavaType quoteJavaDecs
 
-getStatement ( Ctr__Java__63 _ s) = s
+getStatement ( Ctr__Java__64 _ s) = s
 
 statement :: QuasiQuoter
 statement = QuasiQuoter (quoteJavaExp "tok_Statement_dummy_114" getStatement ) (quoteJavaPat "tok_Statement_dummy_114" getStatement ) quoteJavaType quoteJavaDecs
 
-getStatementBlock ( Ctr__Java__64 _ s) = s
+getStatementBlock ( Ctr__Java__65 _ s) = s
 
 statementBlock :: QuasiQuoter
 statementBlock = QuasiQuoter (quoteJavaExp "tok_StatementBlock_dummy_113" getStatementBlock ) (quoteJavaPat "tok_StatementBlock_dummy_113" getStatementBlock ) quoteJavaType quoteJavaDecs
 
-getStatementList ( Ctr__Java__65 _ s) = s
+getStatementList ( Ctr__Java__66 _ s) = s
 
 statementList :: QuasiQuoter
 statementList = QuasiQuoter (quoteJavaExp "tok_StatementList_dummy_112" getStatementList ) (quoteJavaPat "tok_StatementList_dummy_112" getStatementList ) quoteJavaType quoteJavaDecs
 
-getStaticInitializer ( Ctr__Java__66 _ s) = s
+getStaticInitializer ( Ctr__Java__67 _ s) = s
 
 staticInitializer :: QuasiQuoter
 staticInitializer = QuasiQuoter (quoteJavaExp "tok_StaticInitializer_dummy_111" getStaticInitializer ) (quoteJavaPat "tok_StaticInitializer_dummy_111" getStaticInitializer ) quoteJavaType quoteJavaDecs
 
-getSwitchCaseList ( Ctr__Java__67 _ s) = s
+getSwitchCaseList ( Ctr__Java__68 _ s) = s
 
 switchCaseList :: QuasiQuoter
 switchCaseList = QuasiQuoter (quoteJavaExp "tok_SwitchCaseList_dummy_110" getSwitchCaseList ) (quoteJavaPat "tok_SwitchCaseList_dummy_110" getSwitchCaseList ) quoteJavaType quoteJavaDecs
 
-getSwitchStatement ( Ctr__Java__68 _ s) = s
+getSwitchStatement ( Ctr__Java__69 _ s) = s
 
 switchStatement :: QuasiQuoter
 switchStatement = QuasiQuoter (quoteJavaExp "tok_SwitchStatement_dummy_109" getSwitchStatement ) (quoteJavaPat "tok_SwitchStatement_dummy_109" getSwitchStatement ) quoteJavaType quoteJavaDecs
 
-getThrowsClause ( Ctr__Java__69 _ s) = s
+getThrowsClause ( Ctr__Java__70 _ s) = s
 
 throwsClause :: QuasiQuoter
 throwsClause = QuasiQuoter (quoteJavaExp "tok_ThrowsClause_dummy_108" getThrowsClause ) (quoteJavaPat "tok_ThrowsClause_dummy_108" getThrowsClause ) quoteJavaType quoteJavaDecs
 
-getTryStatement ( Ctr__Java__70 _ s) = s
+getTryStatement ( Ctr__Java__71 _ s) = s
 
 tryStatement :: QuasiQuoter
 tryStatement = QuasiQuoter (quoteJavaExp "tok_TryStatement_dummy_107" getTryStatement ) (quoteJavaPat "tok_TryStatement_dummy_107" getTryStatement ) quoteJavaType quoteJavaDecs
 
-getType ( Ctr__Java__71 _ s) = s
+getType ( Ctr__Java__72 _ s) = s
 
 __type :: QuasiQuoter
 __type = QuasiQuoter (quoteJavaExp "tok_Type_dummy_106" getType ) (quoteJavaPat "tok_Type_dummy_106" getType ) quoteJavaType quoteJavaDecs
 
-getTypeArgument ( Ctr__Java__72 _ s) = s
+getTypeArgument ( Ctr__Java__73 _ s) = s
 
 typeArgument :: QuasiQuoter
 typeArgument = QuasiQuoter (quoteJavaExp "tok_TypeArgument_dummy_105" getTypeArgument ) (quoteJavaPat "tok_TypeArgument_dummy_105" getTypeArgument ) quoteJavaType quoteJavaDecs
 
-getTypeArguments ( Ctr__Java__73 _ s) = s
+getTypeArguments ( Ctr__Java__74 _ s) = s
 
 typeArguments :: QuasiQuoter
 typeArguments = QuasiQuoter (quoteJavaExp "tok_TypeArguments_dummy_104" getTypeArguments ) (quoteJavaPat "tok_TypeArguments_dummy_104" getTypeArguments ) quoteJavaType quoteJavaDecs
 
-getTypeDeclRest ( Ctr__Java__74 _ s) = s
+getTypeDeclRest ( Ctr__Java__75 _ s) = s
 
 typeDeclRest :: QuasiQuoter
 typeDeclRest = QuasiQuoter (quoteJavaExp "tok_TypeDeclRest_dummy_103" getTypeDeclRest ) (quoteJavaPat "tok_TypeDeclRest_dummy_103" getTypeDeclRest ) quoteJavaType quoteJavaDecs
 
-getTypeDeclaration ( Ctr__Java__75 _ s) = s
+getTypeDeclaration ( Ctr__Java__76 _ s) = s
 
 typeDeclaration :: QuasiQuoter
 typeDeclaration = QuasiQuoter (quoteJavaExp "tok_TypeDeclaration_dummy_102" getTypeDeclaration ) (quoteJavaPat "tok_TypeDeclaration_dummy_102" getTypeDeclaration ) quoteJavaType quoteJavaDecs
 
-getTypeParameter ( Ctr__Java__76 _ s) = s
+getTypeParameter ( Ctr__Java__77 _ s) = s
 
 typeParameter :: QuasiQuoter
 typeParameter = QuasiQuoter (quoteJavaExp "tok_TypeParameter_dummy_101" getTypeParameter ) (quoteJavaPat "tok_TypeParameter_dummy_101" getTypeParameter ) quoteJavaType quoteJavaDecs
 
-getTypeParameters ( Ctr__Java__77 _ s) = s
+getTypeParameters ( Ctr__Java__78 _ s) = s
 
 typeParameters :: QuasiQuoter
 typeParameters = QuasiQuoter (quoteJavaExp "tok_TypeParameters_dummy_100" getTypeParameters ) (quoteJavaPat "tok_TypeParameters_dummy_100" getTypeParameters ) quoteJavaType quoteJavaDecs
 
-getTypeSpecifier ( Ctr__Java__78 _ s) = s
+getTypeSpecifier ( Ctr__Java__79 _ s) = s
 
 typeSpecifier :: QuasiQuoter
 typeSpecifier = QuasiQuoter (quoteJavaExp "tok_TypeSpecifier_dummy_99" getTypeSpecifier ) (quoteJavaPat "tok_TypeSpecifier_dummy_99" getTypeSpecifier ) quoteJavaType quoteJavaDecs
 
-getVariableDeclaration ( Ctr__Java__79 _ s) = s
+getVariableDeclaration ( Ctr__Java__80 _ s) = s
 
 variableDeclaration :: QuasiQuoter
 variableDeclaration = QuasiQuoter (quoteJavaExp "tok_VariableDeclaration_dummy_98" getVariableDeclaration ) (quoteJavaPat "tok_VariableDeclaration_dummy_98" getVariableDeclaration ) quoteJavaType quoteJavaDecs
 
-getVariableDeclarator ( Ctr__Java__80 _ s) = s
+getVariableDeclarator ( Ctr__Java__81 _ s) = s
 
 variableDeclarator :: QuasiQuoter
 variableDeclarator = QuasiQuoter (quoteJavaExp "tok_VariableDeclarator_dummy_97" getVariableDeclarator ) (quoteJavaPat "tok_VariableDeclarator_dummy_97" getVariableDeclarator ) quoteJavaType quoteJavaDecs
 
-getVariableDeclaratorList ( Ctr__Java__81 _ s) = s
+getVariableDeclaratorList ( Ctr__Java__82 _ s) = s
 
 variableDeclaratorList :: QuasiQuoter
 variableDeclaratorList = QuasiQuoter (quoteJavaExp "tok_VariableDeclaratorList_dummy_96" getVariableDeclaratorList ) (quoteJavaPat "tok_VariableDeclaratorList_dummy_96" getVariableDeclaratorList ) quoteJavaType quoteJavaDecs
 
-getVariableInitializer ( Ctr__Java__82 _ s) = s
+getVariableInitializer ( Ctr__Java__83 _ s) = s
 
 variableInitializer :: QuasiQuoter
 variableInitializer = QuasiQuoter (quoteJavaExp "tok_VariableInitializer_dummy_95" getVariableInitializer ) (quoteJavaPat "tok_VariableInitializer_dummy_95" getVariableInitializer ) quoteJavaType quoteJavaDecs
 
-getVariableInitializerList ( Ctr__Java__83 _ s) = s
+getVariableInitializerList ( Ctr__Java__84 _ s) = s
 
 variableInitializerList :: QuasiQuoter
 variableInitializerList = QuasiQuoter (quoteJavaExp "tok_VariableInitializerList_dummy_94" getVariableInitializerList ) (quoteJavaPat "tok_VariableInitializerList_dummy_94" getVariableInitializerList ) quoteJavaType quoteJavaDecs
 
-getWhileStatement ( Ctr__Java__84 _ s) = s
+getWhileStatement ( Ctr__Java__85 _ s) = s
 
 whileStatement :: QuasiQuoter
 whileStatement = QuasiQuoter (quoteJavaExp "tok_WhileStatement_dummy_93" getWhileStatement ) (quoteJavaPat "tok_WhileStatement_dummy_93" getWhileStatement ) quoteJavaType quoteJavaDecs
 
-getWildcardType ( Ctr__Java__85 _ s) = s
+getWildcardType ( Ctr__Java__86 _ s) = s
 
 wildcardType :: QuasiQuoter
 wildcardType = QuasiQuoter (quoteJavaExp "tok_WildcardType_dummy_92" getWildcardType ) (quoteJavaPat "tok_WildcardType_dummy_92" getWildcardType ) quoteJavaType quoteJavaDecs


### PR DESCRIPTION
## Summary

This change introduces a new `ClassOrInterfaceType` grammar rule to the Java grammar and updates all generated artifacts accordingly. The new rule captures the JLS concept of a supertype reference (a possibly qualified name with optional type arguments), and its introduction resolves one of the previously documented shift/reduce conflicts in the grammar.

## Key Changes

- **Grammar (`test-grammars/java.pg`)**: 
  - Added new `ClassOrInterfaceType` rule: `ClassOrInterfaceType = CompoundName TypeArguments ;`
  - Updated `ExtendsList` and `ImplementsList` to use `ClassOrInterfaceType` instead of bare `CompoundName`
  - Reduced documented shift/reduce conflicts from 18 to 17 (family 6 now has 2 states instead of 3)
  - Updated conflict inventory documentation to explain why the third state (pure type position with `Type -> CompoundName` reduce) vanished when `RelationalExpression` became non-associative

- **Generated Lexer (`test/golden/java/JavaLexer.x`)**:
  - Added token definition for `tok_ClassOrInterfaceType_dummy_165`
  - Renumbered all subsequent dummy tokens (165-177) to accommodate the new rule

- **Generated Parser (`test/golden/java/JavaParser.y`)**:
  - Added token declaration for `tok_ClassOrInterfaceType_dummy_165`
  - Added quasi-quoter token `qq_ClassOrInterfaceType`
  - Added new production rule for `ClassOrInterfaceType` in the `Java` rule
  - Renumbered all dummy tokens and constructor indices to reflect the new rule insertion

- **Generated Quasi-Quoter (`test/golden/java/JavaQQ.hs`)**:
  - Added quasi-quoter support for `ClassOrInterfaceType`

- **Test Artifacts**:
  - Updated token numbering in `test-grammars/java/lexical/operators.tokens` to reflect renumbered tokens
  - Updated blacklist files to reflect improved grammar support (20 additional files now parse successfully)

## Implementation Details

The `ClassOrInterfaceType` rule safely allows nullable `TypeArguments` directly after `CompoundName` in extends/implements position because no expression interpretation competes there. The epsilon-reduce of empty `TypeArguments` (on `,`, `{`, or `implements`) is the state's only action on those tokens, and `<` is a plain shift into `NonEmptyTypeArguments`. This contrasts with the `Type` rule, which must spell out its `NonEmptyTypeArguments` alternative due to expression context ambiguities.

This change demonstrates the grammar's evolution toward better handling of Java's generic type system while maintaining LALR(1) parsability.

https://claude.ai/code/session_01AsA6sDDHw9SFoCd8vz3Ptv