### PR TITLE
Compile GrammarQQ into rtk and smoke-test quasi-quotation

### DIFF
--- a/BOOTSTRAP.md
+++ b/BOOTSTRAP.md
@@ -10,12 +10,13 @@ compiler compiled by itself, RTK is self-hosting:
   language.** Changes to the grammar language land in grammar.pg (and the
   regenerated goldens) FIRST.
 - **The generated front end is the default.** `GrammarLexer.x` /
-  `GrammarParser.y` — RTK's own output for grammar.pg — are compiled into rtk
-  straight from the golden snapshot in `test/golden/grammar/`;
+  `GrammarParser.y` / `GrammarQQ.hs` — RTK's own output for grammar.pg — are
+  compiled into rtk straight from the golden snapshot in `test/golden/grammar/`;
   `src/generated/ASTAdapter.hs` converts the generated AST to the pipeline's
   `InitialGrammar`, after which everything (normalization, code generation) is
   front-end independent. `--use-generated` is still accepted as an explicit
-  choice.
+  choice. (The compiled-in quasi-quoter quotes fragments as the *generated*
+  AST types; the unit suite smoke-tests it.)
 - **The hand-written `Lexer.x` / `Parser.y` are the reference oracle.** They
   are selected with `rtk --use-handwritten` and exist to keep the equivalence
   harness honest: they follow grammar.pg, not the other way round, and change

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- The generated quasi-quoter for RTK's own grammar language (`GrammarQQ`) is
+  compiled into rtk, beside `GrammarLexer`/`GrammarParser` in the snapshot
+  front-end component — possible since 0.11 made generated quasi-quoters
+  dependency-light (`template-haskell`, a GHC boot library, is the only
+  dependency the quasi-quoter adds). Grammar fragments can now be quoted
+  in-tree, and the unit suite smoke-tests it: `[clause| Name * |]` parses at
+  rtk's own compile time, `$cl`-style metavariables splice and bind through
+  the `Anti_*` constructors in both expression and pattern context. The
+  quotes produce the generated AST types, not the pipeline's
+  `InitialGrammar`; migrating the pipeline onto the generated AST so
+  normalization rewrites can be quasi-quoted is the follow-up (tasks 8c/8d
+  in docs/qq-grammar-rewrites-plan.md)
 - PL/0 compiler tutorial (`tutorials/pl0-compiler/`): the language of Brian
   Callahan's "Let's write a compiler" tutorial series, at the series'
   parts 1-3 ("validator") milestone. Baseline Wirth PL/0 — empty statements
@@ -68,8 +80,8 @@ gained PVP bounds; CI a pinned, cached toolchain.
   `<Name>Lexer.x`/`<Name>Parser.y` pair and typechecks the result with
   `ghc -fno-code`. The golden suite diffs text only and sat green while the
   debug-test and t1 snapshots did not compile; the gate closes that
-  test-architecture hole (QQ goldens join once the regex-posix dependency
-  is dropped, task 8b)
+  test-architecture hole (the `<Name>QQ.hs` goldens are gated too, since
+  generated quasi-quoters dropped their regex dependency — see Fixed)
 - Source positions in generated ASTs: every constructor that generated
   parsers build (except the quasi-quotation-only `Anti_*` splice
   constructors) now stores the position of its alternative's first symbol
@@ -309,6 +321,17 @@ gained PVP bounds; CI a pinned, cached toolchain.
   declaration context compiled into nonsense. Both now `fail` in `TH.Q`,
   making the misuse a GHC compile error at the splice site ("this
   quasi-quoter cannot be used in a type/declaration context")
+- A `$name` metavariable at the end of a line (or of the whole quote body)
+  silently stayed unrewritten, failing with a confusing parse error at the
+  `$`: the generated quasi-quoter's metavariable scan used regex-posix,
+  whose default newline option made the terminator class never match `\n`.
+  The scan is now a plain character function with the documented semantics
+  preserved (`$$` escapes, explicit `$Type:name` passthrough, the
+  unknown-metavariable error). Generated QQ modules consequently import no
+  regex packages at all — `regex-posix`/`regex-base` (which were never
+  declared rtk dependencies and compiled only as transitive flukes) are
+  gone from every user's generated-code dependency footprint, and the
+  README/cabal generated-code dependency lists shrank accordingly
 - Writing into a missing output directory no longer escapes as a raw
   `IOException`: `rtk g.pg /tmp/does/not/exist` now creates the directory
   and succeeds; IO failures that remain (no permission, a file where the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -237,8 +237,9 @@ make test          # or: cabal test
 
 Runs the two cabal test suites defined in rtk.cabal:
 - `unit` (test/UnitTests.hs) - HUnit tests for StrQuote, token post-processing,
-  pipeline error handling, normalization behavior on small inline grammars, and
-  normalization invariants checked against every grammar in test-grammars/
+  pipeline error handling, normalization behavior on small inline grammars,
+  normalization invariants checked against every grammar in test-grammars/, and
+  a smoke test of the compiled-in generated quasi-quoter (GrammarQQ)
 - `golden` (test/GoldenTests.hs) - golden/snapshot tests: the generated
   `<Name>Lexer.x`, `<Name>Parser.y` and `<Name>QQ.hs` for every grammar in
   test-grammars/ are compared against the snapshots in test/golden/

--- a/docs/qq-grammar-rewrites-plan.md
+++ b/docs/qq-grammar-rewrites-plan.md
@@ -1,16 +1,18 @@
 # Plan: grammar rewrites with RTK's own QQ — migrating the pipeline off `InitialGrammar`
 
-Status: PLANNED (follow-up to the default-front-end flip, PR #112).
+Status: 8b DONE; 8a, 8c, 8d PLANNED (follow-up to the default-front-end
+flip, PR #112).
 
 The flip made grammar.pg authoritative and the generated front end the
 default, but the pipeline still computes over the original hand-written data
 structures: `ASTAdapter.convertGrammar` converts the generated AST (the
 `Ctr__*` constructors from `GrammarParser`) into `Syntax.InitialGrammar`
 immediately after parsing, and `Normalize`/`GenX`/`GenY`/`GenQ` operate on
-`InitialGrammar`/`NormalGrammar`. `GrammarQQ.hs` is not compiled into rtk at
-all (`rtk.cabal` keeps it out to avoid `regex-posix` + TH in the build), so
-rewrites cannot be written as `[rule| … |]` / `[cl| … |]` quasi-quoted
-patterns inside rtk itself.
+`InitialGrammar`/`NormalGrammar`. `GrammarQQ.hs` is now compiled into rtk
+(task 8b), but its quoters produce the *generated* AST types, not the
+`InitialGrammar`/`NormalGrammar` the pipeline computes over — so rewrites
+still cannot be written as `[rule| … |]` / `[cl| … |]` quasi-quoted patterns
+inside the pipeline until 8c migrates it.
 
 This file sketches that migration as four self-contained task blobs (8a–8d).
 Each blob is written to be pasted into a fresh session as the task
@@ -102,6 +104,13 @@ self-describing) and parsed identically by the reference parser.
 ---
 
 ## Task 8b — Compile GrammarQQ into rtk (build prerequisite)
+
+**Status: DONE.** Step 1 (the regex drop) landed with the asm.pg tutorial
+work, which hit the regex scanner's newline bug for real; the rest landed
+as its own change: `GrammarQQ` is compiled in the `generated-frontend`
+component (template-haskell is its only extra dependency), `cabal test
+unit` smoke-tests `[clause| … |]` quotes and `Anti_*` splices in both
+contexts, and the `*QQ.hs` goldens are part of `make test-compile-goldens`.
 
 ### TL;DR
 

--- a/rtk.cabal
+++ b/rtk.cabal
@@ -42,14 +42,24 @@ Common warnings
 -- previous rtk binary like every self-hosting compiler's stage files).
 -- Compiling the snapshot directly means `make accept-golden` keeps the build
 -- input of the default front end in sync by construction.
--- GrammarQQ deliberately stays out: compiling the generated quasi-quoter
--- would pull Template Haskell into the bootstrap build path.
+-- GrammarQQ, the generated quasi-quoter, is compiled in beside them
+-- (task 8b): generated quasi-quoters need no regex packages anymore, only
+-- template-haskell (a GHC boot library), so rtk's own code and tests can
+-- quote grammar fragments ([clause| ... |]) against the generated AST.
 -- Separate component because generated alex code trips -Wunused-matches
 -- (happy output carries its own -w; alex output does not suppress that one),
 -- and the snapshot must not be edited to placate the linter.
 Library generated-frontend
   Import:            warnings
   ghc-options:       -Wno-unused-matches
+  -- GrammarQQ's quote projections (get<Type>) deliberately match only the
+  -- start wrapper's constructor for their type - the quote pipeline cannot
+  -- produce anything else - and generated QQ internals carry no signatures;
+  -- the metavariable scanner's local 'rule' shadows the top-level 'rule'
+  -- quoter. Same policy as -Wno-unused-matches above: generated code, not
+  -- edited to placate the linter.
+  ghc-options:       -Wno-incomplete-patterns -Wno-missing-signatures
+                     -Wno-name-shadowing
   -- The snapshot's splice-token actions use 'tail', which GHC >= 9.8 warns
   -- about on every use (-Wx-partial, on by default). Same policy as
   -- -Wno-unused-matches above: generated code, not edited to placate the
@@ -60,13 +70,16 @@ Library generated-frontend
   Hs-Source-Dirs:    test/golden/grammar
   Exposed-Modules:
                      GrammarLexer,
-                     GrammarParser
+                     GrammarParser,
+                     GrammarQQ
   Build-Depends:
                      base                 >= 4.17 && < 4.19,
                      array                >= 0.5  && < 0.6,
                      syb                  >= 0.7  && < 0.8,
                      -- grammar.pg's imports section pulls in Data.Map
-                     containers           >= 0.6  && < 0.7
+                     containers           >= 0.6  && < 0.7,
+                     -- the generated quasi-quoter builds TH splices
+                     template-haskell     >= 2.19 && < 2.21
   Build-Tool-Depends: happy:happy == 2.2.*, alex:alex == 3.5.*
   Default-Extensions:  DeriveDataTypeable, StandaloneDeriving
 
@@ -134,6 +147,9 @@ Test-Suite unit
   Build-Depends:
                      base       >= 4.17 && < 4.19,
                      rtk,
+                     -- the compiled-in snapshot front end, for the GrammarQQ
+                     -- smoke test (its quoters produce the generated AST types)
+                     generated-frontend,
                      HUnit      >= 1.6  && < 1.7,
                      containers >= 0.6  && < 0.7,
                      directory  >= 1.3  && < 1.4,

--- a/src/generated/README.md
+++ b/src/generated/README.md
@@ -31,12 +31,14 @@ exactly like the stage files of any self-hosting compiler — and
 `make accept-golden` advances it, so the build input of the default front end
 stays in sync with the generators by construction.
 
-`GrammarQQ.hs` (the generated quasi-quoter) is deliberately **not** compiled
-into rtk: it would drag `regex-posix` and Template Haskell splices into the
-build. An earlier sketch of the adapter used quasi-quotation to pattern match
-on the generated AST; the real adapter is plain total pattern matching on the
-generated constructors (`Ctr__…`), which is deterministic and dependency-free.
-The golden snapshot pins those constructor names.
+`GrammarQQ.hs` (the generated quasi-quoter) is compiled in from the same
+snapshot (task 8b of `docs/qq-grammar-rewrites-plan.md`): generated
+quasi-quoters need no regex packages anymore, only `template-haskell`, so
+rtk's own code and tests can quote grammar fragments against the generated
+AST — `cabal test unit` smoke-tests `[clause| … |]` quotes and `Anti_*`
+splices in-tree. The adapter itself stays plain total pattern matching on
+the generated constructors (`Ctr__…`), which is deterministic and
+dependency-free; the golden snapshot pins those constructor names.
 
 ## What the adapter must replicate
 

--- a/test/UnitTests.hs
+++ b/test/UnitTests.hs
@@ -6,6 +6,7 @@
 --   * pipeline error handling (ported from EmptyGrammar_Test.hs)
 --   * normalization behavior on small inline grammars
 --   * normalization invariants checked against every grammar in test-grammars/
+--   * the compiled-in generated quasi-quoter (GrammarQQ smoke test)
 module Main (main) where
 
 import Control.Exception (SomeException, evaluate, try)
@@ -21,6 +22,8 @@ import Test.HUnit
 import Diagnostics (Diagnostic (..), SourcePos (..), renderDiagnostic)
 import GenX (isAlexEscape)
 import Grammar (isClauseSeqLifted)
+import GrammarParser (Clause)
+import GrammarQQ (clause)
 import Lexer (AlexPosn (..), PosToken (..), Token (..))
 import Normalize (fillConstructorNames, normalizeTopLevelClauses)
 import Syntax
@@ -42,6 +45,7 @@ main = do
         , TestLabel "pipeline error handling" errorHandlingTests
         , TestLabel "normalization behavior" normalizationTests
         , TestLabel "self-hosted front end" selfHostedFrontEndTests
+        , TestLabel "compiled-in quasi-quoter (GrammarQQ)" grammarQQTests
         ] ++ perGrammar ++ astEquality
     when (errors results + failures results /= 0) exitFailure
 
@@ -719,6 +723,51 @@ selfHostedFrontEndTests = TestList
                 "defined more than once" `isInfixOf` diagMessage d
                 && "line 2, column 1" `isInfixOf` diagMessage d
     ]
+
+--------------------------------------------------------------------------------
+-- The compiled-in generated quasi-quoter (GrammarQQ)
+--------------------------------------------------------------------------------
+
+-- | Smoke test for the snapshot's quasi-quoter, compiled into rtk beside
+-- GrammarLexer/GrammarParser: the quotes below are parsed by the generated
+-- front end at rtk's OWN compile time, and Anti_* splices work in both
+-- expression and pattern context. Note the quotes produce the generated AST
+-- types ('GrammarParser.Clause' here), not 'Syntax.IClause' - bridging that
+-- gap is the pipeline migration (task 8c in docs/qq-grammar-rewrites-plan.md).
+grammarQQTests :: Test
+grammarQQTests = TestList
+    [ TestLabel "an expression quote builds a clause and splices $vars" $ TestCase $ do
+        -- $cl resolves via grammar.pg's @shortcuts(cl) to a Clause
+        -- metavariable; in expression context the Anti_Clause splice inserts
+        -- the local 'cl' into the quoted star repetition
+        let cl = [clause| Name |] :: Clause
+        assertEqual "spliced clause equals the directly quoted one"
+            [clause| Name * |] [clause| $cl * |]
+    , TestLabel "a pattern quote matches modulo positions and binds splices" $ TestCase $
+        -- pattern and scrutinee come from different quote bodies, so their
+        -- positions differ; patterns wildcard every RtkPos field, and the
+        -- metavariable binds the repeated clause through the Anti_Clause
+        -- splice
+        assertEqual "the inner clause is bound"
+            (Just [clause| Name |]) (starInner [clause| Name * |])
+    , TestLabel "a pattern quote still discriminates clause shapes" $ TestCase $
+        assertEqual "a plus clause does not match the star pattern"
+            Nothing (starInner [clause| Name + |])
+    , TestLabel "the quoted language's own literals lex inside quotes" $ TestCase $
+        -- Name '*' is a sequence (a rule reference, then a string literal),
+        -- distinct from the star repetition Name *
+        assertBool "sequence with a '*' literal differs from the star clause"
+            ([clause| Name '*' |] /= [clause| Name * |])
+    ]
+
+-- | A matcher defined by a quasi-quoted pattern. The scrutinee stays an
+-- opaque argument: applied to a quoted clause directly, GHC sees the
+-- expanded constructors on both sides, proves each match's outcome at
+-- compile time and rejects the would-be-exercised alternative as redundant
+-- under -Werror.
+starInner :: Clause -> Maybe Clause
+starInner [clause| $cl2 * |] = Just cl2
+starInner _                  = Nothing
 
 -- | Both front ends must produce the same 'InitialGrammar' for every grammar
 -- in the corpus, source positions included: the generated front end captures


### PR DESCRIPTION
## Summary

Integrate the generated quasi-quoter (`GrammarQQ.hs`) into rtk's build and add comprehensive smoke tests for quasi-quotation support. This enables grammar fragments to be quoted in-tree using `[clause| ... |]` syntax, with metavariable splicing and pattern matching in both expression and pattern contexts.

## Key Changes

- **Build integration**: Add `GrammarQQ` to the `generated-frontend` library component in `rtk.cabal`, with `template-haskell` as its only new dependency (a GHC boot library). Suppress linter warnings for generated code patterns (`-Wno-incomplete-patterns`, `-Wno-missing-signatures`, `-Wno-name-shadowing`).

- **Unit test suite**: Add `grammarQQTests` to `test/UnitTests.hs` with four test cases:
  - Expression quotes with metavariable splicing (`$cl` in `[clause| $cl * |]`)
  - Pattern quotes that match modulo positions and bind splices
  - Pattern discrimination (star vs. plus repetitions)
  - Quoted language literals (distinguishing `Name '*'` sequence from `Name *` repetition)
  - Helper function `starInner` demonstrates pattern matching on quasi-quoted clauses

- **Documentation updates**: 
  - Mark task 8b as DONE in `docs/qq-grammar-rewrites-plan.md`
  - Update `src/generated/README.md` to reflect that `GrammarQQ.hs` is now compiled in
  - Update `BOOTSTRAP.md` to list `GrammarQQ.hs` alongside the lexer and parser
  - Update `CLAUDE.md` test documentation to mention the GrammarQQ smoke test
  - Add CHANGELOG entry documenting the feature and the regex-posix dependency removal

- **Test dependencies**: Add `generated-frontend` to the `unit` test suite's build dependencies so it can import `GrammarQQ` and `GrammarParser`.

## Implementation Details

The quasi-quoter produces the *generated* AST types (`GrammarParser.Clause`), not the pipeline's `InitialGrammar`/`NormalGrammar`. This is a prerequisite for task 8c (migrating the pipeline to use the generated AST), which will enable rewrites to be written as quasi-quoted patterns inside the pipeline itself.

The smoke tests verify that:
- Quotes parse at rtk's own compile time
- `Anti_*` splice constructors work in both expression and pattern contexts
- Pattern matching on quoted clauses works correctly with position wildcarding
- The quoted language's own syntax (string literals) is properly distinguished from quasi-quotation operators

https://claude.ai/code/session_01TKBmYAaBeDM2Mf94nQ8zAA