### PR TITLE
Add PL/0 compiler tutorial (Callahan's "Let's write a compiler", parts 1-3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,6 +169,7 @@ jobs:
         run_test "C Compiler Tutorial" "make -C tutorials/c-compiler test"
         run_test "Write You a Haskell Tutorial" "make -C tutorials/write-you-a-haskell test"
         run_test "Lets Build a Compiler Tutorial" "make -C tutorials/lets-build-a-compiler test"
+        run_test "PL/0 Compiler Tutorial" "make -C tutorials/pl0-compiler test"
         run_test "Apache Commons Lexical Tests" "make test-lex-commons-lang-all"
         run_test "Apache Commons Parser Tests" "make test-parse-commons-lang-all"
         # test-debug and test-debug-all exercise the same debug flags but

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- PL/0 compiler tutorial (`tutorials/pl0-compiler/`): the language of Brian
+  Callahan's "Let's write a compiler" tutorial series, at the series'
+  parts 1-3 ("validator") milestone. Baseline Wirth PL/0 — empty statements
+  via `StatementOpt`, unary signs, `{ ... }` comments — generated from
+  `pl0.pg` into a conflict-free Happy parser that is byte-identical under
+  both front ends. Ships a validator driver (`Main.hs`), a valid/invalid
+  test corpus with positioned-diagnostic checks (`run_tests.sh`), and a
+  quasi-quotation test suite (`TestQQ.hs`) exercising construction,
+  splicing, pattern matching with metavariables (a miniature PL/0 → C code
+  generator) and SYB-based AST rewrite rules; wired into CI via
+  `make -C tutorials/pl0-compiler test`
+
 ## [0.11] - 2026-06-12
 
 Highlights: RTK is now self-hosting by default — grammar files are parsed

--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -29,3 +29,10 @@ separate repository with minimal surgery.
   work on the generated AST through quasi-quotation patterns and splices.
   Currently at milestone 0 (the parts 2-4 expression language plus a
   QQ-pattern interpreter).
+- [`pl0-compiler/`](pl0-compiler/) — an implementation of Brian Callahan's
+  ["Let's write a compiler"](https://briancallahan.net/blog/20210814.html)
+  tutorial series (PL/0): the lexer and parser of the original — most of its
+  hand-written C — are generated from `pl0.pg`, and the quasi-quotation test
+  suite doubles as a miniature of the upcoming PL/0 → C code generator (QQ
+  pattern matching, splices, and SYB rewrite rules over the generated AST).
+  Currently at parts 1-3 (the series' parser/"validator" milestone).

--- a/tutorials/pl0-compiler/.gitignore
+++ b/tutorials/pl0-compiler/.gitignore
@@ -1,0 +1,6 @@
+gen/
+build/
+/pl0
+/test-qq
+*.hi
+*.o

--- a/tutorials/pl0-compiler/Main.hs
+++ b/tutorials/pl0-compiler/Main.hs
@@ -1,0 +1,57 @@
+import System.Environment (getArgs)
+import Pl0Lexer
+import Pl0Parser
+import Text.Show.Pretty (ppShow)
+import System.Exit (exitFailure, exitSuccess)
+
+data ParseMode = LexOnly | FullParse
+    deriving (Eq, Show)
+
+parseArgs :: [String] -> Either String (ParseMode, String)
+parseArgs args = case args of
+    ["--lex-only", file] -> Right (LexOnly, file)
+    [file] -> Right (FullParse, file)
+    _ -> Left "Usage: pl0 [--lex-only] <pl0-file>"
+
+-- The generated lexer and parser encode error positions as "LINE:COL:message"
+-- (machine-splittable); render them back human-readably for the console
+renderError :: String -> String
+renderError err =
+    case span (/= ':') err of
+        (l, ':' : rest1) | [(line, "")] <- (reads l :: [(Int, String)]) ->
+            case span (/= ':') rest1 of
+                (c, ':' : msg) | [(col, "")] <- (reads c :: [(Int, String)]) ->
+                    "line " ++ show line ++ ", column " ++ show col ++ ": " ++ msg
+                _ -> err
+        _ -> err
+
+-- PL/0 parser driver: the "validator" stage of the tutorial that
+-- pl0.pg follows (parts 1-3 of "Let's write a compiler").
+-- For quasi-quotation tests, see TestQQ.hs
+main :: IO ()
+main = do
+    args <- getArgs
+    case parseArgs args of
+        Left errMsg -> do
+            putStrLn errMsg
+            exitFailure
+        Right (mode, file) -> do
+            content <- readFile file
+
+            case mode of
+                LexOnly -> do
+                    -- Only perform lexical analysis
+                    let tokens = either (errorWithoutStackTrace . renderError) id $
+                                   scanTokens content
+                    putStrLn "=== Lexical analysis successful! ==="
+                    putStrLn $ "Token count: " ++ show (length tokens)
+                    exitSuccess
+
+                FullParse -> do
+                    -- Perform full parse; lexer and parser report errors as Left
+                    let ast = either (errorWithoutStackTrace . renderError) id $
+                                scanTokens content >>= parsePl0
+                    putStrLn "=== Parsed PL/0 AST ==="
+                    putStrLn $ ppShow ast
+                    putStrLn "\n=== Parse successful! ==="
+                    exitSuccess

--- a/tutorials/pl0-compiler/Makefile
+++ b/tutorials/pl0-compiler/Makefile
@@ -1,0 +1,45 @@
+# Builds the PL/0 validator against the RTK checkout two levels up.
+# All Haskell tooling (rtk, alex, happy, and ghc with RTK's package set)
+# is taken from the parent project via `cabal exec`, so build RTK first:
+#
+#     cd ../.. && cabal build
+#
+# Targets:
+#     make build   - generate front end from pl0.pg and build pl0 + test-qq
+#     make test    - run the quasi-quotation tests and the parser tests
+#     make clean
+
+ROOT := ../..
+HERE := tutorials/pl0-compiler
+GEN  := gen
+
+GENERATED := $(GEN)/Pl0Lexer.hs $(GEN)/Pl0Parser.hs $(GEN)/Pl0QQ.hs
+
+.PHONY: all build test clean
+
+all: build
+
+build: pl0 test-qq
+
+$(GEN)/Pl0Lexer.x $(GEN)/Pl0Parser.y $(GEN)/Pl0QQ.hs &: pl0.pg
+	mkdir -p $(GEN)
+	cd $(ROOT) && cabal exec rtk -- $(HERE)/pl0.pg $(HERE)/$(GEN)
+
+$(GEN)/%.hs: $(GEN)/%.x
+	cd $(ROOT) && cabal exec alex -- -g $(HERE)/$< -o $(HERE)/$@
+
+$(GEN)/%.hs: $(GEN)/%.y
+	cd $(ROOT) && cabal exec happy -- $(HERE)/$< --ghc -i$(HERE)/$(GEN)/$*.info -o $(HERE)/$@
+
+pl0: Main.hs $(GENERATED)
+	cd $(ROOT) && cabal exec -- ghc --make $(HERE)/Main.hs -i$(HERE) -i$(HERE)/$(GEN) -outputdir $(HERE)/build/pl0 -o $(HERE)/pl0
+
+test-qq: TestQQ.hs $(GENERATED)
+	cd $(ROOT) && cabal exec -- ghc --make $(HERE)/TestQQ.hs -i$(HERE) -i$(HERE)/$(GEN) -outputdir $(HERE)/build/test-qq -o $(HERE)/test-qq
+
+test: build
+	./test-qq
+	./run_tests.sh
+
+clean:
+	rm -rf $(GEN) build pl0 test-qq

--- a/tutorials/pl0-compiler/README.md
+++ b/tutorials/pl0-compiler/README.md
@@ -1,0 +1,117 @@
+# Let's Write a Compiler — with RTK
+
+An implementation of Brian Callahan's
+["Let's write a compiler"](https://briancallahan.net/blog/20210814.html)
+tutorial series (PL/0, Wirth's teaching language) in which RTK replaces the
+two largest hand-written components: the lexer (part 2 of the series) and
+the parser (part 3) are generated from [`pl0.pg`](pl0.pg), together with AST
+types and quasi-quoters that the upcoming passes are written against.
+
+**Status: parts 1–3** — the series' "validator" milestone: `pl0 file.pl0`
+parses baseline Wirth PL/0 and prints the AST, with positioned diagnostics
+for lexical and syntax errors. The original is single-pass (its parser emits
+C as it goes); this implementation is deliberately multi-pass (parse → AST →
+check → emit), which is what the quasi-quoters are for.
+
+## Layout
+
+| File | Role |
+|------|------|
+| `pl0.pg` | The PL/0 grammar. Everything under `gen/` is generated from it. |
+| `Main.hs` | Validator driver: `pl0 [--lex-only] file.pl0` parses and pretty-prints the AST. |
+| `TestQQ.hs` | Tests of the full QQ feature set, including a miniature PL/0 → C code generator and SYB rewrite rules over the generated AST. |
+| `run_tests.sh` | Checks every program under `tests/valid` parses and every program under `tests/invalid` is rejected with a positioned error. |
+
+## Building and testing
+
+The tutorial borrows all Haskell tooling from the RTK checkout two levels up
+(`cabal exec rtk/alex/happy/ghc`), so build RTK first:
+
+```bash
+cd ../..
+cabal build          # plus the toolchain setup described in /CLAUDE.md
+cd tutorials/pl0-compiler
+
+make build           # pl0.pg -> gen/{Pl0Lexer,Pl0Parser,Pl0QQ} -> pl0, test-qq
+make test            # QQ feature tests + parser tests
+```
+
+## The grammar, in RTK idioms
+
+- The expression hierarchy uses `,`-lifted pass-throughs
+  (`Expression: Term = ... | ,Factor ;`), so `Expression`, `Term` and
+  `Factor` share one AST type with no wrapper constructors, parentheses are
+  transparent, and one QQ pattern matches any expression node.
+- Wirth's grammar makes every statement position optional
+  (`statement = [ ... ]`); `StatementOpt = Statement? ;` is that bracketed
+  statement as a named rule, so `begin end.`, a trailing `;` before `end`,
+  and the minimal program `.` all parse, and `$so1` metavariables bind
+  either an empty or a present statement.
+- `Integer: number = [0-9]+ ;` gives the number token a real `Integer`
+  payload; `@shortcuts` declarations (`e`, `s`, `so`, `c`, `id`, `n`) name
+  the metavariables.
+- The parser is conflict-free (no shift/reduce, no reduce/reduce), and the
+  grammar generates byte-identically under both of RTK's front ends.
+
+A faithfulness detail worth knowing: Wirth allows a sign only at the *start*
+of an expression (`expression = [+|-] term {(+|-) term}`), so `-a + +b` is
+invalid PL/0 — `tests/invalid/sign-in-continuation.pl0` pins exactly that.
+
+## What "full RTK power" looks like here
+
+`TestQQ.hs` contains a miniature of the upcoming C code generator, written
+entirely as QQ patterns — no generated constructor names in sight:
+
+```haskell
+cgStmt [statement| $id1 := $e1 |]       = cgIdent id1 ++ " = " ++ cgExpr e1 ++ ";"
+cgStmt [statement| while $c1 do $so1 |] = "while " ++ cgCond c1 ++ " " ++ cgStmtOpt so1
+
+cgExpr [expression| $e1 + $e2 |]        = "(" ++ cgExpr e1 ++ " + " ++ cgExpr e2 ++ ")"
+```
+
+construction and splicing:
+
+```haskell
+let eLhs = [expression| x + 1 |]
+    eRhs = [expression| y - 1 |]
+in  [expression| $eLhs * $eRhs |]       -- == [expression| (x + 1) * (y - 1) |]
+```
+
+and AST rewrite rules, with QQ patterns on the left and QQ values on the
+right, lifted over whole trees by SYB:
+
+```haskell
+simplify [expression| $e1 + 0 |] = e1
+simplify [expression| $e1 * 1 |] = e1
+simplify x = x
+
+optimize = everywhere (mkT simplify)    -- (x + 0) * 1 + y * 1  ~>  x + y
+```
+
+The grammar-convention and limitation notes in
+[`../c-compiler/README.md`](../c-compiler/README.md) apply here unchanged;
+`pl0.pg` keeps the *scalar* antiquote shape for `Statement` (no named list
+rule), so `$s1` binds one statement and `begin` blocks are matched
+positionally (`begin $s1 ; $s2 end`) or through the list constructor.
+
+## Roadmap
+
+Following the blog series:
+
+4. testing infrastructure (partly here already: `tests/`, `run_tests.sh`)
+5. a C code generator — as a separate pass over the AST via QQ patterns;
+   candidate: build the output with the assembly-grammar approach from
+   `../c-compiler` instead of strings
+6. I/O statements (`writeInt`, `readInt into`, ...)
+7. arrays (`size`, indexing)
+8. strings, `forward` declarations, `exit`, `and`/`or`/`not`, `mod`
+
+Semantic checks (symbol table, assignment/call target validation, the
+depth-1 nesting rule of the reference compiler
+[`pl0c`](https://github.com/ibara/pl0c)) slot in before code generation;
+generated AST nodes carry source positions (`RtkPos`/`rtkPosOf`), so those
+diagnostics can name lines like the parser's do.
+
+This directory deliberately depends on the parent checkout only through
+`cabal exec`; giving it its own `.cabal` file is all it takes to move it to
+its own repository.

--- a/tutorials/pl0-compiler/TestQQ.hs
+++ b/tutorials/pl0-compiler/TestQQ.hs
@@ -1,0 +1,190 @@
+{-# LANGUAGE QuasiQuotes #-}
+
+-- PL/0 Quasi-Quotation Test Suite
+--
+-- Exercises the full quasi-quotation feature set on the PL/0 grammar:
+-- construction, anti-quotation (splicing), pattern matching with
+-- metavariables, and AST rewrite rules. The cg* functions below are a
+-- miniature of a PL/0 -> C code generator written entirely against QQ
+-- patterns; auto-generated constructor names appear only for leaf
+-- unwrapping (Ident/Number), the statement-list of 'begin', and the
+-- Program/Block shells. Positions (RtkPos) are equality-transparent
+-- and become wildcards in QQ patterns, so they never get in the way.
+--
+-- Metavariable naming: a $var must start with a shortcut declared in
+-- pl0.pg ($e* Expression, $s* Statement, $so* StatementOpt,
+-- $c* Condition, $id* Ident, $n* Number) or with a type name
+-- ($statementOpt1, ...); see docs/why-qq-limitations.md.
+
+import Pl0Lexer
+import Pl0Parser
+import Pl0QQ
+import Data.Generics (everywhere, mkT)
+import Control.Monad (unless)
+import System.Exit (exitFailure)
+
+-- ===== miniature code generator: QQ patterns all the way down =====
+
+cgStmt :: Statement -> String
+cgStmt [statement| $id1 := $e1 |]       = cgIdent id1 ++ " = " ++ cgExpr e1 ++ ";"
+cgStmt [statement| call $id1 |]         = cgIdent id1 ++ "();"
+cgStmt [statement| if $c1 then $so1 |]  = "if " ++ cgCond c1 ++ " " ++ cgStmtOpt so1
+cgStmt [statement| while $c1 do $so1 |] = "while " ++ cgCond c1 ++ " " ++ cgStmtOpt so1
+cgStmt (Ctr__Statement__2 _ sts)        = "{ " ++ unwords (map cgStmtOpt sts) ++ " }"
+cgStmt other = error ("cgStmt: unhandled statement: " ++ show other)
+
+-- Wirth's statement is optional everywhere it appears; the empty
+-- statement compiles to C's empty statement
+cgStmtOpt :: StatementOpt -> String
+cgStmtOpt [statementOpt| |]     = ";"
+cgStmtOpt [statementOpt| $s1 |] = cgStmt s1
+cgStmtOpt other = error ("cgStmtOpt: unhandled statement: " ++ show other)
+
+cgCond :: Condition -> String
+cgCond [condition| odd $e1 |]    = "(" ++ cgExpr e1 ++ " % 2 != 0)"
+cgCond [condition| $e1 = $e2 |]  = "(" ++ cgExpr e1 ++ " == " ++ cgExpr e2 ++ ")"
+cgCond [condition| $e1 # $e2 |]  = "(" ++ cgExpr e1 ++ " != " ++ cgExpr e2 ++ ")"
+cgCond [condition| $e1 < $e2 |]  = "(" ++ cgExpr e1 ++ " < " ++ cgExpr e2 ++ ")"
+cgCond [condition| $e1 <= $e2 |] = "(" ++ cgExpr e1 ++ " <= " ++ cgExpr e2 ++ ")"
+cgCond [condition| $e1 > $e2 |]  = "(" ++ cgExpr e1 ++ " > " ++ cgExpr e2 ++ ")"
+cgCond [condition| $e1 >= $e2 |] = "(" ++ cgExpr e1 ++ " >= " ++ cgExpr e2 ++ ")"
+cgCond other = error ("cgCond: unhandled condition: " ++ show other)
+
+cgExpr :: Expression -> String
+cgExpr [expression| $e1 + $e2 |] = "(" ++ cgExpr e1 ++ " + " ++ cgExpr e2 ++ ")"
+cgExpr [expression| $e1 - $e2 |] = "(" ++ cgExpr e1 ++ " - " ++ cgExpr e2 ++ ")"
+cgExpr [expression| $e1 * $e2 |] = "(" ++ cgExpr e1 ++ " * " ++ cgExpr e2 ++ ")"
+cgExpr [expression| $e1 / $e2 |] = "(" ++ cgExpr e1 ++ " / " ++ cgExpr e2 ++ ")"
+cgExpr [expression| - $e1 |]     = "(-" ++ cgExpr e1 ++ ")"
+cgExpr [expression| + $e1 |]     = cgExpr e1
+cgExpr [expression| $id1 |]      = cgIdent id1
+cgExpr [expression| $n1 |]       = cgNum n1
+cgExpr other = error ("cgExpr: unhandled expression: " ++ show other)
+
+cgIdent :: Ident -> String
+cgIdent (Ctr__Ident__0 _ name) = name
+cgIdent (Anti_Ident v) = error ("cgIdent: unexpected anti node: " ++ v)
+
+cgNum :: Number -> String
+cgNum (Ctr__Number__0 _ i) = show i
+cgNum (Anti_Number v) = error ("cgNum: unexpected anti node: " ++ v)
+
+-- ===== AST rewrite rules: QQ patterns + QQ construction with SYB =====
+
+simplify :: Expression -> Expression
+simplify [expression| $e1 + 0 |] = e1
+simplify [expression| 0 + $e1 |] = e1
+simplify [expression| $e1 - 0 |] = e1
+simplify [expression| $e1 * 1 |] = e1
+simplify [expression| 1 * $e1 |] = e1
+simplify x = x
+
+optimize :: Expression -> Expression
+optimize = everywhere (mkT simplify)
+
+-- Statement lists: positional element metavariables work; a single
+-- metavariable for the whole list is not supported for inline lists
+-- (it would bind one element; see docs/why-qq-limitations.md)
+isAssignPair :: Statement -> Bool
+isAssignPair [statement| begin $s1 ; $s2 end |] =
+    cgStmt s1 == "x = 1;" && cgStmt s2 == "y = x;"
+isAssignPair _ = False
+
+-- ===== test harness =====
+
+check :: String -> String -> String -> IO Bool
+check name expected actual
+    | expected == actual = do
+        putStrLn ("PASS: " ++ name)
+        return True
+    | otherwise = do
+        putStrLn ("FAIL: " ++ name)
+        putStrLn ("  expected: " ++ expected)
+        putStrLn ("  actual:   " ++ actual)
+        return False
+
+checkBool :: String -> Bool -> IO Bool
+checkBool name b = check name "True" (show b)
+
+main :: IO ()
+main = do
+    putStrLn "PL/0 Quasi-Quotation Test Suite"
+    putStrLn "==============================="
+
+    let eLhs    = [expression| x + 1 |]
+        eRhs    = [expression| y - 1 |]
+        spliced = [expression| $eLhs * $eRhs |]
+
+    results <- sequence
+        [ -- Construction builds the documented AST shape, with correct
+          -- precedence and no wrapper nodes for the Term/Factor chain;
+          -- positions compare as equal by construction (RtkPos Eq)
+          checkBool "construction: x + 2 * y has the expected AST"
+              ([expression| x + 2 * y |] ==
+               Ctr__Expression__6 rtkNoPos
+                   (Ctr__Expression__0 rtkNoPos (Ctr__Ident__0 rtkNoPos "x"))
+                   (Ctr__Expression__3 rtkNoPos
+                       (Ctr__Expression__1 rtkNoPos (Ctr__Number__0 rtkNoPos 2))
+                       (Ctr__Expression__0 rtkNoPos (Ctr__Ident__0 rtkNoPos "y"))))
+
+          -- Anti-quotation: splicing sub-ASTs equals direct construction
+        , checkBool "splice: ($e1 * $e2) == direct construction"
+              (spliced == [expression| (x + 1) * (y - 1) |])
+
+          -- Pattern matching with metavariables drives the code generator
+        , check "codegen: spliced expression"
+              "((x + 1) * (y - 1))" (cgExpr spliced)
+        , check "codegen: unary minus and plus"
+              "((-x) + y)" (cgExpr [expression| - x + y |])
+        , check "codegen: statement"
+              "while (x < 10) x = (x + 1);"
+              (cgStmt [statement| while x < 10 do x := x + 1 |])
+        , check "codegen: if with odd"
+              "if (n % 2 != 0) res = (res * b);"
+              (cgStmt [statement| if odd n then res := res * b |])
+        , check "codegen: all relational operators"
+              "(a == b) (a != b) (a < b) (a <= b) (a > b) (a >= b)"
+              (unwords (map cgCond
+                  [ [condition| a = b |], [condition| a # b |]
+                  , [condition| a < b |], [condition| a <= b |]
+                  , [condition| a > b |], [condition| a >= b |] ]))
+
+          -- Wirth's empty statement, at its own optional position
+        , check "codegen: empty statement"
+              ";" (cgStmtOpt [statementOpt| |])
+        , check "codegen: empty branch (if x = 0 then ;)"
+              "if (x == 0) ;"
+              (cgStmt [statement| if x = 0 then |])
+
+        , checkBool "pattern: two-element begin block"
+              (isAssignPair [statement| begin x := 1 ; y := x end |])
+
+          -- Rewrite rules: QQ patterns on the left, QQ values on the right
+        , check "rewrite: identity-element elimination"
+              "(x + y)"
+              (cgExpr (optimize [expression| (x + 0) * 1 + y * 1 |]))
+
+          -- Spliced result of a rewrite into a new statement
+        , let e9 = optimize [expression| (res + 0) * 1 |]
+          in check "splice rewritten expression into statement"
+              "out = res;" (cgStmt [statement| out := $e9 |])
+
+          -- The same parser handles files at runtime (Either API);
+          -- navigate the Program/Block shell and code-generate the body
+        , let parsed = scanTokens "var x; begin x := 6 * 7; if odd x then x := 0 end."
+                         >>= parsePl0
+          in check "runtime parse -> codegen"
+              "{ x = (6 * 7); if (x % 2 != 0) x = 0; }"
+              (case parsed of
+                   Right (Ctr__Program__12 _ (Ctr__Block__0 _ _ _ _ so)) ->
+                       cgStmtOpt so
+                   Right other -> "<unexpected program shape: " ++ show other ++ ">"
+                   Left err -> "<parse failed: " ++ err ++ ">")
+        ]
+
+    putStrLn "==============================="
+    let failed = length (filter not results)
+    unless (failed == 0) $ do
+        putStrLn (show failed ++ " test(s) failed")
+        exitFailure
+    putStrLn ("All " ++ show (length results) ++ " tests passed")

--- a/tutorials/pl0-compiler/pl0.pg
+++ b/tutorials/pl0-compiler/pl0.pg
@@ -1,0 +1,72 @@
+grammar 'Pl0';
+
+# PL/0 grammar (Niklaus Wirth), as used in Brian Callahan's tutorial series
+# "Let's write a compiler" (https://briancallahan.net/blog/20210814.html),
+# parts 1-3: the baseline language, before the I/O / array / string
+# extensions of the later parts.
+#
+# The expression hierarchy follows the same idiom as grammar.pg's Clause
+# rules: Term and Factor share the Expression data type, and their
+# pass-through alternatives are lifted (,), so the AST has no wrapper
+# noise and parenthesized expressions are transparent.
+
+Program = Block '.' ;
+
+Block = ConstDecl? VarDecl? Procedure* StatementOpt ;
+
+ConstDecl = 'const' ConstDef+ ~ ',' ';' ;
+
+ConstDef = Ident '=' Number ;
+
+VarDecl = 'var' Ident+ ~ ',' ';' ;
+
+Procedure = 'procedure' Ident ';' Block ';' ;
+
+# Wirth's grammar makes every statement position optional
+# (statement = [ ... ]); StatementOpt is that bracketed statement, so
+# programs like 'begin end.', a trailing ';' before 'end' and the
+# minimal program '.' are all valid.
+@shortcuts(so)
+StatementOpt = Statement? ;
+
+@shortcuts(s)
+Statement = Ident ':=' Expression
+          | 'call' Ident
+          | 'begin' StatementOpt+ ~ ';' 'end'
+          | 'if' Condition 'then' StatementOpt
+          | 'while' Condition 'do' StatementOpt ;
+
+@shortcuts(c)
+Condition = 'odd' Expression
+          | Expression '=' Expression
+          | Expression '#' Expression
+          | Expression '<' Expression
+          | Expression '<=' Expression
+          | Expression '>' Expression
+          | Expression '>=' Expression ;
+
+@shortcuts(e)
+Expression = Expression '+' Term
+           | Expression '-' Term
+           | '-' Term
+           | '+' Term
+           | ,Term ;
+
+Expression: Term = Term '*' Factor
+                 | Term '/' Factor
+                 | ,Factor ;
+
+Expression: Factor = Ident
+                   | Number
+                   | '(' ,Expression ')' ;
+
+@shortcuts(id)
+Ident = ident ;
+
+@shortcuts(n)
+Number = number ;
+
+ident = [A-Za-z_][A-Za-z0-9_]* ;
+Integer: number = [0-9]+ ;
+Ignore: ws = [ \t\r\n]+ ;
+Ignore: comment = '{' ([^}]|[\n])* '}' ;

--- a/tutorials/pl0-compiler/run_tests.sh
+++ b/tutorials/pl0-compiler/run_tests.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Parser ("validator") tests, the deliverable of parts 1-3 of the tutorial:
+#   - valid programs: pl0 must accept them (exit 0)
+#   - invalid programs: pl0 must exit non-zero with a positioned diagnostic
+#     (every error message names a line number)
+cd "$(dirname "$0")" || exit 1
+
+if [ ! -x ./pl0 ]; then
+    echo "pl0 not built; run 'make build' first" >&2
+    exit 1
+fi
+
+fail=0
+
+for f in tests/valid/*.pl0; do
+    if ./pl0 "$f" >/dev/null 2>&1; then
+        echo "PASS  $f"
+    else
+        echo "FAIL  $f (validator rejected a valid program)"
+        fail=1
+    fi
+done
+
+for f in tests/invalid/*.pl0; do
+    err=$(./pl0 "$f" 2>&1 >/dev/null)
+    if ./pl0 "$f" >/dev/null 2>&1; then
+        echo "FAIL  $f (validator accepted an invalid program)"
+        fail=1
+    elif ! printf '%s' "$err" | grep -q "line"; then
+        echo "FAIL  $f (rejected, but the diagnostic has no position: $err)"
+        fail=1
+    else
+        echo "PASS  $f (rejected: $err)"
+    fi
+done
+
+if [ "$fail" = 0 ]; then
+    echo "All PL/0 parser tests passed."
+fi
+exit "$fail"

--- a/tutorials/pl0-compiler/tests/invalid/assign-eq.pl0
+++ b/tutorials/pl0-compiler/tests/invalid/assign-eq.pl0
@@ -1,0 +1,7 @@
+{ '=' is comparison; assignment is ':=' }
+
+var x;
+
+begin
+   x = 1
+end.

--- a/tutorials/pl0-compiler/tests/invalid/bad-token.pl0
+++ b/tutorials/pl0-compiler/tests/invalid/bad-token.pl0
@@ -1,0 +1,7 @@
+{ '?' is not a PL/0 token (a lexical error, not a parse error) }
+
+var x?;
+
+begin
+   x := 1
+end.

--- a/tutorials/pl0-compiler/tests/invalid/missing-dot.pl0
+++ b/tutorials/pl0-compiler/tests/invalid/missing-dot.pl0
@@ -1,0 +1,3 @@
+{ a program is a block followed by '.' }
+
+begin end

--- a/tutorials/pl0-compiler/tests/invalid/missing-then.pl0
+++ b/tutorials/pl0-compiler/tests/invalid/missing-then.pl0
@@ -1,0 +1,7 @@
+{ 'if' requires 'then' }
+
+var x;
+
+begin
+   if x = 1 x := 2
+end.

--- a/tutorials/pl0-compiler/tests/invalid/sign-in-continuation.pl0
+++ b/tutorials/pl0-compiler/tests/invalid/sign-in-continuation.pl0
@@ -1,0 +1,9 @@
+{ Wirth's grammar allows a sign only at the start of an expression
+  (expression = [+|-] term ...), so a sign after a binary operator
+  is invalid PL/0 }
+
+var a, b, x;
+
+begin
+   x := -a + +b
+end.

--- a/tutorials/pl0-compiler/tests/valid/edge-cases.pl0
+++ b/tutorials/pl0-compiler/tests/valid/edge-cases.pl0
@@ -1,0 +1,22 @@
+{ edge-cases.pl0 - grammar corner cases: comments, multiple const
+  definitions, unary signs, every relational operator, odd, nested
+  blocks, and the empty statement (trailing ';', 'begin end', bare
+  'then ;') }
+
+const a = 1, b = 2;
+var x, y;
+
+begin
+   x := -a + b * 2;
+   y := +a;
+   if odd x then x := x + 1;
+   if x = 2 then y := 1;
+   if x # 3 then y := 2;
+   if x < 10 then y := 3;
+   if x <= 10 then y := 4;
+   if x > 0 then y := 5;
+   if x >= 1 then y := 6;
+   while x > 0 do x := x - (y / 2 + 1);
+   begin end;
+   if x = 0 then ;
+end.

--- a/tutorials/pl0-compiler/tests/valid/minimal.pl0
+++ b/tutorials/pl0-compiler/tests/valid/minimal.pl0
@@ -1,0 +1,2 @@
+{ minimal.pl0 - the smallest valid PL/0 program: an empty block }
+.

--- a/tutorials/pl0-compiler/tests/valid/primes.pl0
+++ b/tutorials/pl0-compiler/tests/valid/primes.pl0
@@ -1,0 +1,32 @@
+{ primes.pl0 - count the primes up to max by trial division }
+
+const max = 100;
+var arg, ret, count;
+
+procedure isprime;
+{ arg: the number to test; ret: 1 if it is prime, 0 otherwise }
+var n;
+begin
+   ret := 1;
+   n := 2;
+   while n * n <= arg do
+   begin
+      if arg / n * n = arg then
+      begin
+         ret := 0;
+         n := arg
+      end;
+      n := n + 1
+   end
+end;
+
+begin
+   count := 0;
+   arg := 2;
+   while arg <= max do
+   begin
+      call isprime;
+      if ret = 1 then count := count + 1;
+      arg := arg + 1
+   end
+end.

--- a/tutorials/pl0-compiler/tests/valid/square.pl0
+++ b/tutorials/pl0-compiler/tests/valid/square.pl0
@@ -1,0 +1,18 @@
+{ square.pl0 - squares of 1..10, after Wirth's classic PL/0 example
+  (without I/O, which the baseline language does not have) }
+
+var x, squ;
+
+procedure square;
+begin
+   squ := x * x
+end;
+
+begin
+   x := 1;
+   while x <= 10 do
+   begin
+      call square;
+      x := x + 1
+   end
+end.


### PR DESCRIPTION
## Summary

Adds a second tutorial project following the structure PR #93 established: an implementation of Brian Callahan's ["Let's write a compiler"](https://briancallahan.net/blog/20210814.html) series (PL/0), currently at the series' parts 1–3 ("validator") milestone. RTK replaces the two largest hand-written components of the original C implementation — the lexer and the parser are generated from a single grammar file, and the quasi-quotation test suite doubles as a miniature of the upcoming PL/0 → C code generator.

## Layout (`tutorials/pl0-compiler/`)

- `pl0.pg` — baseline Wirth PL/0: const/var/procedure declarations, all statement forms incl. the empty statement (`StatementOpt` mirrors Wirth's `statement = [ ... ]`), six relational operators, `odd`, unary signs, `{ ... }` comments. Conflict-free Happy parser, byte-identical under both front ends.
- `Main.hs` — validator driver (`pl0 [--lex-only] file.pl0`), positioned diagnostics via the `Either` API.
- `TestQQ.hs` — 13 runtime-asserted tests of the full QQ feature set: construction (AST-shape equality), anti-quotation splicing, pattern matching with metavariables (a miniature PL/0 → C code generator), and SYB rewrite rules (`$e1 + 0 → e1`) over the generated AST.
- `tests/valid/` — four programs (Wirth's classic squares example, a prime counter, a grammar-corner-case file, and the minimal program `.`).
- `tests/invalid/` — five programs that must be rejected *with a positioned diagnostic*, including the Wirth subtlety that a sign is only legal at the start of an expression (`-a + +b` is invalid PL/0).
- `Makefile` / `run_tests.sh` / `README.md` / `.gitignore` — per the c-compiler tutorial conventions (toolchain via `cabal exec` from the parent checkout, generated front end under `gen/`).

## CI

One new line in the test workflow: `run_test "PL/0 Compiler Tutorial" "make -C tutorials/pl0-compiler test"`, next to the existing C tutorial entry. No goldens in the parent suites (tutorial grammars stay out of `test-grammars/`, matching `c.pg`).

## Verification

Locally green: tutorial suite (13/13 QQ tests, 4/4 valid, 5/5 invalid rejected with line/column positions), root `make test` (unit + golden suites), and `make test-compile-goldens`.

https://claude.ai/code/session_01EBm29GHBEyf4ydudf972ds

---
_Generated by [Claude Code](https://claude.ai/code/session_01EBm29GHBEyf4ydudf972ds)_