### PR TITLE
Add the Let's Build a Compiler tutorial (milestone 0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,6 +168,7 @@ jobs:
         run_test "P QQ Pattern Matching Tests" "make test-p"
         run_test "C Compiler Tutorial" "make -C tutorials/c-compiler test"
         run_test "Write You a Haskell Tutorial" "make -C tutorials/write-you-a-haskell test"
+        run_test "Lets Build a Compiler Tutorial" "make -C tutorials/lets-build-a-compiler test"
         run_test "Apache Commons Lexical Tests" "make test-lex-commons-lang-all"
         run_test "Apache Commons Parser Tests" "make test-parse-commons-lang-all"
         # test-debug and test-debug-all exercise the same debug flags but

--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -22,3 +22,10 @@ separate repository with minimal surgery.
   type checking, algorithm W, evaluation - pattern-matches concrete syntax
   via the generated quasi-quoters. Each language ships a test suite and a
   REPL.
+- [`lets-build-a-compiler/`](lets-build-a-compiler/) — an implementation of
+  Jack Crenshaw's ["Let's Build a Compiler"](https://compilers.iecc.com/crenshaw/)
+  tutorial: the hand-rolled recursive descent parser the tutorial spends most
+  of its chapters on is replaced by an RTK grammar, and the compiler passes
+  work on the generated AST through quasi-quotation patterns and splices.
+  Currently at milestone 0 (the parts 2-4 expression language plus a
+  QQ-pattern interpreter).

--- a/tutorials/lets-build-a-compiler/.gitignore
+++ b/tutorials/lets-build-a-compiler/.gitignore
@@ -1,0 +1,5 @@
+gen/
+build/
+/test-qq
+*.hi
+*.o

--- a/tutorials/lets-build-a-compiler/Makefile
+++ b/tutorials/lets-build-a-compiler/Makefile
@@ -1,0 +1,41 @@
+# Builds the milestone-0 calculator against the RTK checkout two levels up.
+# All Haskell tooling (rtk, alex, happy, and ghc with RTK's package set)
+# is taken from the parent project via `cabal exec`, so build RTK first:
+#
+#     cd ../.. && cabal build
+#
+# Targets:
+#     make build   - generate the front end from calc.pg and build test-qq
+#     make test    - run the quasi-quotation test suite
+#     make clean
+
+ROOT := ../..
+HERE := tutorials/lets-build-a-compiler
+GEN  := gen
+
+GENERATED := $(GEN)/CalcLexer.hs $(GEN)/CalcParser.hs $(GEN)/CalcQQ.hs
+
+.PHONY: all build test clean
+
+all: build
+
+build: test-qq
+
+$(GEN)/CalcLexer.x $(GEN)/CalcParser.y $(GEN)/CalcQQ.hs &: calc.pg
+	mkdir -p $(GEN)
+	cd $(ROOT) && cabal exec rtk -- $(HERE)/calc.pg $(HERE)/$(GEN)
+
+$(GEN)/%.hs: $(GEN)/%.x
+	cd $(ROOT) && cabal exec alex -- -g $(HERE)/$< -o $(HERE)/$@
+
+$(GEN)/%.hs: $(GEN)/%.y
+	cd $(ROOT) && cabal exec happy -- $(HERE)/$< --ghc -i$(HERE)/$(GEN)/$*.info -o $(HERE)/$@
+
+test-qq: TestQQ.hs $(GENERATED)
+	cd $(ROOT) && cabal exec -- ghc --make $(HERE)/TestQQ.hs -i$(HERE) -i$(HERE)/$(GEN) -outputdir $(HERE)/build/test-qq -o $(HERE)/test-qq
+
+test: build
+	./test-qq
+
+clean:
+	rm -rf $(GEN) build test-qq

--- a/tutorials/lets-build-a-compiler/README.md
+++ b/tutorials/lets-build-a-compiler/README.md
@@ -1,0 +1,56 @@
+# Let's Build a Compiler — with RTK
+
+An implementation of Jack Crenshaw's classic tutorial
+["Let's Build a Compiler"](https://compilers.iecc.com/crenshaw/) (1988-1995)
+where the hand-rolled recursive descent parser — the bulk of the tutorial's
+code — is replaced by an RTK grammar, and the later passes work on the
+generated AST with quasi-quotation pattern matching and antiquote splices.
+
+Crenshaw's compiler is single-pass by design: it emits code *while* parsing
+and never builds a syntax tree. This project deliberately departs from that:
+the grammar produces an AST, and what the tutorial does in seven chapters of
+scanner/parser mechanics (parts 2-3, 6-7, 11-12) collapses into one `.pg`
+file. The freed-up AST is what enables the pieces the original can't do,
+like source-to-source rewrites written in concrete syntax.
+
+## Status: milestone 0 (tutorial parts 2-4)
+
+| File | Role |
+|------|------|
+| `calc.pg` | The expression/assignment language of parts 2-3 as an RTK grammar: precedence cascade, unary minus, parentheses, `{ }` comments |
+| `TestQQ.hs` | Part 4's interpreter in miniature, written entirely with QQ patterns, plus the full quasi-quotation feature checklist (construction, scalar/list splices, pattern matching, whole-list binders) |
+
+```sh
+cd ../.. && cabal build      # build the RTK toolchain first
+cd tutorials/lets-build-a-compiler
+make test
+```
+
+## Roadmap
+
+| Milestone | Tutorial parts | Deliverable |
+|-----------|----------------|-------------|
+| 0 (this)  | 2-4 | calc grammar + QQ interpreter + idiom verification |
+| 1 | 5-12 | `tiny.pg`: the complete TINY 1.3 language (PROGRAM/VAR/IF/WHILE/READ/WRITE, boolean and relational operators) |
+| 2 | 10 | two backends: an interpreter for executable tests, and a 68000 emitter mirroring the tutorial's exact instruction sequences |
+| 3 | 5, 12 | the RTK showcase: FOR/REPEAT as grammar sugar desugared to core WHILE via QQ rewrites, constant folding as an AST pass |
+| 4 (maybe) | 13-14 | procedures and types (the KISS subset) |
+
+## RTK idioms this tutorial leans on
+
+- **Precedence cascades**: every level (`Expr`/`Term`/`Factor`) shares one
+  AST type and chains down with a `,`-lifted pass-through, so there are no
+  wrapper constructors and `[expr| $e1 + $e2 |]` pattern-matches any
+  addition node regardless of nesting depth.
+- **Quoter vs. shortcut naming**: the quasi-quoter is the lowercased *type*
+  name (`[expr| ... |]`, `[stmt| ... |]`); `@shortcuts` declarations only
+  control how `$`-variable prefixes resolve (`$e1` → `Expr`, `$body` →
+  `StmtList`).
+- **One anti-quote shape per type**: rule order decides whether a type's
+  antiquotes are scalar or whole-list. `StmtList` is declared before `Stmt`
+  (so `$body` binds a `[Stmt]`), while `ExprList` comes after the `Expr`
+  cascade (so `$e1` stays a single expression and `print($e1, $e2)` is a
+  fixed-arity pattern).
+- **Leaf destructors**: token payloads can't be bound by antiquotes, so
+  literals go through one hand-written accessor (`litVal`) over the
+  generated constructor; everything else is QQ.

--- a/tutorials/lets-build-a-compiler/TestQQ.hs
+++ b/tutorials/lets-build-a-compiler/TestQQ.hs
@@ -1,0 +1,115 @@
+{-# LANGUAGE QuasiQuotes #-}
+
+-- Milestone-0 test suite: the full RTK quasi-quotation feature checklist,
+-- exercised against calc.pg. The evaluator doubles as Crenshaw's part 4
+-- (an interpreter) in miniature: every language construct is destructured
+-- with a quasi-quotation pattern, never with a raw constructor match.
+--
+-- Token payloads (the integer literal, the variable name) cannot be bound
+-- by an antiquote ($x works on whole syntax sorts only), so leaf nodes go
+-- through one hand-written destructor (litVal). AST equality ignores
+-- source positions (RtkPos compares equal by design), which is what lets
+-- parsed, constructed and spliced trees be compared directly.
+--
+-- Exits non-zero on any mismatch. Run with: make test
+
+import qualified Data.Map as M
+import System.Exit (exitFailure)
+
+import CalcLexer
+import CalcParser
+import CalcQQ
+
+parseOrDie :: String -> Prog
+parseOrDie src = either errorWithoutStackTrace (\v -> v) (scanTokens src >>= parseCalc)
+
+-- ---------------------------------------------------------------------------
+-- The interpreter (Crenshaw part 4, on an AST instead of during the parse)
+-- ---------------------------------------------------------------------------
+
+type Env = M.Map Var Int
+
+-- leaf destructor: the one place a generated constructor is unavoidable
+litVal :: Lit -> Int
+litVal (Ctr__Lit__0 _ n) = n
+litVal other = error $ "litVal: unexpected literal node: " ++ show other
+
+evalE :: Env -> Expr -> Int
+evalE env [expr| $e1 + $e2 |] = evalE env e1 + evalE env e2
+evalE env [expr| $e1 - $e2 |] = evalE env e1 - evalE env e2
+evalE env [expr| $e1 * $e2 |] = evalE env e1 * evalE env e2
+evalE env [expr| $e1 / $e2 |] = evalE env e1 `div` evalE env e2
+evalE env [expr| - $e1 |]     = negate (evalE env e1)
+evalE _   [expr| $lit1 |]     = litVal lit1
+evalE env [expr| $var1 |]     =
+    case M.lookup var1 env of
+      Just v  -> v
+      Nothing -> error $ "evalE: unbound variable: " ++ show var1
+evalE _ other = error $ "evalE: unmatched expression: " ++ show other
+
+runStmt :: (Env, [Int]) -> Stmt -> (Env, [Int])
+runStmt (env, out) [stmt| $var1 = $e1 |]     = (M.insert var1 (evalE env e1) env, out)
+runStmt (env, out) [stmt| print($e1) |]      = (env, out ++ [evalE env e1])
+runStmt (env, out) [stmt| print($e1, $e2) |] = (env, out ++ [evalE env e1, evalE env e2])
+runStmt _ other = error $ "runStmt: unmatched statement: " ++ show other
+
+runProg :: Prog -> [Int]
+runProg [prog| $bodyAll |] = snd $ foldl runStmt (M.empty, []) bodyAll
+runProg other = error $ "runProg: unmatched program: " ++ show other
+
+-- ---------------------------------------------------------------------------
+-- Test driver
+-- ---------------------------------------------------------------------------
+
+check :: (Eq a, Show a) => String -> a -> a -> IO Bool
+check name got want
+  | got == want = do putStrLn $ "PASS: " ++ name
+                     return True
+  | otherwise   = do putStrLn $ "FAIL: " ++ name
+                     putStrLn $ "  expected: " ++ show want
+                     putStrLn $ "  got:      " ++ show got
+                     return False
+
+main :: IO ()
+main = do
+    let prg = parseOrDie
+          "x = 2 + 3 * 4;          { precedence }\n\
+          \y = (x - 2) * 2;        { grouping }\n\
+          \print(x, y);\n\
+          \print(-y / 2 + 1)       { unary minus }"
+
+    -- whole-body list antiquote in a let pattern
+    let [prog| $bodyXs |] = prg
+
+    -- list splice in construction: reuse the parsed statements, append two
+    let prg2 = [prog| $bodyXs ; z = x + 1 ; print(z) |]
+
+    -- construction with nested antiquote splices
+    let e_five = [expr| 5 |]
+        e_big  = [expr| $e_five * ($e_five + 1) |]
+
+    results <- sequence
+      [ check "parse + eval (typed Int tokens, sep lists, precedence, comments)"
+              (runProg prg) [14, 24, -11]
+      , check "whole-list pattern binds all statements"
+              (length bodyXs) 4
+      , check "stmt pattern with Var/Expr antiquotes"
+              (case head bodyXs of
+                 [stmt| $var1 = $e1 |] -> (var1 == [var| x |], evalE M.empty e1)
+                 _                     -> (False, 0))
+              (True, 14)
+      , check "precedence shapes patterns: 1 + 2 * 3 splits at '+'"
+              (case [expr| 1 + 2 * 3 |] of
+                 [expr| $e1 + $e2 |] -> (evalE M.empty e1, evalE M.empty e2)
+                 _                   -> (-1, -1))
+              (1, 6)
+      , check "parens are lifted away: (1) + 2 == 1 + 2"
+              [expr| (1) + 2 |] [expr| 1 + 2 |]
+      , check "antiquote splice into construction" (evalE M.empty e_big) 30
+      , check "list splice + construction runs"
+              (runProg prg2) [14, 24, -11, 15]
+      ]
+
+    if and results
+      then putStrLn $ "All " ++ show (length results) ++ " Calc QQ tests passed."
+      else exitFailure

--- a/tutorials/lets-build-a-compiler/calc.pg
+++ b/tutorials/lets-build-a-compiler/calc.pg
@@ -1,0 +1,64 @@
+grammar 'Calc';
+
+# Milestone 0 of "Let's Build a Compiler" (Jack Crenshaw, 1988-1995,
+# https://compilers.iecc.com/crenshaw/): the expression/assignment language
+# that parts 2-4 of the tutorial hand-build in Pascal, as one RTK grammar.
+# TestQQ.hs plays the role of part 4 (an interpreter): it evaluates this
+# language by quasi-quotation pattern matching over the generated AST.
+#
+# The grammar doubles as the idiom checklist for the TINY grammar of
+# milestone 1 (tutorial parts 5-12), so every construct TINY will rely on
+# appears here once: a precedence cascade, typed tokens, separated lists,
+# and both anti-quote shapes (scalar and list).
+
+# Prog will become TINY's real 'PROGRAM ... END' '.' rule in milestone 1;
+# for now a calc program is just a statement list.
+Prog = StmtList ;
+
+# NOTE: StmtList must be normalized BEFORE Stmt: RTK allows one anti-quote
+# shape per AST type (scalar or list), and statement anti-quotes should be
+# the list shape ($body binds/splices a whole [Stmt]).
+@shortcuts(body)
+StmtList = Stmt+ ~ ';' ;
+
+@shortcuts(s)
+Stmt = Var '=' Expr
+     | 'print' '(' ExprList ')' ;
+
+# Crenshaw's part 2-3 expressions as a precedence cascade in the
+# grammar.pg idiom: every level shares the Expr type and chains down via a
+# ,-lifted pass-through, so no per-level wrapper constructors exist and a
+# QQ pattern like [expr| $e1 + $e2 |] matches any addition node directly.
+# (Splice-token placement is handled by RTK's unit-production cover
+# analysis; see Normalize.hs.)
+@shortcuts(e)
+Expr = Expr '+' Term
+     | Expr '-' Term
+     | ,Term ;
+
+Expr: Term = Term '*' Factor
+           | Term '/' Factor
+           | ,Factor ;
+
+Expr: Factor = '(' ,Expr ')'
+             | '-' Factor
+             | Lit
+             | Var ;
+
+# Declared after the Expr cascade, so expression anti-quotes keep the
+# scalar shape: $e1 is one Expr, and print($e1, $e2) is a fixed
+# two-argument pattern.
+ExprList = Expr+ ~ ',' ;
+
+Lit = num ;
+Var = id ;
+
+# ----------------------------------------------------------------------------
+# Lexical rules
+# ----------------------------------------------------------------------------
+
+Int: num = [0-9]+ ;
+id = [a-z][a-z0-9_]* ;
+Ignore: ws = [ \t\n\r]+ ;
+# Crenshaw's TINY uses curly-brace comments (part 12)
+Ignore: comment = '{' ([^}\n] | [\n])* '}' ;


### PR DESCRIPTION
## Summary

Adds Jack Crenshaw's ["Let's Build a Compiler"](https://compilers.iecc.com/crenshaw/) as the second tutorial project, following the `tutorials/<name>/` layout established by #93: a self-contained directory that reaches into the parent checkout only for the RTK toolchain via `cabal exec`.

The tutorial's thesis: the hand-rolled recursive descent parser Crenshaw spends most of his chapters on collapses into one RTK grammar, and the compiler passes work on the generated AST through quasi-quotation patterns and splices instead of emitting code mid-parse.

## Milestone 0 (tutorial parts 2–4)

- `tutorials/lets-build-a-compiler/calc.pg` — the parts 2–3 expression/assignment language: precedence cascade in the `,`-lifted shared-type idiom, unary minus, parentheses, curly-brace comments, typed `Int` tokens, `~`-separated lists, and both anti-quote shapes (scalar `$e1`, whole-list `$body`) with the rule ordering that selects them documented in place.
- `tutorials/lets-build-a-compiler/TestQQ.hs` — part 4's interpreter in miniature: an evaluator written entirely with QQ patterns, doubling as a 7-check feature checklist (construction, scalar/list splices, pattern matching through the precedence cascade, whole-list binders, paren lifting).
- `Makefile`, `.gitignore`, `README.md` (with the milestone roadmap: TINY 1.3 next, then interpreter + 68000 emitter, then FOR/REPEAT desugaring and constant folding as QQ rewrites), registered in `tutorials/README.md`.
- CI: new "Lets Build a Compiler Tutorial" entry running `make -C tutorials/lets-build-a-compiler test`, next to the C tutorial's entry.

## Test plan

- [x] `make -C tutorials/lets-build-a-compiler test` — 7/7 QQ checks pass locally
- [x] `make test` — unit (139) and golden (55) suites unaffected
- [x] CI run on this PR

https://claude.ai/code/session_011L83UidVs2fAsigBDpaxJA

---
_Generated by [Claude Code](https://claude.ai/code/session_011L83UidVs2fAsigBDpaxJA)_