### PR TITLE
Add named constructors: label an alternative to name its AST constructor

### DIFF
--- a/BOOTSTRAP.md
+++ b/BOOTSTRAP.md
@@ -67,9 +67,18 @@ enforced by the harness above, and full textual identity was never the goal.)
 1. Edit `test-grammars/grammar.pg` — the spec.
 2. `make accept-golden` and review the diff of `test/golden/` (this also
    advances the bootstrap stage that the default front end is compiled from).
-3. Update the hand-written `Lexer.x` / `Parser.y` so the reference follows the
+3. If the change alters the generated AST's shape or constructor names,
+   update `src/generated/ASTAdapter.hs` to match and rebuild — the adapter
+   is compiled against the snapshot. grammar.pg names every
+   constructor-producing alternative (`RuleSimple`, `Star`, `Labeled`, …),
+   so the adapter's pattern matches are stable prose names: reordering or
+   inserting alternatives does not rename constructors. A change to the
+   label syntax itself is two-phase: the checked-in stage must be able to
+   parse the new grammar.pg before `accept-golden` can run (bootstrap via
+   `rtk --use-handwritten` when it cannot).
+4. Update the hand-written `Lexer.x` / `Parser.y` so the reference follows the
    spec and the equivalence harness is green again.
-4. `cabal test` — both suites must pass.
+5. `cabal test` — both suites must pass.
 
 ## Error reporting parity
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Named constructors (task 8a): an alternative may carry a leading label —
+  `Expr = Add: Expr '+' Term | Term ;` — that names its generated AST
+  constructor (`Add RtkPos Expr Term`) instead of the positional
+  `Ctr__<Rule>__<index>` default, so code and quasi-quote patterns written
+  against generated ASTs survive alternative reordering and insertion. The
+  label binds tighter than `|`, scopes over one alternative's sequence, and
+  works inside parenthesized groups (naming the extracted group's
+  constructor, including under repetition through the list-proxy
+  machinery). Unlabeled alternatives keep today's generated names
+  byte-for-byte. Misuse is rejected with positioned diagnostics: names
+  must start uppercase, the generated-name prefixes `Ctr__`/`Anti_` are
+  reserved, explicit names must be unique across the whole grammar (all
+  constructors share one generated Haskell module, and the shared-type
+  constructor deduplication in GenAST would otherwise silently merge
+  duplicates), and lifted (`,Rule`) alternatives — which produce no
+  constructor — cannot be named, nor can anything in a lexical rule.
+  Surface syntax chosen over a trailing `@ctor(Name)` annotation after
+  proving LALR feasibility: the labeled grammar.pg's generated parser has
+  0 happy conflicts (as before) and the reference `Parser.y` keeps exactly
+  its 4 pre-existing state-6 reduce/reduce conflicts
 - The generated quasi-quoter for RTK's own grammar language (`GrammarQQ`) is
   compiled into rtk, beside `GrammarLexer`/`GrammarParser` in the snapshot
   front-end component — possible since 0.11 made generated quasi-quoters
@@ -39,6 +59,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (wired into CI) runs Norvig's own test cases plus the examples, and the
   tutorial's README is a section-by-section walkthrough against the
   original essay
+
+### Changed
+- grammar.pg names every constructor-producing alternative (`RuleSimple`,
+  `Star`, `Labeled`, `Ref`, ...), so the generated grammar front end's AST
+  reads like prose and `src/generated/ASTAdapter.hs` no longer references
+  any positional `Ctr__*` constructor — the ergonomics prerequisite for
+  retiring `InitialGrammar` (task 8c). The two `?`-rules whose
+  empty/present alternatives are synthesized (and therefore unnameable) —
+  `ImportsOpt` and `OptDelim` — are restructured away: the imports block is
+  inlined into `Grammar`'s two alternatives (`GrammarDef`/`GrammarImports`)
+  and the `~` delimiter into `Star`/`StarDelim`/`Plus`/`PlusDelim`. The
+  accepted language is unchanged; only grammar.pg's own AST shape moved
+
+### Fixed
+- The reference lexer (`Lexer.x`) now accepts underscores in identifiers,
+  as grammar.pg's `id = [a-zA-Z][A-Za-z0-9_]*` has always specified; it
+  used to stop at the first `_` with a lexical error while the generated
+  (default) front end accepted the name — an invisible front-end
+  divergence until label names like `Mk_1` exercised it
 
 ## [0.11] - 2026-06-12
 

--- a/DEBUG_OPTIONS.md
+++ b/DEBUG_OPTIONS.md
@@ -202,45 +202,49 @@ rtk test-grammars/grammar.pg test-out --debug-rule=Clause
 ======================================================================
   RULE TRACE: 'Clause' - Tokens
 ======================================================================
-Mentioned 11 time(s) in the token stream:
-  line 28, column 24: Id "Clause"
-  line 40, column 1: Id "Clause"
+Mentioned 12 time(s) in the token stream:
+  line 33, column 36: Id "Clause"
+  line 46, column 1: Id "Clause"
   ...
 
 ======================================================================
   RULE TRACE: 'Clause' - After Parse
 ======================================================================
--- Rule 'Clause' (line 40, column 1)
+-- Rule 'Clause' (line 46, column 1)
 IRule
   { getIDataTypeName = Nothing
   , getIRuleName = "Clause"
   , getIClause =
       IAlt
-        [ ISeq
-            [ IId { getIdStr = "Clause" }
-            , IStrLit "|"
-            , IId { getIdStr = "Clause2" }
-            ]
-        , ISeq [ ILifted IId { getIdStr = "Clause2" } ]
+        [ ICtor
+            "Alt"
+            (ISeq
+               [ IId { getIdStr = "Clause" }
+               , IStrLit "|"
+               , IId { getIdStr = "Clause1" }
+               ])
+        , ISeq [ ILifted IId { getIdStr = "Clause1" } ]
         ]
   , ...
   }
--- Rule 'Clause2' (line 43, column 1)  [matches via its 'Clause' data type]
+-- Rule 'Clause1' (line 53, column 1)  [matches via its 'Clause' data type]
 ...
 
 ======================================================================
   RULE TRACE: 'Clause' - After String Normalization
 ======================================================================
--- Rule 'Clause' (line 40, column 1)
+-- Rule 'Clause' (line 46, column 1)
 IRule
   { ...
   , getIClause =
       IAlt
-        [ ISeq
-            [ IId { getIdStr = "Clause" }
-            , IIgnore IId { getIdStr = "tok__pipe__11" }   -- was IStrLit "|"
-            , IId { getIdStr = "Clause2" }
-            ]
+        [ ICtor
+            "Alt"
+            (ISeq
+               [ IId { getIdStr = "Clause" }
+               , IIgnore IId { getIdStr = "tok__pipe__11" }   -- was IStrLit "|"
+               , IId { getIdStr = "Clause1" }
+               ])
         , ... ]
   }
 ...
@@ -248,11 +252,12 @@ IRule
 ======================================================================
   RULE TRACE: 'Clause' - After Clause Normalization
 ======================================================================
-  Clause (5 rules)
+  Clause (6 rules)
     - Clause5: 6 alternatives
-    - Clause4: 4 alternatives
+    - Clause4: 6 alternatives
     - Clause3: 3 alternatives
     - Clause2: 2 alternatives
+    - Clause1: 2 alternatives
     - Clause: 2 alternatives
 SyntaxRuleGroup
   { getSDataTypeName = "Clause"
@@ -269,7 +274,8 @@ SyntaxRuleGroup
 ======================================================================
   RULE TRACE: 'Clause' - After Constructor Fill
 ======================================================================
-  ...same group, with the empty constructor names filled in:
+  ...same group; named alternatives keep their labels and the unnamed
+  (here: lifted) ones get generated names filled in:
                     [ STSeq "Anti_Clause" [ SSId "qq_Clause" ]
                     , STSeq
                         "Ctr__Clause__0"
@@ -277,6 +283,8 @@ SyntaxRuleGroup
                         , SSLifted "Clause"
                         , SSIgnore "tok__rparen__8"
                         ]
+                    , STSeq "Ref" [ SSId "Name" ]
+                    , STSeq "Lit" [ SSId "StrLit" ]
                     , ... ]
 ```
 

--- a/Lexer.x
+++ b/Lexer.x
@@ -9,7 +9,10 @@ import Diagnostics (Diagnostic, diagnosticFromPositioned, renderDiagnostic)
 
 $digit = 0-9
 $alpha = [a-zA-Z]
-$alphaDigit = [a-zA-Z0-9]
+-- grammar.pg's id rule is [a-zA-Z][A-Za-z0-9_]*: underscores continue an
+-- identifier. The reference lexer follows the spec (it used to reject '_',
+-- a divergence the generated front end never had).
+$alphaDigit = [a-zA-Z0-9_]
 $dq     = "
 $squote     = '
 $notsq = [^']

--- a/Normalize.hs
+++ b/Normalize.hs
@@ -4,7 +4,9 @@ module Normalize(normalizeTopLevelClauses, fillConstructorNames)
 
 import Syntax
 import Diagnostics (Diagnostic(..), showSourcePos)
-import Grammar (isNotIgnored)
+import Grammar (isClauseSeqLifted, isNotIgnored)
+import Data.Char (isUpper)
+import Control.Monad (foldM, foldM_)
 import Data.Generics
 import Data.Maybe
 import qualified Data.Map as M
@@ -12,8 +14,12 @@ import qualified Data.List as L
 import qualified Data.Set as S
 import Control.Lens
 
-import Control.Monad.State.Strict hiding (lift)
-import Control.Monad.State.Strict (lift)
+-- explicit import list: mtl 2.2 re-exports all of Control.Monad from this
+-- module while mtl >= 2.3 (GHC 9.6's toolchain) does not, so an open import
+-- makes the Control.Monad import above unused on one compiler and required
+-- on the other - either way fatal under -Werror
+import Control.Monad.State.Strict (State, StateT, gets, lift, modify,
+                                   runState, runStateT)
 
 -- In the normal form top level clause of the non-lexical rule can be the following:
 -- 1. simple_clause *
@@ -296,10 +302,14 @@ checkNormalClause (IIgnore c) = do
     _ -> normError $ "ignore (!) cannot be applied to: " ++ showClause c
 checkNormalClause (IId idName) = do
   return $ STAltOfSeq [STSeq "" [SSId idName]]
+checkNormalClause (ICtor n c) = do
+  s <- checkNamedClauseSeq n c
+  return $ STAltOfSeq [s]
 checkNormalClause c = normError $ "this clause cannot be used in a syntax rule: " ++ showClause c
                                   ++ " (regular expressions and '.' are only allowed in lexical rules)"
 
 checkNormalClauseSeq :: IClause -> Normalization STSeq
+checkNormalClauseSeq (ICtor n c) = checkNamedClauseSeq n c
 checkNormalClauseSeq (ISeq cs) = do
   cs1 <- mapM checkSimpleClause cs
   checkLiftedInSeq cs cs1
@@ -307,6 +317,24 @@ checkNormalClauseSeq (ISeq cs) = do
 checkNormalClauseSeq ic = do
   c1 <- checkSimpleClause ic
   return $ STSeq "" [c1]
+
+-- A named alternative ("Star: Clause5 '*'"): the body normalizes exactly
+-- like the same alternative would unlabeled, and the user's name replaces
+-- the generated Ctr__ one. Note this means a label always produces a
+-- constructor: a sole "R = L: A* ;" alternative is a data declaration whose
+-- L wraps the (proxied) list, where the unlabeled spelling would have made
+-- R a bare list alias. Only a lifted (,) alternative cannot be named - it
+-- passes another rule's value through and produces no constructor, so a
+-- name on it would silently vanish (GenY ignores names on lifted
+-- alternatives, GenAST filters them from the data declaration).
+checkNamedClauseSeq :: ConstructorName -> IClause -> Normalization STSeq
+checkNamedClauseSeq n c = do
+  STSeq _ cs1 <- checkNormalClauseSeq c
+  if isClauseSeqLifted cs1
+    then normError $ "the lifted (,) alternative '" ++ showClause c
+                     ++ "' passes another rule's value through and produces no constructor,"
+                     ++ " so it cannot be named '" ++ n ++ "': remove the label or the ','"
+    else return $ STSeq n cs1
 
 -- A lifted (,) clause must be the only non-ignored clause of its sequence.
 -- Check it here, where the offending rule is still known, instead of failing
@@ -365,6 +393,56 @@ checkDuplicateRuleNames = go M.empty
     firstDefinedAt r = case getIRulePos r of
       Just pos -> " (first definition at " ++ showSourcePos pos ++ ")"
       Nothing  -> ""
+
+-- Explicit constructor names ("Name: ..." alternative labels) are validated
+-- up front, while the offending rule and its position are still known:
+--
+--   * the name must be constructor-shaped (start with an uppercase letter;
+--     the lexer already restricts it to [A-Za-z0-9_]*);
+--   * the generated-name conventions are reserved: 'Ctr__' (Normalize fills
+--     unnamed alternatives with such names) and 'Anti_' (the quasi-quotation
+--     splice constructors built by addAntiRuleCached);
+--   * explicit names must be unique across the WHOLE grammar, not just their
+--     own rule: all constructors land in one generated Haskell module, and a
+--     duplicate within a shared-type group would additionally be merged
+--     silently by GenAST's constructor-name deduplication (which exists for
+--     the Anti_ alternatives), dropping one of the user's alternatives;
+--   * lexical rules carry no AST constructors, so labels there are rejected
+--     rather than silently ignored.
+checkCtorLabels :: [IRule] -> Normalization ()
+checkCtorLabels = foldM_ checkRule M.empty
+  where
+    checkRule seen r = do
+      currentRule .= Just r
+      foldM (checkName r) seen (ctorLabels (getIClause r))
+    ctorLabels :: IClause -> [ConstructorName]
+    ctorLabels = everything (++) ([] `mkQ` label)
+      where label (ICtor n _) = [n]
+            label _           = []
+    checkName r seen n
+      | isLexicalRule (getIRuleName r) =
+          normError $ "a constructor name ('" ++ n ++ ":') cannot appear in a lexical rule:"
+                      ++ " tokens carry no AST constructors"
+      | not (startsUpper n) =
+          normError $ "constructor name '" ++ n ++ "' must start with an uppercase letter"
+      | "Ctr__" `L.isPrefixOf` n =
+          normError $ "constructor name '" ++ n ++ "' uses the reserved prefix 'Ctr__'"
+                      ++ " (rtk generates such names for unnamed alternatives)"
+      | "Anti_" `L.isPrefixOf` n =
+          normError $ "constructor name '" ++ n ++ "' uses the reserved prefix 'Anti_'"
+                      ++ " (rtk generates such names for quasi-quotation splices)"
+      | Just firstUse <- M.lookup n seen =
+          normError $ "constructor name '" ++ n ++ "' is already used"
+                      ++ inRule firstUse
+                      ++ ": explicit constructor names must be unique across the grammar"
+                      ++ " (all constructors share one generated Haskell module)"
+      | otherwise = return $ M.insert n r seen
+    startsUpper (ch : _) = isUpper ch
+    startsUpper []       = False
+    inRule r = " in rule '" ++ getIRuleName r ++ "'"
+               ++ case getIRulePos r of
+                    Just pos -> " (at " ++ showSourcePos pos ++ ")"
+                    Nothing  -> ""
 
 -- Every bare-name reference inside a clause.
 allIdRefs :: IClause -> [ID]
@@ -535,6 +613,7 @@ computeQQAttachPoints grammar = M.fromList $ map attachFor groups
       ISeq cs      -> all (clauseNullable env) cs
       ILifted c1   -> clauseNullable env c1
       IIgnore c1   -> clauseNullable env c1
+      ICtor _ c1   -> clauseNullable env c1
     isNullable = clauseNullable nullableRules
 
     -- The alternatives a clause normalizes to, mirroring checkNormalClause:
@@ -642,6 +721,7 @@ doNM :: InitialGrammar -> Normalization ()
 doNM grammar = do
   let grammar0 = everywhereBut (False `mkQ` (isLexicalRule . getIRuleName)) (mkT removeOpts) grammar
   checkDuplicateRuleNames $ getIRules grammar0
+  checkCtorLabels $ getIRules grammar0
   mapM_ (\r -> do currentRule .= Just r
                   normalizeRule r)
         $ getIRules grammar0

--- a/Parser.y
+++ b/Parser.y
@@ -74,8 +74,17 @@ Rule : id '=' ClauseAlt ';'         { IRule Nothing Nothing (idStr $1) $3 [] (Ju
 
 ClauseAlt : ClauseAlt1              { mkAlt (reverse $1) }
 
-ClauseAlt1 : ClauseAlt1 '|' ClauseSeq   { $3 : $1 }
-           | ClauseSeq                  { [$1] }
+ClauseAlt1 : ClauseAlt1 '|' ClauseSeqL  { $3 : $1 }
+           | ClauseSeqL                 { [$1] }
+
+-- A named alternative: "Star: Clause5 '*'" names the alternative's AST
+-- constructor. The label binds tighter than '|' and scopes over the whole
+-- sequence, mirroring grammar.pg's Clause1 rule. No conflict with the
+-- 'Type ':' Name '='' rule-header forms: ':' never follows a clause symbol
+-- (clauses are fenced off by '=' ... ';'), so on ':' the parser always
+-- shifts toward the label.
+ClauseSeqL : id ':' ClauseSeq           { ICtor (idStr $1) $3 }
+           | ClauseSeq                  { $1 }
 
 ClauseSeq : ClauseSeq1              { mkSeq (reverse $1) }
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,31 @@ Int:    num = [0-9]+ ;
 Ignore: ws  = [ \t\n]+ ;
 ```
 
+### Named constructors
+
+By default the constructor generated for an alternative is positional
+(`Ctr__<Rule>__<index>`), so inserting or reordering alternatives silently
+renames constructors. An alternative may opt in to a stable name with a
+leading label:
+
+```
+Expr = Add: Expr '+' Term
+     | Sub: Expr '-' Term
+     | Term ;
+```
+
+generates `data Expr = Add RtkPos Expr Term | Sub RtkPos Expr Term |
+Ctr__Expr__0 RtkPos Term | ...` — code and quasi-quote patterns written
+against `Add`/`Sub` survive grammar edits. The label binds tighter than `|`
+and names exactly one alternative; it also works inside parenthesized
+groups (`(Pair: key '=' value)*` names the extracted group's constructor).
+Unlabeled alternatives keep their generated names. Explicit names must
+start with an uppercase letter, must be unique across the whole grammar
+(all constructors share one generated module), must avoid the reserved
+`Ctr__`/`Anti_` prefixes, and cannot name a lifted (`,Rule`) alternative —
+it passes a value through and produces no constructor. rtk rejects each of
+these with a positioned diagnostic.
+
 See `test-grammars/grammar.pg` for the grammar language described in itself —
 that file is the authoritative definition of the grammar language: rtk parses
 your grammar with the parser it generated from it (self-hosting).

--- a/Syntax.hs
+++ b/Syntax.hs
@@ -49,6 +49,11 @@ data IClause = IId { getIdStr :: ID }
              | IOpt IClause
              | ILifted IClause
              | IIgnore IClause
+             -- | A named alternative ("Star: Clause5 '*'"): the user-chosen
+             -- constructor name for one alternative of a rule. Appears only
+             -- at the alternative level (directly under 'IAlt', or as a
+             -- rule's whole clause), wrapping the alternative's sequence.
+             | ICtor ConstructorName IClause
               deriving (Eq, Show, Data)
 
 -- Render a clause the way it appears in the grammar source, for error messages
@@ -64,6 +69,7 @@ showClause (ISeq cs)       = unwords (map showClause cs)
 showClause (IOpt c)        = showClause c ++ "?"
 showClause (ILifted c)     = "," ++ showClause c
 showClause (IIgnore c)     = "!" ++ showClause c
+showClause (ICtor n c)     = n ++ ": " ++ showClause c
 
 showDelim :: Maybe IClause -> String
 showDelim = maybe "" (\d -> " ~ " ++ showClause d)

--- a/docs/qq-grammar-rewrites-plan.md
+++ b/docs/qq-grammar-rewrites-plan.md
@@ -1,7 +1,9 @@
 # Plan: grammar rewrites with RTK's own QQ — migrating the pipeline off `InitialGrammar`
 
-Status: 8b DONE; 8a, 8c, 8d PLANNED (follow-up to the default-front-end
-flip, PR #112).
+Status: 8a DONE (named constructors — leading-label syntax `Add: Expr '+'
+Term`, grammar.pg fully labeled, `ASTAdapter` free of `Ctr__*` references);
+8b DONE (GrammarQQ compiled into rtk); 8c, 8d PLANNED (follow-up to the
+default-front-end flip, PR #112).
 
 The flip made grammar.pg authoritative and the generated front end the
 default, but the pipeline still computes over the original hand-written data

--- a/src/generated/ASTAdapter.hs
+++ b/src/generated/ASTAdapter.hs
@@ -9,17 +9,19 @@
 -- construction.
 --
 -- The conversion is plain total pattern matching on the generated
--- constructors. It has to replicate two things the hand-written front end
--- does between lexing and parsing:
+-- constructors, which carry the names grammar.pg assigns with its
+-- alternative labels (@RuleSimple@, @Star@, @Labeled@, ...). It has to
+-- replicate two things the hand-written front end does between lexing and
+-- parsing:
 --
 --   * the hand-written lexer strips literal delimiters from token text
 --     (quotes around @'str'@, brackets around @[regex]@, triple quotes around
 --     @\"\"\"bigstr\"\"\"@) while the generated lexer keeps the full match,
---     so 'convertGrammar' strips them here;
+--     so the adapter strips them here;
 --
 --   * 'TokenProcessing.processTokens' applies 'unBackQuote' to string and
---     regex literals, so 'convertGrammar' applies the same exported function
---     to those leaves.
+--     regex literals, so the adapter applies the same exported function to
+--     those leaves.
 --
 -- Every generated constructor (except the quasi-quotation-only @Anti_*@
 -- ones) carries the source position of its first symbol in its first field;
@@ -64,20 +66,28 @@ scanTokensGenerated src =
 
 -- | Convert the generated AST to the hand-written 'InitialGrammar'.
 convertGrammar :: GP.Grammar -> InitialGrammar
-convertGrammar (GP.Ctr__Grammar__11 _ gname imports rules) =
+convertGrammar (GP.GrammarDef _ gname rules) =
     InitialGrammar { getIGrammarName = strLit gname
-                   , getImports     = importsOpt imports
+                   , getImports     = ""
+                   , getIRules      = map rule rules
+                   }
+convertGrammar (GP.GrammarImports _ gname imports rules) =
+    InitialGrammar { getIGrammarName = strLit gname
+                   , getImports     = stripEnds 3 imports
                    , getIRules      = map rule rules
                    }
 convertGrammar g = qqOnly "Grammar" g
 
 rule :: GP.Rule -> IRule
-rule (GP.Ctr__Rule__0 p n c)     = mkRule p Nothing         Nothing         n c
-rule (GP.Ctr__Rule__1 p t n c)   = mkRule p (Just (name t)) Nothing         n c
-rule (GP.Ctr__Rule__2 p t f n c) = mkRule p (Just (name t)) (Just (name f)) n c
-rule (GP.Ctr__Rule__3 p f n c)   = mkRule p Nothing         (Just (name f)) n c
-rule (GP.Ctr__Rule__4 _ opts r)  = addRuleOptions (map option opts) (rule r)
-rule r@GP.Anti_Rule{}            = qqOnly "Rule" r
+rule (GP.RuleSimple p n c)         = mkRule p Nothing         Nothing         n c
+rule (GP.RuleTyped p t n c)        = mkRule p (Just (name t)) Nothing         n c
+rule (GP.RuleTypedFunc p t f n c)  = mkRule p (Just (name t)) (Just (name f)) n c
+-- a rule's position is where the rule starts: for the '.Func:' form that is
+-- the dot itself, matching the first-symbol positions captured by generated
+-- parsers
+rule (GP.RuleFunc p f n c)         = mkRule p Nothing         (Just (name f)) n c
+rule (GP.RuleWithOptions _ opts r) = addRuleOptions (map option opts) (rule r)
+rule r@GP.Anti_Rule{}              = qqOnly "Rule" r
 
 mkRule :: GP.RtkPos -> Maybe String -> Maybe String -> GP.Name -> GP.Clause -> IRule
 mkRule p dataType dataFunc n c =
@@ -89,79 +99,79 @@ sourcePos :: GP.RtkPos -> SourcePos
 sourcePos (GP.RtkPos (GL.AlexPn _ line col)) = SourcePos line col
 
 option :: GP.Option -> IOption
-option (GP.Ctr__Option__0 _ ids) = OShortcuts (map name ids)
-option (GP.Ctr__Option__1 _)     = OSymmacro
-option o@GP.Anti_Option{}        = qqOnly "Option" o
-
-importsOpt :: GP.ImportsOpt -> String
-importsOpt (GP.Ctr__ImportsOpt__0 _)                           = ""
-importsOpt (GP.Ctr__ImportsOpt__1 _ (GP.Ctr__Rule_0__0 _ big)) = stripEnds 3 big
-importsOpt i@GP.Anti_ImportsOpt{}                              = qqOnly "ImportsOpt" i
+option (GP.Shortcuts _ ids) = OShortcuts (map name ids)
+option (GP.Symmacro _)      = OSymmacro
+option o@GP.Anti_Option{}   = qqOnly "Option" o
 
 -- | A clause in alternative position: a rule's right-hand side or a
 -- parenthesized group. The hand-written parser always wraps these as an
 -- alternative of sequences, even degenerate ones, so this does too.
 topClause :: GP.Clause -> IClause
-topClause c = IAlt [ ISeq (map preClause (seqElems alt)) | alt <- altElems c ]
+topClause c = IAlt (map altClause (altElems c))
+
+-- | One alternative: a constructor label wraps the alternative's sequence
+-- in 'ICtor', exactly like the hand-written parser's ClauseSeqL rule.
+altClause :: GP.Clause -> IClause
+altClause (GP.Labeled _ n body) = ICtor (name n) (ISeq (map preClause (seqElems body)))
+altClause alt                   = ISeq (map preClause (seqElems alt))
 
 -- | Flatten the left-recursive @'|'@ spine into source-order alternatives.
 -- The right operand of each node is a single alternative, never another
 -- alternation (parenthesized alternations stay as elements and get wrapped
 -- by 'itemClause').
 altElems :: GP.Clause -> [GP.Clause]
-altElems (GP.Ctr__Clause__14 _ l r) = altElems l ++ [r]
-altElems c                          = [c]
+altElems (GP.Alt _ l r) = altElems l ++ [r]
+altElems c              = [c]
 
 -- | Flatten the left-recursive juxtaposition spine of one alternative.
 seqElems :: GP.Clause -> [GP.Clause]
-seqElems (GP.Ctr__Clause__12 _ l r) = seqElems l ++ [r]
-seqElems c                          = [c]
+seqElems (GP.Seq _ l r) = seqElems l ++ [r]
+seqElems c              = [c]
 
 preClause :: GP.Clause -> IClause
-preClause (GP.Ctr__Clause__9 _ c)  = ILifted (postClause c)
-preClause (GP.Ctr__Clause__10 _ c) = IIgnore (postClause c)
-preClause c                        = postClause c
+preClause (GP.Lifted _ c)  = ILifted (postClause c)
+preClause (GP.Ignored _ c) = IIgnore (postClause c)
+preClause c                = postClause c
 
 postClause :: GP.Clause -> IClause
-postClause (GP.Ctr__Clause__5 _ c d) = IStar (itemClause c) (delim d)
-postClause (GP.Ctr__Clause__6 _ c d) = IPlus (itemClause c) (delim d)
-postClause (GP.Ctr__Clause__7 _ c)   = IOpt (itemClause c)
-postClause c                         = itemClause c
+postClause (GP.Star _ c)        = IStar (itemClause c) Nothing
+postClause (GP.StarDelim _ c d) = IStar (itemClause c) (Just (itemClause d))
+postClause (GP.Plus _ c)        = IPlus (itemClause c) Nothing
+postClause (GP.PlusDelim _ c d) = IPlus (itemClause c) (Just (itemClause d))
+postClause (GP.Opt _ c)         = IOpt (itemClause c)
+postClause c                    = itemClause c
 
 -- | A clause in item position: a leaf, or — when it is still a sequence,
--- alternation, lift, ignore or repetition — a construct that can only have
--- come from a parenthesized group, which the hand-written parser represents
--- as a nested @IAlt [ISeq …]@. The generated parser drops the parentheses
--- themselves, so redundant parens around a single leaf normalize away.
+-- alternation, label, lift, ignore or repetition — a construct that can only
+-- have come from a parenthesized group, which the hand-written parser
+-- represents as a nested @IAlt [...]@. The generated parser drops the
+-- parentheses themselves, so redundant parens around a single leaf normalize
+-- away.
 itemClause :: GP.Clause -> IClause
-itemClause (GP.Ctr__Clause__1 _ n) = IId (name n)
-itemClause (GP.Ctr__Clause__2 _ s) = IStrLit (strLit s)
-itemClause (GP.Ctr__Clause__3 _)   = IDot
-itemClause (GP.Ctr__Clause__4 _ s) = IRegExpLit (unBackQuote (stripEnds 1 s))
-itemClause c@GP.Anti_Clause{}      = qqOnly "Clause" c
-itemClause c                       = topClause c
-
-delim :: GP.OptDelim -> Maybe IClause
-delim (GP.Ctr__OptDelim__0 _)                            = Nothing
-delim (GP.Ctr__OptDelim__1 _ (GP.Ctr__Rule_4__0 _ c))    = Just (itemClause c)
-delim d@GP.Anti_OptDelim{}                               = qqOnly "OptDelim" d
+itemClause (GP.Ref _ n)       = IId (name n)
+itemClause (GP.Lit _ s)       = IStrLit (strLit s)
+itemClause (GP.Dot _)         = IDot
+itemClause (GP.Regex _ s)     = IRegExpLit (unBackQuote (stripEnds 1 s))
+itemClause c@GP.Anti_Clause{} = qqOnly "Clause" c
+itemClause c                  = topClause c
 
 name :: GP.Name -> String
-name (GP.Ctr__Name__0 _ s) = s
-name n@GP.Anti_Name{}      = qqOnly "Name" n
+name (GP.Ident _ s)   = s
+name n@GP.Anti_Name{} = qqOnly "Name" n
 
 strLit :: GP.StrLit -> String
-strLit (GP.Ctr__StrLit__0 _ s) = unBackQuote (stripEnds 1 s)
-strLit s@GP.Anti_StrLit{}      = qqOnly "StrLit" s
+strLit (GP.Str _ s)       = unBackQuote (stripEnds 1 s)
+strLit s@GP.Anti_StrLit{} = qqOnly "StrLit" s
 
 -- | Drop @n@ delimiter characters from both ends of a token's text.
 stripEnds :: Int -> String -> String
 stripEnds n s = take (length s - 2 * n) (drop n s)
 
 -- | The generated grammar also contains constructors that only quasi-quote
--- splices can produce: @Anti_*@ metavariables and the @Ctr__Grammar__0..10@
--- start-rule wrappers around dummy tokens. Parsing a grammar source file
--- cannot reach them, so they are an internal error rather than a diagnostic.
+-- splices can produce: @Anti_*@ metavariables and the start-rule wrappers
+-- around dummy tokens (synthesized alternatives, so they keep generated
+-- positional names). Parsing a grammar source file cannot reach them, so
+-- they are an internal error rather than a diagnostic.
 qqOnly :: Show a => String -> a -> b
 qqOnly ty v = error $ "ASTAdapter: quasi-quotation-only " ++ ty
                    ++ " constructor cannot come from a grammar file: " ++ show v

--- a/src/generated/README.md
+++ b/src/generated/README.md
@@ -37,8 +37,10 @@ quasi-quoters need no regex packages anymore, only `template-haskell`, so
 rtk's own code and tests can quote grammar fragments against the generated
 AST — `cabal test unit` smoke-tests `[clause| … |]` quotes and `Anti_*`
 splices in-tree. The adapter itself stays plain total pattern matching on
-the generated constructors (`Ctr__…`), which is deterministic and
-dependency-free; the golden snapshot pins those constructor names.
+the generated constructors, which is deterministic and dependency-free.
+grammar.pg names every constructor-producing alternative (`RuleSimple`,
+`Star`, `Labeled`, …), so those matches are stable prose names rather than
+positional `Ctr__<Rule>__<index>` ones; the golden snapshot pins them.
 
 ## What the adapter must replicate
 

--- a/test-grammars/grammar-main.hs
+++ b/test-grammars/grammar-main.hs
@@ -31,15 +31,18 @@ main = do
     file <- getGrammarFileName
     content <- readFile file
     let grm = either (errorWithoutStackTrace . renderError) id $ scanTokens content >>= parseGrammar
-    let [grammar|grammar $StrLit:str ; $importsOpt|] = [grammar|grammar 'test' ;|]
-    let [rule|Rule = $cl1 | $clause2 | $clause3 | $clause4 ;|] = [rule| Rule = id '=' Clause ';' 
+    let [grammar|grammar $StrLit:str ; $ruleList|] = [grammar|grammar 'test' ;|]
+    let [rule|Rule = $cl1 | $clause2 | $clause3 | $clause4 ;|] = [rule| Rule = id '=' Clause ';'
                                                                       | id ':' id '=' Clause ';'
                                                                       | id '.' id ':' id '=' Clause ';'
                                                                       | '.' id ':' id '=' Clause ';' ;|]
-    --putStrLn $ show cl1
-    --putStrLn $ show clause3
-    --putStrLn $ show str
-    let [grammar|grammar $StrLit:nm ; $importsOpt $ruleList|] = grm
-    putStrLn $ show importsOpt
---    putStrLn $ ppShow [ruleList| $ruleList_rl1 RuleAAA = $Clause:cl1; |]
+    -- A named alternative round-trips through a quote: the 'Mk:' label
+    -- parses at quoter compile time and the pattern's metavariable binds the
+    -- whole labeled clause at run time.
+    let [rule|R = $clNamed ;|] = [rule|R = Mk: id '=' Clause ';' ;|]
+    putStrLn $ show clNamed
+    -- grammar.pg itself carries an imports block; project the grammar name
+    -- out of the generated AST's named constructor
+    let GrammarImports _ nm imports rules = grm
+    putStrLn $ show nm
     return 0

--- a/test-grammars/grammar.pg
+++ b/test-grammars/grammar.pg
@@ -10,58 +10,71 @@ import qualified Data.Map as M
 """
 
 /*
-Grammar rules section. These rules are started with capital letter
+Grammar rules section. These rules are started with capital letter.
+
+An alternative may carry a constructor name: 'Star: Clause5 '*'' makes the
+generated AST constructor for that alternative 'Star' instead of the
+positional default 'Ctr__<Rule>__<index>'. Every constructor-producing
+alternative below is named, so the generated front end's AST reads like
+prose and survives alternative reordering. Lifted (,Rule1) alternatives
+pass another rule's value through, produce no constructor, and therefore
+carry no name.
 */
 
-/* a */
-
-Grammar = 'grammar' StrLit ';' ImportsOpt RuleList ;
-
-ImportsOpt = ('imports' bigstr)? ;
+Grammar = GrammarDef: 'grammar' StrLit ';' RuleList
+        | GrammarImports: 'grammar' StrLit ';' 'imports' bigstr RuleList ;
 
 RuleList = Rule *;
 
 @shortcuts(r)
-Rule = OptionList Rule1
+Rule = RuleWithOptions: OptionList Rule1
      | ,Rule1 ;
 
-Rule: Rule1 = Name '=' Clause ';' 
-            | Name ':' Name '=' Clause ';'
-            | Name '.' Name ':' Name '=' Clause ';'
-            | '.' Name ':' Name '=' Clause ';' ;
+Rule: Rule1 = RuleSimple: Name '=' Clause ';'
+            | RuleTyped: Name ':' Name '=' Clause ';'
+            | RuleTypedFunc: Name '.' Name ':' Name '=' Clause ';'
+            | RuleFunc: '.' Name ':' Name '=' Clause ';' ;
 
 OptionList = Option+ ;
 
-Option = '@shortcuts' '(' IdList ')' | '@symmacro' ;
+Option = Shortcuts: '@shortcuts' '(' IdList ')'
+       | Symmacro: '@symmacro' ;
 
 IdList = Name* ~ ',' ;
 
 @shortcuts(cl)
-Clause = Clause '|' Clause2
-         | ,Clause2;
+Clause = Alt: Clause '|' Clause1
+       | ,Clause1 ;
 
-Clause: Clause2 = Clause2 Clause3
-                  | ,Clause3 ;
+# The constructor-name label itself: it binds tighter than '|' and scopes
+# over the whole juxtaposition sequence (one alternative). The bare ':'
+# token cannot collide with the rule-header forms above because clauses are
+# fenced off by '=' ... ';'.
+Clause: Clause1 = Labeled: Name ':' Clause2
+                | ,Clause2 ;
 
-Clause: Clause3 = ',' Clause4 
-                | '!' Clause4
+Clause: Clause2 = Seq: Clause2 Clause3
+                | ,Clause3 ;
+
+Clause: Clause3 = Lifted: ',' Clause4
+                | Ignored: '!' Clause4
                 | ,Clause4 ;
 
-Clause: Clause4 = Clause5 '*' OptDelim
-                | Clause5 '+' OptDelim
-                | Clause5 '?'
+Clause: Clause4 = Star: Clause5 '*'
+                | StarDelim: Clause5 '*' '~' Clause5
+                | Plus: Clause5 '+'
+                | PlusDelim: Clause5 '+' '~' Clause5
+                | Opt: Clause5 '?'
                 | ,Clause5 ;
 
 Clause: Clause5 = '(' ,Clause ')'
-                | Name
-                | StrLit
-                | '.'
-                | regexplit ;
+                | Ref: Name
+                | Lit: StrLit
+                | Dot: '.'
+                | Regex: regexplit ;
 
-OptDelim = ('~' Clause5)? ;
-
-StrLit = str ;
-Name = id ;
+StrLit = Str: str ;
+Name = Ident: id ;
 
 /*
 Lexical rules section. These rules are started with regular letter
@@ -90,4 +103,3 @@ regexplit = '[' ([^\]] | '\\]')* ']' ;
 Ignore: ws = [ \t\n]+ ;
 Ignore: comment = '#' .* [\n] ;
 Ignore: comment1 = '/*' ([^\*]|[\*][^\/]|[\n])* '*/';
-

--- a/test/UnitTests.hs
+++ b/test/UnitTests.hs
@@ -13,7 +13,7 @@ import Control.Exception (SomeException, evaluate, try)
 import Control.Monad (when)
 import Data.List (find, group, isInfixOf, isPrefixOf, nub, sort)
 import qualified Data.Map as M
-import Data.Maybe (maybeToList)
+import Data.Maybe (listToMaybe, maybeToList)
 import qualified Data.Set as S
 import System.Exit (exitFailure)
 import System.FilePath (takeBaseName)
@@ -44,6 +44,7 @@ main = do
         , TestLabel "diagnostics" diagnosticsTests
         , TestLabel "pipeline error handling" errorHandlingTests
         , TestLabel "normalization behavior" normalizationTests
+        , TestLabel "named constructors" namedConstructorTests
         , TestLabel "self-hosted front end" selfHostedFrontEndTests
         , TestLabel "compiled-in quasi-quoter (GrammarQQ)" grammarQQTests
         ] ++ perGrammar ++ astEquality
@@ -675,6 +676,185 @@ testFillConstructorNames = TestCase $ do
     assertBool "anti constructors survive filling"
         ("Anti_Item" `elem` [ c | STSeq c _ <- allSeqs filled ])
     assertEqual "filling is idempotent" filled (fillConstructorNames filled)
+
+--------------------------------------------------------------------------------
+-- Named constructors ("Label: ..." alternative labels)
+--------------------------------------------------------------------------------
+
+namedConstructorTests :: Test
+namedConstructorTests = TestList
+    [ TestLabel "a label names the alternative's constructor; unnamed ones keep generated names" testCtorLabelOverride
+    , TestLabel "the named constructor reaches the generated artifacts" testCtorLabelArtifacts
+    , TestLabel "a label inside a parenthesized group names the proxy's constructor" testCtorLabelInGroup
+    , TestLabel "a labeled sole repetition gets a constructor instead of a list alias" testCtorLabelForcesConstructor
+    , TestLabel "both front ends parse labels into the same ICtor shape" testCtorLabelFrontEndEquality
+    , TestLabel "a lowercase label is rejected" $ TestCase $
+        expectDiagnostic "a lowercase constructor name"
+            (normalizeGrammarSource "grammar 'X';\nFoo = bad: aa ;\naa = [a]+ ;\n") $ \d -> do
+            assertEqual "context names the rule" (Just "in rule 'Foo'") (diagContext d)
+            assertEqual "position of 'Foo'" (Just (SourcePos 2 1)) (diagPos d)
+            assertBool ("unexpected message: " ++ diagMessage d) $
+                "must start with an uppercase letter" `isInfixOf` diagMessage d
+                && "bad" `isInfixOf` diagMessage d
+    , TestLabel "the reserved Ctr__ prefix is rejected" $ TestCase $
+        expectDiagnostic "a Ctr__ constructor name"
+            (normalizeGrammarSource "grammar 'X';\nFoo = Ctr__Foo__0: aa ;\naa = [a]+ ;\n") $ \d -> do
+            assertEqual "position of 'Foo'" (Just (SourcePos 2 1)) (diagPos d)
+            assertBool ("unexpected message: " ++ diagMessage d) $
+                "reserved prefix 'Ctr__'" `isInfixOf` diagMessage d
+    , TestLabel "the reserved Anti_ prefix is rejected" $ TestCase $
+        expectDiagnostic "an Anti_ constructor name"
+            (normalizeGrammarSource "grammar 'X';\nFoo = Anti_Foo: aa ;\naa = [a]+ ;\n") $ \d -> do
+            assertEqual "position of 'Foo'" (Just (SourcePos 2 1)) (diagPos d)
+            assertBool ("unexpected message: " ++ diagMessage d) $
+                "reserved prefix 'Anti_'" `isInfixOf` diagMessage d
+    , TestLabel "duplicate explicit names are rejected across the whole grammar" $ TestCase $
+        -- the two rules even have different types: constructor names share
+        -- one generated Haskell module, so the clash is global
+        expectDiagnostic "a duplicate constructor name"
+            (normalizeGrammarSource
+                "grammar 'X';\nFoo = Mk: aa ;\nBar = Mk: bb ;\naa = [a]+ ;\nbb = [b]+ ;\n") $ \d -> do
+            assertEqual "context names the second rule" (Just "in rule 'Bar'") (diagContext d)
+            assertEqual "position of 'Bar'" (Just (SourcePos 3 1)) (diagPos d)
+            assertBool ("unexpected message: " ++ diagMessage d) $
+                "already used in rule 'Foo'" `isInfixOf` diagMessage d
+                && "line 2, column 1" `isInfixOf` diagMessage d
+    , TestLabel "duplicate explicit names within one rule are rejected" $ TestCase $
+        expectDiagnostic "a duplicate constructor name in one rule"
+            (normalizeGrammarSource "grammar 'X';\nFoo = Mk: aa | Mk: bb ;\naa = [a]+ ;\nbb = [b]+ ;\n") $ \d ->
+            assertBool ("unexpected message: " ++ diagMessage d) $
+                "already used in rule 'Foo'" `isInfixOf` diagMessage d
+    , TestLabel "a label in a lexical rule is rejected" $ TestCase $
+        expectDiagnostic "a label in a lexical rule"
+            (normalizeGrammarSource "grammar 'X';\nFoo = tok ;\ntok = Mk: [a]+ ;\n") $ \d -> do
+            assertEqual "context names the lexical rule" (Just "in rule 'tok'") (diagContext d)
+            assertEqual "position of 'tok'" (Just (SourcePos 3 1)) (diagPos d)
+            assertBool ("unexpected message: " ++ diagMessage d) $
+                "lexical rule" `isInfixOf` diagMessage d
+    , TestLabel "a label on a lifted alternative is rejected" $ TestCase $
+        -- a lifted alternative passes a value through and produces no
+        -- constructor; silently dropping the name would be worse
+        expectDiagnostic "a label on a lifted alternative"
+            (normalizeGrammarSource "grammar 'X';\nFoo = Mk: ,Bar | aa ;\nBar = bb ;\naa = [a]+ ;\nbb = [b]+ ;\n") $ \d -> do
+            assertEqual "context names the rule" (Just "in rule 'Foo'") (diagContext d)
+            assertBool ("unexpected message: " ++ diagMessage d) $
+                "produces no constructor" `isInfixOf` diagMessage d
+                && "Mk" `isInfixOf` diagMessage d
+    ]
+
+-- | The user's name wins for the labeled alternatives; the unlabeled one is
+-- still filled with a generated positional name, and the splice (Anti_)
+-- machinery is unaffected.
+testCtorLabelOverride :: Test
+testCtorLabelOverride = TestCase $
+    case normalizeGrammarSource namedExprGrammar of
+        Left d  -> assertFailure $ "normalization failed: " ++ show d
+        Right g -> assertEqual "constructors of the Expr group"
+            (Just ["Anti_Expr", "Add", "Neg", "Ctr__Expr__0"])
+            (lookupCtors "Expr" g)
+  where
+    lookupCtors t g = listToMaybe
+        [ [ c | SyntaxRule _ (STAltOfSeq alts) <- getSRules grp, STSeq c _ <- alts ]
+        | grp <- getSyntaxRuleGroups g, getSDataTypeName grp == t ]
+
+namedExprGrammar :: String
+namedExprGrammar = unlines
+    [ "grammar 'Named';"
+    , "Top = Expr ;"
+    , "Expr = Add: Term '+' Term"
+    , "     | Neg: '-' Term"
+    , "     | Term ;"
+    , "Term = num ;"
+    , "Int: num = [0-9]+ ;"
+    ]
+
+-- | End to end: the names appear in the generated parser's data declaration
+-- and semantic actions, with the leading RtkPos field like any generated
+-- constructor.
+testCtorLabelArtifacts :: Test
+testCtorLabelArtifacts = TestCase $
+    case normalizeGrammarSource namedExprGrammar >>= artifactsFor of
+        Left d -> assertFailure $ "generation failed: " ++ show d
+        Right artifacts -> case lookup "NamedParser.y" artifacts of
+            Nothing -> assertFailure "no NamedParser.y artifact generated"
+            Just y -> do
+                assertBool "data declaration carries the named constructors"
+                    ("Add RtkPos Term Term" `isInfixOf` y && "Neg RtkPos Term" `isInfixOf` y)
+                assertBool "the unnamed alternative keeps a generated name"
+                    ("Ctr__Expr__0 RtkPos Term" `isInfixOf` y)
+                assertBool "semantic actions build the named constructor"
+                    ("{ Add (rtkPosOf $1) $1 $3 }" `isInfixOf` y)
+                assertBool "the named constructors have position projections"
+                    ("rtkPosOf (Add p _ _) = p" `isInfixOf` y)
+
+-- | A label inside a parenthesized group names the constructor of the
+-- anonymous rule the group is extracted into - here under a repetition, so
+-- the label also flows through the list-element proxy machinery.
+testCtorLabelInGroup :: Test
+testCtorLabelInGroup = TestCase $ do
+    let g = normalizeNoFill $ unlines
+                [ "grammar 'Grp';"
+                , "S = (Pair: aa bb)+ ;"
+                , "aa = [a]+ ;"
+                , "bb = [b]+ ;"
+                ]
+    assertEqual "the extracted group's alternative carries the user's name"
+        [STSeq "Pair" [SSId "aa", SSId "bb"]]
+        [ alt | SyntaxRule rn (STAltOfSeq alts) <- allRules g
+              , "Rule_" `isPrefixOf` rn, alt@(STSeq "Pair" _) <- alts ]
+
+-- | A label always produces a constructor: a sole "L: Item*" alternative
+-- yields a data declaration whose constructor wraps the (proxied) list,
+-- where the unlabeled spelling would have made the rule a bare list alias.
+testCtorLabelForcesConstructor :: Test
+testCtorLabelForcesConstructor = TestCase $ do
+    let g = normalizeNoFill $ unlines
+                [ "grammar 'Lst';"
+                , "Top = S ;"
+                , "S = Wrap: Item* ;"
+                , "Item = aa ;"
+                , "aa = [a]+ ;"
+                ]
+    case [ alts | SyntaxRule "S" (STAltOfSeq alts) <- allRules g ] of
+        [alts] -> assertBool ("expected a Wrap constructor over a proxy, got: " ++ show alts) $
+            not $ null [ () | STSeq "Wrap" [SSId proxy] <- alts, "Rule_" `isPrefixOf` proxy ]
+        other -> assertFailure $ "expected S to be a data group, got: " ++ show other
+
+-- | Both front ends must represent labels identically: as an 'ICtor' node
+-- wrapping the alternative's sequence. Checked structurally against the
+-- expected shape AND between the two front ends, for a plain labeled
+-- alternative, a labeled group as a whole alternative (which merges into
+-- the enclosing alternation like any group), and a labeled group in element
+-- position (which stays a nested single-alternative alternation). The label
+-- 'Mk_1' also pins identifier lexing parity: grammar.pg's id rule allows
+-- underscores, which the reference lexer used to reject.
+testCtorLabelFrontEndEquality :: Test
+testCtorLabelFrontEndEquality = TestCase $ do
+    let src = unlines
+            [ "grammar 'Eq';"
+            , "S = Mk_1: aa bb | cc ;"
+            , "T = (L: aa) ;"
+            , "U = aa (M: bb) ;"
+            , "aa = [a]+ ;"
+            , "bb = [b]+ ;"
+            , "cc = [c]+ ;"
+            ]
+    case (parseGrammarSource src, parseGrammarSourceGenerated src) of
+        (Right h, Right g) -> do
+            assertEqual "hand-written vs generated front end (positions included)" h g
+            let clauseOf n = getIClause <$> find ((== n) . getIRuleName) (getIRules h)
+            assertEqual "labeled alternative shape"
+                (Just (IAlt [ ICtor "Mk_1" (ISeq [IId "aa", IId "bb"])
+                            , ISeq [IId "cc"] ]))
+                (clauseOf "S")
+            assertEqual "labeled group as the whole alternative merges into the alternation"
+                (Just (IAlt [ICtor "L" (ISeq [IId "aa"])]))
+                (clauseOf "T")
+            assertEqual "labeled group in element position stays nested"
+                (Just (IAlt [ISeq [IId "aa", IAlt [ICtor "M" (ISeq [IId "bb"])]]]))
+                (clauseOf "U")
+        (Left d, _) -> assertFailure $ "hand-written front end failed: " ++ show d
+        (_, Left d) -> assertFailure $ "generated front end failed: " ++ show d
 
 --------------------------------------------------------------------------------
 -- Self-hosted front end (the lexer/parser RTK generated from grammar.pg)

--- a/test/golden/grammar/GrammarLexer.x
+++ b/test/golden/grammar/GrammarLexer.x
@@ -15,30 +15,28 @@ $dq = "
 $ndq = [^\"]
 $backslash = [\\]
 
-tokens :- "tok_Clause_dummy_14" { simple Tk__tok_Clause_dummy_14 }
-          "tok_Grammar_dummy_15" { simple Tk__tok_Grammar_dummy_15 }
-          "tok_IdList_dummy_13" { simple Tk__tok_IdList_dummy_13 }
-          "tok_ImportsOpt_dummy_12" { simple Tk__tok_ImportsOpt_dummy_12 }
-          "tok_Name_dummy_11" { simple Tk__tok_Name_dummy_11 }
-          "tok_OptDelim_dummy_10" { simple Tk__tok_OptDelim_dummy_10 }
-          "tok_Option_dummy_9" { simple Tk__tok_Option_dummy_9 }
-          "tok_OptionList_dummy_8" { simple Tk__tok_OptionList_dummy_8 }
-          "tok_Rule_dummy_7" { simple Tk__tok_Rule_dummy_7 }
-          "tok_RuleList_dummy_6" { simple Tk__tok_RuleList_dummy_6 }
-          "tok_StrLit_dummy_5" { simple Tk__tok_StrLit_dummy_5 }
-          "~" { simple Tk__tok__tilde__16 }
+tokens :- "tok_Clause_dummy_10" { simple Tk__tok_Clause_dummy_10 }
+          "tok_Grammar_dummy_11" { simple Tk__tok_Grammar_dummy_11 }
+          "tok_IdList_dummy_9" { simple Tk__tok_IdList_dummy_9 }
+          "tok_Name_dummy_8" { simple Tk__tok_Name_dummy_8 }
+          "tok_Option_dummy_7" { simple Tk__tok_Option_dummy_7 }
+          "tok_OptionList_dummy_6" { simple Tk__tok_OptionList_dummy_6 }
+          "tok_Rule_dummy_5" { simple Tk__tok_Rule_dummy_5 }
+          "tok_RuleList_dummy_4" { simple Tk__tok_RuleList_dummy_4 }
+          "tok_StrLit_dummy_3" { simple Tk__tok_StrLit_dummy_3 }
+          "~" { simple Tk__tok__tilde__14 }
           "|" { simple Tk__tok__pipe__11 }
           "imports" { simple Tk__tok_imports_2 }
           "grammar" { simple Tk__tok_grammar_0 }
           "@symmacro" { simple Tk__tok__symbol_symmacro_9 }
           "@shortcuts" { simple Tk__tok__symbol_shortcuts_6 }
-          "?" { simple Tk__tok__symbol__15 }
+          "?" { simple Tk__tok__symbol__16 }
           "=" { simple Tk__tok__eql__3 }
           ";" { simple Tk__tok__semi__1 }
           ":" { simple Tk__tok__colon__4 }
           "." { simple Tk__tok__dot__5 }
           "," { simple Tk__tok__coma__10 }
-          "+" { simple Tk__tok__plus__14 }
+          "+" { simple Tk__tok__plus__15 }
           "*" { simple Tk__tok__star__13 }
           ")" { simple Tk__tok__rparen__8 }
           "(" { simple Tk__tok__lparen__7 }
@@ -52,43 +50,39 @@ tokens :- "tok_Clause_dummy_14" { simple Tk__tok_Clause_dummy_14 }
           ([a-zA-Z]  [A-Za-z0-9_]*) { simple1 $  Tk__id . (id) }
           ("$"  "Name"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_Name . ((tail . dropWhile (/= ':'))) }
           ("$"  "StrLit"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_StrLit . ((tail . dropWhile (/= ':'))) }
-          ("$"  "OptDelim"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_OptDelim . ((tail . dropWhile (/= ':'))) }
           ("$"  "Clause"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_Clause . ((tail . dropWhile (/= ':'))) }
           ("$"  "IdList"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_IdList . ((tail . dropWhile (/= ':'))) }
           ("$"  "Option"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_Option . ((tail . dropWhile (/= ':'))) }
           ("$"  "OptionList"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_OptionList . ((tail . dropWhile (/= ':'))) }
           ("$"  "Rule"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_Rule . ((tail . dropWhile (/= ':'))) }
           ("$"  "RuleList"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_RuleList . ((tail . dropWhile (/= ':'))) }
-          ("$"  "ImportsOpt"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_ImportsOpt . ((tail . dropWhile (/= ':'))) }
           ("$"  "Grammar"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_Grammar . ((tail . dropWhile (/= ':'))) }
           . { rtkError }
 
 {
 data Token = EndOfFile |
-             Tk__tok_Clause_dummy_14 |
-             Tk__tok_Grammar_dummy_15 |
-             Tk__tok_IdList_dummy_13 |
-             Tk__tok_ImportsOpt_dummy_12 |
-             Tk__tok_Name_dummy_11 |
-             Tk__tok_OptDelim_dummy_10 |
-             Tk__tok_Option_dummy_9 |
-             Tk__tok_OptionList_dummy_8 |
-             Tk__tok_Rule_dummy_7 |
-             Tk__tok_RuleList_dummy_6 |
-             Tk__tok_StrLit_dummy_5 |
-             Tk__tok__tilde__16 |
+             Tk__tok_Clause_dummy_10 |
+             Tk__tok_Grammar_dummy_11 |
+             Tk__tok_IdList_dummy_9 |
+             Tk__tok_Name_dummy_8 |
+             Tk__tok_Option_dummy_7 |
+             Tk__tok_OptionList_dummy_6 |
+             Tk__tok_Rule_dummy_5 |
+             Tk__tok_RuleList_dummy_4 |
+             Tk__tok_StrLit_dummy_3 |
+             Tk__tok__tilde__14 |
              Tk__tok__pipe__11 |
              Tk__tok_imports_2 |
              Tk__tok_grammar_0 |
              Tk__tok__symbol_symmacro_9 |
              Tk__tok__symbol_shortcuts_6 |
-             Tk__tok__symbol__15 |
+             Tk__tok__symbol__16 |
              Tk__tok__eql__3 |
              Tk__tok__semi__1 |
              Tk__tok__colon__4 |
              Tk__tok__dot__5 |
              Tk__tok__coma__10 |
-             Tk__tok__plus__14 |
+             Tk__tok__plus__15 |
              Tk__tok__star__13 |
              Tk__tok__rparen__8 |
              Tk__tok__lparen__7 |
@@ -99,14 +93,12 @@ data Token = EndOfFile |
              Tk__id String |
              Tk__qq_Name String |
              Tk__qq_StrLit String |
-             Tk__qq_OptDelim String |
              Tk__qq_Clause String |
              Tk__qq_IdList String |
              Tk__qq_Option String |
              Tk__qq_OptionList String |
              Tk__qq_Rule String |
              Tk__qq_RuleList String |
-             Tk__qq_ImportsOpt String |
              Tk__qq_Grammar String
              deriving (Show)
 

--- a/test/golden/grammar/GrammarParser.y
+++ b/test/golden/grammar/GrammarParser.y
@@ -14,30 +14,28 @@ import qualified GrammarLexer as L (Token(..), PosToken(..), AlexPosn(..), alexS
 %token
 
 rtk__eof { L.PosToken _ L.EndOfFile }
-tok_Clause_dummy_14 { L.PosToken _ L.Tk__tok_Clause_dummy_14 }
-tok_Grammar_dummy_15 { L.PosToken _ L.Tk__tok_Grammar_dummy_15 }
-tok_IdList_dummy_13 { L.PosToken _ L.Tk__tok_IdList_dummy_13 }
-tok_ImportsOpt_dummy_12 { L.PosToken _ L.Tk__tok_ImportsOpt_dummy_12 }
-tok_Name_dummy_11 { L.PosToken _ L.Tk__tok_Name_dummy_11 }
-tok_OptDelim_dummy_10 { L.PosToken _ L.Tk__tok_OptDelim_dummy_10 }
-tok_Option_dummy_9 { L.PosToken _ L.Tk__tok_Option_dummy_9 }
-tok_OptionList_dummy_8 { L.PosToken _ L.Tk__tok_OptionList_dummy_8 }
-tok_Rule_dummy_7 { L.PosToken _ L.Tk__tok_Rule_dummy_7 }
-tok_RuleList_dummy_6 { L.PosToken _ L.Tk__tok_RuleList_dummy_6 }
-tok_StrLit_dummy_5 { L.PosToken _ L.Tk__tok_StrLit_dummy_5 }
-tok__tilde__16 { L.PosToken _ L.Tk__tok__tilde__16 }
+tok_Clause_dummy_10 { L.PosToken _ L.Tk__tok_Clause_dummy_10 }
+tok_Grammar_dummy_11 { L.PosToken _ L.Tk__tok_Grammar_dummy_11 }
+tok_IdList_dummy_9 { L.PosToken _ L.Tk__tok_IdList_dummy_9 }
+tok_Name_dummy_8 { L.PosToken _ L.Tk__tok_Name_dummy_8 }
+tok_Option_dummy_7 { L.PosToken _ L.Tk__tok_Option_dummy_7 }
+tok_OptionList_dummy_6 { L.PosToken _ L.Tk__tok_OptionList_dummy_6 }
+tok_Rule_dummy_5 { L.PosToken _ L.Tk__tok_Rule_dummy_5 }
+tok_RuleList_dummy_4 { L.PosToken _ L.Tk__tok_RuleList_dummy_4 }
+tok_StrLit_dummy_3 { L.PosToken _ L.Tk__tok_StrLit_dummy_3 }
+tok__tilde__14 { L.PosToken _ L.Tk__tok__tilde__14 }
 tok__pipe__11 { L.PosToken _ L.Tk__tok__pipe__11 }
 tok_imports_2 { L.PosToken _ L.Tk__tok_imports_2 }
 tok_grammar_0 { L.PosToken _ L.Tk__tok_grammar_0 }
 tok__symbol_symmacro_9 { L.PosToken _ L.Tk__tok__symbol_symmacro_9 }
 tok__symbol_shortcuts_6 { L.PosToken _ L.Tk__tok__symbol_shortcuts_6 }
-tok__symbol__15 { L.PosToken _ L.Tk__tok__symbol__15 }
+tok__symbol__16 { L.PosToken _ L.Tk__tok__symbol__16 }
 tok__eql__3 { L.PosToken _ L.Tk__tok__eql__3 }
 tok__semi__1 { L.PosToken _ L.Tk__tok__semi__1 }
 tok__colon__4 { L.PosToken _ L.Tk__tok__colon__4 }
 tok__dot__5 { L.PosToken _ L.Tk__tok__dot__5 }
 tok__coma__10 { L.PosToken _ L.Tk__tok__coma__10 }
-tok__plus__14 { L.PosToken _ L.Tk__tok__plus__14 }
+tok__plus__15 { L.PosToken _ L.Tk__tok__plus__15 }
 tok__star__13 { L.PosToken _ L.Tk__tok__star__13 }
 tok__rparen__8 { L.PosToken _ L.Tk__tok__rparen__8 }
 tok__lparen__7 { L.PosToken _ L.Tk__tok__lparen__7 }
@@ -48,108 +46,98 @@ str { L.PosToken _ (L.Tk__str _) }
 id { L.PosToken _ (L.Tk__id _) }
 qq_Name { L.PosToken _ (L.Tk__qq_Name _) }
 qq_StrLit { L.PosToken _ (L.Tk__qq_StrLit _) }
-qq_OptDelim { L.PosToken _ (L.Tk__qq_OptDelim _) }
 qq_Clause { L.PosToken _ (L.Tk__qq_Clause _) }
 qq_IdList { L.PosToken _ (L.Tk__qq_IdList _) }
 qq_Option { L.PosToken _ (L.Tk__qq_Option _) }
 qq_OptionList { L.PosToken _ (L.Tk__qq_OptionList _) }
 qq_Rule { L.PosToken _ (L.Tk__qq_Rule _) }
 qq_RuleList { L.PosToken _ (L.Tk__qq_RuleList _) }
-qq_ImportsOpt { L.PosToken _ (L.Tk__qq_ImportsOpt _) }
 qq_Grammar { L.PosToken _ (L.Tk__qq_Grammar _) }
 
 %%
 
 Grammar__top : Grammar rtk__eof { $1 }
 
-Grammar : tok_Grammar_dummy_15 Grammar tok_Grammar_dummy_15 { Ctr__Grammar__0 (rtkPosOf $1) $2 } |
-          tok_Clause_dummy_14 Clause tok_Clause_dummy_14 { Ctr__Grammar__1 (rtkPosOf $1) $2 } |
-          tok_IdList_dummy_13 IdList tok_IdList_dummy_13 { Ctr__Grammar__2 (rtkPosOf $1) (reverse $2) } |
-          tok_ImportsOpt_dummy_12 ImportsOpt tok_ImportsOpt_dummy_12 { Ctr__Grammar__3 (rtkPosOf $1) $2 } |
-          tok_Name_dummy_11 Name tok_Name_dummy_11 { Ctr__Grammar__4 (rtkPosOf $1) $2 } |
-          tok_OptDelim_dummy_10 OptDelim tok_OptDelim_dummy_10 { Ctr__Grammar__5 (rtkPosOf $1) $2 } |
-          tok_Option_dummy_9 Option tok_Option_dummy_9 { Ctr__Grammar__6 (rtkPosOf $1) $2 } |
-          tok_OptionList_dummy_8 OptionList tok_OptionList_dummy_8 { Ctr__Grammar__7 (rtkPosOf $1) (reverse $2) } |
-          tok_Rule_dummy_7 Rule tok_Rule_dummy_7 { Ctr__Grammar__8 (rtkPosOf $1) $2 } |
-          tok_RuleList_dummy_6 RuleList tok_RuleList_dummy_6 { Ctr__Grammar__9 (rtkPosOf $1) (reverse $2) } |
-          tok_StrLit_dummy_5 StrLit tok_StrLit_dummy_5 { Ctr__Grammar__10 (rtkPosOf $1) $2 }
+Grammar : tok_Grammar_dummy_11 Grammar tok_Grammar_dummy_11 { Ctr__Grammar__0 (rtkPosOf $1) $2 } |
+          tok_Clause_dummy_10 Clause tok_Clause_dummy_10 { Ctr__Grammar__1 (rtkPosOf $1) $2 } |
+          tok_IdList_dummy_9 IdList tok_IdList_dummy_9 { Ctr__Grammar__2 (rtkPosOf $1) (reverse $2) } |
+          tok_Name_dummy_8 Name tok_Name_dummy_8 { Ctr__Grammar__3 (rtkPosOf $1) $2 } |
+          tok_Option_dummy_7 Option tok_Option_dummy_7 { Ctr__Grammar__4 (rtkPosOf $1) $2 } |
+          tok_OptionList_dummy_6 OptionList tok_OptionList_dummy_6 { Ctr__Grammar__5 (rtkPosOf $1) (reverse $2) } |
+          tok_Rule_dummy_5 Rule tok_Rule_dummy_5 { Ctr__Grammar__6 (rtkPosOf $1) $2 } |
+          tok_RuleList_dummy_4 RuleList tok_RuleList_dummy_4 { Ctr__Grammar__7 (rtkPosOf $1) (reverse $2) } |
+          tok_StrLit_dummy_3 StrLit tok_StrLit_dummy_3 { Ctr__Grammar__8 (rtkPosOf $1) $2 }
 
 Grammar : qq_Grammar { Anti_Grammar (tkVal_qq_Grammar $1) } |
-          tok_grammar_0 StrLit tok__semi__1 ImportsOpt RuleList { Ctr__Grammar__11 (rtkPosOf $1) $2 $4 (reverse $5) }
+          tok_grammar_0 StrLit tok__semi__1 RuleList { GrammarDef (rtkPosOf $1) $2 (reverse $4) } |
+          tok_grammar_0 StrLit tok__semi__1 tok_imports_2 bigstr RuleList { GrammarImports (rtkPosOf $1) $2 (tkVal_bigstr $5) (reverse $6) }
 
 Clause5 : qq_Clause { Anti_Clause (tkVal_qq_Clause $1) } |
           tok__lparen__7 Clause tok__rparen__8 { $2 } |
-          Name { Ctr__Clause__1 (rtkPosOf $1) $1 } |
-          StrLit { Ctr__Clause__2 (rtkPosOf $1) $1 } |
-          tok__dot__5 { Ctr__Clause__3 (rtkPosOf $1) } |
-          regexplit { Ctr__Clause__4 (rtkPosOf $1) (tkVal_regexplit $1) }
+          Name { Ref (rtkPosOf $1) $1 } |
+          StrLit { Lit (rtkPosOf $1) $1 } |
+          tok__dot__5 { Dot (rtkPosOf $1) } |
+          regexplit { Regex (rtkPosOf $1) (tkVal_regexplit $1) }
 
-Clause4 : Clause5 tok__star__13 OptDelim { Ctr__Clause__5 (rtkPosOf $1) $1 $3 } |
-          Clause5 tok__plus__14 OptDelim { Ctr__Clause__6 (rtkPosOf $1) $1 $3 } |
-          Clause5 tok__symbol__15 { Ctr__Clause__7 (rtkPosOf $1) $1 } |
+Clause4 : Clause5 tok__star__13 { Star (rtkPosOf $1) $1 } |
+          Clause5 tok__star__13 tok__tilde__14 Clause5 { StarDelim (rtkPosOf $1) $1 $4 } |
+          Clause5 tok__plus__15 { Plus (rtkPosOf $1) $1 } |
+          Clause5 tok__plus__15 tok__tilde__14 Clause5 { PlusDelim (rtkPosOf $1) $1 $4 } |
+          Clause5 tok__symbol__16 { Opt (rtkPosOf $1) $1 } |
           Clause5 { $1 }
 
-Clause3 : tok__coma__10 Clause4 { Ctr__Clause__9 (rtkPosOf $1) $2 } |
-          tok__exclamation__12 Clause4 { Ctr__Clause__10 (rtkPosOf $1) $2 } |
+Clause3 : tok__coma__10 Clause4 { Lifted (rtkPosOf $1) $2 } |
+          tok__exclamation__12 Clause4 { Ignored (rtkPosOf $1) $2 } |
           Clause4 { $1 }
 
-Clause2 : Clause2 Clause3 { Ctr__Clause__12 (rtkPosOf $1) $1 $2 } |
+Clause2 : Clause2 Clause3 { Seq (rtkPosOf $1) $1 $2 } |
           Clause3 { $1 }
 
-Clause : Clause tok__pipe__11 Clause2 { Ctr__Clause__14 (rtkPosOf $1) $1 $3 } |
-         Clause2 { $1 }
+Clause1 : Name tok__colon__4 Clause2 { Labeled (rtkPosOf $1) $1 $3 } |
+          Clause2 { $1 }
 
-IdList__plus_list_ : ListElem_IdList3 { [$1] } |
-                     IdList__plus_list_ tok__coma__10 ListElem_IdList3 { $3 : $1 }
+Clause : Clause tok__pipe__11 Clause1 { Alt (rtkPosOf $1) $1 $3 } |
+         Clause1 { $1 }
+
+IdList__plus_list_ : ListElem_IdList2 { [$1] } |
+                     IdList__plus_list_ tok__coma__10 ListElem_IdList2 { $3 : $1 }
 
 IdList : IdList__plus_list_ { $1 } |
          {- empty -} { [] }
 
-ImportsOpt : qq_ImportsOpt { Anti_ImportsOpt (tkVal_qq_ImportsOpt $1) } |
-             { Ctr__ImportsOpt__0 rtkNoPos } |
-             Rule_0 { Ctr__ImportsOpt__1 (rtkPosOf $1) $1 }
-
 Name : qq_Name { Anti_Name (tkVal_qq_Name $1) } |
-       id { Ctr__Name__0 (rtkPosOf $1) (tkVal_id $1) }
+       id { Ident (rtkPosOf $1) (tkVal_id $1) }
 
-ListElem_IdList3 : qq_IdList { Anti_Name (tkVal_qq_IdList $1) } |
+ListElem_IdList2 : qq_IdList { Anti_Name (tkVal_qq_IdList $1) } |
                    Name { $1 }
 
-OptDelim : qq_OptDelim { Anti_OptDelim (tkVal_qq_OptDelim $1) } |
-           { Ctr__OptDelim__0 rtkNoPos } |
-           Rule_4 { Ctr__OptDelim__1 (rtkPosOf $1) $1 }
-
 Option : qq_Option { Anti_Option (tkVal_qq_Option $1) } |
-         tok__symbol_shortcuts_6 tok__lparen__7 IdList tok__rparen__8 { Ctr__Option__0 (rtkPosOf $1) (reverse $3) } |
-         tok__symbol_symmacro_9 { Ctr__Option__1 (rtkPosOf $1) }
+         tok__symbol_shortcuts_6 tok__lparen__7 IdList tok__rparen__8 { Shortcuts (rtkPosOf $1) (reverse $3) } |
+         tok__symbol_symmacro_9 { Symmacro (rtkPosOf $1) }
 
-ListElem_OptionList2 : qq_OptionList { Anti_Option (tkVal_qq_OptionList $1) } |
+ListElem_OptionList1 : qq_OptionList { Anti_Option (tkVal_qq_OptionList $1) } |
                        Option { $1 }
 
-OptionList : ListElem_OptionList2 { [$1] } |
-             OptionList ListElem_OptionList2 { $2 : $1 }
+OptionList : ListElem_OptionList1 { [$1] } |
+             OptionList ListElem_OptionList1 { $2 : $1 }
 
 Rule1 : qq_Rule { Anti_Rule (tkVal_qq_Rule $1) } |
-        Name tok__eql__3 Clause tok__semi__1 { Ctr__Rule__0 (rtkPosOf $1) $1 $3 } |
-        Name tok__colon__4 Name tok__eql__3 Clause tok__semi__1 { Ctr__Rule__1 (rtkPosOf $1) $1 $3 $5 } |
-        Name tok__dot__5 Name tok__colon__4 Name tok__eql__3 Clause tok__semi__1 { Ctr__Rule__2 (rtkPosOf $1) $1 $3 $5 $7 } |
-        tok__dot__5 Name tok__colon__4 Name tok__eql__3 Clause tok__semi__1 { Ctr__Rule__3 (rtkPosOf $1) $2 $4 $6 }
+        Name tok__eql__3 Clause tok__semi__1 { RuleSimple (rtkPosOf $1) $1 $3 } |
+        Name tok__colon__4 Name tok__eql__3 Clause tok__semi__1 { RuleTyped (rtkPosOf $1) $1 $3 $5 } |
+        Name tok__dot__5 Name tok__colon__4 Name tok__eql__3 Clause tok__semi__1 { RuleTypedFunc (rtkPosOf $1) $1 $3 $5 $7 } |
+        tok__dot__5 Name tok__colon__4 Name tok__eql__3 Clause tok__semi__1 { RuleFunc (rtkPosOf $1) $2 $4 $6 }
 
-Rule : OptionList Rule1 { Ctr__Rule__4 (rtkPosOf (reverse $1)) (reverse $1) $2 } |
+Rule : OptionList Rule1 { RuleWithOptions (rtkPosOf (reverse $1)) (reverse $1) $2 } |
        Rule1 { $1 }
 
-ListElem_RuleList1 : qq_RuleList { Anti_Rule (tkVal_qq_RuleList $1) } |
+ListElem_RuleList0 : qq_RuleList { Anti_Rule (tkVal_qq_RuleList $1) } |
                      Rule { $1 }
 
 RuleList : {- empty -} { [] } |
-           RuleList ListElem_RuleList1 { $2 : $1 }
-
-Rule_0 : tok_imports_2 bigstr { Ctr__Rule_0__0 (rtkPosOf $1) (tkVal_bigstr $2) }
-
-Rule_4 : tok__tilde__16 Clause5 { Ctr__Rule_4__0 (rtkPosOf $1) $2 }
+           RuleList ListElem_RuleList0 { $2 : $1 }
 
 StrLit : qq_StrLit { Anti_StrLit (tkVal_qq_StrLit $1) } |
-         str { Ctr__StrLit__0 (rtkPosOf $1) (tkVal_str $1) }
+         str { Str (rtkPosOf $1) (tkVal_str $1) }
 
 
 {
@@ -161,30 +149,28 @@ parseError (L.PosToken (L.AlexPn _ line col) tok : _) =
 -- Render a token the way it appears in the source, for error messages
 showRtkToken :: L.Token -> String
 showRtkToken L.EndOfFile = "end of input"
-showRtkToken L.Tk__tok_Clause_dummy_14 = "'tok_Clause_dummy_14'"
-showRtkToken L.Tk__tok_Grammar_dummy_15 = "'tok_Grammar_dummy_15'"
-showRtkToken L.Tk__tok_IdList_dummy_13 = "'tok_IdList_dummy_13'"
-showRtkToken L.Tk__tok_ImportsOpt_dummy_12 = "'tok_ImportsOpt_dummy_12'"
-showRtkToken L.Tk__tok_Name_dummy_11 = "'tok_Name_dummy_11'"
-showRtkToken L.Tk__tok_OptDelim_dummy_10 = "'tok_OptDelim_dummy_10'"
-showRtkToken L.Tk__tok_Option_dummy_9 = "'tok_Option_dummy_9'"
-showRtkToken L.Tk__tok_OptionList_dummy_8 = "'tok_OptionList_dummy_8'"
-showRtkToken L.Tk__tok_Rule_dummy_7 = "'tok_Rule_dummy_7'"
-showRtkToken L.Tk__tok_RuleList_dummy_6 = "'tok_RuleList_dummy_6'"
-showRtkToken L.Tk__tok_StrLit_dummy_5 = "'tok_StrLit_dummy_5'"
-showRtkToken L.Tk__tok__tilde__16 = "'~'"
+showRtkToken L.Tk__tok_Clause_dummy_10 = "'tok_Clause_dummy_10'"
+showRtkToken L.Tk__tok_Grammar_dummy_11 = "'tok_Grammar_dummy_11'"
+showRtkToken L.Tk__tok_IdList_dummy_9 = "'tok_IdList_dummy_9'"
+showRtkToken L.Tk__tok_Name_dummy_8 = "'tok_Name_dummy_8'"
+showRtkToken L.Tk__tok_Option_dummy_7 = "'tok_Option_dummy_7'"
+showRtkToken L.Tk__tok_OptionList_dummy_6 = "'tok_OptionList_dummy_6'"
+showRtkToken L.Tk__tok_Rule_dummy_5 = "'tok_Rule_dummy_5'"
+showRtkToken L.Tk__tok_RuleList_dummy_4 = "'tok_RuleList_dummy_4'"
+showRtkToken L.Tk__tok_StrLit_dummy_3 = "'tok_StrLit_dummy_3'"
+showRtkToken L.Tk__tok__tilde__14 = "'~'"
 showRtkToken L.Tk__tok__pipe__11 = "'|'"
 showRtkToken L.Tk__tok_imports_2 = "'imports'"
 showRtkToken L.Tk__tok_grammar_0 = "'grammar'"
 showRtkToken L.Tk__tok__symbol_symmacro_9 = "'@symmacro'"
 showRtkToken L.Tk__tok__symbol_shortcuts_6 = "'@shortcuts'"
-showRtkToken L.Tk__tok__symbol__15 = "'?'"
+showRtkToken L.Tk__tok__symbol__16 = "'?'"
 showRtkToken L.Tk__tok__eql__3 = "'='"
 showRtkToken L.Tk__tok__semi__1 = "';'"
 showRtkToken L.Tk__tok__colon__4 = "':'"
 showRtkToken L.Tk__tok__dot__5 = "'.'"
 showRtkToken L.Tk__tok__coma__10 = "','"
-showRtkToken L.Tk__tok__plus__14 = "'+'"
+showRtkToken L.Tk__tok__plus__15 = "'+'"
 showRtkToken L.Tk__tok__star__13 = "'*'"
 showRtkToken L.Tk__tok__rparen__8 = "')'"
 showRtkToken L.Tk__tok__lparen__7 = "'('"
@@ -195,14 +181,12 @@ showRtkToken (L.Tk__str v) = "str " ++ show v
 showRtkToken (L.Tk__id v) = "id " ++ show v
 showRtkToken (L.Tk__qq_Name v) = "qq_Name " ++ show v
 showRtkToken (L.Tk__qq_StrLit v) = "qq_StrLit " ++ show v
-showRtkToken (L.Tk__qq_OptDelim v) = "qq_OptDelim " ++ show v
 showRtkToken (L.Tk__qq_Clause v) = "qq_Clause " ++ show v
 showRtkToken (L.Tk__qq_IdList v) = "qq_IdList " ++ show v
 showRtkToken (L.Tk__qq_Option v) = "qq_Option " ++ show v
 showRtkToken (L.Tk__qq_OptionList v) = "qq_OptionList " ++ show v
 showRtkToken (L.Tk__qq_Rule v) = "qq_Rule " ++ show v
 showRtkToken (L.Tk__qq_RuleList v) = "qq_RuleList " ++ show v
-showRtkToken (L.Tk__qq_ImportsOpt v) = "qq_ImportsOpt " ++ show v
 showRtkToken (L.Tk__qq_Grammar v) = "qq_Grammar " ++ show v
 
 -- Source position of a node: every constructor except the Anti_* splice
@@ -253,9 +237,6 @@ tkVal_qq_Name t = error ("rtk internal error: token qq_Name expected, got " ++ s
 tkVal_qq_StrLit :: L.PosToken -> String
 tkVal_qq_StrLit (L.PosToken _ (L.Tk__qq_StrLit v)) = v
 tkVal_qq_StrLit t = error ("rtk internal error: token qq_StrLit expected, got " ++ showRtkToken (L.ptToken t))
-tkVal_qq_OptDelim :: L.PosToken -> String
-tkVal_qq_OptDelim (L.PosToken _ (L.Tk__qq_OptDelim v)) = v
-tkVal_qq_OptDelim t = error ("rtk internal error: token qq_OptDelim expected, got " ++ showRtkToken (L.ptToken t))
 tkVal_qq_Clause :: L.PosToken -> String
 tkVal_qq_Clause (L.PosToken _ (L.Tk__qq_Clause v)) = v
 tkVal_qq_Clause t = error ("rtk internal error: token qq_Clause expected, got " ++ showRtkToken (L.ptToken t))
@@ -274,9 +255,6 @@ tkVal_qq_Rule t = error ("rtk internal error: token qq_Rule expected, got " ++ s
 tkVal_qq_RuleList :: L.PosToken -> String
 tkVal_qq_RuleList (L.PosToken _ (L.Tk__qq_RuleList v)) = v
 tkVal_qq_RuleList t = error ("rtk internal error: token qq_RuleList expected, got " ++ showRtkToken (L.ptToken t))
-tkVal_qq_ImportsOpt :: L.PosToken -> String
-tkVal_qq_ImportsOpt (L.PosToken _ (L.Tk__qq_ImportsOpt v)) = v
-tkVal_qq_ImportsOpt t = error ("rtk internal error: token qq_ImportsOpt expected, got " ++ showRtkToken (L.ptToken t))
 tkVal_qq_Grammar :: L.PosToken -> String
 tkVal_qq_Grammar (L.PosToken _ (L.Tk__qq_Grammar v)) = v
 tkVal_qq_Grammar t = error ("rtk internal error: token qq_Grammar expected, got " ++ showRtkToken (L.ptToken t))
@@ -284,16 +262,15 @@ tkVal_qq_Grammar t = error ("rtk internal error: token qq_Grammar expected, got 
 data Grammar = Ctr__Grammar__0 RtkPos Grammar |
                Ctr__Grammar__1 RtkPos Clause |
                Ctr__Grammar__2 RtkPos IdList |
-               Ctr__Grammar__3 RtkPos ImportsOpt |
-               Ctr__Grammar__4 RtkPos Name |
-               Ctr__Grammar__5 RtkPos OptDelim |
-               Ctr__Grammar__6 RtkPos Option |
-               Ctr__Grammar__7 RtkPos OptionList |
-               Ctr__Grammar__8 RtkPos Rule |
-               Ctr__Grammar__9 RtkPos RuleList |
-               Ctr__Grammar__10 RtkPos StrLit |
+               Ctr__Grammar__3 RtkPos Name |
+               Ctr__Grammar__4 RtkPos Option |
+               Ctr__Grammar__5 RtkPos OptionList |
+               Ctr__Grammar__6 RtkPos Rule |
+               Ctr__Grammar__7 RtkPos RuleList |
+               Ctr__Grammar__8 RtkPos StrLit |
                Anti_Grammar String |
-               Ctr__Grammar__11 RtkPos StrLit ImportsOpt RuleList
+               GrammarDef RtkPos StrLit RuleList |
+               GrammarImports RtkPos StrLit String RuleList
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Grammar where
     rtkPosOf (Ctr__Grammar__0 p _) = p
@@ -305,95 +282,76 @@ instance RtkPosOf Grammar where
     rtkPosOf (Ctr__Grammar__6 p _) = p
     rtkPosOf (Ctr__Grammar__7 p _) = p
     rtkPosOf (Ctr__Grammar__8 p _) = p
-    rtkPosOf (Ctr__Grammar__9 p _) = p
-    rtkPosOf (Ctr__Grammar__10 p _) = p
     rtkPosOf (Anti_Grammar _) = rtkNoPos
-    rtkPosOf (Ctr__Grammar__11 p _ _ _) = p
+    rtkPosOf (GrammarDef p _ _) = p
+    rtkPosOf (GrammarImports p _ _ _) = p
 data Clause = Anti_Clause String |
-              Ctr__Clause__1 RtkPos Name |
-              Ctr__Clause__2 RtkPos StrLit |
-              Ctr__Clause__3 RtkPos |
-              Ctr__Clause__4 RtkPos String |
-              Ctr__Clause__5 RtkPos Clause OptDelim |
-              Ctr__Clause__6 RtkPos Clause OptDelim |
-              Ctr__Clause__7 RtkPos Clause |
-              Ctr__Clause__9 RtkPos Clause |
-              Ctr__Clause__10 RtkPos Clause |
-              Ctr__Clause__12 RtkPos Clause Clause |
-              Ctr__Clause__14 RtkPos Clause Clause
+              Ref RtkPos Name |
+              Lit RtkPos StrLit |
+              Dot RtkPos |
+              Regex RtkPos String |
+              Star RtkPos Clause |
+              StarDelim RtkPos Clause Clause |
+              Plus RtkPos Clause |
+              PlusDelim RtkPos Clause Clause |
+              Opt RtkPos Clause |
+              Lifted RtkPos Clause |
+              Ignored RtkPos Clause |
+              Seq RtkPos Clause Clause |
+              Labeled RtkPos Name Clause |
+              Alt RtkPos Clause Clause
               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Clause where
     rtkPosOf (Anti_Clause _) = rtkNoPos
-    rtkPosOf (Ctr__Clause__1 p _) = p
-    rtkPosOf (Ctr__Clause__2 p _) = p
-    rtkPosOf (Ctr__Clause__3 p) = p
-    rtkPosOf (Ctr__Clause__4 p _) = p
-    rtkPosOf (Ctr__Clause__5 p _ _) = p
-    rtkPosOf (Ctr__Clause__6 p _ _) = p
-    rtkPosOf (Ctr__Clause__7 p _) = p
-    rtkPosOf (Ctr__Clause__9 p _) = p
-    rtkPosOf (Ctr__Clause__10 p _) = p
-    rtkPosOf (Ctr__Clause__12 p _ _) = p
-    rtkPosOf (Ctr__Clause__14 p _ _) = p
+    rtkPosOf (Ref p _) = p
+    rtkPosOf (Lit p _) = p
+    rtkPosOf (Dot p) = p
+    rtkPosOf (Regex p _) = p
+    rtkPosOf (Star p _) = p
+    rtkPosOf (StarDelim p _ _) = p
+    rtkPosOf (Plus p _) = p
+    rtkPosOf (PlusDelim p _ _) = p
+    rtkPosOf (Opt p _) = p
+    rtkPosOf (Lifted p _) = p
+    rtkPosOf (Ignored p _) = p
+    rtkPosOf (Seq p _ _) = p
+    rtkPosOf (Labeled p _ _) = p
+    rtkPosOf (Alt p _ _) = p
 type IdList = [Name]
-data ImportsOpt = Anti_ImportsOpt String |
-                  Ctr__ImportsOpt__0 RtkPos |
-                  Ctr__ImportsOpt__1 RtkPos Rule_0
-                  deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-instance RtkPosOf ImportsOpt where
-    rtkPosOf (Anti_ImportsOpt _) = rtkNoPos
-    rtkPosOf (Ctr__ImportsOpt__0 p) = p
-    rtkPosOf (Ctr__ImportsOpt__1 p _) = p
 data Name = Anti_Name String |
-            Ctr__Name__0 RtkPos String
+            Ident RtkPos String
             deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Name where
     rtkPosOf (Anti_Name _) = rtkNoPos
-    rtkPosOf (Ctr__Name__0 p _) = p
-data OptDelim = Anti_OptDelim String |
-                Ctr__OptDelim__0 RtkPos |
-                Ctr__OptDelim__1 RtkPos Rule_4
-                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-instance RtkPosOf OptDelim where
-    rtkPosOf (Anti_OptDelim _) = rtkNoPos
-    rtkPosOf (Ctr__OptDelim__0 p) = p
-    rtkPosOf (Ctr__OptDelim__1 p _) = p
+    rtkPosOf (Ident p _) = p
 data Option = Anti_Option String |
-              Ctr__Option__0 RtkPos IdList |
-              Ctr__Option__1 RtkPos
+              Shortcuts RtkPos IdList |
+              Symmacro RtkPos
               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Option where
     rtkPosOf (Anti_Option _) = rtkNoPos
-    rtkPosOf (Ctr__Option__0 p _) = p
-    rtkPosOf (Ctr__Option__1 p) = p
+    rtkPosOf (Shortcuts p _) = p
+    rtkPosOf (Symmacro p) = p
 type OptionList = [Option]
 data Rule = Anti_Rule String |
-            Ctr__Rule__0 RtkPos Name Clause |
-            Ctr__Rule__1 RtkPos Name Name Clause |
-            Ctr__Rule__2 RtkPos Name Name Name Clause |
-            Ctr__Rule__3 RtkPos Name Name Clause |
-            Ctr__Rule__4 RtkPos OptionList Rule
+            RuleSimple RtkPos Name Clause |
+            RuleTyped RtkPos Name Name Clause |
+            RuleTypedFunc RtkPos Name Name Name Clause |
+            RuleFunc RtkPos Name Name Clause |
+            RuleWithOptions RtkPos OptionList Rule
             deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule where
     rtkPosOf (Anti_Rule _) = rtkNoPos
-    rtkPosOf (Ctr__Rule__0 p _ _) = p
-    rtkPosOf (Ctr__Rule__1 p _ _ _) = p
-    rtkPosOf (Ctr__Rule__2 p _ _ _ _) = p
-    rtkPosOf (Ctr__Rule__3 p _ _ _) = p
-    rtkPosOf (Ctr__Rule__4 p _ _) = p
+    rtkPosOf (RuleSimple p _ _) = p
+    rtkPosOf (RuleTyped p _ _ _) = p
+    rtkPosOf (RuleTypedFunc p _ _ _ _) = p
+    rtkPosOf (RuleFunc p _ _ _) = p
+    rtkPosOf (RuleWithOptions p _ _) = p
 type RuleList = [Rule]
-data Rule_0 = Ctr__Rule_0__0 RtkPos String
-              deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-instance RtkPosOf Rule_0 where
-    rtkPosOf (Ctr__Rule_0__0 p _) = p
-data Rule_4 = Ctr__Rule_4__0 RtkPos Clause
-              deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-instance RtkPosOf Rule_4 where
-    rtkPosOf (Ctr__Rule_4__0 p _) = p
 data StrLit = Anti_StrLit String |
-              Ctr__StrLit__0 RtkPos String
+              Str RtkPos String
               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf StrLit where
     rtkPosOf (Anti_StrLit _) = rtkNoPos
-    rtkPosOf (Ctr__StrLit__0 p _) = p
+    rtkPosOf (Str p _) = p
 }

--- a/test/golden/grammar/GrammarQQ.hs
+++ b/test/golden/grammar/GrammarQQ.hs
@@ -64,7 +64,7 @@ rtkRenderError err =
                 _ -> err
         _ -> err
 
-qqShortcuts = M.fromList [ ("grammar","Grammar"),("clause","Clause"),("idList","IdList"),("importsOpt","ImportsOpt"),("name","Name"),("optDelim","OptDelim"),("option","Option"),("optionList","OptionList"),("rule","Rule"),("ruleList","RuleList"),("strLit","StrLit"),("cl","Clause"),("r","Rule")]
+qqShortcuts = M.fromList [ ("grammar","Grammar"),("clause","Clause"),("idList","IdList"),("name","Name"),("option","Option"),("optionList","OptionList"),("rule","Rule"),("ruleList","RuleList"),("strLit","StrLit"),("cl","Clause"),("r","Rule")]
 
 -- A quasi-quote pattern must match an AST parsed from anywhere in a source
 -- file, while the pattern itself was parsed from the quote body - so every
@@ -81,7 +81,7 @@ quoteGrammarExp dummy func s = do
            Left err -> fail (rtkRenderError err)
            Right a -> return a
   let expr = func ast
-  dataToExpQ (const Nothing `Generics.extQ` antiGrammarExp `Generics.extQ` antiImportsOptExp `Generics.extQ` antiRuleExp `Generics.extQ` antiOptionExp `Generics.extQ` antiNameExp `Generics.extQ` antiClauseExp `Generics.extQ` antiOptDelimExp `Generics.extQ` antiStrLitExp) expr
+  dataToExpQ (const Nothing `Generics.extQ` antiGrammarExp `Generics.extQ` antiRuleExp `Generics.extQ` antiOptionExp `Generics.extQ` antiNameExp `Generics.extQ` antiClauseExp `Generics.extQ` antiStrLitExp) expr
 quoteGrammarPat :: Data.Data a => String -> (Grammar -> a) -> String -> TH.PatQ
 quoteGrammarPat dummy func s = do
   s1 <- either fail return (replaceAllPatterns s)
@@ -89,16 +89,11 @@ quoteGrammarPat dummy func s = do
            Left err -> fail (rtkRenderError err)
            Right a -> return a
   let expr = func ast
-  dataToPatQ (const Nothing `Generics.extQ` rtkPosWildPat `Generics.extQ` antiGrammarPat `Generics.extQ` antiImportsOptPat `Generics.extQ` antiRulePat `Generics.extQ` antiOptionPat `Generics.extQ` antiNamePat `Generics.extQ` antiClausePat `Generics.extQ` antiOptDelimPat `Generics.extQ` antiStrLitPat) expr
+  dataToPatQ (const Nothing `Generics.extQ` rtkPosWildPat `Generics.extQ` antiGrammarPat `Generics.extQ` antiRulePat `Generics.extQ` antiOptionPat `Generics.extQ` antiNamePat `Generics.extQ` antiClausePat `Generics.extQ` antiStrLitPat) expr
 
 antiStrLitExp :: StrLit -> Maybe (TH.Q TH.Exp )
 antiStrLitExp ( Anti_StrLit v) = Just $ TH.varE (TH.mkName v)
 antiStrLitExp _ = Nothing
-
-
-antiOptDelimExp :: OptDelim -> Maybe (TH.Q TH.Exp )
-antiOptDelimExp ( Anti_OptDelim v) = Just $ TH.varE (TH.mkName v)
-antiOptDelimExp _ = Nothing
 
 
 antiClauseExp :: Clause -> Maybe (TH.Q TH.Exp )
@@ -108,7 +103,7 @@ antiClauseExp _ = Nothing
 
 antiNameExp :: [ Name ] -> Maybe (TH.Q TH.Exp)
 antiNameExp ((Anti_Name v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiGrammarExp `Generics.extQ` antiImportsOptExp `Generics.extQ` antiRuleExp `Generics.extQ` antiOptionExp `Generics.extQ` antiNameExp `Generics.extQ` antiClauseExp `Generics.extQ` antiOptDelimExp `Generics.extQ` antiStrLitExp) rest
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiGrammarExp `Generics.extQ` antiRuleExp `Generics.extQ` antiOptionExp `Generics.extQ` antiNameExp `Generics.extQ` antiClauseExp `Generics.extQ` antiStrLitExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
 antiNameExp _ = Nothing
@@ -116,7 +111,7 @@ antiNameExp _ = Nothing
 
 antiOptionExp :: [ Option ] -> Maybe (TH.Q TH.Exp)
 antiOptionExp ((Anti_Option v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiGrammarExp `Generics.extQ` antiImportsOptExp `Generics.extQ` antiRuleExp `Generics.extQ` antiOptionExp `Generics.extQ` antiNameExp `Generics.extQ` antiClauseExp `Generics.extQ` antiOptDelimExp `Generics.extQ` antiStrLitExp) rest
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiGrammarExp `Generics.extQ` antiRuleExp `Generics.extQ` antiOptionExp `Generics.extQ` antiNameExp `Generics.extQ` antiClauseExp `Generics.extQ` antiStrLitExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
 antiOptionExp _ = Nothing
@@ -124,15 +119,10 @@ antiOptionExp _ = Nothing
 
 antiRuleExp :: [ Rule ] -> Maybe (TH.Q TH.Exp)
 antiRuleExp ((Anti_Rule v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiGrammarExp `Generics.extQ` antiImportsOptExp `Generics.extQ` antiRuleExp `Generics.extQ` antiOptionExp `Generics.extQ` antiNameExp `Generics.extQ` antiClauseExp `Generics.extQ` antiOptDelimExp `Generics.extQ` antiStrLitExp) rest
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiGrammarExp `Generics.extQ` antiRuleExp `Generics.extQ` antiOptionExp `Generics.extQ` antiNameExp `Generics.extQ` antiClauseExp `Generics.extQ` antiStrLitExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
 antiRuleExp _ = Nothing
-
-
-antiImportsOptExp :: ImportsOpt -> Maybe (TH.Q TH.Exp )
-antiImportsOptExp ( Anti_ImportsOpt v) = Just $ TH.varE (TH.mkName v)
-antiImportsOptExp _ = Nothing
 
 
 antiGrammarExp :: Grammar -> Maybe (TH.Q TH.Exp )
@@ -144,11 +134,6 @@ antiGrammarExp _ = Nothing
 antiStrLitPat :: StrLit -> Maybe (TH.Q TH.Pat )
 antiStrLitPat ( Anti_StrLit v) = Just $ TH.varP (TH.mkName v)
 antiStrLitPat _ = Nothing
-
-
-antiOptDelimPat :: OptDelim -> Maybe (TH.Q TH.Pat )
-antiOptDelimPat ( Anti_OptDelim v) = Just $ TH.varP (TH.mkName v)
-antiOptDelimPat _ = Nothing
 
 
 antiClausePat :: Clause -> Maybe (TH.Q TH.Pat )
@@ -171,11 +156,6 @@ antiRulePat [Anti_Rule v] = Just $ TH.varP (TH.mkName v)
 antiRulePat _ = Nothing
 
 
-antiImportsOptPat :: ImportsOpt -> Maybe (TH.Q TH.Pat )
-antiImportsOptPat ( Anti_ImportsOpt v) = Just $ TH.varP (TH.mkName v)
-antiImportsOptPat _ = Nothing
-
-
 antiGrammarPat :: Grammar -> Maybe (TH.Q TH.Pat )
 antiGrammarPat ( Anti_Grammar v) = Just $ TH.varP (TH.mkName v)
 antiGrammarPat _ = Nothing
@@ -189,55 +169,45 @@ quoteGrammarDecs _ = fail "this quasi-quoter cannot be used in a declaration con
 getGrammar ( Ctr__Grammar__0 _ s) = s
 
 grammar :: QuasiQuoter
-grammar = QuasiQuoter (quoteGrammarExp "tok_Grammar_dummy_15" getGrammar ) (quoteGrammarPat "tok_Grammar_dummy_15" getGrammar ) quoteGrammarType quoteGrammarDecs
+grammar = QuasiQuoter (quoteGrammarExp "tok_Grammar_dummy_11" getGrammar ) (quoteGrammarPat "tok_Grammar_dummy_11" getGrammar ) quoteGrammarType quoteGrammarDecs
 
 getClause ( Ctr__Grammar__1 _ s) = s
 
 clause :: QuasiQuoter
-clause = QuasiQuoter (quoteGrammarExp "tok_Clause_dummy_14" getClause ) (quoteGrammarPat "tok_Clause_dummy_14" getClause ) quoteGrammarType quoteGrammarDecs
+clause = QuasiQuoter (quoteGrammarExp "tok_Clause_dummy_10" getClause ) (quoteGrammarPat "tok_Clause_dummy_10" getClause ) quoteGrammarType quoteGrammarDecs
 
 getIdList ( Ctr__Grammar__2 _ s) = s
 
 idList :: QuasiQuoter
-idList = QuasiQuoter (quoteGrammarExp "tok_IdList_dummy_13" getIdList ) (quoteGrammarPat "tok_IdList_dummy_13" getIdList ) quoteGrammarType quoteGrammarDecs
+idList = QuasiQuoter (quoteGrammarExp "tok_IdList_dummy_9" getIdList ) (quoteGrammarPat "tok_IdList_dummy_9" getIdList ) quoteGrammarType quoteGrammarDecs
 
-getImportsOpt ( Ctr__Grammar__3 _ s) = s
-
-importsOpt :: QuasiQuoter
-importsOpt = QuasiQuoter (quoteGrammarExp "tok_ImportsOpt_dummy_12" getImportsOpt ) (quoteGrammarPat "tok_ImportsOpt_dummy_12" getImportsOpt ) quoteGrammarType quoteGrammarDecs
-
-getName ( Ctr__Grammar__4 _ s) = s
+getName ( Ctr__Grammar__3 _ s) = s
 
 name :: QuasiQuoter
-name = QuasiQuoter (quoteGrammarExp "tok_Name_dummy_11" getName ) (quoteGrammarPat "tok_Name_dummy_11" getName ) quoteGrammarType quoteGrammarDecs
+name = QuasiQuoter (quoteGrammarExp "tok_Name_dummy_8" getName ) (quoteGrammarPat "tok_Name_dummy_8" getName ) quoteGrammarType quoteGrammarDecs
 
-getOptDelim ( Ctr__Grammar__5 _ s) = s
-
-optDelim :: QuasiQuoter
-optDelim = QuasiQuoter (quoteGrammarExp "tok_OptDelim_dummy_10" getOptDelim ) (quoteGrammarPat "tok_OptDelim_dummy_10" getOptDelim ) quoteGrammarType quoteGrammarDecs
-
-getOption ( Ctr__Grammar__6 _ s) = s
+getOption ( Ctr__Grammar__4 _ s) = s
 
 option :: QuasiQuoter
-option = QuasiQuoter (quoteGrammarExp "tok_Option_dummy_9" getOption ) (quoteGrammarPat "tok_Option_dummy_9" getOption ) quoteGrammarType quoteGrammarDecs
+option = QuasiQuoter (quoteGrammarExp "tok_Option_dummy_7" getOption ) (quoteGrammarPat "tok_Option_dummy_7" getOption ) quoteGrammarType quoteGrammarDecs
 
-getOptionList ( Ctr__Grammar__7 _ s) = s
+getOptionList ( Ctr__Grammar__5 _ s) = s
 
 optionList :: QuasiQuoter
-optionList = QuasiQuoter (quoteGrammarExp "tok_OptionList_dummy_8" getOptionList ) (quoteGrammarPat "tok_OptionList_dummy_8" getOptionList ) quoteGrammarType quoteGrammarDecs
+optionList = QuasiQuoter (quoteGrammarExp "tok_OptionList_dummy_6" getOptionList ) (quoteGrammarPat "tok_OptionList_dummy_6" getOptionList ) quoteGrammarType quoteGrammarDecs
 
-getRule ( Ctr__Grammar__8 _ s) = s
+getRule ( Ctr__Grammar__6 _ s) = s
 
 rule :: QuasiQuoter
-rule = QuasiQuoter (quoteGrammarExp "tok_Rule_dummy_7" getRule ) (quoteGrammarPat "tok_Rule_dummy_7" getRule ) quoteGrammarType quoteGrammarDecs
+rule = QuasiQuoter (quoteGrammarExp "tok_Rule_dummy_5" getRule ) (quoteGrammarPat "tok_Rule_dummy_5" getRule ) quoteGrammarType quoteGrammarDecs
 
-getRuleList ( Ctr__Grammar__9 _ s) = s
+getRuleList ( Ctr__Grammar__7 _ s) = s
 
 ruleList :: QuasiQuoter
-ruleList = QuasiQuoter (quoteGrammarExp "tok_RuleList_dummy_6" getRuleList ) (quoteGrammarPat "tok_RuleList_dummy_6" getRuleList ) quoteGrammarType quoteGrammarDecs
+ruleList = QuasiQuoter (quoteGrammarExp "tok_RuleList_dummy_4" getRuleList ) (quoteGrammarPat "tok_RuleList_dummy_4" getRuleList ) quoteGrammarType quoteGrammarDecs
 
-getStrLit ( Ctr__Grammar__10 _ s) = s
+getStrLit ( Ctr__Grammar__8 _ s) = s
 
 strLit :: QuasiQuoter
-strLit = QuasiQuoter (quoteGrammarExp "tok_StrLit_dummy_5" getStrLit ) (quoteGrammarPat "tok_StrLit_dummy_5" getStrLit ) quoteGrammarType quoteGrammarDecs
+strLit = QuasiQuoter (quoteGrammarExp "tok_StrLit_dummy_3" getStrLit ) (quoteGrammarPat "tok_StrLit_dummy_3" getStrLit ) quoteGrammarType quoteGrammarDecs
 


### PR DESCRIPTION
An alternative may now carry a leading label — Expr = Add: Expr '+' Term
| Term ; — naming its generated constructor (Add RtkPos Expr Term)
instead of the positional Ctr__<Rule>__<index> default, so code and QQ
patterns written against generated ASTs survive alternative reordering
(task 8a of docs/qq-grammar-rewrites-plan.md, the ergonomics prerequisite
for retiring InitialGrammar).

Surface syntax: the leading label (plan candidate 1), chosen after
proving LALR feasibility over the trailing @ctor(...) annotation: the
labeled grammar.pg's generated parser keeps 0 happy conflicts and the
reference Parser.y keeps exactly its 4 pre-existing state-6
reduce/reduce conflicts. The feared collision of Name ':' with the
rule-header forms cannot arise: ':' never follows a clause symbol
(clauses are fenced by '=' ... ';'), so the parser always shifts toward
the label.

Pipeline: IClause gains ICtor, represented identically by both front
ends (refereed by the dual-front-end AST equality suite);
Normalize.checkNamedClauseSeq makes the user name win over
fillConstructorNames' generated one; checkCtorLabels rejects, with
positioned diagnostics, names that don't start uppercase, the reserved
Ctr__/Anti_ prefixes, duplicates anywhere in the grammar (all
constructors share one generated module, and GenAST's shared-type dedup
would silently merge duplicates), labels in lexical rules, and labels on
lifted alternatives (which produce no constructor). Unlabeled
alternatives keep today's generated names byte-for-byte — no other
corpus golden changes.

grammar.pg names every constructor-producing alternative (GrammarDef,
RuleSimple, Star, Labeled, Ref, ...), so ASTAdapter's pattern matches
read like prose — zero Ctr__* references remain. The two ?-rules whose
empty/present alternatives are synthesized (hence unnameable) are
restructured away: the imports block inlined into Grammar (GrammarDef /
GrammarImports), the ~ delimiter into Star/StarDelim/Plus/PlusDelim; the
accepted language is unchanged. The bootstrap stage advances two-phase
(snapshot generated via the reference front end, adapter rewritten,
rebuilt); the fixed point holds: a default invocation reproduces
test/golden/grammar/ byte-for-byte.

Also fixes a latent reference-front-end divergence the new tests
exposed: Lexer.x rejected '_' inside identifiers while grammar.pg has
always specified id = [a-zA-Z][A-Za-z0-9_]*.

https://claude.ai/code/session_01YWfgLtPa43WxZT6fiUVgbo