### PR TITLE
Add lambdas and method references (Phase 4f)

### DIFF
--- a/test-grammars/java.pg
+++ b/test-grammars/java.pg
@@ -85,7 +85,11 @@ grammar 'Java';
 # Statement to StatementBlock (JLS 14.20): 'try try { } catch ...' is no
 # longer derivable, so the clauses' owner is always explicit. See
 # TryStatement. The cast-vs-paren decision one token AFTER ')' is
-# conflict-free; see CastExpression.
+# conflict-free; see CastExpression. Lambda expressions and method
+# references add ZERO conflicts: '->' and '::' are fresh tokens that no
+# reduce lookahead contains, so every lambda head and reference form is
+# decided by a plain shift - see the NOTEs at AssignmentExpression and
+# PostfixExpression.
 # ============================================================================
 
 Java = CompilationUnit ;
@@ -496,8 +500,58 @@ SwitchStatement =
 # UPDATED: All expression rules now use shared "Expression" type for QQ support
 Expression : Expression = AssignmentExpression ;
 
+# Lambda expressions (JLS 15.27) sit alongside the assignment alternative,
+# exactly where the JLS puts them. Every form is decided by a plain shift of
+# a token no competing interpretation claims:
+#  - 'id ->': '->' directly follows the shifted id. No reduce ever has '->'
+#    in its lookahead - the token only ever follows a lambda head - so the
+#    name interpretation of the id (epsilon-starting CompoundNameTail) is
+#    untouched on every other lookahead.
+#  - '( )': ')' directly after the operand-position '(' had NO action before
+#    (an empty parenthesized expression does not exist), so the empty
+#    parameter list is a fresh shift.
+#  - '( id , id ... )': two or more INFERRED parameters. The ',' after the
+#    first id commits to the parameter list - inside an operand-position
+#    '(' no expression continues with ',' (argument lists live behind a
+#    call's own '(', a different automaton state), so the shift is
+#    conflict-free. Only plain identifiers are derivable: TYPED parameter
+#    lists ('(Foo a, Bar b) -> e') would need the full type-vs-expression
+#    cover machinery in yet another position and are NOT supported (see
+#    KNOWN LIMITATION below).
+#  - '( Expression ) ->': the SINGLE parenthesized parameter '(x) -> e'
+#    rides the cast machinery: the parser already parses '(' Expression ')'
+#    and decides cast-vs-paren one token after ')' (see CastExpression);
+#    '->' joins that decision point as a third, conflict-free outcome. That
+#    the parenthesized Expression is a bare identifier is a semantic check
+#    (javac's job), like rejecting 'default' on ordinary methods: '(a+b)->e'
+#    parses here and javac would reject it.
+#
+# The body swallows everything an Expression can ('x -> y + 1' puts the sum
+# in the body, JLS-correct: the body extends as far right as possible), and
+# a '{' after '->' starts a statement block - no Expression starts with '{',
+# so the two body forms never compete.
+#
+# In a conditional, the TRUE branch is a full Expression and accepts a
+# lambda ('cond ? x -> a : y'); the FALSE branch is a ConditionalExpression
+# and does not - JLS 15.25 puts LambdaExpression in the false branch too,
+# but spelling it there would let the bare '? :' chain rederive itself; the
+# parenthesized form '(y -> b)' covers it. Annotation element values
+# (ConditionalExpression, see AnnotationElement) correctly exclude lambdas.
+#
+# KNOWN LIMITATION: a lambda directly under a CAST ('(Runnable) () -> f()')
+# does not parse - the cast operand (UnaryExpressionNotPlusMinus) cannot
+# derive a lambda, and lifting lambdas into it would put 'id ->' behind
+# every cast head. Parenthesizing the lambda works: '(Runnable) (() -> f())'.
+# Typed parameter lists are out for the same cover-grammar cost, see above.
 Expression : AssignmentExpression =
- ConditionalExpression (AssignmentOp AssignmentExpression)? ;
+ ConditionalExpression (AssignmentOp AssignmentExpression)?
+ | id '->' LambdaBody
+ | '(' ')' '->' LambdaBody
+ | '(' id (',' id)+ ')' '->' LambdaBody
+ | '(' Expression ')' '->' LambdaBody ;
+
+# JLS 15.27.2: an expression body or a block body; '{' decides.
+LambdaBody = Expression | StatementBlock ;
 
 # COMMENTED OUT - CAUSES LEFT RECURSION:
  # | Expression (/*NumericExpressionEnd
@@ -636,13 +690,28 @@ Expression : UnaryExpressionNotPlusMinus =
 # shift keeps the name unreduced - and parses through the PrimaryNoPostfix
 # alternative anchored on 'id CompoundNameTail' instead; see the NOTE
 # there.
+#
+# The '::' alternatives are method references (JLS 15.13): 'Foo::bar',
+# 'this::handle', 'obj.field::m', 'f()::m', '(expr)::m', and the
+# constructor form 'Foo::new'. '::' is a fresh token no other rule
+# mentions, so the shift is unambiguous, and after it the id/'new' split is
+# a plain token choice. A bare name base reduces CompoundName -> ... ->
+# PostfixExpression on lookahead '::' before the shift - '::' competes with
+# nothing there (the greedy family-3 '.'-shift only fires on '.'). Lexing:
+# maximal munch keeps '::' one token (never two ':') and '->' one token
+# (never '-' '>'), while 'a-->b' still lexes as 'a' '--' '>' 'b' ('--'
+# matches the input, '->' does not). NOT covered (rare): array-type refs
+# ('String[]::new'), 'super::m', and explicit type arguments on the
+# reference ('Foo::<T>bar').
 Expression : PostfixExpression =
  PrimaryNoPostfix
  | PostfixExpression PostfixOp
  | PostfixExpression '.' id
  | PostfixExpression '.' id '(' Arglist ')'
  | PostfixExpression '.' NonEmptyTypeArguments id '(' Arglist ')'
- | PostfixExpression '[' Expression ']' ;
+ | PostfixExpression '[' Expression ']'
+ | PostfixExpression '::' id
+ | PostfixExpression '::' 'new' ;
 
 # The 'CompoundName '[' Expression ']'' alternative anchors array access on
 # the unreduced name (JLS ArrayAccess: Name [ Expression ]). It must sit here

--- a/test-grammars/java/lexical/operators.java
+++ b/test-grammars/java/lexical/operators.java
@@ -20,5 +20,10 @@ class Operators {
         ++a;
         --a;
         int e = c ? a : b;
+        Runnable r = () -> m();
+        IntUnaryOperator f = x -> x - 1;
+        Supplier<Operators> s = Operators::new;
+        IntPredicate p = Operators::odd;
+        boolean g = a-- > b;
     }
 }

--- a/test-grammars/java/lexical/operators.tokens
+++ b/test-grammars/java/lexical/operators.tokens
@@ -10,134 +10,178 @@ Tk__tok_int_24
 Tk__id "a"
 Tk__tok__eql__10
 Tk__integerLiteral "1"
-Tk__tok__plus__77
+Tk__tok__plus__78
 Tk__integerLiteral "2"
-Tk__tok__minus__78
+Tk__tok__minus__79
 Tk__integerLiteral "3"
 Tk__tok__star__5
 Tk__integerLiteral "4"
-Tk__tok__symbol__79
-Tk__integerLiteral "5"
 Tk__tok__symbol__80
+Tk__integerLiteral "5"
+Tk__tok__symbol__81
 Tk__integerLiteral "6"
 Tk__tok__semi__1
 Tk__id "a"
-Tk__tok__plus__eql__53
+Tk__tok__plus__eql__54
 Tk__integerLiteral "1"
 Tk__tok__semi__1
 Tk__id "a"
-Tk__tok__minus__eql__54
+Tk__tok__minus__eql__55
 Tk__integerLiteral "1"
 Tk__tok__semi__1
 Tk__id "a"
-Tk__tok__star__eql__55
+Tk__tok__star__eql__56
 Tk__integerLiteral "2"
 Tk__tok__semi__1
 Tk__id "a"
-Tk__tok__symbol__eql__56
+Tk__tok__symbol__eql__57
 Tk__integerLiteral "2"
 Tk__tok__semi__1
 Tk__id "a"
-Tk__tok__symbol__eql__60
+Tk__tok__symbol__eql__61
 Tk__integerLiteral "2"
-Tk__tok__semi__1
-Tk__id "a"
-Tk__tok__symbol__symbol__eql__61
-Tk__integerLiteral "1"
 Tk__tok__semi__1
 Tk__id "a"
 Tk__tok__symbol__symbol__eql__62
 Tk__integerLiteral "1"
 Tk__tok__semi__1
 Tk__id "a"
-Tk__tok__symbol__symbol__symbol__eql__63
+Tk__tok__symbol__symbol__eql__63
 Tk__integerLiteral "1"
 Tk__tok__semi__1
 Tk__id "a"
-Tk__tok__symbol__eql__58
-Tk__integerLiteral "1"
-Tk__tok__semi__1
-Tk__id "a"
-Tk__tok__pipe__eql__57
+Tk__tok__symbol__symbol__symbol__eql__64
 Tk__integerLiteral "1"
 Tk__tok__semi__1
 Tk__id "a"
 Tk__tok__symbol__eql__59
 Tk__integerLiteral "1"
 Tk__tok__semi__1
+Tk__id "a"
+Tk__tok__pipe__eql__58
+Tk__integerLiteral "1"
+Tk__tok__semi__1
+Tk__id "a"
+Tk__tok__symbol__eql__60
+Tk__integerLiteral "1"
+Tk__tok__semi__1
 Tk__tok_int_24
 Tk__id "b"
 Tk__tok__eql__10
 Tk__id "a"
-Tk__tok__symbol__symbol__76
+Tk__tok__symbol__symbol__77
 Tk__integerLiteral "1"
 Tk__tok__pipe__48
 Tk__id "a"
-Tk__tok__symbol__72
-Tk__tok__symbol__72
+Tk__tok__symbol__73
+Tk__tok__symbol__73
 Tk__integerLiteral "2"
-Tk__tok__symbol__68
+Tk__tok__symbol__69
 Tk__id "a"
-Tk__tok__symbol__72
-Tk__tok__symbol__72
-Tk__tok__symbol__72
+Tk__tok__symbol__73
+Tk__tok__symbol__73
+Tk__tok__symbol__73
 Tk__integerLiteral "3"
-Tk__tok__symbol__67
-Tk__tok__tilde__83
+Tk__tok__symbol__68
+Tk__tok__tilde__84
 Tk__id "a"
 Tk__tok__semi__1
 Tk__tok_boolean_20
 Tk__id "c"
 Tk__tok__eql__10
 Tk__id "a"
-Tk__tok__symbol__71
-Tk__id "b"
-Tk__tok__pipe__pipe__65
-Tk__id "a"
 Tk__tok__symbol__72
 Tk__id "b"
-Tk__tok__symbol__symbol__66
+Tk__tok__pipe__pipe__66
 Tk__id "a"
-Tk__tok__symbol__eql__73
+Tk__tok__symbol__73
 Tk__id "b"
-Tk__tok__pipe__48
+Tk__tok__symbol__symbol__67
 Tk__id "a"
 Tk__tok__symbol__eql__74
 Tk__id "b"
+Tk__tok__pipe__48
+Tk__id "a"
+Tk__tok__symbol__eql__75
+Tk__id "b"
+Tk__tok__symbol__69
+Tk__id "a"
+Tk__tok__eql__eql__70
+Tk__id "b"
 Tk__tok__symbol__68
 Tk__id "a"
-Tk__tok__eql__eql__69
-Tk__id "b"
-Tk__tok__symbol__67
-Tk__id "a"
-Tk__tok__exclamation__eql__70
+Tk__tok__exclamation__eql__71
 Tk__id "b"
 Tk__tok__semi__1
 Tk__tok_boolean_20
 Tk__id "d"
 Tk__tok__eql__10
-Tk__tok__exclamation__84
+Tk__tok__exclamation__85
 Tk__id "c"
 Tk__tok__semi__1
 Tk__id "a"
-Tk__tok__plus__plus__81
+Tk__tok__plus__plus__82
 Tk__tok__semi__1
 Tk__id "a"
-Tk__tok__minus__minus__82
+Tk__tok__minus__minus__83
 Tk__tok__semi__1
-Tk__tok__plus__plus__81
+Tk__tok__plus__plus__82
 Tk__id "a"
 Tk__tok__semi__1
-Tk__tok__minus__minus__82
+Tk__tok__minus__minus__83
 Tk__id "a"
 Tk__tok__semi__1
 Tk__tok_int_24
 Tk__id "e"
 Tk__tok__eql__10
 Tk__id "c"
-Tk__tok__symbol__64
+Tk__tok__symbol__65
 Tk__id "a"
 Tk__tok__colon__37
+Tk__id "b"
+Tk__tok__semi__1
+Tk__id "Runnable"
+Tk__id "r"
+Tk__tok__eql__10
+Tk__tok__lparen__7
+Tk__tok__rparen__8
+Tk__tok__minus__symbol__53
+Tk__id "m"
+Tk__tok__lparen__7
+Tk__tok__rparen__8
+Tk__tok__semi__1
+Tk__id "IntUnaryOperator"
+Tk__id "f"
+Tk__tok__eql__10
+Tk__id "x"
+Tk__tok__minus__symbol__53
+Tk__id "x"
+Tk__tok__minus__79
+Tk__integerLiteral "1"
+Tk__tok__semi__1
+Tk__id "Supplier"
+Tk__tok__symbol__72
+Tk__id "Operators"
+Tk__tok__symbol__73
+Tk__id "s"
+Tk__tok__eql__10
+Tk__id "Operators"
+Tk__tok__colon__colon__86
+Tk__tok_new_87
+Tk__tok__semi__1
+Tk__id "IntPredicate"
+Tk__id "p"
+Tk__tok__eql__10
+Tk__id "Operators"
+Tk__tok__colon__colon__86
+Tk__id "odd"
+Tk__tok__semi__1
+Tk__tok_boolean_20
+Tk__id "g"
+Tk__tok__eql__10
+Tk__id "a"
+Tk__tok__minus__minus__83
+Tk__tok__symbol__73
 Tk__id "b"
 Tk__tok__semi__1
 Tk__tok__symbol__15

--- a/test-suites/commons-lang-parser-blacklist-tests.txt
+++ b/test-suites/commons-lang-parser-blacklist-tests.txt
@@ -1,66 +1,46 @@
 # Blacklist for full parsing tests (test sources)
 # These files use features not yet supported by the grammar, chiefly:
-# - lambda expressions (->), method references (::)
-# - anonymous inner classes
-# - array initializers in 'new' (new int[] {...})
+# - anonymous inner classes (new Foo() { ... })
+# - array initializers in annotation values (@Foo({A, B})) and in array
+#   creation (new int[] {1, 2})
 # - generic methods with a void/primitive return type (<T> void m(...))
+# - a lambda directly under a cast ((Predicate<T>) t -> ...)
 #
-# Total: 175 files blacklisted, 92 files passing
+# Total: 95 files blacklisted, 172 files passing
 # As grammar support is added, remove files from this list
 
 org/apache/commons/lang3/AnnotationUtilsTest.java
 org/apache/commons/lang3/AppendableJoinerTest.java
-org/apache/commons/lang3/ArrayFillTest.java
-org/apache/commons/lang3/ArraySorterTest.java
 org/apache/commons/lang3/ArrayUtilsAddTest.java
 org/apache/commons/lang3/ArrayUtilsInsertTest.java
 org/apache/commons/lang3/ArrayUtilsRemoveMultipleTest.java
 org/apache/commons/lang3/ArrayUtilsRemoveTest.java
-org/apache/commons/lang3/ArrayUtilsSetTest.java
 org/apache/commons/lang3/ArrayUtilsTest.java
 org/apache/commons/lang3/BooleanUtilsTest.java
 org/apache/commons/lang3/CachedRandomBitsTest.java
-org/apache/commons/lang3/CharRangeTest.java
 org/apache/commons/lang3/CharSequenceUtilsTest.java
 org/apache/commons/lang3/CharSetTest.java
-org/apache/commons/lang3/CharUtilsTest.java
 org/apache/commons/lang3/ClassLoaderUtilsTest.java
-org/apache/commons/lang3/ClassPathUtilsTest.java
-org/apache/commons/lang3/ClassUtilsOssFuzzTest.java
 org/apache/commons/lang3/ClassUtilsTest.java
 org/apache/commons/lang3/ConversionTest.java
-org/apache/commons/lang3/DoubleRangeTest.java
 org/apache/commons/lang3/EnumUtilsTest.java
 org/apache/commons/lang3/FunctionsTest.java
-org/apache/commons/lang3/IntegerRangeTest.java
 org/apache/commons/lang3/LocaleUtilsTest.java
-org/apache/commons/lang3/LongRangeTest.java
 org/apache/commons/lang3/ObjectUtilsTest.java
 org/apache/commons/lang3/RandomStringUtilsTest.java
-org/apache/commons/lang3/RandomUtilsTest.java
 org/apache/commons/lang3/RangeTest.java
-org/apache/commons/lang3/RegExUtilsTest.java
 org/apache/commons/lang3/RuntimeEnvironmentTest.java
 org/apache/commons/lang3/SerializationUtilsTest.java
-org/apache/commons/lang3/StreamsTest.java
-org/apache/commons/lang3/StringEscapeUtilsTest.java
-org/apache/commons/lang3/StringUtilsAbbreviateTest.java
 org/apache/commons/lang3/StringUtilsContainsTest.java
 org/apache/commons/lang3/StringUtilsEqualsIndexOfTest.java
 org/apache/commons/lang3/StringUtilsTest.java
 org/apache/commons/lang3/StringUtilsTrimStripTest.java
 org/apache/commons/lang3/StringUtilsValueOfTest.java
 org/apache/commons/lang3/SystemPropertiesTest.java
-org/apache/commons/lang3/ThreadUtilsTest.java
 org/apache/commons/lang3/ValidateTest.java
-org/apache/commons/lang3/builder/CompareToBuilderTest.java
-org/apache/commons/lang3/builder/ConversionTest.java
 org/apache/commons/lang3/builder/DefaultToStringStyleTest.java
 org/apache/commons/lang3/builder/DiffBuilderTest.java
-org/apache/commons/lang3/builder/DiffResultTest.java
-org/apache/commons/lang3/builder/DiffTest.java
 org/apache/commons/lang3/builder/EqualsBuilderReflectJreImplementationTest.java
-org/apache/commons/lang3/builder/HashCodeBuilderTest.java
 org/apache/commons/lang3/builder/JsonToStringStyleTest.java
 org/apache/commons/lang3/builder/MultiLineToStringStyleTest.java
 org/apache/commons/lang3/builder/MultilineRecursiveToStringStyleTest.java
@@ -68,7 +48,6 @@ org/apache/commons/lang3/builder/NoClassNameToStringStyleTest.java
 org/apache/commons/lang3/builder/NoFieldNamesToStringStyleTest.java
 org/apache/commons/lang3/builder/RecursiveToStringStyleTest.java
 org/apache/commons/lang3/builder/ReflectionDiffBuilderTest.java
-org/apache/commons/lang3/builder/ReflectionToStringBuilderConcurrencyTest.java
 org/apache/commons/lang3/builder/ReflectionToStringBuilderExcludeTest.java
 org/apache/commons/lang3/builder/ReflectionToStringBuilderIncludeTest.java
 org/apache/commons/lang3/builder/ShortPrefixToStringStyleTest.java
@@ -76,30 +55,14 @@ org/apache/commons/lang3/builder/SimpleToStringStyleTest.java
 org/apache/commons/lang3/builder/StandardToStringStyleTest.java
 org/apache/commons/lang3/builder/TestClassBuilder.java
 org/apache/commons/lang3/builder/ToStringBuilderTest.java
-org/apache/commons/lang3/builder/ToStringStyleConcurrencyTest.java
-org/apache/commons/lang3/compare/ComparableUtilsTest.java
-org/apache/commons/lang3/concurrent/AbstractConcurrentInitializerCloseAndExceptionsTest.java
 org/apache/commons/lang3/concurrent/AtomicInitializerNonObjectTest.java
 org/apache/commons/lang3/concurrent/AtomicInitializerObjectTest.java
-org/apache/commons/lang3/concurrent/AtomicInitializerSupplierTest.java
 org/apache/commons/lang3/concurrent/AtomicSafeInitializerSupplierTest.java
 org/apache/commons/lang3/concurrent/AtomicSafeInitializerTest.java
 org/apache/commons/lang3/concurrent/BackgroundInitializerSupplierTest.java
 org/apache/commons/lang3/concurrent/BackgroundInitializerTest.java
-org/apache/commons/lang3/concurrent/BasicThreadFactoryTest.java
-org/apache/commons/lang3/concurrent/CallableBackgroundInitializerTest.java
-org/apache/commons/lang3/concurrent/CircuitBreakingExceptionTest.java
-org/apache/commons/lang3/concurrent/ConcurrentExceptionTest.java
-org/apache/commons/lang3/concurrent/ConcurrentRuntimeExceptionTest.java
-org/apache/commons/lang3/concurrent/ConcurrentUtilsTest.java
 org/apache/commons/lang3/concurrent/EventCountCircuitBreakerTest.java
-org/apache/commons/lang3/concurrent/FutureTasksTest.java
 org/apache/commons/lang3/concurrent/LazyInitializerAnonClassTest.java
-org/apache/commons/lang3/concurrent/LazyInitializerCloserTest.java
-org/apache/commons/lang3/concurrent/LazyInitializerFailableCloserTest.java
-org/apache/commons/lang3/concurrent/LazyInitializerSupplierTest.java
-org/apache/commons/lang3/concurrent/MemoizerComputableTest.java
-org/apache/commons/lang3/concurrent/MemoizerFunctionTest.java
 org/apache/commons/lang3/concurrent/MultiBackgroundInitializerSupplierTest.java
 org/apache/commons/lang3/concurrent/MultiBackgroundInitializerTest.java
 org/apache/commons/lang3/concurrent/TimedSemaphoreTest.java
@@ -107,41 +70,14 @@ org/apache/commons/lang3/concurrent/UncheckedFutureTest.java
 org/apache/commons/lang3/concurrent/locks/LockingVisitorsTest.java
 org/apache/commons/lang3/event/EventListenerSupportTest.java
 org/apache/commons/lang3/event/EventUtilsTest.java
-org/apache/commons/lang3/exception/CloneFailedExceptionTest.java
 org/apache/commons/lang3/exception/ContextedRuntimeExceptionTest.java
 org/apache/commons/lang3/exception/ExceptionUtilsTest.java
 org/apache/commons/lang3/function/AnnotationTestFixture.java
-org/apache/commons/lang3/function/BooleanConsumerTest.java
-org/apache/commons/lang3/function/ByteConsumerTest.java
 org/apache/commons/lang3/function/ByteSupplierTest.java
-org/apache/commons/lang3/function/ConsumersTest.java
 org/apache/commons/lang3/function/FailableTest.java
-org/apache/commons/lang3/function/FunctionsTest.java
-org/apache/commons/lang3/function/IntToCharFunctionTest.java
 org/apache/commons/lang3/function/MethodFixtures.java
-org/apache/commons/lang3/function/MethodInvokersBiConsumerTest.java
-org/apache/commons/lang3/function/MethodInvokersBiFunctionTest.java
-org/apache/commons/lang3/function/MethodInvokersFailableBiConsumerTest.java
-org/apache/commons/lang3/function/MethodInvokersFailableBiFunctionTest.java
-org/apache/commons/lang3/function/MethodInvokersFailableFunctionTest.java
-org/apache/commons/lang3/function/MethodInvokersFunctionTest.java
 org/apache/commons/lang3/function/Objects.java
-org/apache/commons/lang3/function/ObjectsTest.java
-org/apache/commons/lang3/function/SuppliersTest.java
-org/apache/commons/lang3/function/ToBooleanBiFunctionTest.java
-org/apache/commons/lang3/function/TriConsumerTest.java
-org/apache/commons/lang3/function/TriFunctionTest.java
 org/apache/commons/lang3/math/FractionTest.java
-org/apache/commons/lang3/math/IEEE754rUtilsTest.java
-org/apache/commons/lang3/math/NumberUtilsTest.java
-org/apache/commons/lang3/mutable/MutableBooleanTest.java
-org/apache/commons/lang3/mutable/MutableByteTest.java
-org/apache/commons/lang3/mutable/MutableDoubleTest.java
-org/apache/commons/lang3/mutable/MutableFloatTest.java
-org/apache/commons/lang3/mutable/MutableIntTest.java
-org/apache/commons/lang3/mutable/MutableLongTest.java
-org/apache/commons/lang3/mutable/MutableShortTest.java
-org/apache/commons/lang3/mutable/PrintAtomicVsMutable.java
 org/apache/commons/lang3/reflect/ConstructorUtilsTest.java
 org/apache/commons/lang3/reflect/FieldUtilsTest.java
 org/apache/commons/lang3/reflect/MethodUtilsTest.java
@@ -152,34 +88,19 @@ org/apache/commons/lang3/reflect/testbed/PrivatelyShadowedChild.java
 org/apache/commons/lang3/stream/FailableStreamTest.java
 org/apache/commons/lang3/stream/IntStreamsTest.java
 org/apache/commons/lang3/stream/LangCollectorsTest.java
-org/apache/commons/lang3/stream/StreamsTest.java
 org/apache/commons/lang3/text/CompositeFormatTest.java
 org/apache/commons/lang3/text/ExtendedMessageFormatTest.java
-org/apache/commons/lang3/text/FormattableUtilsTest.java
 org/apache/commons/lang3/text/StrBuilderAppendInsertTest.java
 org/apache/commons/lang3/text/StrBuilderTest.java
 org/apache/commons/lang3/text/StrSubstitutorTest.java
 org/apache/commons/lang3/text/StrTokenizerTest.java
 org/apache/commons/lang3/text/WordUtilsTest.java
 org/apache/commons/lang3/text/translate/LookupTranslatorTest.java
-org/apache/commons/lang3/text/translate/NumericEntityUnescaperTest.java
-org/apache/commons/lang3/text/translate/UnicodeUnescaperTest.java
-org/apache/commons/lang3/time/DateUtilsFragmentTest.java
-org/apache/commons/lang3/time/DateUtilsTest.java
 org/apache/commons/lang3/time/DurationFormatUtilsTest.java
 org/apache/commons/lang3/time/DurationUtilsTest.java
 org/apache/commons/lang3/time/FastDateFormatTest.java
 org/apache/commons/lang3/time/FastDateParserTest.java
 org/apache/commons/lang3/time/FastDateParser_TimeZoneStrategyTest.java
-org/apache/commons/lang3/time/FastDatePrinterTest.java
-org/apache/commons/lang3/time/FastDatePrinterTimeZonesTest.java
-org/apache/commons/lang3/time/GmtTimeZoneTest.java
-org/apache/commons/lang3/time/StopWatchTest.java
-org/apache/commons/lang3/tuple/ImmutablePairTest.java
-org/apache/commons/lang3/tuple/ImmutableTripleTest.java
-org/apache/commons/lang3/tuple/MutablePairTest.java
-org/apache/commons/lang3/tuple/MutableTripleTest.java
 org/apache/commons/lang3/tuple/PairTest.java
-org/apache/commons/lang3/tuple/TripleTest.java
 org/apache/commons/lang3/util/FluentBitSetTest.java
 org/apache/commons/lang3/util/IterableStringTokenizerTest.java

--- a/test-suites/commons-lang-parser-blacklist.txt
+++ b/test-suites/commons-lang-parser-blacklist.txt
@@ -1,66 +1,45 @@
 # Blacklist for full parsing tests (main sources)
 # These files use features not yet supported by the grammar, chiefly:
-# - lambda expressions (->), method references (::)
-# - anonymous inner classes
+# - anonymous inner classes (new Foo() { ... })
 # - a doc comment directly before 'package' (package-info.java)
 # - generic methods with a void/primitive return type (<T> void m(...))
+# - array initializers in annotation values (@Foo({A, B})) and in array
+#   creation (new int[] {1, 2})
+# - a lambda directly under a cast ((Predicate<T>) t -> ...)
 #
-# Total: 133 files blacklisted, 126 files passing
+# Total: 77 files blacklisted, 182 files passing
 # As grammar support is added, remove files from this list
 
 org/apache/commons/lang3/AnnotationUtils.java
 org/apache/commons/lang3/AppendableJoiner.java
-org/apache/commons/lang3/ArchUtils.java
 org/apache/commons/lang3/ArrayUtils.java
 org/apache/commons/lang3/BooleanUtils.java
 org/apache/commons/lang3/CharSequenceUtils.java
-org/apache/commons/lang3/CharSet.java
-org/apache/commons/lang3/CharSetUtils.java
-org/apache/commons/lang3/CharUtils.java
 org/apache/commons/lang3/ClassUtils.java
 org/apache/commons/lang3/EnumUtils.java
 org/apache/commons/lang3/Functions.java
 org/apache/commons/lang3/JavaVersion.java
-org/apache/commons/lang3/LocaleUtils.java
 org/apache/commons/lang3/ObjectUtils.java
-org/apache/commons/lang3/RandomStringUtils.java
-org/apache/commons/lang3/RandomUtils.java
 org/apache/commons/lang3/Range.java
-org/apache/commons/lang3/RuntimeEnvironment.java
-org/apache/commons/lang3/Streams.java
 org/apache/commons/lang3/StringEscapeUtils.java
 org/apache/commons/lang3/StringUtils.java
-org/apache/commons/lang3/Strings.java
-org/apache/commons/lang3/SystemProperties.java
-org/apache/commons/lang3/SystemUtils.java
 org/apache/commons/lang3/ThreadUtils.java
 org/apache/commons/lang3/Validate.java
 org/apache/commons/lang3/arch/Processor.java
 org/apache/commons/lang3/arch/package-info.java
 org/apache/commons/lang3/builder/DiffBuilder.java
-org/apache/commons/lang3/builder/DiffResult.java
-org/apache/commons/lang3/builder/EqualsBuilder.java
 org/apache/commons/lang3/builder/HashCodeBuilder.java
 org/apache/commons/lang3/builder/ReflectionToStringBuilder.java
 org/apache/commons/lang3/builder/ToStringBuilder.java
-org/apache/commons/lang3/builder/ToStringStyle.java
 org/apache/commons/lang3/builder/package-info.java
-org/apache/commons/lang3/compare/ComparableUtils.java
 org/apache/commons/lang3/compare/package-info.java
 org/apache/commons/lang3/concurrent/AbstractCircuitBreaker.java
 org/apache/commons/lang3/concurrent/LazyInitializer.java
-org/apache/commons/lang3/concurrent/Memoizer.java
-org/apache/commons/lang3/concurrent/MultiBackgroundInitializer.java
-org/apache/commons/lang3/concurrent/TimedSemaphore.java
-org/apache/commons/lang3/concurrent/UncheckedFuture.java
-org/apache/commons/lang3/concurrent/locks/LockingVisitors.java
 org/apache/commons/lang3/concurrent/locks/package-info.java
 org/apache/commons/lang3/concurrent/package-info.java
 org/apache/commons/lang3/event/EventListenerSupport.java
 org/apache/commons/lang3/event/EventUtils.java
 org/apache/commons/lang3/event/package-info.java
-org/apache/commons/lang3/exception/DefaultExceptionContext.java
-org/apache/commons/lang3/exception/ExceptionUtils.java
 org/apache/commons/lang3/exception/package-info.java
 org/apache/commons/lang3/function/BooleanConsumer.java
 org/apache/commons/lang3/function/ByteConsumer.java
@@ -72,39 +51,16 @@ org/apache/commons/lang3/function/FailableBiPredicate.java
 org/apache/commons/lang3/function/FailableByteConsumer.java
 org/apache/commons/lang3/function/FailableConsumer.java
 org/apache/commons/lang3/function/FailableDoubleConsumer.java
-org/apache/commons/lang3/function/FailableDoubleFunction.java
 org/apache/commons/lang3/function/FailableDoublePredicate.java
-org/apache/commons/lang3/function/FailableDoubleToIntFunction.java
-org/apache/commons/lang3/function/FailableDoubleToLongFunction.java
 org/apache/commons/lang3/function/FailableDoubleUnaryOperator.java
 org/apache/commons/lang3/function/FailableFunction.java
 org/apache/commons/lang3/function/FailableIntConsumer.java
-org/apache/commons/lang3/function/FailableIntFunction.java
 org/apache/commons/lang3/function/FailableIntPredicate.java
-org/apache/commons/lang3/function/FailableIntToDoubleFunction.java
-org/apache/commons/lang3/function/FailableIntToFloatFunction.java
-org/apache/commons/lang3/function/FailableIntToLongFunction.java
 org/apache/commons/lang3/function/FailableIntUnaryOperator.java
 org/apache/commons/lang3/function/FailableLongConsumer.java
-org/apache/commons/lang3/function/FailableLongFunction.java
 org/apache/commons/lang3/function/FailableLongPredicate.java
-org/apache/commons/lang3/function/FailableLongToDoubleFunction.java
-org/apache/commons/lang3/function/FailableLongToIntFunction.java
 org/apache/commons/lang3/function/FailableLongUnaryOperator.java
-org/apache/commons/lang3/function/FailableObjDoubleConsumer.java
-org/apache/commons/lang3/function/FailableObjIntConsumer.java
-org/apache/commons/lang3/function/FailableObjLongConsumer.java
 org/apache/commons/lang3/function/FailablePredicate.java
-org/apache/commons/lang3/function/FailableSupplier.java
-org/apache/commons/lang3/function/FailableToBooleanFunction.java
-org/apache/commons/lang3/function/FailableToDoubleBiFunction.java
-org/apache/commons/lang3/function/FailableToDoubleFunction.java
-org/apache/commons/lang3/function/FailableToIntBiFunction.java
-org/apache/commons/lang3/function/FailableToIntFunction.java
-org/apache/commons/lang3/function/FailableToLongBiFunction.java
-org/apache/commons/lang3/function/FailableToLongFunction.java
-org/apache/commons/lang3/function/Predicates.java
-org/apache/commons/lang3/function/Suppliers.java
 org/apache/commons/lang3/function/TriConsumer.java
 org/apache/commons/lang3/function/TriFunction.java
 org/apache/commons/lang3/function/package-info.java
@@ -112,30 +68,20 @@ org/apache/commons/lang3/math/package-info.java
 org/apache/commons/lang3/mutable/Mutable.java
 org/apache/commons/lang3/mutable/package-info.java
 org/apache/commons/lang3/package-info.java
-org/apache/commons/lang3/reflect/FieldUtils.java
-org/apache/commons/lang3/reflect/MethodUtils.java
 org/apache/commons/lang3/reflect/TypeUtils.java
 org/apache/commons/lang3/reflect/package-info.java
-org/apache/commons/lang3/stream/LangCollectors.java
-org/apache/commons/lang3/stream/Streams.java
 org/apache/commons/lang3/stream/package-info.java
-org/apache/commons/lang3/text/ExtendedMessageFormat.java
 org/apache/commons/lang3/text/StrBuilder.java
 org/apache/commons/lang3/text/StrMatcher.java
 org/apache/commons/lang3/text/StrSubstitutor.java
 org/apache/commons/lang3/text/package-info.java
 org/apache/commons/lang3/text/translate/NumericEntityUnescaper.java
 org/apache/commons/lang3/text/translate/package-info.java
-org/apache/commons/lang3/time/AbstractFormatCache.java
-org/apache/commons/lang3/time/CalendarUtils.java
 org/apache/commons/lang3/time/DateUtils.java
-org/apache/commons/lang3/time/DurationFormatUtils.java
 org/apache/commons/lang3/time/DurationUtils.java
 org/apache/commons/lang3/time/FastDateFormat.java
 org/apache/commons/lang3/time/FastDateParser.java
-org/apache/commons/lang3/time/FastDatePrinter.java
 org/apache/commons/lang3/time/StopWatch.java
-org/apache/commons/lang3/time/TimeZones.java
 org/apache/commons/lang3/time/package-info.java
 org/apache/commons/lang3/tuple/Pair.java
 org/apache/commons/lang3/tuple/package-info.java

--- a/test/golden/java/JavaLexer.x
+++ b/test/golden/java/JavaLexer.x
@@ -12,112 +12,113 @@ import Data.Data (Data)
 @floatTypeSuffix = ([fFdD])
 $backslash = [\\]
 
-tokens :- "tok_AdditiveOp_dummy_190" { simple Tk__tok_AdditiveOp_dummy_190 }
-          "tok_Annotation_dummy_189" { simple Tk__tok_Annotation_dummy_189 }
-          "tok_AnnotationArguments_dummy_188" { simple Tk__tok_AnnotationArguments_dummy_188 }
-          "tok_AnnotationDeclaration_dummy_187" { simple Tk__tok_AnnotationDeclaration_dummy_187 }
-          "tok_AnnotationElement_dummy_186" { simple Tk__tok_AnnotationElement_dummy_186 }
-          "tok_AnnotationList_dummy_185" { simple Tk__tok_AnnotationList_dummy_185 }
-          "tok_AnnotationTypeElement_dummy_184" { simple Tk__tok_AnnotationTypeElement_dummy_184 }
-          "tok_AnnotationTypeElementList_dummy_183" { simple Tk__tok_AnnotationTypeElementList_dummy_183 }
-          "tok_Arglist_dummy_182" { simple Tk__tok_Arglist_dummy_182 }
-          "tok_AssignmentOp_dummy_181" { simple Tk__tok_AssignmentOp_dummy_181 }
-          "tok_CatchList_dummy_180" { simple Tk__tok_CatchList_dummy_180 }
-          "tok_CatchParameter_dummy_179" { simple Tk__tok_CatchParameter_dummy_179 }
-          "tok_ClassDeclaration_dummy_178" { simple Tk__tok_ClassDeclaration_dummy_178 }
-          "tok_ClassOrInterfaceType_dummy_177" { simple Tk__tok_ClassOrInterfaceType_dummy_177 }
-          "tok_CompilationUnit_dummy_176" { simple Tk__tok_CompilationUnit_dummy_176 }
-          "tok_CompoundName_dummy_175" { simple Tk__tok_CompoundName_dummy_175 }
-          "tok_CompoundNameTail_dummy_174" { simple Tk__tok_CompoundNameTail_dummy_174 }
-          "tok_CreationExpression_dummy_173" { simple Tk__tok_CreationExpression_dummy_173 }
-          "tok_DimExprs_dummy_172" { simple Tk__tok_DimExprs_dummy_172 }
-          "tok_Dims_dummy_171" { simple Tk__tok_Dims_dummy_171 }
-          "tok_DoStatement_dummy_170" { simple Tk__tok_DoStatement_dummy_170 }
-          "tok_DocComment_dummy_169" { simple Tk__tok_DocComment_dummy_169 }
-          "tok_EnumConstant_dummy_168" { simple Tk__tok_EnumConstant_dummy_168 }
-          "tok_EnumConstantList_dummy_167" { simple Tk__tok_EnumConstantList_dummy_167 }
-          "tok_EnumDeclaration_dummy_166" { simple Tk__tok_EnumDeclaration_dummy_166 }
-          "tok_EqualityOp_dummy_165" { simple Tk__tok_EqualityOp_dummy_165 }
-          "tok_Expression_dummy_164" { simple Tk__tok_Expression_dummy_164 }
-          "tok_ExtendsList_dummy_163" { simple Tk__tok_ExtendsList_dummy_163 }
-          "tok_FieldDeclaration_dummy_162" { simple Tk__tok_FieldDeclaration_dummy_162 }
-          "tok_FieldDeclarationList_dummy_161" { simple Tk__tok_FieldDeclarationList_dummy_161 }
-          "tok_ForEachHeader_dummy_160" { simple Tk__tok_ForEachHeader_dummy_160 }
-          "tok_ForStatement_dummy_159" { simple Tk__tok_ForStatement_dummy_159 }
-          "tok_IfStatement_dummy_158" { simple Tk__tok_IfStatement_dummy_158 }
-          "tok_ImplementsList_dummy_157" { simple Tk__tok_ImplementsList_dummy_157 }
-          "tok_ImportHead_dummy_156" { simple Tk__tok_ImportHead_dummy_156 }
-          "tok_ImportList_dummy_155" { simple Tk__tok_ImportList_dummy_155 }
-          "tok_ImportName_dummy_154" { simple Tk__tok_ImportName_dummy_154 }
-          "tok_ImportStatement_dummy_153" { simple Tk__tok_ImportStatement_dummy_153 }
-          "tok_InterfaceDeclaration_dummy_152" { simple Tk__tok_InterfaceDeclaration_dummy_152 }
-          "tok_Java_dummy_191" { simple Tk__tok_Java_dummy_191 }
-          "tok_Literal_dummy_151" { simple Tk__tok_Literal_dummy_151 }
-          "tok_LocalModifierList1_dummy_150" { simple Tk__tok_LocalModifierList1_dummy_150 }
-          "tok_MemberAfterFirstId_dummy_149" { simple Tk__tok_MemberAfterFirstId_dummy_149 }
-          "tok_MemberDeclaration_dummy_148" { simple Tk__tok_MemberDeclaration_dummy_148 }
-          "tok_MemberRest_dummy_147" { simple Tk__tok_MemberRest_dummy_147 }
-          "tok_Modifier_dummy_146" { simple Tk__tok_Modifier_dummy_146 }
-          "tok_ModifierList_dummy_145" { simple Tk__tok_ModifierList_dummy_145 }
-          "tok_MoreTypeSpecifier_dummy_144" { simple Tk__tok_MoreTypeSpecifier_dummy_144 }
-          "tok_MoreVariableDeclarators_dummy_143" { simple Tk__tok_MoreVariableDeclarators_dummy_143 }
-          "tok_MultiplicativeOp_dummy_142" { simple Tk__tok_MultiplicativeOp_dummy_142 }
-          "tok_NonEmptyDims_dummy_141" { simple Tk__tok_NonEmptyDims_dummy_141 }
-          "tok_NonEmptyTypeArguments_dummy_140" { simple Tk__tok_NonEmptyTypeArguments_dummy_140 }
-          "tok_OptDocComment_dummy_139" { simple Tk__tok_OptDocComment_dummy_139 }
-          "tok_OptElsePart_dummy_138" { simple Tk__tok_OptElsePart_dummy_138 }
-          "tok_OptExpression_dummy_137" { simple Tk__tok_OptExpression_dummy_137 }
-          "tok_OptFinally_dummy_136" { simple Tk__tok_OptFinally_dummy_136 }
-          "tok_OptId_dummy_135" { simple Tk__tok_OptId_dummy_135 }
-          "tok_OptVariableInitializer_dummy_134" { simple Tk__tok_OptVariableInitializer_dummy_134 }
-          "tok_Package_dummy_133" { simple Tk__tok_Package_dummy_133 }
-          "tok_ParamModifierList_dummy_132" { simple Tk__tok_ParamModifierList_dummy_132 }
-          "tok_Parameter_dummy_131" { simple Tk__tok_Parameter_dummy_131 }
-          "tok_ParameterList_dummy_130" { simple Tk__tok_ParameterList_dummy_130 }
-          "tok_PostfixOp_dummy_129" { simple Tk__tok_PostfixOp_dummy_129 }
-          "tok_PrefixOp_dummy_128" { simple Tk__tok_PrefixOp_dummy_128 }
-          "tok_PrimitiveTypeKeyword_dummy_127" { simple Tk__tok_PrimitiveTypeKeyword_dummy_127 }
-          "tok_RelationalOp_dummy_126" { simple Tk__tok_RelationalOp_dummy_126 }
-          "tok_Resource_dummy_125" { simple Tk__tok_Resource_dummy_125 }
-          "tok_ResourceSpec_dummy_124" { simple Tk__tok_ResourceSpec_dummy_124 }
-          "tok_ShiftOp_dummy_123" { simple Tk__tok_ShiftOp_dummy_123 }
-          "tok_Statement_dummy_122" { simple Tk__tok_Statement_dummy_122 }
-          "tok_StatementBlock_dummy_121" { simple Tk__tok_StatementBlock_dummy_121 }
-          "tok_StatementList_dummy_120" { simple Tk__tok_StatementList_dummy_120 }
-          "tok_StaticInitializer_dummy_119" { simple Tk__tok_StaticInitializer_dummy_119 }
-          "tok_SwitchCaseList_dummy_118" { simple Tk__tok_SwitchCaseList_dummy_118 }
-          "tok_SwitchStatement_dummy_117" { simple Tk__tok_SwitchStatement_dummy_117 }
-          "tok_ThrowsClause_dummy_116" { simple Tk__tok_ThrowsClause_dummy_116 }
-          "tok_TryStatement_dummy_115" { simple Tk__tok_TryStatement_dummy_115 }
-          "tok_Type_dummy_114" { simple Tk__tok_Type_dummy_114 }
-          "tok_TypeArgument_dummy_113" { simple Tk__tok_TypeArgument_dummy_113 }
-          "tok_TypeArguments_dummy_112" { simple Tk__tok_TypeArguments_dummy_112 }
-          "tok_TypeDeclRest_dummy_111" { simple Tk__tok_TypeDeclRest_dummy_111 }
-          "tok_TypeDeclaration_dummy_110" { simple Tk__tok_TypeDeclaration_dummy_110 }
-          "tok_TypeParameter_dummy_109" { simple Tk__tok_TypeParameter_dummy_109 }
-          "tok_TypeParameters_dummy_108" { simple Tk__tok_TypeParameters_dummy_108 }
-          "tok_TypeSpecifier_dummy_107" { simple Tk__tok_TypeSpecifier_dummy_107 }
-          "tok_VariableDeclaration_dummy_106" { simple Tk__tok_VariableDeclaration_dummy_106 }
-          "tok_VariableDeclarator_dummy_105" { simple Tk__tok_VariableDeclarator_dummy_105 }
-          "tok_VariableDeclaratorList_dummy_104" { simple Tk__tok_VariableDeclaratorList_dummy_104 }
-          "tok_VariableInitializer_dummy_103" { simple Tk__tok_VariableInitializer_dummy_103 }
-          "tok_VariableInitializerList_dummy_102" { simple Tk__tok_VariableInitializerList_dummy_102 }
-          "tok_WhileStatement_dummy_101" { simple Tk__tok_WhileStatement_dummy_101 }
-          "tok_WildcardType_dummy_100" { simple Tk__tok_WildcardType_dummy_100 }
-          "~" { simple Tk__tok__tilde__83 }
+tokens :- "tok_AdditiveOp_dummy_193" { simple Tk__tok_AdditiveOp_dummy_193 }
+          "tok_Annotation_dummy_192" { simple Tk__tok_Annotation_dummy_192 }
+          "tok_AnnotationArguments_dummy_191" { simple Tk__tok_AnnotationArguments_dummy_191 }
+          "tok_AnnotationDeclaration_dummy_190" { simple Tk__tok_AnnotationDeclaration_dummy_190 }
+          "tok_AnnotationElement_dummy_189" { simple Tk__tok_AnnotationElement_dummy_189 }
+          "tok_AnnotationList_dummy_188" { simple Tk__tok_AnnotationList_dummy_188 }
+          "tok_AnnotationTypeElement_dummy_187" { simple Tk__tok_AnnotationTypeElement_dummy_187 }
+          "tok_AnnotationTypeElementList_dummy_186" { simple Tk__tok_AnnotationTypeElementList_dummy_186 }
+          "tok_Arglist_dummy_185" { simple Tk__tok_Arglist_dummy_185 }
+          "tok_AssignmentOp_dummy_184" { simple Tk__tok_AssignmentOp_dummy_184 }
+          "tok_CatchList_dummy_183" { simple Tk__tok_CatchList_dummy_183 }
+          "tok_CatchParameter_dummy_182" { simple Tk__tok_CatchParameter_dummy_182 }
+          "tok_ClassDeclaration_dummy_181" { simple Tk__tok_ClassDeclaration_dummy_181 }
+          "tok_ClassOrInterfaceType_dummy_180" { simple Tk__tok_ClassOrInterfaceType_dummy_180 }
+          "tok_CompilationUnit_dummy_179" { simple Tk__tok_CompilationUnit_dummy_179 }
+          "tok_CompoundName_dummy_178" { simple Tk__tok_CompoundName_dummy_178 }
+          "tok_CompoundNameTail_dummy_177" { simple Tk__tok_CompoundNameTail_dummy_177 }
+          "tok_CreationExpression_dummy_176" { simple Tk__tok_CreationExpression_dummy_176 }
+          "tok_DimExprs_dummy_175" { simple Tk__tok_DimExprs_dummy_175 }
+          "tok_Dims_dummy_174" { simple Tk__tok_Dims_dummy_174 }
+          "tok_DoStatement_dummy_173" { simple Tk__tok_DoStatement_dummy_173 }
+          "tok_DocComment_dummy_172" { simple Tk__tok_DocComment_dummy_172 }
+          "tok_EnumConstant_dummy_171" { simple Tk__tok_EnumConstant_dummy_171 }
+          "tok_EnumConstantList_dummy_170" { simple Tk__tok_EnumConstantList_dummy_170 }
+          "tok_EnumDeclaration_dummy_169" { simple Tk__tok_EnumDeclaration_dummy_169 }
+          "tok_EqualityOp_dummy_168" { simple Tk__tok_EqualityOp_dummy_168 }
+          "tok_Expression_dummy_167" { simple Tk__tok_Expression_dummy_167 }
+          "tok_ExtendsList_dummy_166" { simple Tk__tok_ExtendsList_dummy_166 }
+          "tok_FieldDeclaration_dummy_165" { simple Tk__tok_FieldDeclaration_dummy_165 }
+          "tok_FieldDeclarationList_dummy_164" { simple Tk__tok_FieldDeclarationList_dummy_164 }
+          "tok_ForEachHeader_dummy_163" { simple Tk__tok_ForEachHeader_dummy_163 }
+          "tok_ForStatement_dummy_162" { simple Tk__tok_ForStatement_dummy_162 }
+          "tok_IfStatement_dummy_161" { simple Tk__tok_IfStatement_dummy_161 }
+          "tok_ImplementsList_dummy_160" { simple Tk__tok_ImplementsList_dummy_160 }
+          "tok_ImportHead_dummy_159" { simple Tk__tok_ImportHead_dummy_159 }
+          "tok_ImportList_dummy_158" { simple Tk__tok_ImportList_dummy_158 }
+          "tok_ImportName_dummy_157" { simple Tk__tok_ImportName_dummy_157 }
+          "tok_ImportStatement_dummy_156" { simple Tk__tok_ImportStatement_dummy_156 }
+          "tok_InterfaceDeclaration_dummy_155" { simple Tk__tok_InterfaceDeclaration_dummy_155 }
+          "tok_Java_dummy_194" { simple Tk__tok_Java_dummy_194 }
+          "tok_LambdaBody_dummy_154" { simple Tk__tok_LambdaBody_dummy_154 }
+          "tok_Literal_dummy_153" { simple Tk__tok_Literal_dummy_153 }
+          "tok_LocalModifierList1_dummy_152" { simple Tk__tok_LocalModifierList1_dummy_152 }
+          "tok_MemberAfterFirstId_dummy_151" { simple Tk__tok_MemberAfterFirstId_dummy_151 }
+          "tok_MemberDeclaration_dummy_150" { simple Tk__tok_MemberDeclaration_dummy_150 }
+          "tok_MemberRest_dummy_149" { simple Tk__tok_MemberRest_dummy_149 }
+          "tok_Modifier_dummy_148" { simple Tk__tok_Modifier_dummy_148 }
+          "tok_ModifierList_dummy_147" { simple Tk__tok_ModifierList_dummy_147 }
+          "tok_MoreTypeSpecifier_dummy_146" { simple Tk__tok_MoreTypeSpecifier_dummy_146 }
+          "tok_MoreVariableDeclarators_dummy_145" { simple Tk__tok_MoreVariableDeclarators_dummy_145 }
+          "tok_MultiplicativeOp_dummy_144" { simple Tk__tok_MultiplicativeOp_dummy_144 }
+          "tok_NonEmptyDims_dummy_143" { simple Tk__tok_NonEmptyDims_dummy_143 }
+          "tok_NonEmptyTypeArguments_dummy_142" { simple Tk__tok_NonEmptyTypeArguments_dummy_142 }
+          "tok_OptDocComment_dummy_141" { simple Tk__tok_OptDocComment_dummy_141 }
+          "tok_OptElsePart_dummy_140" { simple Tk__tok_OptElsePart_dummy_140 }
+          "tok_OptExpression_dummy_139" { simple Tk__tok_OptExpression_dummy_139 }
+          "tok_OptFinally_dummy_138" { simple Tk__tok_OptFinally_dummy_138 }
+          "tok_OptId_dummy_137" { simple Tk__tok_OptId_dummy_137 }
+          "tok_OptVariableInitializer_dummy_136" { simple Tk__tok_OptVariableInitializer_dummy_136 }
+          "tok_Package_dummy_135" { simple Tk__tok_Package_dummy_135 }
+          "tok_ParamModifierList_dummy_134" { simple Tk__tok_ParamModifierList_dummy_134 }
+          "tok_Parameter_dummy_133" { simple Tk__tok_Parameter_dummy_133 }
+          "tok_ParameterList_dummy_132" { simple Tk__tok_ParameterList_dummy_132 }
+          "tok_PostfixOp_dummy_131" { simple Tk__tok_PostfixOp_dummy_131 }
+          "tok_PrefixOp_dummy_130" { simple Tk__tok_PrefixOp_dummy_130 }
+          "tok_PrimitiveTypeKeyword_dummy_129" { simple Tk__tok_PrimitiveTypeKeyword_dummy_129 }
+          "tok_RelationalOp_dummy_128" { simple Tk__tok_RelationalOp_dummy_128 }
+          "tok_Resource_dummy_127" { simple Tk__tok_Resource_dummy_127 }
+          "tok_ResourceSpec_dummy_126" { simple Tk__tok_ResourceSpec_dummy_126 }
+          "tok_ShiftOp_dummy_125" { simple Tk__tok_ShiftOp_dummy_125 }
+          "tok_Statement_dummy_124" { simple Tk__tok_Statement_dummy_124 }
+          "tok_StatementBlock_dummy_123" { simple Tk__tok_StatementBlock_dummy_123 }
+          "tok_StatementList_dummy_122" { simple Tk__tok_StatementList_dummy_122 }
+          "tok_StaticInitializer_dummy_121" { simple Tk__tok_StaticInitializer_dummy_121 }
+          "tok_SwitchCaseList_dummy_120" { simple Tk__tok_SwitchCaseList_dummy_120 }
+          "tok_SwitchStatement_dummy_119" { simple Tk__tok_SwitchStatement_dummy_119 }
+          "tok_ThrowsClause_dummy_118" { simple Tk__tok_ThrowsClause_dummy_118 }
+          "tok_TryStatement_dummy_117" { simple Tk__tok_TryStatement_dummy_117 }
+          "tok_Type_dummy_116" { simple Tk__tok_Type_dummy_116 }
+          "tok_TypeArgument_dummy_115" { simple Tk__tok_TypeArgument_dummy_115 }
+          "tok_TypeArguments_dummy_114" { simple Tk__tok_TypeArguments_dummy_114 }
+          "tok_TypeDeclRest_dummy_113" { simple Tk__tok_TypeDeclRest_dummy_113 }
+          "tok_TypeDeclaration_dummy_112" { simple Tk__tok_TypeDeclaration_dummy_112 }
+          "tok_TypeParameter_dummy_111" { simple Tk__tok_TypeParameter_dummy_111 }
+          "tok_TypeParameters_dummy_110" { simple Tk__tok_TypeParameters_dummy_110 }
+          "tok_TypeSpecifier_dummy_109" { simple Tk__tok_TypeSpecifier_dummy_109 }
+          "tok_VariableDeclaration_dummy_108" { simple Tk__tok_VariableDeclaration_dummy_108 }
+          "tok_VariableDeclarator_dummy_107" { simple Tk__tok_VariableDeclarator_dummy_107 }
+          "tok_VariableDeclaratorList_dummy_106" { simple Tk__tok_VariableDeclaratorList_dummy_106 }
+          "tok_VariableInitializer_dummy_105" { simple Tk__tok_VariableInitializer_dummy_105 }
+          "tok_VariableInitializerList_dummy_104" { simple Tk__tok_VariableInitializerList_dummy_104 }
+          "tok_WhileStatement_dummy_103" { simple Tk__tok_WhileStatement_dummy_103 }
+          "tok_WildcardType_dummy_102" { simple Tk__tok_WildcardType_dummy_102 }
+          "~" { simple Tk__tok__tilde__84 }
           "}" { simple Tk__tok__symbol__15 }
-          "||" { simple Tk__tok__pipe__pipe__65 }
-          "|=" { simple Tk__tok__pipe__eql__57 }
+          "||" { simple Tk__tok__pipe__pipe__66 }
+          "|=" { simple Tk__tok__pipe__eql__58 }
           "|" { simple Tk__tok__pipe__48 }
           "{" { simple Tk__tok__symbol__14 }
           "while" { simple Tk__tok_while_45 }
           "void" { simple Tk__tok_void_28 }
           "try" { simple Tk__tok_try_50 }
-          "true" { simple Tk__tok_true_86 }
-          "transient" { simple Tk__tok_transient_95 }
+          "true" { simple Tk__tok_true_88 }
+          "transient" { simple Tk__tok_transient_97 }
           "throws" { simple Tk__tok_throws_29 }
           "throw" { simple Tk__tok_throw_35 }
-          "threadsafe" { simple Tk__tok_threadsafe_94 }
+          "threadsafe" { simple Tk__tok_threadsafe_96 }
           "this" { simple Tk__tok_this_41 }
           "synchronized" { simple Tk__tok_synchronized_34 }
           "switch" { simple Tk__tok_switch_52 }
@@ -125,17 +126,17 @@ tokens :- "tok_AdditiveOp_dummy_190" { simple Tk__tok_AdditiveOp_dummy_190 }
           "static" { simple Tk__tok_static_3 }
           "short" { simple Tk__tok_short_23 }
           "return" { simple Tk__tok_return_33 }
-          "public" { simple Tk__tok_public_89 }
-          "protected" { simple Tk__tok_protected_91 }
-          "private" { simple Tk__tok_private_90 }
+          "public" { simple Tk__tok_public_91 }
+          "protected" { simple Tk__tok_protected_93 }
+          "private" { simple Tk__tok_private_92 }
           "package" { simple Tk__tok_package_0 }
-          "null" { simple Tk__tok_null_88 }
-          "new" { simple Tk__tok_new_85 }
-          "native" { simple Tk__tok_native_92 }
+          "null" { simple Tk__tok_null_90 }
+          "new" { simple Tk__tok_new_87 }
+          "native" { simple Tk__tok_native_94 }
           "long" { simple Tk__tok_long_26 }
           "interface" { simple Tk__tok_interface_16 }
           "int" { simple Tk__tok_int_24 }
-          "instanceof" { simple Tk__tok_instanceof_75 }
+          "instanceof" { simple Tk__tok_instanceof_76 }
           "import" { simple Tk__tok_import_2 }
           "implements" { simple Tk__tok_implements_12 }
           "if" { simple Tk__tok_if_43 }
@@ -143,7 +144,7 @@ tokens :- "tok_AdditiveOp_dummy_190" { simple Tk__tok_AdditiveOp_dummy_190 }
           "float" { simple Tk__tok_float_25 }
           "finally" { simple Tk__tok_finally_49 }
           "final" { simple Tk__tok_final_31 }
-          "false" { simple Tk__tok_false_87 }
+          "false" { simple Tk__tok_false_89 }
           "extends" { simple Tk__tok_extends_11 }
           "enum" { simple Tk__tok_enum_17 }
           "else" { simple Tk__tok_else_42 }
@@ -159,47 +160,49 @@ tokens :- "tok_AdditiveOp_dummy_190" { simple Tk__tok_AdditiveOp_dummy_190 }
           "break" { simple Tk__tok_break_38 }
           "boolean" { simple Tk__tok_boolean_20 }
           "assert" { simple Tk__tok_assert_36 }
-          "abstract" { simple Tk__tok_abstract_93 }
-          "^=" { simple Tk__tok__symbol__eql__59 }
-          "^" { simple Tk__tok__symbol__67 }
+          "abstract" { simple Tk__tok_abstract_95 }
+          "^=" { simple Tk__tok__symbol__eql__60 }
+          "^" { simple Tk__tok__symbol__68 }
           "]" { simple Tk__tok__sq_bkt_r__19 }
           "[" { simple Tk__tok__sq_bkt_l__18 }
           "@" { simple Tk__tok__symbol__6 }
-          "?" { simple Tk__tok__symbol__64 }
-          ">>>=" { simple Tk__tok__symbol__symbol__symbol__eql__63 }
-          ">>=" { simple Tk__tok__symbol__symbol__eql__62 }
-          ">=" { simple Tk__tok__symbol__eql__74 }
-          ">" { simple Tk__tok__symbol__72 }
-          "==" { simple Tk__tok__eql__eql__69 }
+          "?" { simple Tk__tok__symbol__65 }
+          ">>>=" { simple Tk__tok__symbol__symbol__symbol__eql__64 }
+          ">>=" { simple Tk__tok__symbol__symbol__eql__63 }
+          ">=" { simple Tk__tok__symbol__eql__75 }
+          ">" { simple Tk__tok__symbol__73 }
+          "==" { simple Tk__tok__eql__eql__70 }
           "=" { simple Tk__tok__eql__10 }
-          "<=" { simple Tk__tok__symbol__eql__73 }
-          "<<=" { simple Tk__tok__symbol__symbol__eql__61 }
-          "<<" { simple Tk__tok__symbol__symbol__76 }
-          "<" { simple Tk__tok__symbol__71 }
+          "<=" { simple Tk__tok__symbol__eql__74 }
+          "<<=" { simple Tk__tok__symbol__symbol__eql__62 }
+          "<<" { simple Tk__tok__symbol__symbol__77 }
+          "<" { simple Tk__tok__symbol__72 }
           ";" { simple Tk__tok__semi__1 }
+          "::" { simple Tk__tok__colon__colon__86 }
           ":" { simple Tk__tok__colon__37 }
-          "/=" { simple Tk__tok__symbol__eql__56 }
-          "/" { simple Tk__tok__symbol__79 }
+          "/=" { simple Tk__tok__symbol__eql__57 }
+          "/" { simple Tk__tok__symbol__80 }
           "..." { simple Tk__tok__dot__dot__dot__32 }
           "." { simple Tk__tok__dot__4 }
-          "-=" { simple Tk__tok__minus__eql__54 }
-          "--" { simple Tk__tok__minus__minus__82 }
-          "-" { simple Tk__tok__minus__78 }
+          "->" { simple Tk__tok__minus__symbol__53 }
+          "-=" { simple Tk__tok__minus__eql__55 }
+          "--" { simple Tk__tok__minus__minus__83 }
+          "-" { simple Tk__tok__minus__79 }
           "," { simple Tk__tok__coma__9 }
-          "+=" { simple Tk__tok__plus__eql__53 }
-          "++" { simple Tk__tok__plus__plus__81 }
-          "+" { simple Tk__tok__plus__77 }
-          "*=" { simple Tk__tok__star__eql__55 }
+          "+=" { simple Tk__tok__plus__eql__54 }
+          "++" { simple Tk__tok__plus__plus__82 }
+          "+" { simple Tk__tok__plus__78 }
+          "*=" { simple Tk__tok__star__eql__56 }
           "*" { simple Tk__tok__star__5 }
           ")" { simple Tk__tok__rparen__8 }
           "(" { simple Tk__tok__lparen__7 }
-          "&=" { simple Tk__tok__symbol__eql__58 }
-          "&&" { simple Tk__tok__symbol__symbol__66 }
-          "&" { simple Tk__tok__symbol__68 }
-          "%=" { simple Tk__tok__symbol__eql__60 }
-          "%" { simple Tk__tok__symbol__80 }
-          "!=" { simple Tk__tok__exclamation__eql__70 }
-          "!" { simple Tk__tok__exclamation__84 }
+          "&=" { simple Tk__tok__symbol__eql__59 }
+          "&&" { simple Tk__tok__symbol__symbol__67 }
+          "&" { simple Tk__tok__symbol__69 }
+          "%=" { simple Tk__tok__symbol__eql__61 }
+          "%" { simple Tk__tok__symbol__81 }
+          "!=" { simple Tk__tok__exclamation__eql__71 }
+          "!" { simple Tk__tok__exclamation__85 }
           ("/*"  ([^\*\n]| [\n])  ([\n]| [^\*\n]| [\*]  [^\/\n]| [\*]  [\n])*  "*/") ;
           ("//"  [^\n]*  \n) ;
           ([\ \t\n\r]+) ;
@@ -234,6 +237,7 @@ tokens :- "tok_AdditiveOp_dummy_190" { simple Tk__tok_AdditiveOp_dummy_190 }
           ("$"  "RelationalOp"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_RelationalOp . ((tail . dropWhile (/= ':'))) }
           ("$"  "EqualityOp"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_EqualityOp . ((tail . dropWhile (/= ':'))) }
           ("$"  "AssignmentOp"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_AssignmentOp . ((tail . dropWhile (/= ':'))) }
+          ("$"  "LambdaBody"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_LambdaBody . ((tail . dropWhile (/= ':'))) }
           ("$"  "Expression"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_Expression . ((tail . dropWhile (/= ':'))) }
           ("$"  "SwitchStatement"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_SwitchStatement . ((tail . dropWhile (/= ':'))) }
           ("$"  "SwitchCaseList"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_SwitchCaseList . ((tail . dropWhile (/= ':'))) }
@@ -307,112 +311,113 @@ tokens :- "tok_AdditiveOp_dummy_190" { simple Tk__tok_AdditiveOp_dummy_190 }
 
 {
 data Token = EndOfFile |
-             Tk__tok_AdditiveOp_dummy_190 |
-             Tk__tok_Annotation_dummy_189 |
-             Tk__tok_AnnotationArguments_dummy_188 |
-             Tk__tok_AnnotationDeclaration_dummy_187 |
-             Tk__tok_AnnotationElement_dummy_186 |
-             Tk__tok_AnnotationList_dummy_185 |
-             Tk__tok_AnnotationTypeElement_dummy_184 |
-             Tk__tok_AnnotationTypeElementList_dummy_183 |
-             Tk__tok_Arglist_dummy_182 |
-             Tk__tok_AssignmentOp_dummy_181 |
-             Tk__tok_CatchList_dummy_180 |
-             Tk__tok_CatchParameter_dummy_179 |
-             Tk__tok_ClassDeclaration_dummy_178 |
-             Tk__tok_ClassOrInterfaceType_dummy_177 |
-             Tk__tok_CompilationUnit_dummy_176 |
-             Tk__tok_CompoundName_dummy_175 |
-             Tk__tok_CompoundNameTail_dummy_174 |
-             Tk__tok_CreationExpression_dummy_173 |
-             Tk__tok_DimExprs_dummy_172 |
-             Tk__tok_Dims_dummy_171 |
-             Tk__tok_DoStatement_dummy_170 |
-             Tk__tok_DocComment_dummy_169 |
-             Tk__tok_EnumConstant_dummy_168 |
-             Tk__tok_EnumConstantList_dummy_167 |
-             Tk__tok_EnumDeclaration_dummy_166 |
-             Tk__tok_EqualityOp_dummy_165 |
-             Tk__tok_Expression_dummy_164 |
-             Tk__tok_ExtendsList_dummy_163 |
-             Tk__tok_FieldDeclaration_dummy_162 |
-             Tk__tok_FieldDeclarationList_dummy_161 |
-             Tk__tok_ForEachHeader_dummy_160 |
-             Tk__tok_ForStatement_dummy_159 |
-             Tk__tok_IfStatement_dummy_158 |
-             Tk__tok_ImplementsList_dummy_157 |
-             Tk__tok_ImportHead_dummy_156 |
-             Tk__tok_ImportList_dummy_155 |
-             Tk__tok_ImportName_dummy_154 |
-             Tk__tok_ImportStatement_dummy_153 |
-             Tk__tok_InterfaceDeclaration_dummy_152 |
-             Tk__tok_Java_dummy_191 |
-             Tk__tok_Literal_dummy_151 |
-             Tk__tok_LocalModifierList1_dummy_150 |
-             Tk__tok_MemberAfterFirstId_dummy_149 |
-             Tk__tok_MemberDeclaration_dummy_148 |
-             Tk__tok_MemberRest_dummy_147 |
-             Tk__tok_Modifier_dummy_146 |
-             Tk__tok_ModifierList_dummy_145 |
-             Tk__tok_MoreTypeSpecifier_dummy_144 |
-             Tk__tok_MoreVariableDeclarators_dummy_143 |
-             Tk__tok_MultiplicativeOp_dummy_142 |
-             Tk__tok_NonEmptyDims_dummy_141 |
-             Tk__tok_NonEmptyTypeArguments_dummy_140 |
-             Tk__tok_OptDocComment_dummy_139 |
-             Tk__tok_OptElsePart_dummy_138 |
-             Tk__tok_OptExpression_dummy_137 |
-             Tk__tok_OptFinally_dummy_136 |
-             Tk__tok_OptId_dummy_135 |
-             Tk__tok_OptVariableInitializer_dummy_134 |
-             Tk__tok_Package_dummy_133 |
-             Tk__tok_ParamModifierList_dummy_132 |
-             Tk__tok_Parameter_dummy_131 |
-             Tk__tok_ParameterList_dummy_130 |
-             Tk__tok_PostfixOp_dummy_129 |
-             Tk__tok_PrefixOp_dummy_128 |
-             Tk__tok_PrimitiveTypeKeyword_dummy_127 |
-             Tk__tok_RelationalOp_dummy_126 |
-             Tk__tok_Resource_dummy_125 |
-             Tk__tok_ResourceSpec_dummy_124 |
-             Tk__tok_ShiftOp_dummy_123 |
-             Tk__tok_Statement_dummy_122 |
-             Tk__tok_StatementBlock_dummy_121 |
-             Tk__tok_StatementList_dummy_120 |
-             Tk__tok_StaticInitializer_dummy_119 |
-             Tk__tok_SwitchCaseList_dummy_118 |
-             Tk__tok_SwitchStatement_dummy_117 |
-             Tk__tok_ThrowsClause_dummy_116 |
-             Tk__tok_TryStatement_dummy_115 |
-             Tk__tok_Type_dummy_114 |
-             Tk__tok_TypeArgument_dummy_113 |
-             Tk__tok_TypeArguments_dummy_112 |
-             Tk__tok_TypeDeclRest_dummy_111 |
-             Tk__tok_TypeDeclaration_dummy_110 |
-             Tk__tok_TypeParameter_dummy_109 |
-             Tk__tok_TypeParameters_dummy_108 |
-             Tk__tok_TypeSpecifier_dummy_107 |
-             Tk__tok_VariableDeclaration_dummy_106 |
-             Tk__tok_VariableDeclarator_dummy_105 |
-             Tk__tok_VariableDeclaratorList_dummy_104 |
-             Tk__tok_VariableInitializer_dummy_103 |
-             Tk__tok_VariableInitializerList_dummy_102 |
-             Tk__tok_WhileStatement_dummy_101 |
-             Tk__tok_WildcardType_dummy_100 |
-             Tk__tok__tilde__83 |
+             Tk__tok_AdditiveOp_dummy_193 |
+             Tk__tok_Annotation_dummy_192 |
+             Tk__tok_AnnotationArguments_dummy_191 |
+             Tk__tok_AnnotationDeclaration_dummy_190 |
+             Tk__tok_AnnotationElement_dummy_189 |
+             Tk__tok_AnnotationList_dummy_188 |
+             Tk__tok_AnnotationTypeElement_dummy_187 |
+             Tk__tok_AnnotationTypeElementList_dummy_186 |
+             Tk__tok_Arglist_dummy_185 |
+             Tk__tok_AssignmentOp_dummy_184 |
+             Tk__tok_CatchList_dummy_183 |
+             Tk__tok_CatchParameter_dummy_182 |
+             Tk__tok_ClassDeclaration_dummy_181 |
+             Tk__tok_ClassOrInterfaceType_dummy_180 |
+             Tk__tok_CompilationUnit_dummy_179 |
+             Tk__tok_CompoundName_dummy_178 |
+             Tk__tok_CompoundNameTail_dummy_177 |
+             Tk__tok_CreationExpression_dummy_176 |
+             Tk__tok_DimExprs_dummy_175 |
+             Tk__tok_Dims_dummy_174 |
+             Tk__tok_DoStatement_dummy_173 |
+             Tk__tok_DocComment_dummy_172 |
+             Tk__tok_EnumConstant_dummy_171 |
+             Tk__tok_EnumConstantList_dummy_170 |
+             Tk__tok_EnumDeclaration_dummy_169 |
+             Tk__tok_EqualityOp_dummy_168 |
+             Tk__tok_Expression_dummy_167 |
+             Tk__tok_ExtendsList_dummy_166 |
+             Tk__tok_FieldDeclaration_dummy_165 |
+             Tk__tok_FieldDeclarationList_dummy_164 |
+             Tk__tok_ForEachHeader_dummy_163 |
+             Tk__tok_ForStatement_dummy_162 |
+             Tk__tok_IfStatement_dummy_161 |
+             Tk__tok_ImplementsList_dummy_160 |
+             Tk__tok_ImportHead_dummy_159 |
+             Tk__tok_ImportList_dummy_158 |
+             Tk__tok_ImportName_dummy_157 |
+             Tk__tok_ImportStatement_dummy_156 |
+             Tk__tok_InterfaceDeclaration_dummy_155 |
+             Tk__tok_Java_dummy_194 |
+             Tk__tok_LambdaBody_dummy_154 |
+             Tk__tok_Literal_dummy_153 |
+             Tk__tok_LocalModifierList1_dummy_152 |
+             Tk__tok_MemberAfterFirstId_dummy_151 |
+             Tk__tok_MemberDeclaration_dummy_150 |
+             Tk__tok_MemberRest_dummy_149 |
+             Tk__tok_Modifier_dummy_148 |
+             Tk__tok_ModifierList_dummy_147 |
+             Tk__tok_MoreTypeSpecifier_dummy_146 |
+             Tk__tok_MoreVariableDeclarators_dummy_145 |
+             Tk__tok_MultiplicativeOp_dummy_144 |
+             Tk__tok_NonEmptyDims_dummy_143 |
+             Tk__tok_NonEmptyTypeArguments_dummy_142 |
+             Tk__tok_OptDocComment_dummy_141 |
+             Tk__tok_OptElsePart_dummy_140 |
+             Tk__tok_OptExpression_dummy_139 |
+             Tk__tok_OptFinally_dummy_138 |
+             Tk__tok_OptId_dummy_137 |
+             Tk__tok_OptVariableInitializer_dummy_136 |
+             Tk__tok_Package_dummy_135 |
+             Tk__tok_ParamModifierList_dummy_134 |
+             Tk__tok_Parameter_dummy_133 |
+             Tk__tok_ParameterList_dummy_132 |
+             Tk__tok_PostfixOp_dummy_131 |
+             Tk__tok_PrefixOp_dummy_130 |
+             Tk__tok_PrimitiveTypeKeyword_dummy_129 |
+             Tk__tok_RelationalOp_dummy_128 |
+             Tk__tok_Resource_dummy_127 |
+             Tk__tok_ResourceSpec_dummy_126 |
+             Tk__tok_ShiftOp_dummy_125 |
+             Tk__tok_Statement_dummy_124 |
+             Tk__tok_StatementBlock_dummy_123 |
+             Tk__tok_StatementList_dummy_122 |
+             Tk__tok_StaticInitializer_dummy_121 |
+             Tk__tok_SwitchCaseList_dummy_120 |
+             Tk__tok_SwitchStatement_dummy_119 |
+             Tk__tok_ThrowsClause_dummy_118 |
+             Tk__tok_TryStatement_dummy_117 |
+             Tk__tok_Type_dummy_116 |
+             Tk__tok_TypeArgument_dummy_115 |
+             Tk__tok_TypeArguments_dummy_114 |
+             Tk__tok_TypeDeclRest_dummy_113 |
+             Tk__tok_TypeDeclaration_dummy_112 |
+             Tk__tok_TypeParameter_dummy_111 |
+             Tk__tok_TypeParameters_dummy_110 |
+             Tk__tok_TypeSpecifier_dummy_109 |
+             Tk__tok_VariableDeclaration_dummy_108 |
+             Tk__tok_VariableDeclarator_dummy_107 |
+             Tk__tok_VariableDeclaratorList_dummy_106 |
+             Tk__tok_VariableInitializer_dummy_105 |
+             Tk__tok_VariableInitializerList_dummy_104 |
+             Tk__tok_WhileStatement_dummy_103 |
+             Tk__tok_WildcardType_dummy_102 |
+             Tk__tok__tilde__84 |
              Tk__tok__symbol__15 |
-             Tk__tok__pipe__pipe__65 |
-             Tk__tok__pipe__eql__57 |
+             Tk__tok__pipe__pipe__66 |
+             Tk__tok__pipe__eql__58 |
              Tk__tok__pipe__48 |
              Tk__tok__symbol__14 |
              Tk__tok_while_45 |
              Tk__tok_void_28 |
              Tk__tok_try_50 |
-             Tk__tok_true_86 |
-             Tk__tok_transient_95 |
+             Tk__tok_true_88 |
+             Tk__tok_transient_97 |
              Tk__tok_throws_29 |
              Tk__tok_throw_35 |
-             Tk__tok_threadsafe_94 |
+             Tk__tok_threadsafe_96 |
              Tk__tok_this_41 |
              Tk__tok_synchronized_34 |
              Tk__tok_switch_52 |
@@ -420,17 +425,17 @@ data Token = EndOfFile |
              Tk__tok_static_3 |
              Tk__tok_short_23 |
              Tk__tok_return_33 |
-             Tk__tok_public_89 |
-             Tk__tok_protected_91 |
-             Tk__tok_private_90 |
+             Tk__tok_public_91 |
+             Tk__tok_protected_93 |
+             Tk__tok_private_92 |
              Tk__tok_package_0 |
-             Tk__tok_null_88 |
-             Tk__tok_new_85 |
-             Tk__tok_native_92 |
+             Tk__tok_null_90 |
+             Tk__tok_new_87 |
+             Tk__tok_native_94 |
              Tk__tok_long_26 |
              Tk__tok_interface_16 |
              Tk__tok_int_24 |
-             Tk__tok_instanceof_75 |
+             Tk__tok_instanceof_76 |
              Tk__tok_import_2 |
              Tk__tok_implements_12 |
              Tk__tok_if_43 |
@@ -438,7 +443,7 @@ data Token = EndOfFile |
              Tk__tok_float_25 |
              Tk__tok_finally_49 |
              Tk__tok_final_31 |
-             Tk__tok_false_87 |
+             Tk__tok_false_89 |
              Tk__tok_extends_11 |
              Tk__tok_enum_17 |
              Tk__tok_else_42 |
@@ -454,47 +459,49 @@ data Token = EndOfFile |
              Tk__tok_break_38 |
              Tk__tok_boolean_20 |
              Tk__tok_assert_36 |
-             Tk__tok_abstract_93 |
-             Tk__tok__symbol__eql__59 |
-             Tk__tok__symbol__67 |
+             Tk__tok_abstract_95 |
+             Tk__tok__symbol__eql__60 |
+             Tk__tok__symbol__68 |
              Tk__tok__sq_bkt_r__19 |
              Tk__tok__sq_bkt_l__18 |
              Tk__tok__symbol__6 |
-             Tk__tok__symbol__64 |
-             Tk__tok__symbol__symbol__symbol__eql__63 |
-             Tk__tok__symbol__symbol__eql__62 |
-             Tk__tok__symbol__eql__74 |
-             Tk__tok__symbol__72 |
-             Tk__tok__eql__eql__69 |
+             Tk__tok__symbol__65 |
+             Tk__tok__symbol__symbol__symbol__eql__64 |
+             Tk__tok__symbol__symbol__eql__63 |
+             Tk__tok__symbol__eql__75 |
+             Tk__tok__symbol__73 |
+             Tk__tok__eql__eql__70 |
              Tk__tok__eql__10 |
-             Tk__tok__symbol__eql__73 |
-             Tk__tok__symbol__symbol__eql__61 |
-             Tk__tok__symbol__symbol__76 |
-             Tk__tok__symbol__71 |
+             Tk__tok__symbol__eql__74 |
+             Tk__tok__symbol__symbol__eql__62 |
+             Tk__tok__symbol__symbol__77 |
+             Tk__tok__symbol__72 |
              Tk__tok__semi__1 |
+             Tk__tok__colon__colon__86 |
              Tk__tok__colon__37 |
-             Tk__tok__symbol__eql__56 |
-             Tk__tok__symbol__79 |
+             Tk__tok__symbol__eql__57 |
+             Tk__tok__symbol__80 |
              Tk__tok__dot__dot__dot__32 |
              Tk__tok__dot__4 |
-             Tk__tok__minus__eql__54 |
-             Tk__tok__minus__minus__82 |
-             Tk__tok__minus__78 |
+             Tk__tok__minus__symbol__53 |
+             Tk__tok__minus__eql__55 |
+             Tk__tok__minus__minus__83 |
+             Tk__tok__minus__79 |
              Tk__tok__coma__9 |
-             Tk__tok__plus__eql__53 |
-             Tk__tok__plus__plus__81 |
-             Tk__tok__plus__77 |
-             Tk__tok__star__eql__55 |
+             Tk__tok__plus__eql__54 |
+             Tk__tok__plus__plus__82 |
+             Tk__tok__plus__78 |
+             Tk__tok__star__eql__56 |
              Tk__tok__star__5 |
              Tk__tok__rparen__8 |
              Tk__tok__lparen__7 |
-             Tk__tok__symbol__eql__58 |
-             Tk__tok__symbol__symbol__66 |
-             Tk__tok__symbol__68 |
-             Tk__tok__symbol__eql__60 |
-             Tk__tok__symbol__80 |
-             Tk__tok__exclamation__eql__70 |
-             Tk__tok__exclamation__84 |
+             Tk__tok__symbol__eql__59 |
+             Tk__tok__symbol__symbol__67 |
+             Tk__tok__symbol__69 |
+             Tk__tok__symbol__eql__61 |
+             Tk__tok__symbol__81 |
+             Tk__tok__exclamation__eql__71 |
+             Tk__tok__exclamation__85 |
              Tk__doccomment String |
              Tk__id String |
              Tk__string String |
@@ -526,6 +533,7 @@ data Token = EndOfFile |
              Tk__qq_RelationalOp String |
              Tk__qq_EqualityOp String |
              Tk__qq_AssignmentOp String |
+             Tk__qq_LambdaBody String |
              Tk__qq_Expression String |
              Tk__qq_SwitchStatement String |
              Tk__qq_SwitchCaseList String |

--- a/test/golden/java/JavaParser.y
+++ b/test/golden/java/JavaParser.y
@@ -14,112 +14,113 @@ import qualified JavaLexer as L (Token(..), PosToken(..), AlexPosn(..), alexScan
 %token
 
 rtk__eof { L.PosToken _ L.EndOfFile }
-tok_AdditiveOp_dummy_190 { L.PosToken _ L.Tk__tok_AdditiveOp_dummy_190 }
-tok_Annotation_dummy_189 { L.PosToken _ L.Tk__tok_Annotation_dummy_189 }
-tok_AnnotationArguments_dummy_188 { L.PosToken _ L.Tk__tok_AnnotationArguments_dummy_188 }
-tok_AnnotationDeclaration_dummy_187 { L.PosToken _ L.Tk__tok_AnnotationDeclaration_dummy_187 }
-tok_AnnotationElement_dummy_186 { L.PosToken _ L.Tk__tok_AnnotationElement_dummy_186 }
-tok_AnnotationList_dummy_185 { L.PosToken _ L.Tk__tok_AnnotationList_dummy_185 }
-tok_AnnotationTypeElement_dummy_184 { L.PosToken _ L.Tk__tok_AnnotationTypeElement_dummy_184 }
-tok_AnnotationTypeElementList_dummy_183 { L.PosToken _ L.Tk__tok_AnnotationTypeElementList_dummy_183 }
-tok_Arglist_dummy_182 { L.PosToken _ L.Tk__tok_Arglist_dummy_182 }
-tok_AssignmentOp_dummy_181 { L.PosToken _ L.Tk__tok_AssignmentOp_dummy_181 }
-tok_CatchList_dummy_180 { L.PosToken _ L.Tk__tok_CatchList_dummy_180 }
-tok_CatchParameter_dummy_179 { L.PosToken _ L.Tk__tok_CatchParameter_dummy_179 }
-tok_ClassDeclaration_dummy_178 { L.PosToken _ L.Tk__tok_ClassDeclaration_dummy_178 }
-tok_ClassOrInterfaceType_dummy_177 { L.PosToken _ L.Tk__tok_ClassOrInterfaceType_dummy_177 }
-tok_CompilationUnit_dummy_176 { L.PosToken _ L.Tk__tok_CompilationUnit_dummy_176 }
-tok_CompoundName_dummy_175 { L.PosToken _ L.Tk__tok_CompoundName_dummy_175 }
-tok_CompoundNameTail_dummy_174 { L.PosToken _ L.Tk__tok_CompoundNameTail_dummy_174 }
-tok_CreationExpression_dummy_173 { L.PosToken _ L.Tk__tok_CreationExpression_dummy_173 }
-tok_DimExprs_dummy_172 { L.PosToken _ L.Tk__tok_DimExprs_dummy_172 }
-tok_Dims_dummy_171 { L.PosToken _ L.Tk__tok_Dims_dummy_171 }
-tok_DoStatement_dummy_170 { L.PosToken _ L.Tk__tok_DoStatement_dummy_170 }
-tok_DocComment_dummy_169 { L.PosToken _ L.Tk__tok_DocComment_dummy_169 }
-tok_EnumConstant_dummy_168 { L.PosToken _ L.Tk__tok_EnumConstant_dummy_168 }
-tok_EnumConstantList_dummy_167 { L.PosToken _ L.Tk__tok_EnumConstantList_dummy_167 }
-tok_EnumDeclaration_dummy_166 { L.PosToken _ L.Tk__tok_EnumDeclaration_dummy_166 }
-tok_EqualityOp_dummy_165 { L.PosToken _ L.Tk__tok_EqualityOp_dummy_165 }
-tok_Expression_dummy_164 { L.PosToken _ L.Tk__tok_Expression_dummy_164 }
-tok_ExtendsList_dummy_163 { L.PosToken _ L.Tk__tok_ExtendsList_dummy_163 }
-tok_FieldDeclaration_dummy_162 { L.PosToken _ L.Tk__tok_FieldDeclaration_dummy_162 }
-tok_FieldDeclarationList_dummy_161 { L.PosToken _ L.Tk__tok_FieldDeclarationList_dummy_161 }
-tok_ForEachHeader_dummy_160 { L.PosToken _ L.Tk__tok_ForEachHeader_dummy_160 }
-tok_ForStatement_dummy_159 { L.PosToken _ L.Tk__tok_ForStatement_dummy_159 }
-tok_IfStatement_dummy_158 { L.PosToken _ L.Tk__tok_IfStatement_dummy_158 }
-tok_ImplementsList_dummy_157 { L.PosToken _ L.Tk__tok_ImplementsList_dummy_157 }
-tok_ImportHead_dummy_156 { L.PosToken _ L.Tk__tok_ImportHead_dummy_156 }
-tok_ImportList_dummy_155 { L.PosToken _ L.Tk__tok_ImportList_dummy_155 }
-tok_ImportName_dummy_154 { L.PosToken _ L.Tk__tok_ImportName_dummy_154 }
-tok_ImportStatement_dummy_153 { L.PosToken _ L.Tk__tok_ImportStatement_dummy_153 }
-tok_InterfaceDeclaration_dummy_152 { L.PosToken _ L.Tk__tok_InterfaceDeclaration_dummy_152 }
-tok_Java_dummy_191 { L.PosToken _ L.Tk__tok_Java_dummy_191 }
-tok_Literal_dummy_151 { L.PosToken _ L.Tk__tok_Literal_dummy_151 }
-tok_LocalModifierList1_dummy_150 { L.PosToken _ L.Tk__tok_LocalModifierList1_dummy_150 }
-tok_MemberAfterFirstId_dummy_149 { L.PosToken _ L.Tk__tok_MemberAfterFirstId_dummy_149 }
-tok_MemberDeclaration_dummy_148 { L.PosToken _ L.Tk__tok_MemberDeclaration_dummy_148 }
-tok_MemberRest_dummy_147 { L.PosToken _ L.Tk__tok_MemberRest_dummy_147 }
-tok_Modifier_dummy_146 { L.PosToken _ L.Tk__tok_Modifier_dummy_146 }
-tok_ModifierList_dummy_145 { L.PosToken _ L.Tk__tok_ModifierList_dummy_145 }
-tok_MoreTypeSpecifier_dummy_144 { L.PosToken _ L.Tk__tok_MoreTypeSpecifier_dummy_144 }
-tok_MoreVariableDeclarators_dummy_143 { L.PosToken _ L.Tk__tok_MoreVariableDeclarators_dummy_143 }
-tok_MultiplicativeOp_dummy_142 { L.PosToken _ L.Tk__tok_MultiplicativeOp_dummy_142 }
-tok_NonEmptyDims_dummy_141 { L.PosToken _ L.Tk__tok_NonEmptyDims_dummy_141 }
-tok_NonEmptyTypeArguments_dummy_140 { L.PosToken _ L.Tk__tok_NonEmptyTypeArguments_dummy_140 }
-tok_OptDocComment_dummy_139 { L.PosToken _ L.Tk__tok_OptDocComment_dummy_139 }
-tok_OptElsePart_dummy_138 { L.PosToken _ L.Tk__tok_OptElsePart_dummy_138 }
-tok_OptExpression_dummy_137 { L.PosToken _ L.Tk__tok_OptExpression_dummy_137 }
-tok_OptFinally_dummy_136 { L.PosToken _ L.Tk__tok_OptFinally_dummy_136 }
-tok_OptId_dummy_135 { L.PosToken _ L.Tk__tok_OptId_dummy_135 }
-tok_OptVariableInitializer_dummy_134 { L.PosToken _ L.Tk__tok_OptVariableInitializer_dummy_134 }
-tok_Package_dummy_133 { L.PosToken _ L.Tk__tok_Package_dummy_133 }
-tok_ParamModifierList_dummy_132 { L.PosToken _ L.Tk__tok_ParamModifierList_dummy_132 }
-tok_Parameter_dummy_131 { L.PosToken _ L.Tk__tok_Parameter_dummy_131 }
-tok_ParameterList_dummy_130 { L.PosToken _ L.Tk__tok_ParameterList_dummy_130 }
-tok_PostfixOp_dummy_129 { L.PosToken _ L.Tk__tok_PostfixOp_dummy_129 }
-tok_PrefixOp_dummy_128 { L.PosToken _ L.Tk__tok_PrefixOp_dummy_128 }
-tok_PrimitiveTypeKeyword_dummy_127 { L.PosToken _ L.Tk__tok_PrimitiveTypeKeyword_dummy_127 }
-tok_RelationalOp_dummy_126 { L.PosToken _ L.Tk__tok_RelationalOp_dummy_126 }
-tok_Resource_dummy_125 { L.PosToken _ L.Tk__tok_Resource_dummy_125 }
-tok_ResourceSpec_dummy_124 { L.PosToken _ L.Tk__tok_ResourceSpec_dummy_124 }
-tok_ShiftOp_dummy_123 { L.PosToken _ L.Tk__tok_ShiftOp_dummy_123 }
-tok_Statement_dummy_122 { L.PosToken _ L.Tk__tok_Statement_dummy_122 }
-tok_StatementBlock_dummy_121 { L.PosToken _ L.Tk__tok_StatementBlock_dummy_121 }
-tok_StatementList_dummy_120 { L.PosToken _ L.Tk__tok_StatementList_dummy_120 }
-tok_StaticInitializer_dummy_119 { L.PosToken _ L.Tk__tok_StaticInitializer_dummy_119 }
-tok_SwitchCaseList_dummy_118 { L.PosToken _ L.Tk__tok_SwitchCaseList_dummy_118 }
-tok_SwitchStatement_dummy_117 { L.PosToken _ L.Tk__tok_SwitchStatement_dummy_117 }
-tok_ThrowsClause_dummy_116 { L.PosToken _ L.Tk__tok_ThrowsClause_dummy_116 }
-tok_TryStatement_dummy_115 { L.PosToken _ L.Tk__tok_TryStatement_dummy_115 }
-tok_Type_dummy_114 { L.PosToken _ L.Tk__tok_Type_dummy_114 }
-tok_TypeArgument_dummy_113 { L.PosToken _ L.Tk__tok_TypeArgument_dummy_113 }
-tok_TypeArguments_dummy_112 { L.PosToken _ L.Tk__tok_TypeArguments_dummy_112 }
-tok_TypeDeclRest_dummy_111 { L.PosToken _ L.Tk__tok_TypeDeclRest_dummy_111 }
-tok_TypeDeclaration_dummy_110 { L.PosToken _ L.Tk__tok_TypeDeclaration_dummy_110 }
-tok_TypeParameter_dummy_109 { L.PosToken _ L.Tk__tok_TypeParameter_dummy_109 }
-tok_TypeParameters_dummy_108 { L.PosToken _ L.Tk__tok_TypeParameters_dummy_108 }
-tok_TypeSpecifier_dummy_107 { L.PosToken _ L.Tk__tok_TypeSpecifier_dummy_107 }
-tok_VariableDeclaration_dummy_106 { L.PosToken _ L.Tk__tok_VariableDeclaration_dummy_106 }
-tok_VariableDeclarator_dummy_105 { L.PosToken _ L.Tk__tok_VariableDeclarator_dummy_105 }
-tok_VariableDeclaratorList_dummy_104 { L.PosToken _ L.Tk__tok_VariableDeclaratorList_dummy_104 }
-tok_VariableInitializer_dummy_103 { L.PosToken _ L.Tk__tok_VariableInitializer_dummy_103 }
-tok_VariableInitializerList_dummy_102 { L.PosToken _ L.Tk__tok_VariableInitializerList_dummy_102 }
-tok_WhileStatement_dummy_101 { L.PosToken _ L.Tk__tok_WhileStatement_dummy_101 }
-tok_WildcardType_dummy_100 { L.PosToken _ L.Tk__tok_WildcardType_dummy_100 }
-tok__tilde__83 { L.PosToken _ L.Tk__tok__tilde__83 }
+tok_AdditiveOp_dummy_193 { L.PosToken _ L.Tk__tok_AdditiveOp_dummy_193 }
+tok_Annotation_dummy_192 { L.PosToken _ L.Tk__tok_Annotation_dummy_192 }
+tok_AnnotationArguments_dummy_191 { L.PosToken _ L.Tk__tok_AnnotationArguments_dummy_191 }
+tok_AnnotationDeclaration_dummy_190 { L.PosToken _ L.Tk__tok_AnnotationDeclaration_dummy_190 }
+tok_AnnotationElement_dummy_189 { L.PosToken _ L.Tk__tok_AnnotationElement_dummy_189 }
+tok_AnnotationList_dummy_188 { L.PosToken _ L.Tk__tok_AnnotationList_dummy_188 }
+tok_AnnotationTypeElement_dummy_187 { L.PosToken _ L.Tk__tok_AnnotationTypeElement_dummy_187 }
+tok_AnnotationTypeElementList_dummy_186 { L.PosToken _ L.Tk__tok_AnnotationTypeElementList_dummy_186 }
+tok_Arglist_dummy_185 { L.PosToken _ L.Tk__tok_Arglist_dummy_185 }
+tok_AssignmentOp_dummy_184 { L.PosToken _ L.Tk__tok_AssignmentOp_dummy_184 }
+tok_CatchList_dummy_183 { L.PosToken _ L.Tk__tok_CatchList_dummy_183 }
+tok_CatchParameter_dummy_182 { L.PosToken _ L.Tk__tok_CatchParameter_dummy_182 }
+tok_ClassDeclaration_dummy_181 { L.PosToken _ L.Tk__tok_ClassDeclaration_dummy_181 }
+tok_ClassOrInterfaceType_dummy_180 { L.PosToken _ L.Tk__tok_ClassOrInterfaceType_dummy_180 }
+tok_CompilationUnit_dummy_179 { L.PosToken _ L.Tk__tok_CompilationUnit_dummy_179 }
+tok_CompoundName_dummy_178 { L.PosToken _ L.Tk__tok_CompoundName_dummy_178 }
+tok_CompoundNameTail_dummy_177 { L.PosToken _ L.Tk__tok_CompoundNameTail_dummy_177 }
+tok_CreationExpression_dummy_176 { L.PosToken _ L.Tk__tok_CreationExpression_dummy_176 }
+tok_DimExprs_dummy_175 { L.PosToken _ L.Tk__tok_DimExprs_dummy_175 }
+tok_Dims_dummy_174 { L.PosToken _ L.Tk__tok_Dims_dummy_174 }
+tok_DoStatement_dummy_173 { L.PosToken _ L.Tk__tok_DoStatement_dummy_173 }
+tok_DocComment_dummy_172 { L.PosToken _ L.Tk__tok_DocComment_dummy_172 }
+tok_EnumConstant_dummy_171 { L.PosToken _ L.Tk__tok_EnumConstant_dummy_171 }
+tok_EnumConstantList_dummy_170 { L.PosToken _ L.Tk__tok_EnumConstantList_dummy_170 }
+tok_EnumDeclaration_dummy_169 { L.PosToken _ L.Tk__tok_EnumDeclaration_dummy_169 }
+tok_EqualityOp_dummy_168 { L.PosToken _ L.Tk__tok_EqualityOp_dummy_168 }
+tok_Expression_dummy_167 { L.PosToken _ L.Tk__tok_Expression_dummy_167 }
+tok_ExtendsList_dummy_166 { L.PosToken _ L.Tk__tok_ExtendsList_dummy_166 }
+tok_FieldDeclaration_dummy_165 { L.PosToken _ L.Tk__tok_FieldDeclaration_dummy_165 }
+tok_FieldDeclarationList_dummy_164 { L.PosToken _ L.Tk__tok_FieldDeclarationList_dummy_164 }
+tok_ForEachHeader_dummy_163 { L.PosToken _ L.Tk__tok_ForEachHeader_dummy_163 }
+tok_ForStatement_dummy_162 { L.PosToken _ L.Tk__tok_ForStatement_dummy_162 }
+tok_IfStatement_dummy_161 { L.PosToken _ L.Tk__tok_IfStatement_dummy_161 }
+tok_ImplementsList_dummy_160 { L.PosToken _ L.Tk__tok_ImplementsList_dummy_160 }
+tok_ImportHead_dummy_159 { L.PosToken _ L.Tk__tok_ImportHead_dummy_159 }
+tok_ImportList_dummy_158 { L.PosToken _ L.Tk__tok_ImportList_dummy_158 }
+tok_ImportName_dummy_157 { L.PosToken _ L.Tk__tok_ImportName_dummy_157 }
+tok_ImportStatement_dummy_156 { L.PosToken _ L.Tk__tok_ImportStatement_dummy_156 }
+tok_InterfaceDeclaration_dummy_155 { L.PosToken _ L.Tk__tok_InterfaceDeclaration_dummy_155 }
+tok_Java_dummy_194 { L.PosToken _ L.Tk__tok_Java_dummy_194 }
+tok_LambdaBody_dummy_154 { L.PosToken _ L.Tk__tok_LambdaBody_dummy_154 }
+tok_Literal_dummy_153 { L.PosToken _ L.Tk__tok_Literal_dummy_153 }
+tok_LocalModifierList1_dummy_152 { L.PosToken _ L.Tk__tok_LocalModifierList1_dummy_152 }
+tok_MemberAfterFirstId_dummy_151 { L.PosToken _ L.Tk__tok_MemberAfterFirstId_dummy_151 }
+tok_MemberDeclaration_dummy_150 { L.PosToken _ L.Tk__tok_MemberDeclaration_dummy_150 }
+tok_MemberRest_dummy_149 { L.PosToken _ L.Tk__tok_MemberRest_dummy_149 }
+tok_Modifier_dummy_148 { L.PosToken _ L.Tk__tok_Modifier_dummy_148 }
+tok_ModifierList_dummy_147 { L.PosToken _ L.Tk__tok_ModifierList_dummy_147 }
+tok_MoreTypeSpecifier_dummy_146 { L.PosToken _ L.Tk__tok_MoreTypeSpecifier_dummy_146 }
+tok_MoreVariableDeclarators_dummy_145 { L.PosToken _ L.Tk__tok_MoreVariableDeclarators_dummy_145 }
+tok_MultiplicativeOp_dummy_144 { L.PosToken _ L.Tk__tok_MultiplicativeOp_dummy_144 }
+tok_NonEmptyDims_dummy_143 { L.PosToken _ L.Tk__tok_NonEmptyDims_dummy_143 }
+tok_NonEmptyTypeArguments_dummy_142 { L.PosToken _ L.Tk__tok_NonEmptyTypeArguments_dummy_142 }
+tok_OptDocComment_dummy_141 { L.PosToken _ L.Tk__tok_OptDocComment_dummy_141 }
+tok_OptElsePart_dummy_140 { L.PosToken _ L.Tk__tok_OptElsePart_dummy_140 }
+tok_OptExpression_dummy_139 { L.PosToken _ L.Tk__tok_OptExpression_dummy_139 }
+tok_OptFinally_dummy_138 { L.PosToken _ L.Tk__tok_OptFinally_dummy_138 }
+tok_OptId_dummy_137 { L.PosToken _ L.Tk__tok_OptId_dummy_137 }
+tok_OptVariableInitializer_dummy_136 { L.PosToken _ L.Tk__tok_OptVariableInitializer_dummy_136 }
+tok_Package_dummy_135 { L.PosToken _ L.Tk__tok_Package_dummy_135 }
+tok_ParamModifierList_dummy_134 { L.PosToken _ L.Tk__tok_ParamModifierList_dummy_134 }
+tok_Parameter_dummy_133 { L.PosToken _ L.Tk__tok_Parameter_dummy_133 }
+tok_ParameterList_dummy_132 { L.PosToken _ L.Tk__tok_ParameterList_dummy_132 }
+tok_PostfixOp_dummy_131 { L.PosToken _ L.Tk__tok_PostfixOp_dummy_131 }
+tok_PrefixOp_dummy_130 { L.PosToken _ L.Tk__tok_PrefixOp_dummy_130 }
+tok_PrimitiveTypeKeyword_dummy_129 { L.PosToken _ L.Tk__tok_PrimitiveTypeKeyword_dummy_129 }
+tok_RelationalOp_dummy_128 { L.PosToken _ L.Tk__tok_RelationalOp_dummy_128 }
+tok_Resource_dummy_127 { L.PosToken _ L.Tk__tok_Resource_dummy_127 }
+tok_ResourceSpec_dummy_126 { L.PosToken _ L.Tk__tok_ResourceSpec_dummy_126 }
+tok_ShiftOp_dummy_125 { L.PosToken _ L.Tk__tok_ShiftOp_dummy_125 }
+tok_Statement_dummy_124 { L.PosToken _ L.Tk__tok_Statement_dummy_124 }
+tok_StatementBlock_dummy_123 { L.PosToken _ L.Tk__tok_StatementBlock_dummy_123 }
+tok_StatementList_dummy_122 { L.PosToken _ L.Tk__tok_StatementList_dummy_122 }
+tok_StaticInitializer_dummy_121 { L.PosToken _ L.Tk__tok_StaticInitializer_dummy_121 }
+tok_SwitchCaseList_dummy_120 { L.PosToken _ L.Tk__tok_SwitchCaseList_dummy_120 }
+tok_SwitchStatement_dummy_119 { L.PosToken _ L.Tk__tok_SwitchStatement_dummy_119 }
+tok_ThrowsClause_dummy_118 { L.PosToken _ L.Tk__tok_ThrowsClause_dummy_118 }
+tok_TryStatement_dummy_117 { L.PosToken _ L.Tk__tok_TryStatement_dummy_117 }
+tok_Type_dummy_116 { L.PosToken _ L.Tk__tok_Type_dummy_116 }
+tok_TypeArgument_dummy_115 { L.PosToken _ L.Tk__tok_TypeArgument_dummy_115 }
+tok_TypeArguments_dummy_114 { L.PosToken _ L.Tk__tok_TypeArguments_dummy_114 }
+tok_TypeDeclRest_dummy_113 { L.PosToken _ L.Tk__tok_TypeDeclRest_dummy_113 }
+tok_TypeDeclaration_dummy_112 { L.PosToken _ L.Tk__tok_TypeDeclaration_dummy_112 }
+tok_TypeParameter_dummy_111 { L.PosToken _ L.Tk__tok_TypeParameter_dummy_111 }
+tok_TypeParameters_dummy_110 { L.PosToken _ L.Tk__tok_TypeParameters_dummy_110 }
+tok_TypeSpecifier_dummy_109 { L.PosToken _ L.Tk__tok_TypeSpecifier_dummy_109 }
+tok_VariableDeclaration_dummy_108 { L.PosToken _ L.Tk__tok_VariableDeclaration_dummy_108 }
+tok_VariableDeclarator_dummy_107 { L.PosToken _ L.Tk__tok_VariableDeclarator_dummy_107 }
+tok_VariableDeclaratorList_dummy_106 { L.PosToken _ L.Tk__tok_VariableDeclaratorList_dummy_106 }
+tok_VariableInitializer_dummy_105 { L.PosToken _ L.Tk__tok_VariableInitializer_dummy_105 }
+tok_VariableInitializerList_dummy_104 { L.PosToken _ L.Tk__tok_VariableInitializerList_dummy_104 }
+tok_WhileStatement_dummy_103 { L.PosToken _ L.Tk__tok_WhileStatement_dummy_103 }
+tok_WildcardType_dummy_102 { L.PosToken _ L.Tk__tok_WildcardType_dummy_102 }
+tok__tilde__84 { L.PosToken _ L.Tk__tok__tilde__84 }
 tok__symbol__15 { L.PosToken _ L.Tk__tok__symbol__15 }
-tok__pipe__pipe__65 { L.PosToken _ L.Tk__tok__pipe__pipe__65 }
-tok__pipe__eql__57 { L.PosToken _ L.Tk__tok__pipe__eql__57 }
+tok__pipe__pipe__66 { L.PosToken _ L.Tk__tok__pipe__pipe__66 }
+tok__pipe__eql__58 { L.PosToken _ L.Tk__tok__pipe__eql__58 }
 tok__pipe__48 { L.PosToken _ L.Tk__tok__pipe__48 }
 tok__symbol__14 { L.PosToken _ L.Tk__tok__symbol__14 }
 tok_while_45 { L.PosToken _ L.Tk__tok_while_45 }
 tok_void_28 { L.PosToken _ L.Tk__tok_void_28 }
 tok_try_50 { L.PosToken _ L.Tk__tok_try_50 }
-tok_true_86 { L.PosToken _ L.Tk__tok_true_86 }
-tok_transient_95 { L.PosToken _ L.Tk__tok_transient_95 }
+tok_true_88 { L.PosToken _ L.Tk__tok_true_88 }
+tok_transient_97 { L.PosToken _ L.Tk__tok_transient_97 }
 tok_throws_29 { L.PosToken _ L.Tk__tok_throws_29 }
 tok_throw_35 { L.PosToken _ L.Tk__tok_throw_35 }
-tok_threadsafe_94 { L.PosToken _ L.Tk__tok_threadsafe_94 }
+tok_threadsafe_96 { L.PosToken _ L.Tk__tok_threadsafe_96 }
 tok_this_41 { L.PosToken _ L.Tk__tok_this_41 }
 tok_synchronized_34 { L.PosToken _ L.Tk__tok_synchronized_34 }
 tok_switch_52 { L.PosToken _ L.Tk__tok_switch_52 }
@@ -127,17 +128,17 @@ tok_super_40 { L.PosToken _ L.Tk__tok_super_40 }
 tok_static_3 { L.PosToken _ L.Tk__tok_static_3 }
 tok_short_23 { L.PosToken _ L.Tk__tok_short_23 }
 tok_return_33 { L.PosToken _ L.Tk__tok_return_33 }
-tok_public_89 { L.PosToken _ L.Tk__tok_public_89 }
-tok_protected_91 { L.PosToken _ L.Tk__tok_protected_91 }
-tok_private_90 { L.PosToken _ L.Tk__tok_private_90 }
+tok_public_91 { L.PosToken _ L.Tk__tok_public_91 }
+tok_protected_93 { L.PosToken _ L.Tk__tok_protected_93 }
+tok_private_92 { L.PosToken _ L.Tk__tok_private_92 }
 tok_package_0 { L.PosToken _ L.Tk__tok_package_0 }
-tok_null_88 { L.PosToken _ L.Tk__tok_null_88 }
-tok_new_85 { L.PosToken _ L.Tk__tok_new_85 }
-tok_native_92 { L.PosToken _ L.Tk__tok_native_92 }
+tok_null_90 { L.PosToken _ L.Tk__tok_null_90 }
+tok_new_87 { L.PosToken _ L.Tk__tok_new_87 }
+tok_native_94 { L.PosToken _ L.Tk__tok_native_94 }
 tok_long_26 { L.PosToken _ L.Tk__tok_long_26 }
 tok_interface_16 { L.PosToken _ L.Tk__tok_interface_16 }
 tok_int_24 { L.PosToken _ L.Tk__tok_int_24 }
-tok_instanceof_75 { L.PosToken _ L.Tk__tok_instanceof_75 }
+tok_instanceof_76 { L.PosToken _ L.Tk__tok_instanceof_76 }
 tok_import_2 { L.PosToken _ L.Tk__tok_import_2 }
 tok_implements_12 { L.PosToken _ L.Tk__tok_implements_12 }
 tok_if_43 { L.PosToken _ L.Tk__tok_if_43 }
@@ -145,7 +146,7 @@ tok_for_46 { L.PosToken _ L.Tk__tok_for_46 }
 tok_float_25 { L.PosToken _ L.Tk__tok_float_25 }
 tok_finally_49 { L.PosToken _ L.Tk__tok_finally_49 }
 tok_final_31 { L.PosToken _ L.Tk__tok_final_31 }
-tok_false_87 { L.PosToken _ L.Tk__tok_false_87 }
+tok_false_89 { L.PosToken _ L.Tk__tok_false_89 }
 tok_extends_11 { L.PosToken _ L.Tk__tok_extends_11 }
 tok_enum_17 { L.PosToken _ L.Tk__tok_enum_17 }
 tok_else_42 { L.PosToken _ L.Tk__tok_else_42 }
@@ -161,47 +162,49 @@ tok_byte_21 { L.PosToken _ L.Tk__tok_byte_21 }
 tok_break_38 { L.PosToken _ L.Tk__tok_break_38 }
 tok_boolean_20 { L.PosToken _ L.Tk__tok_boolean_20 }
 tok_assert_36 { L.PosToken _ L.Tk__tok_assert_36 }
-tok_abstract_93 { L.PosToken _ L.Tk__tok_abstract_93 }
-tok__symbol__eql__59 { L.PosToken _ L.Tk__tok__symbol__eql__59 }
-tok__symbol__67 { L.PosToken _ L.Tk__tok__symbol__67 }
+tok_abstract_95 { L.PosToken _ L.Tk__tok_abstract_95 }
+tok__symbol__eql__60 { L.PosToken _ L.Tk__tok__symbol__eql__60 }
+tok__symbol__68 { L.PosToken _ L.Tk__tok__symbol__68 }
 tok__sq_bkt_r__19 { L.PosToken _ L.Tk__tok__sq_bkt_r__19 }
 tok__sq_bkt_l__18 { L.PosToken _ L.Tk__tok__sq_bkt_l__18 }
 tok__symbol__6 { L.PosToken _ L.Tk__tok__symbol__6 }
-tok__symbol__64 { L.PosToken _ L.Tk__tok__symbol__64 }
-tok__symbol__symbol__symbol__eql__63 { L.PosToken _ L.Tk__tok__symbol__symbol__symbol__eql__63 }
-tok__symbol__symbol__eql__62 { L.PosToken _ L.Tk__tok__symbol__symbol__eql__62 }
-tok__symbol__eql__74 { L.PosToken _ L.Tk__tok__symbol__eql__74 }
-tok__symbol__72 { L.PosToken _ L.Tk__tok__symbol__72 }
-tok__eql__eql__69 { L.PosToken _ L.Tk__tok__eql__eql__69 }
+tok__symbol__65 { L.PosToken _ L.Tk__tok__symbol__65 }
+tok__symbol__symbol__symbol__eql__64 { L.PosToken _ L.Tk__tok__symbol__symbol__symbol__eql__64 }
+tok__symbol__symbol__eql__63 { L.PosToken _ L.Tk__tok__symbol__symbol__eql__63 }
+tok__symbol__eql__75 { L.PosToken _ L.Tk__tok__symbol__eql__75 }
+tok__symbol__73 { L.PosToken _ L.Tk__tok__symbol__73 }
+tok__eql__eql__70 { L.PosToken _ L.Tk__tok__eql__eql__70 }
 tok__eql__10 { L.PosToken _ L.Tk__tok__eql__10 }
-tok__symbol__eql__73 { L.PosToken _ L.Tk__tok__symbol__eql__73 }
-tok__symbol__symbol__eql__61 { L.PosToken _ L.Tk__tok__symbol__symbol__eql__61 }
-tok__symbol__symbol__76 { L.PosToken _ L.Tk__tok__symbol__symbol__76 }
-tok__symbol__71 { L.PosToken _ L.Tk__tok__symbol__71 }
+tok__symbol__eql__74 { L.PosToken _ L.Tk__tok__symbol__eql__74 }
+tok__symbol__symbol__eql__62 { L.PosToken _ L.Tk__tok__symbol__symbol__eql__62 }
+tok__symbol__symbol__77 { L.PosToken _ L.Tk__tok__symbol__symbol__77 }
+tok__symbol__72 { L.PosToken _ L.Tk__tok__symbol__72 }
 tok__semi__1 { L.PosToken _ L.Tk__tok__semi__1 }
+tok__colon__colon__86 { L.PosToken _ L.Tk__tok__colon__colon__86 }
 tok__colon__37 { L.PosToken _ L.Tk__tok__colon__37 }
-tok__symbol__eql__56 { L.PosToken _ L.Tk__tok__symbol__eql__56 }
-tok__symbol__79 { L.PosToken _ L.Tk__tok__symbol__79 }
+tok__symbol__eql__57 { L.PosToken _ L.Tk__tok__symbol__eql__57 }
+tok__symbol__80 { L.PosToken _ L.Tk__tok__symbol__80 }
 tok__dot__dot__dot__32 { L.PosToken _ L.Tk__tok__dot__dot__dot__32 }
 tok__dot__4 { L.PosToken _ L.Tk__tok__dot__4 }
-tok__minus__eql__54 { L.PosToken _ L.Tk__tok__minus__eql__54 }
-tok__minus__minus__82 { L.PosToken _ L.Tk__tok__minus__minus__82 }
-tok__minus__78 { L.PosToken _ L.Tk__tok__minus__78 }
+tok__minus__symbol__53 { L.PosToken _ L.Tk__tok__minus__symbol__53 }
+tok__minus__eql__55 { L.PosToken _ L.Tk__tok__minus__eql__55 }
+tok__minus__minus__83 { L.PosToken _ L.Tk__tok__minus__minus__83 }
+tok__minus__79 { L.PosToken _ L.Tk__tok__minus__79 }
 tok__coma__9 { L.PosToken _ L.Tk__tok__coma__9 }
-tok__plus__eql__53 { L.PosToken _ L.Tk__tok__plus__eql__53 }
-tok__plus__plus__81 { L.PosToken _ L.Tk__tok__plus__plus__81 }
-tok__plus__77 { L.PosToken _ L.Tk__tok__plus__77 }
-tok__star__eql__55 { L.PosToken _ L.Tk__tok__star__eql__55 }
+tok__plus__eql__54 { L.PosToken _ L.Tk__tok__plus__eql__54 }
+tok__plus__plus__82 { L.PosToken _ L.Tk__tok__plus__plus__82 }
+tok__plus__78 { L.PosToken _ L.Tk__tok__plus__78 }
+tok__star__eql__56 { L.PosToken _ L.Tk__tok__star__eql__56 }
 tok__star__5 { L.PosToken _ L.Tk__tok__star__5 }
 tok__rparen__8 { L.PosToken _ L.Tk__tok__rparen__8 }
 tok__lparen__7 { L.PosToken _ L.Tk__tok__lparen__7 }
-tok__symbol__eql__58 { L.PosToken _ L.Tk__tok__symbol__eql__58 }
-tok__symbol__symbol__66 { L.PosToken _ L.Tk__tok__symbol__symbol__66 }
-tok__symbol__68 { L.PosToken _ L.Tk__tok__symbol__68 }
-tok__symbol__eql__60 { L.PosToken _ L.Tk__tok__symbol__eql__60 }
-tok__symbol__80 { L.PosToken _ L.Tk__tok__symbol__80 }
-tok__exclamation__eql__70 { L.PosToken _ L.Tk__tok__exclamation__eql__70 }
-tok__exclamation__84 { L.PosToken _ L.Tk__tok__exclamation__84 }
+tok__symbol__eql__59 { L.PosToken _ L.Tk__tok__symbol__eql__59 }
+tok__symbol__symbol__67 { L.PosToken _ L.Tk__tok__symbol__symbol__67 }
+tok__symbol__69 { L.PosToken _ L.Tk__tok__symbol__69 }
+tok__symbol__eql__61 { L.PosToken _ L.Tk__tok__symbol__eql__61 }
+tok__symbol__81 { L.PosToken _ L.Tk__tok__symbol__81 }
+tok__exclamation__eql__71 { L.PosToken _ L.Tk__tok__exclamation__eql__71 }
+tok__exclamation__85 { L.PosToken _ L.Tk__tok__exclamation__85 }
 doccomment { L.PosToken _ (L.Tk__doccomment _) }
 id { L.PosToken _ (L.Tk__id _) }
 string { L.PosToken _ (L.Tk__string _) }
@@ -233,6 +236,7 @@ qq_ShiftOp { L.PosToken _ (L.Tk__qq_ShiftOp _) }
 qq_RelationalOp { L.PosToken _ (L.Tk__qq_RelationalOp _) }
 qq_EqualityOp { L.PosToken _ (L.Tk__qq_EqualityOp _) }
 qq_AssignmentOp { L.PosToken _ (L.Tk__qq_AssignmentOp _) }
+qq_LambdaBody { L.PosToken _ (L.Tk__qq_LambdaBody _) }
 qq_Expression { L.PosToken _ (L.Tk__qq_Expression _) }
 qq_SwitchStatement { L.PosToken _ (L.Tk__qq_SwitchStatement _) }
 qq_SwitchCaseList { L.PosToken _ (L.Tk__qq_SwitchCaseList _) }
@@ -307,105 +311,106 @@ qq_Java { L.PosToken _ (L.Tk__qq_Java _) }
 
 Java__top : Java rtk__eof { $1 }
 
-Java : tok_Java_dummy_191 Java tok_Java_dummy_191 { Ctr__Java__0 (rtkPosOf $1) $2 } |
-       tok_AdditiveOp_dummy_190 AdditiveOp tok_AdditiveOp_dummy_190 { Ctr__Java__1 (rtkPosOf $1) $2 } |
-       tok_Annotation_dummy_189 Annotation tok_Annotation_dummy_189 { Ctr__Java__2 (rtkPosOf $1) $2 } |
-       tok_AnnotationArguments_dummy_188 AnnotationArguments tok_AnnotationArguments_dummy_188 { Ctr__Java__3 (rtkPosOf $1) $2 } |
-       tok_AnnotationDeclaration_dummy_187 AnnotationDeclaration tok_AnnotationDeclaration_dummy_187 { Ctr__Java__4 (rtkPosOf $1) $2 } |
-       tok_AnnotationElement_dummy_186 AnnotationElement tok_AnnotationElement_dummy_186 { Ctr__Java__5 (rtkPosOf $1) $2 } |
-       tok_AnnotationList_dummy_185 AnnotationList tok_AnnotationList_dummy_185 { Ctr__Java__6 (rtkPosOf $1) (reverse $2) } |
-       tok_AnnotationTypeElement_dummy_184 AnnotationTypeElement tok_AnnotationTypeElement_dummy_184 { Ctr__Java__7 (rtkPosOf $1) $2 } |
-       tok_AnnotationTypeElementList_dummy_183 AnnotationTypeElementList tok_AnnotationTypeElementList_dummy_183 { Ctr__Java__8 (rtkPosOf $1) (reverse $2) } |
-       tok_Arglist_dummy_182 Arglist tok_Arglist_dummy_182 { Ctr__Java__9 (rtkPosOf $1) $2 } |
-       tok_AssignmentOp_dummy_181 AssignmentOp tok_AssignmentOp_dummy_181 { Ctr__Java__10 (rtkPosOf $1) $2 } |
-       tok_CatchList_dummy_180 CatchList tok_CatchList_dummy_180 { Ctr__Java__11 (rtkPosOf $1) (reverse $2) } |
-       tok_CatchParameter_dummy_179 CatchParameter tok_CatchParameter_dummy_179 { Ctr__Java__12 (rtkPosOf $1) $2 } |
-       tok_ClassDeclaration_dummy_178 ClassDeclaration tok_ClassDeclaration_dummy_178 { Ctr__Java__13 (rtkPosOf $1) $2 } |
-       tok_ClassOrInterfaceType_dummy_177 ClassOrInterfaceType tok_ClassOrInterfaceType_dummy_177 { Ctr__Java__14 (rtkPosOf $1) $2 } |
-       tok_CompilationUnit_dummy_176 CompilationUnit tok_CompilationUnit_dummy_176 { Ctr__Java__15 (rtkPosOf $1) $2 } |
-       tok_CompoundName_dummy_175 CompoundName tok_CompoundName_dummy_175 { Ctr__Java__16 (rtkPosOf $1) $2 } |
-       tok_CompoundNameTail_dummy_174 CompoundNameTail tok_CompoundNameTail_dummy_174 { Ctr__Java__17 (rtkPosOf $1) (reverse $2) } |
-       tok_CreationExpression_dummy_173 CreationExpression tok_CreationExpression_dummy_173 { Ctr__Java__18 (rtkPosOf $1) $2 } |
-       tok_DimExprs_dummy_172 DimExprs tok_DimExprs_dummy_172 { Ctr__Java__19 (rtkPosOf $1) (reverse $2) } |
-       tok_Dims_dummy_171 Dims tok_Dims_dummy_171 { Ctr__Java__20 (rtkPosOf $1) (reverse $2) } |
-       tok_DoStatement_dummy_170 DoStatement tok_DoStatement_dummy_170 { Ctr__Java__21 (rtkPosOf $1) $2 } |
-       tok_DocComment_dummy_169 DocComment tok_DocComment_dummy_169 { Ctr__Java__22 (rtkPosOf $1) $2 } |
-       tok_EnumConstant_dummy_168 EnumConstant tok_EnumConstant_dummy_168 { Ctr__Java__23 (rtkPosOf $1) $2 } |
-       tok_EnumConstantList_dummy_167 EnumConstantList tok_EnumConstantList_dummy_167 { Ctr__Java__24 (rtkPosOf $1) $2 } |
-       tok_EnumDeclaration_dummy_166 EnumDeclaration tok_EnumDeclaration_dummy_166 { Ctr__Java__25 (rtkPosOf $1) $2 } |
-       tok_EqualityOp_dummy_165 EqualityOp tok_EqualityOp_dummy_165 { Ctr__Java__26 (rtkPosOf $1) $2 } |
-       tok_Expression_dummy_164 Expression tok_Expression_dummy_164 { Ctr__Java__27 (rtkPosOf $1) $2 } |
-       tok_ExtendsList_dummy_163 ExtendsList tok_ExtendsList_dummy_163 { Ctr__Java__28 (rtkPosOf $1) $2 } |
-       tok_FieldDeclaration_dummy_162 FieldDeclaration tok_FieldDeclaration_dummy_162 { Ctr__Java__29 (rtkPosOf $1) $2 } |
-       tok_FieldDeclarationList_dummy_161 FieldDeclarationList tok_FieldDeclarationList_dummy_161 { Ctr__Java__30 (rtkPosOf $1) (reverse $2) } |
-       tok_ForEachHeader_dummy_160 ForEachHeader tok_ForEachHeader_dummy_160 { Ctr__Java__31 (rtkPosOf $1) $2 } |
-       tok_ForStatement_dummy_159 ForStatement tok_ForStatement_dummy_159 { Ctr__Java__32 (rtkPosOf $1) $2 } |
-       tok_IfStatement_dummy_158 IfStatement tok_IfStatement_dummy_158 { Ctr__Java__33 (rtkPosOf $1) $2 } |
-       tok_ImplementsList_dummy_157 ImplementsList tok_ImplementsList_dummy_157 { Ctr__Java__34 (rtkPosOf $1) $2 } |
-       tok_ImportHead_dummy_156 ImportHead tok_ImportHead_dummy_156 { Ctr__Java__35 (rtkPosOf $1) $2 } |
-       tok_ImportList_dummy_155 ImportList tok_ImportList_dummy_155 { Ctr__Java__36 (rtkPosOf $1) (reverse $2) } |
-       tok_ImportName_dummy_154 ImportName tok_ImportName_dummy_154 { Ctr__Java__37 (rtkPosOf $1) $2 } |
-       tok_ImportStatement_dummy_153 ImportStatement tok_ImportStatement_dummy_153 { Ctr__Java__38 (rtkPosOf $1) $2 } |
-       tok_InterfaceDeclaration_dummy_152 InterfaceDeclaration tok_InterfaceDeclaration_dummy_152 { Ctr__Java__39 (rtkPosOf $1) $2 } |
-       tok_Literal_dummy_151 Literal tok_Literal_dummy_151 { Ctr__Java__40 (rtkPosOf $1) $2 } |
-       tok_LocalModifierList1_dummy_150 LocalModifierList1 tok_LocalModifierList1_dummy_150 { Ctr__Java__41 (rtkPosOf $1) (reverse $2) } |
-       tok_MemberAfterFirstId_dummy_149 MemberAfterFirstId tok_MemberAfterFirstId_dummy_149 { Ctr__Java__42 (rtkPosOf $1) $2 } |
-       tok_MemberDeclaration_dummy_148 MemberDeclaration tok_MemberDeclaration_dummy_148 { Ctr__Java__43 (rtkPosOf $1) $2 } |
-       tok_MemberRest_dummy_147 MemberRest tok_MemberRest_dummy_147 { Ctr__Java__44 (rtkPosOf $1) $2 } |
-       tok_Modifier_dummy_146 Modifier tok_Modifier_dummy_146 { Ctr__Java__45 (rtkPosOf $1) $2 } |
-       tok_ModifierList_dummy_145 ModifierList tok_ModifierList_dummy_145 { Ctr__Java__46 (rtkPosOf $1) (reverse $2) } |
-       tok_MoreTypeSpecifier_dummy_144 MoreTypeSpecifier tok_MoreTypeSpecifier_dummy_144 { Ctr__Java__47 (rtkPosOf $1) $2 } |
-       tok_MoreVariableDeclarators_dummy_143 MoreVariableDeclarators tok_MoreVariableDeclarators_dummy_143 { Ctr__Java__48 (rtkPosOf $1) (reverse $2) } |
-       tok_MultiplicativeOp_dummy_142 MultiplicativeOp tok_MultiplicativeOp_dummy_142 { Ctr__Java__49 (rtkPosOf $1) $2 } |
-       tok_NonEmptyDims_dummy_141 NonEmptyDims tok_NonEmptyDims_dummy_141 { Ctr__Java__50 (rtkPosOf $1) (reverse $2) } |
-       tok_NonEmptyTypeArguments_dummy_140 NonEmptyTypeArguments tok_NonEmptyTypeArguments_dummy_140 { Ctr__Java__51 (rtkPosOf $1) $2 } |
-       tok_OptDocComment_dummy_139 OptDocComment tok_OptDocComment_dummy_139 { Ctr__Java__52 (rtkPosOf $1) $2 } |
-       tok_OptElsePart_dummy_138 OptElsePart tok_OptElsePart_dummy_138 { Ctr__Java__53 (rtkPosOf $1) $2 } |
-       tok_OptExpression_dummy_137 OptExpression tok_OptExpression_dummy_137 { Ctr__Java__54 (rtkPosOf $1) $2 } |
-       tok_OptFinally_dummy_136 OptFinally tok_OptFinally_dummy_136 { Ctr__Java__55 (rtkPosOf $1) $2 } |
-       tok_OptId_dummy_135 OptId tok_OptId_dummy_135 { Ctr__Java__56 (rtkPosOf $1) $2 } |
-       tok_OptVariableInitializer_dummy_134 OptVariableInitializer tok_OptVariableInitializer_dummy_134 { Ctr__Java__57 (rtkPosOf $1) $2 } |
-       tok_Package_dummy_133 Package tok_Package_dummy_133 { Ctr__Java__58 (rtkPosOf $1) $2 } |
-       tok_ParamModifierList_dummy_132 ParamModifierList tok_ParamModifierList_dummy_132 { Ctr__Java__59 (rtkPosOf $1) (reverse $2) } |
-       tok_Parameter_dummy_131 Parameter tok_Parameter_dummy_131 { Ctr__Java__60 (rtkPosOf $1) $2 } |
-       tok_ParameterList_dummy_130 ParameterList tok_ParameterList_dummy_130 { Ctr__Java__61 (rtkPosOf $1) $2 } |
-       tok_PostfixOp_dummy_129 PostfixOp tok_PostfixOp_dummy_129 { Ctr__Java__62 (rtkPosOf $1) $2 } |
-       tok_PrefixOp_dummy_128 PrefixOp tok_PrefixOp_dummy_128 { Ctr__Java__63 (rtkPosOf $1) $2 } |
-       tok_PrimitiveTypeKeyword_dummy_127 PrimitiveTypeKeyword tok_PrimitiveTypeKeyword_dummy_127 { Ctr__Java__64 (rtkPosOf $1) $2 } |
-       tok_RelationalOp_dummy_126 RelationalOp tok_RelationalOp_dummy_126 { Ctr__Java__65 (rtkPosOf $1) $2 } |
-       tok_Resource_dummy_125 Resource tok_Resource_dummy_125 { Ctr__Java__66 (rtkPosOf $1) $2 } |
-       tok_ResourceSpec_dummy_124 ResourceSpec tok_ResourceSpec_dummy_124 { Ctr__Java__67 (rtkPosOf $1) $2 } |
-       tok_ShiftOp_dummy_123 ShiftOp tok_ShiftOp_dummy_123 { Ctr__Java__68 (rtkPosOf $1) $2 } |
-       tok_Statement_dummy_122 Statement tok_Statement_dummy_122 { Ctr__Java__69 (rtkPosOf $1) $2 } |
-       tok_StatementBlock_dummy_121 StatementBlock tok_StatementBlock_dummy_121 { Ctr__Java__70 (rtkPosOf $1) $2 } |
-       tok_StatementList_dummy_120 StatementList tok_StatementList_dummy_120 { Ctr__Java__71 (rtkPosOf $1) (reverse $2) } |
-       tok_StaticInitializer_dummy_119 StaticInitializer tok_StaticInitializer_dummy_119 { Ctr__Java__72 (rtkPosOf $1) $2 } |
-       tok_SwitchCaseList_dummy_118 SwitchCaseList tok_SwitchCaseList_dummy_118 { Ctr__Java__73 (rtkPosOf $1) (reverse $2) } |
-       tok_SwitchStatement_dummy_117 SwitchStatement tok_SwitchStatement_dummy_117 { Ctr__Java__74 (rtkPosOf $1) $2 } |
-       tok_ThrowsClause_dummy_116 ThrowsClause tok_ThrowsClause_dummy_116 { Ctr__Java__75 (rtkPosOf $1) $2 } |
-       tok_TryStatement_dummy_115 TryStatement tok_TryStatement_dummy_115 { Ctr__Java__76 (rtkPosOf $1) $2 } |
-       tok_Type_dummy_114 Type tok_Type_dummy_114 { Ctr__Java__77 (rtkPosOf $1) $2 } |
-       tok_TypeArgument_dummy_113 TypeArgument tok_TypeArgument_dummy_113 { Ctr__Java__78 (rtkPosOf $1) $2 } |
-       tok_TypeArguments_dummy_112 TypeArguments tok_TypeArguments_dummy_112 { Ctr__Java__79 (rtkPosOf $1) $2 } |
-       tok_TypeDeclRest_dummy_111 TypeDeclRest tok_TypeDeclRest_dummy_111 { Ctr__Java__80 (rtkPosOf $1) $2 } |
-       tok_TypeDeclaration_dummy_110 TypeDeclaration tok_TypeDeclaration_dummy_110 { Ctr__Java__81 (rtkPosOf $1) $2 } |
-       tok_TypeParameter_dummy_109 TypeParameter tok_TypeParameter_dummy_109 { Ctr__Java__82 (rtkPosOf $1) $2 } |
-       tok_TypeParameters_dummy_108 TypeParameters tok_TypeParameters_dummy_108 { Ctr__Java__83 (rtkPosOf $1) $2 } |
-       tok_TypeSpecifier_dummy_107 TypeSpecifier tok_TypeSpecifier_dummy_107 { Ctr__Java__84 (rtkPosOf $1) $2 } |
-       tok_VariableDeclaration_dummy_106 VariableDeclaration tok_VariableDeclaration_dummy_106 { Ctr__Java__85 (rtkPosOf $1) $2 } |
-       tok_VariableDeclarator_dummy_105 VariableDeclarator tok_VariableDeclarator_dummy_105 { Ctr__Java__86 (rtkPosOf $1) $2 } |
-       tok_VariableDeclaratorList_dummy_104 VariableDeclaratorList tok_VariableDeclaratorList_dummy_104 { Ctr__Java__87 (rtkPosOf $1) $2 } |
-       tok_VariableInitializer_dummy_103 VariableInitializer tok_VariableInitializer_dummy_103 { Ctr__Java__88 (rtkPosOf $1) $2 } |
-       tok_VariableInitializerList_dummy_102 VariableInitializerList tok_VariableInitializerList_dummy_102 { Ctr__Java__89 (rtkPosOf $1) $2 } |
-       tok_WhileStatement_dummy_101 WhileStatement tok_WhileStatement_dummy_101 { Ctr__Java__90 (rtkPosOf $1) $2 } |
-       tok_WildcardType_dummy_100 WildcardType tok_WildcardType_dummy_100 { Ctr__Java__91 (rtkPosOf $1) $2 }
+Java : tok_Java_dummy_194 Java tok_Java_dummy_194 { Ctr__Java__0 (rtkPosOf $1) $2 } |
+       tok_AdditiveOp_dummy_193 AdditiveOp tok_AdditiveOp_dummy_193 { Ctr__Java__1 (rtkPosOf $1) $2 } |
+       tok_Annotation_dummy_192 Annotation tok_Annotation_dummy_192 { Ctr__Java__2 (rtkPosOf $1) $2 } |
+       tok_AnnotationArguments_dummy_191 AnnotationArguments tok_AnnotationArguments_dummy_191 { Ctr__Java__3 (rtkPosOf $1) $2 } |
+       tok_AnnotationDeclaration_dummy_190 AnnotationDeclaration tok_AnnotationDeclaration_dummy_190 { Ctr__Java__4 (rtkPosOf $1) $2 } |
+       tok_AnnotationElement_dummy_189 AnnotationElement tok_AnnotationElement_dummy_189 { Ctr__Java__5 (rtkPosOf $1) $2 } |
+       tok_AnnotationList_dummy_188 AnnotationList tok_AnnotationList_dummy_188 { Ctr__Java__6 (rtkPosOf $1) (reverse $2) } |
+       tok_AnnotationTypeElement_dummy_187 AnnotationTypeElement tok_AnnotationTypeElement_dummy_187 { Ctr__Java__7 (rtkPosOf $1) $2 } |
+       tok_AnnotationTypeElementList_dummy_186 AnnotationTypeElementList tok_AnnotationTypeElementList_dummy_186 { Ctr__Java__8 (rtkPosOf $1) (reverse $2) } |
+       tok_Arglist_dummy_185 Arglist tok_Arglist_dummy_185 { Ctr__Java__9 (rtkPosOf $1) $2 } |
+       tok_AssignmentOp_dummy_184 AssignmentOp tok_AssignmentOp_dummy_184 { Ctr__Java__10 (rtkPosOf $1) $2 } |
+       tok_CatchList_dummy_183 CatchList tok_CatchList_dummy_183 { Ctr__Java__11 (rtkPosOf $1) (reverse $2) } |
+       tok_CatchParameter_dummy_182 CatchParameter tok_CatchParameter_dummy_182 { Ctr__Java__12 (rtkPosOf $1) $2 } |
+       tok_ClassDeclaration_dummy_181 ClassDeclaration tok_ClassDeclaration_dummy_181 { Ctr__Java__13 (rtkPosOf $1) $2 } |
+       tok_ClassOrInterfaceType_dummy_180 ClassOrInterfaceType tok_ClassOrInterfaceType_dummy_180 { Ctr__Java__14 (rtkPosOf $1) $2 } |
+       tok_CompilationUnit_dummy_179 CompilationUnit tok_CompilationUnit_dummy_179 { Ctr__Java__15 (rtkPosOf $1) $2 } |
+       tok_CompoundName_dummy_178 CompoundName tok_CompoundName_dummy_178 { Ctr__Java__16 (rtkPosOf $1) $2 } |
+       tok_CompoundNameTail_dummy_177 CompoundNameTail tok_CompoundNameTail_dummy_177 { Ctr__Java__17 (rtkPosOf $1) (reverse $2) } |
+       tok_CreationExpression_dummy_176 CreationExpression tok_CreationExpression_dummy_176 { Ctr__Java__18 (rtkPosOf $1) $2 } |
+       tok_DimExprs_dummy_175 DimExprs tok_DimExprs_dummy_175 { Ctr__Java__19 (rtkPosOf $1) (reverse $2) } |
+       tok_Dims_dummy_174 Dims tok_Dims_dummy_174 { Ctr__Java__20 (rtkPosOf $1) (reverse $2) } |
+       tok_DoStatement_dummy_173 DoStatement tok_DoStatement_dummy_173 { Ctr__Java__21 (rtkPosOf $1) $2 } |
+       tok_DocComment_dummy_172 DocComment tok_DocComment_dummy_172 { Ctr__Java__22 (rtkPosOf $1) $2 } |
+       tok_EnumConstant_dummy_171 EnumConstant tok_EnumConstant_dummy_171 { Ctr__Java__23 (rtkPosOf $1) $2 } |
+       tok_EnumConstantList_dummy_170 EnumConstantList tok_EnumConstantList_dummy_170 { Ctr__Java__24 (rtkPosOf $1) $2 } |
+       tok_EnumDeclaration_dummy_169 EnumDeclaration tok_EnumDeclaration_dummy_169 { Ctr__Java__25 (rtkPosOf $1) $2 } |
+       tok_EqualityOp_dummy_168 EqualityOp tok_EqualityOp_dummy_168 { Ctr__Java__26 (rtkPosOf $1) $2 } |
+       tok_Expression_dummy_167 Expression tok_Expression_dummy_167 { Ctr__Java__27 (rtkPosOf $1) $2 } |
+       tok_ExtendsList_dummy_166 ExtendsList tok_ExtendsList_dummy_166 { Ctr__Java__28 (rtkPosOf $1) $2 } |
+       tok_FieldDeclaration_dummy_165 FieldDeclaration tok_FieldDeclaration_dummy_165 { Ctr__Java__29 (rtkPosOf $1) $2 } |
+       tok_FieldDeclarationList_dummy_164 FieldDeclarationList tok_FieldDeclarationList_dummy_164 { Ctr__Java__30 (rtkPosOf $1) (reverse $2) } |
+       tok_ForEachHeader_dummy_163 ForEachHeader tok_ForEachHeader_dummy_163 { Ctr__Java__31 (rtkPosOf $1) $2 } |
+       tok_ForStatement_dummy_162 ForStatement tok_ForStatement_dummy_162 { Ctr__Java__32 (rtkPosOf $1) $2 } |
+       tok_IfStatement_dummy_161 IfStatement tok_IfStatement_dummy_161 { Ctr__Java__33 (rtkPosOf $1) $2 } |
+       tok_ImplementsList_dummy_160 ImplementsList tok_ImplementsList_dummy_160 { Ctr__Java__34 (rtkPosOf $1) $2 } |
+       tok_ImportHead_dummy_159 ImportHead tok_ImportHead_dummy_159 { Ctr__Java__35 (rtkPosOf $1) $2 } |
+       tok_ImportList_dummy_158 ImportList tok_ImportList_dummy_158 { Ctr__Java__36 (rtkPosOf $1) (reverse $2) } |
+       tok_ImportName_dummy_157 ImportName tok_ImportName_dummy_157 { Ctr__Java__37 (rtkPosOf $1) $2 } |
+       tok_ImportStatement_dummy_156 ImportStatement tok_ImportStatement_dummy_156 { Ctr__Java__38 (rtkPosOf $1) $2 } |
+       tok_InterfaceDeclaration_dummy_155 InterfaceDeclaration tok_InterfaceDeclaration_dummy_155 { Ctr__Java__39 (rtkPosOf $1) $2 } |
+       tok_LambdaBody_dummy_154 LambdaBody tok_LambdaBody_dummy_154 { Ctr__Java__40 (rtkPosOf $1) $2 } |
+       tok_Literal_dummy_153 Literal tok_Literal_dummy_153 { Ctr__Java__41 (rtkPosOf $1) $2 } |
+       tok_LocalModifierList1_dummy_152 LocalModifierList1 tok_LocalModifierList1_dummy_152 { Ctr__Java__42 (rtkPosOf $1) (reverse $2) } |
+       tok_MemberAfterFirstId_dummy_151 MemberAfterFirstId tok_MemberAfterFirstId_dummy_151 { Ctr__Java__43 (rtkPosOf $1) $2 } |
+       tok_MemberDeclaration_dummy_150 MemberDeclaration tok_MemberDeclaration_dummy_150 { Ctr__Java__44 (rtkPosOf $1) $2 } |
+       tok_MemberRest_dummy_149 MemberRest tok_MemberRest_dummy_149 { Ctr__Java__45 (rtkPosOf $1) $2 } |
+       tok_Modifier_dummy_148 Modifier tok_Modifier_dummy_148 { Ctr__Java__46 (rtkPosOf $1) $2 } |
+       tok_ModifierList_dummy_147 ModifierList tok_ModifierList_dummy_147 { Ctr__Java__47 (rtkPosOf $1) (reverse $2) } |
+       tok_MoreTypeSpecifier_dummy_146 MoreTypeSpecifier tok_MoreTypeSpecifier_dummy_146 { Ctr__Java__48 (rtkPosOf $1) $2 } |
+       tok_MoreVariableDeclarators_dummy_145 MoreVariableDeclarators tok_MoreVariableDeclarators_dummy_145 { Ctr__Java__49 (rtkPosOf $1) (reverse $2) } |
+       tok_MultiplicativeOp_dummy_144 MultiplicativeOp tok_MultiplicativeOp_dummy_144 { Ctr__Java__50 (rtkPosOf $1) $2 } |
+       tok_NonEmptyDims_dummy_143 NonEmptyDims tok_NonEmptyDims_dummy_143 { Ctr__Java__51 (rtkPosOf $1) (reverse $2) } |
+       tok_NonEmptyTypeArguments_dummy_142 NonEmptyTypeArguments tok_NonEmptyTypeArguments_dummy_142 { Ctr__Java__52 (rtkPosOf $1) $2 } |
+       tok_OptDocComment_dummy_141 OptDocComment tok_OptDocComment_dummy_141 { Ctr__Java__53 (rtkPosOf $1) $2 } |
+       tok_OptElsePart_dummy_140 OptElsePart tok_OptElsePart_dummy_140 { Ctr__Java__54 (rtkPosOf $1) $2 } |
+       tok_OptExpression_dummy_139 OptExpression tok_OptExpression_dummy_139 { Ctr__Java__55 (rtkPosOf $1) $2 } |
+       tok_OptFinally_dummy_138 OptFinally tok_OptFinally_dummy_138 { Ctr__Java__56 (rtkPosOf $1) $2 } |
+       tok_OptId_dummy_137 OptId tok_OptId_dummy_137 { Ctr__Java__57 (rtkPosOf $1) $2 } |
+       tok_OptVariableInitializer_dummy_136 OptVariableInitializer tok_OptVariableInitializer_dummy_136 { Ctr__Java__58 (rtkPosOf $1) $2 } |
+       tok_Package_dummy_135 Package tok_Package_dummy_135 { Ctr__Java__59 (rtkPosOf $1) $2 } |
+       tok_ParamModifierList_dummy_134 ParamModifierList tok_ParamModifierList_dummy_134 { Ctr__Java__60 (rtkPosOf $1) (reverse $2) } |
+       tok_Parameter_dummy_133 Parameter tok_Parameter_dummy_133 { Ctr__Java__61 (rtkPosOf $1) $2 } |
+       tok_ParameterList_dummy_132 ParameterList tok_ParameterList_dummy_132 { Ctr__Java__62 (rtkPosOf $1) $2 } |
+       tok_PostfixOp_dummy_131 PostfixOp tok_PostfixOp_dummy_131 { Ctr__Java__63 (rtkPosOf $1) $2 } |
+       tok_PrefixOp_dummy_130 PrefixOp tok_PrefixOp_dummy_130 { Ctr__Java__64 (rtkPosOf $1) $2 } |
+       tok_PrimitiveTypeKeyword_dummy_129 PrimitiveTypeKeyword tok_PrimitiveTypeKeyword_dummy_129 { Ctr__Java__65 (rtkPosOf $1) $2 } |
+       tok_RelationalOp_dummy_128 RelationalOp tok_RelationalOp_dummy_128 { Ctr__Java__66 (rtkPosOf $1) $2 } |
+       tok_Resource_dummy_127 Resource tok_Resource_dummy_127 { Ctr__Java__67 (rtkPosOf $1) $2 } |
+       tok_ResourceSpec_dummy_126 ResourceSpec tok_ResourceSpec_dummy_126 { Ctr__Java__68 (rtkPosOf $1) $2 } |
+       tok_ShiftOp_dummy_125 ShiftOp tok_ShiftOp_dummy_125 { Ctr__Java__69 (rtkPosOf $1) $2 } |
+       tok_Statement_dummy_124 Statement tok_Statement_dummy_124 { Ctr__Java__70 (rtkPosOf $1) $2 } |
+       tok_StatementBlock_dummy_123 StatementBlock tok_StatementBlock_dummy_123 { Ctr__Java__71 (rtkPosOf $1) $2 } |
+       tok_StatementList_dummy_122 StatementList tok_StatementList_dummy_122 { Ctr__Java__72 (rtkPosOf $1) (reverse $2) } |
+       tok_StaticInitializer_dummy_121 StaticInitializer tok_StaticInitializer_dummy_121 { Ctr__Java__73 (rtkPosOf $1) $2 } |
+       tok_SwitchCaseList_dummy_120 SwitchCaseList tok_SwitchCaseList_dummy_120 { Ctr__Java__74 (rtkPosOf $1) (reverse $2) } |
+       tok_SwitchStatement_dummy_119 SwitchStatement tok_SwitchStatement_dummy_119 { Ctr__Java__75 (rtkPosOf $1) $2 } |
+       tok_ThrowsClause_dummy_118 ThrowsClause tok_ThrowsClause_dummy_118 { Ctr__Java__76 (rtkPosOf $1) $2 } |
+       tok_TryStatement_dummy_117 TryStatement tok_TryStatement_dummy_117 { Ctr__Java__77 (rtkPosOf $1) $2 } |
+       tok_Type_dummy_116 Type tok_Type_dummy_116 { Ctr__Java__78 (rtkPosOf $1) $2 } |
+       tok_TypeArgument_dummy_115 TypeArgument tok_TypeArgument_dummy_115 { Ctr__Java__79 (rtkPosOf $1) $2 } |
+       tok_TypeArguments_dummy_114 TypeArguments tok_TypeArguments_dummy_114 { Ctr__Java__80 (rtkPosOf $1) $2 } |
+       tok_TypeDeclRest_dummy_113 TypeDeclRest tok_TypeDeclRest_dummy_113 { Ctr__Java__81 (rtkPosOf $1) $2 } |
+       tok_TypeDeclaration_dummy_112 TypeDeclaration tok_TypeDeclaration_dummy_112 { Ctr__Java__82 (rtkPosOf $1) $2 } |
+       tok_TypeParameter_dummy_111 TypeParameter tok_TypeParameter_dummy_111 { Ctr__Java__83 (rtkPosOf $1) $2 } |
+       tok_TypeParameters_dummy_110 TypeParameters tok_TypeParameters_dummy_110 { Ctr__Java__84 (rtkPosOf $1) $2 } |
+       tok_TypeSpecifier_dummy_109 TypeSpecifier tok_TypeSpecifier_dummy_109 { Ctr__Java__85 (rtkPosOf $1) $2 } |
+       tok_VariableDeclaration_dummy_108 VariableDeclaration tok_VariableDeclaration_dummy_108 { Ctr__Java__86 (rtkPosOf $1) $2 } |
+       tok_VariableDeclarator_dummy_107 VariableDeclarator tok_VariableDeclarator_dummy_107 { Ctr__Java__87 (rtkPosOf $1) $2 } |
+       tok_VariableDeclaratorList_dummy_106 VariableDeclaratorList tok_VariableDeclaratorList_dummy_106 { Ctr__Java__88 (rtkPosOf $1) $2 } |
+       tok_VariableInitializer_dummy_105 VariableInitializer tok_VariableInitializer_dummy_105 { Ctr__Java__89 (rtkPosOf $1) $2 } |
+       tok_VariableInitializerList_dummy_104 VariableInitializerList tok_VariableInitializerList_dummy_104 { Ctr__Java__90 (rtkPosOf $1) $2 } |
+       tok_WhileStatement_dummy_103 WhileStatement tok_WhileStatement_dummy_103 { Ctr__Java__91 (rtkPosOf $1) $2 } |
+       tok_WildcardType_dummy_102 WildcardType tok_WildcardType_dummy_102 { Ctr__Java__92 (rtkPosOf $1) $2 }
 
 Java : qq_Java { Anti_Java (tkVal_qq_Java $1) } |
-       CompilationUnit { Ctr__Java__92 (rtkPosOf $1) $1 }
+       CompilationUnit { Ctr__Java__93 (rtkPosOf $1) $1 }
 
 AdditiveOp : qq_AdditiveOp { Anti_AdditiveOp (tkVal_qq_AdditiveOp $1) } |
-             tok__plus__77 { Ctr__AdditiveOp__0 (rtkPosOf $1) } |
-             tok__minus__78 { Ctr__AdditiveOp__1 (rtkPosOf $1) }
+             tok__plus__78 { Ctr__AdditiveOp__0 (rtkPosOf $1) } |
+             tok__minus__79 { Ctr__AdditiveOp__1 (rtkPosOf $1) }
 
 ListElem_AnnotationList9 : qq_AnnotationList { Anti_Annotation (tkVal_qq_AnnotationList $1) } |
                            Annotation { $1 }
@@ -437,21 +442,21 @@ AnnotationTypeElementList : {- empty -} { [] } |
 
 Arglist : qq_Arglist { Anti_Arglist (tkVal_qq_Arglist $1) } |
           { Ctr__Arglist__0 rtkNoPos } |
-          Rule_86 { Ctr__Arglist__1 (rtkPosOf $1) $1 }
+          Rule_88 { Ctr__Arglist__1 (rtkPosOf $1) $1 }
 
 AssignmentOp : qq_AssignmentOp { Anti_AssignmentOp (tkVal_qq_AssignmentOp $1) } |
                tok__eql__10 { Ctr__AssignmentOp__0 (rtkPosOf $1) } |
-               tok__plus__eql__53 { Ctr__AssignmentOp__1 (rtkPosOf $1) } |
-               tok__minus__eql__54 { Ctr__AssignmentOp__2 (rtkPosOf $1) } |
-               tok__star__eql__55 { Ctr__AssignmentOp__3 (rtkPosOf $1) } |
-               tok__symbol__eql__56 { Ctr__AssignmentOp__4 (rtkPosOf $1) } |
-               tok__pipe__eql__57 { Ctr__AssignmentOp__5 (rtkPosOf $1) } |
-               tok__symbol__eql__58 { Ctr__AssignmentOp__6 (rtkPosOf $1) } |
-               tok__symbol__eql__59 { Ctr__AssignmentOp__7 (rtkPosOf $1) } |
-               tok__symbol__eql__60 { Ctr__AssignmentOp__8 (rtkPosOf $1) } |
-               tok__symbol__symbol__eql__61 { Ctr__AssignmentOp__9 (rtkPosOf $1) } |
-               tok__symbol__symbol__eql__62 { Ctr__AssignmentOp__10 (rtkPosOf $1) } |
-               tok__symbol__symbol__symbol__eql__63 { Ctr__AssignmentOp__11 (rtkPosOf $1) }
+               tok__plus__eql__54 { Ctr__AssignmentOp__1 (rtkPosOf $1) } |
+               tok__minus__eql__55 { Ctr__AssignmentOp__2 (rtkPosOf $1) } |
+               tok__star__eql__56 { Ctr__AssignmentOp__3 (rtkPosOf $1) } |
+               tok__symbol__eql__57 { Ctr__AssignmentOp__4 (rtkPosOf $1) } |
+               tok__pipe__eql__58 { Ctr__AssignmentOp__5 (rtkPosOf $1) } |
+               tok__symbol__eql__59 { Ctr__AssignmentOp__6 (rtkPosOf $1) } |
+               tok__symbol__eql__60 { Ctr__AssignmentOp__7 (rtkPosOf $1) } |
+               tok__symbol__eql__61 { Ctr__AssignmentOp__8 (rtkPosOf $1) } |
+               tok__symbol__symbol__eql__62 { Ctr__AssignmentOp__9 (rtkPosOf $1) } |
+               tok__symbol__symbol__eql__63 { Ctr__AssignmentOp__10 (rtkPosOf $1) } |
+               tok__symbol__symbol__symbol__eql__64 { Ctr__AssignmentOp__11 (rtkPosOf $1) }
 
 CatchList : {- empty -} { [] } |
             CatchList ListElem_CatchList66 { $2 : $1 }
@@ -472,13 +477,13 @@ CompoundName : qq_CompoundName { Anti_CompoundName (tkVal_qq_CompoundName $1) } 
                id CompoundNameTail { Ctr__CompoundName__0 (rtkPosOf $1) (tkVal_id $1) (reverse $2) }
 
 CompoundNameTail : {- empty -} { [] } |
-                   CompoundNameTail ListElem_CompoundNameTail99 { $2 : $1 }
+                   CompoundNameTail ListElem_CompoundNameTail101 { $2 : $1 }
 
 CreationExpression : qq_CreationExpression { Anti_CreationExpression (tkVal_qq_CreationExpression $1) } |
-                     tok_new_85 TypeSpecifier Rule_82 { Ctr__CreationExpression__0 (rtkPosOf $1) $2 $3 }
+                     tok_new_87 TypeSpecifier Rule_84 { Ctr__CreationExpression__0 (rtkPosOf $1) $2 $3 }
 
-DimExprs : ListElem_DimExprs85 { [$1] } |
-           DimExprs ListElem_DimExprs85 { $2 : $1 }
+DimExprs : ListElem_DimExprs87 { [$1] } |
+           DimExprs ListElem_DimExprs87 { $2 : $1 }
 
 Dims : {- empty -} { [] } |
        Dims ListElem_Dims32 { $2 : $1 }
@@ -499,17 +504,17 @@ EnumDeclaration : qq_EnumDeclaration { Anti_EnumDeclaration (tkVal_qq_EnumDeclar
                   tok_enum_17 id Rule_27 tok__symbol__14 EnumConstantList Rule_28 tok__symbol__15 { Ctr__EnumDeclaration__0 (rtkPosOf $1) (tkVal_id $2) $3 $5 $6 }
 
 EqualityOp : qq_EqualityOp { Anti_EqualityOp (tkVal_qq_EqualityOp $1) } |
-             tok__eql__eql__69 { Ctr__EqualityOp__0 (rtkPosOf $1) } |
-             tok__exclamation__eql__70 { Ctr__EqualityOp__1 (rtkPosOf $1) }
+             tok__eql__eql__70 { Ctr__EqualityOp__0 (rtkPosOf $1) } |
+             tok__exclamation__eql__71 { Ctr__EqualityOp__1 (rtkPosOf $1) }
 
 PrimaryNoPostfix : qq_Expression { Anti_Expression (tkVal_qq_Expression $1) } |
                    Literal { Ctr__Expression__0 (rtkPosOf $1) $1 } |
                    tok_this_41 { Ctr__Expression__1 (rtkPosOf $1) } |
                    tok__lparen__7 Expression tok__rparen__8 { Ctr__Expression__2 (rtkPosOf $1) $2 } |
                    CreationExpression { Ctr__Expression__3 (rtkPosOf $1) $1 } |
-                   CompoundName Rule_78 { Ctr__Expression__4 (rtkPosOf $1) $1 $2 } |
+                   CompoundName Rule_80 { Ctr__Expression__4 (rtkPosOf $1) $1 $2 } |
                    CompoundName tok__sq_bkt_l__18 Expression tok__sq_bkt_r__19 { Ctr__Expression__5 (rtkPosOf $1) $1 $3 } |
-                   tok_super_40 tok__dot__4 id Rule_80 { Ctr__Expression__6 (rtkPosOf $1) (tkVal_id $3) $4 } |
+                   tok_super_40 tok__dot__4 id Rule_82 { Ctr__Expression__6 (rtkPosOf $1) (tkVal_id $3) $4 } |
                    id CompoundNameTail tok__dot__4 tok_class_13 { Ctr__Expression__7 (rtkPosOf $1) (tkVal_id $1) (reverse $2) } |
                    id CompoundNameTail tok__dot__4 tok_this_41 { Ctr__Expression__8 (rtkPosOf $1) (tkVal_id $1) (reverse $2) } |
                    id CompoundNameTail tok__dot__4 NonEmptyTypeArguments id tok__lparen__7 Arglist tok__rparen__8 { Ctr__Expression__9 (rtkPosOf $1) (tkVal_id $1) (reverse $2) $4 (tkVal_id $5) $7 } |
@@ -520,58 +525,64 @@ PostfixExpression : PrimaryNoPostfix { Ctr__Expression__11 (rtkPosOf $1) $1 } |
                     PostfixExpression tok__dot__4 id { Ctr__Expression__13 (rtkPosOf $1) $1 (tkVal_id $3) } |
                     PostfixExpression tok__dot__4 id tok__lparen__7 Arglist tok__rparen__8 { Ctr__Expression__14 (rtkPosOf $1) $1 (tkVal_id $3) $5 } |
                     PostfixExpression tok__dot__4 NonEmptyTypeArguments id tok__lparen__7 Arglist tok__rparen__8 { Ctr__Expression__15 (rtkPosOf $1) $1 $3 (tkVal_id $4) $6 } |
-                    PostfixExpression tok__sq_bkt_l__18 Expression tok__sq_bkt_r__19 { Ctr__Expression__16 (rtkPosOf $1) $1 $3 }
+                    PostfixExpression tok__sq_bkt_l__18 Expression tok__sq_bkt_r__19 { Ctr__Expression__16 (rtkPosOf $1) $1 $3 } |
+                    PostfixExpression tok__colon__colon__86 id { Ctr__Expression__17 (rtkPosOf $1) $1 (tkVal_id $3) } |
+                    PostfixExpression tok__colon__colon__86 tok_new_87 { Ctr__Expression__18 (rtkPosOf $1) $1 }
 
-UnaryExpressionNotPlusMinus : PostfixExpression { Ctr__Expression__17 (rtkPosOf $1) $1 } |
-                              tok__tilde__83 UnaryExpression { Ctr__Expression__18 (rtkPosOf $1) $2 } |
-                              tok__exclamation__84 UnaryExpression { Ctr__Expression__19 (rtkPosOf $1) $2 } |
-                              CastExpression { Ctr__Expression__20 (rtkPosOf $1) $1 }
+UnaryExpressionNotPlusMinus : PostfixExpression { Ctr__Expression__19 (rtkPosOf $1) $1 } |
+                              tok__tilde__84 UnaryExpression { Ctr__Expression__20 (rtkPosOf $1) $2 } |
+                              tok__exclamation__85 UnaryExpression { Ctr__Expression__21 (rtkPosOf $1) $2 } |
+                              CastExpression { Ctr__Expression__22 (rtkPosOf $1) $1 }
 
-UnaryExpression : PrefixOp UnaryExpression { Ctr__Expression__21 (rtkPosOf $1) $1 $2 } |
-                  UnaryExpressionNotPlusMinus { Ctr__Expression__22 (rtkPosOf $1) $1 }
+UnaryExpression : PrefixOp UnaryExpression { Ctr__Expression__23 (rtkPosOf $1) $1 $2 } |
+                  UnaryExpressionNotPlusMinus { Ctr__Expression__24 (rtkPosOf $1) $1 }
 
-CastExpression : tok__lparen__7 PrimitiveTypeKeyword Dims tok__rparen__8 UnaryExpression { Ctr__Expression__23 (rtkPosOf $1) $2 (reverse $3) $5 } |
-                 tok__lparen__7 CompoundName NonEmptyTypeArguments Dims tok__rparen__8 UnaryExpressionNotPlusMinus { Ctr__Expression__24 (rtkPosOf $1) $2 $3 (reverse $4) $6 } |
-                 tok__lparen__7 CompoundName NonEmptyDims tok__rparen__8 UnaryExpressionNotPlusMinus { Ctr__Expression__25 (rtkPosOf $1) $2 (reverse $3) $5 } |
-                 tok__lparen__7 Expression tok__rparen__8 UnaryExpressionNotPlusMinus { Ctr__Expression__26 (rtkPosOf $1) $2 $4 }
+CastExpression : tok__lparen__7 PrimitiveTypeKeyword Dims tok__rparen__8 UnaryExpression { Ctr__Expression__25 (rtkPosOf $1) $2 (reverse $3) $5 } |
+                 tok__lparen__7 CompoundName NonEmptyTypeArguments Dims tok__rparen__8 UnaryExpressionNotPlusMinus { Ctr__Expression__26 (rtkPosOf $1) $2 $3 (reverse $4) $6 } |
+                 tok__lparen__7 CompoundName NonEmptyDims tok__rparen__8 UnaryExpressionNotPlusMinus { Ctr__Expression__27 (rtkPosOf $1) $2 (reverse $3) $5 } |
+                 tok__lparen__7 Expression tok__rparen__8 UnaryExpressionNotPlusMinus { Ctr__Expression__28 (rtkPosOf $1) $2 $4 }
 
-MultiplicativeExpression : UnaryExpression { Ctr__Expression__27 (rtkPosOf $1) $1 } |
-                           MultiplicativeExpression MultiplicativeOp UnaryExpression { Ctr__Expression__28 (rtkPosOf $1) $1 $2 $3 }
+MultiplicativeExpression : UnaryExpression { Ctr__Expression__29 (rtkPosOf $1) $1 } |
+                           MultiplicativeExpression MultiplicativeOp UnaryExpression { Ctr__Expression__30 (rtkPosOf $1) $1 $2 $3 }
 
-AdditiveExpression : MultiplicativeExpression { Ctr__Expression__29 (rtkPosOf $1) $1 } |
-                     AdditiveExpression AdditiveOp MultiplicativeExpression { Ctr__Expression__30 (rtkPosOf $1) $1 $2 $3 }
+AdditiveExpression : MultiplicativeExpression { Ctr__Expression__31 (rtkPosOf $1) $1 } |
+                     AdditiveExpression AdditiveOp MultiplicativeExpression { Ctr__Expression__32 (rtkPosOf $1) $1 $2 $3 }
 
-ShiftExpression : AdditiveExpression { Ctr__Expression__31 (rtkPosOf $1) $1 } |
-                  ShiftExpression ShiftOp AdditiveExpression { Ctr__Expression__32 (rtkPosOf $1) $1 $2 $3 }
+ShiftExpression : AdditiveExpression { Ctr__Expression__33 (rtkPosOf $1) $1 } |
+                  ShiftExpression ShiftOp AdditiveExpression { Ctr__Expression__34 (rtkPosOf $1) $1 $2 $3 }
 
-RelationalExpression : ShiftExpression { Ctr__Expression__33 (rtkPosOf $1) $1 } |
-                       ShiftExpression RelationalOp ShiftExpression { Ctr__Expression__34 (rtkPosOf $1) $1 $2 $3 } |
-                       RelationalExpression tok_instanceof_75 Type { Ctr__Expression__35 (rtkPosOf $1) $1 $3 }
+RelationalExpression : ShiftExpression { Ctr__Expression__35 (rtkPosOf $1) $1 } |
+                       ShiftExpression RelationalOp ShiftExpression { Ctr__Expression__36 (rtkPosOf $1) $1 $2 $3 } |
+                       RelationalExpression tok_instanceof_76 Type { Ctr__Expression__37 (rtkPosOf $1) $1 $3 }
 
-EqualityExpression : RelationalExpression { Ctr__Expression__36 (rtkPosOf $1) $1 } |
-                     EqualityExpression EqualityOp RelationalExpression { Ctr__Expression__37 (rtkPosOf $1) $1 $2 $3 }
+EqualityExpression : RelationalExpression { Ctr__Expression__38 (rtkPosOf $1) $1 } |
+                     EqualityExpression EqualityOp RelationalExpression { Ctr__Expression__39 (rtkPosOf $1) $1 $2 $3 }
 
-AndExpression : EqualityExpression { Ctr__Expression__38 (rtkPosOf $1) $1 } |
-                AndExpression tok__symbol__68 EqualityExpression { Ctr__Expression__39 (rtkPosOf $1) $1 $3 }
+AndExpression : EqualityExpression { Ctr__Expression__40 (rtkPosOf $1) $1 } |
+                AndExpression tok__symbol__69 EqualityExpression { Ctr__Expression__41 (rtkPosOf $1) $1 $3 }
 
-ExclusiveOrExpression : AndExpression { Ctr__Expression__40 (rtkPosOf $1) $1 } |
-                        ExclusiveOrExpression tok__symbol__67 AndExpression { Ctr__Expression__41 (rtkPosOf $1) $1 $3 }
+ExclusiveOrExpression : AndExpression { Ctr__Expression__42 (rtkPosOf $1) $1 } |
+                        ExclusiveOrExpression tok__symbol__68 AndExpression { Ctr__Expression__43 (rtkPosOf $1) $1 $3 }
 
-InclusiveOrEpression : ExclusiveOrExpression { Ctr__Expression__42 (rtkPosOf $1) $1 } |
-                       InclusiveOrEpression tok__pipe__48 ExclusiveOrExpression { Ctr__Expression__43 (rtkPosOf $1) $1 $3 }
+InclusiveOrEpression : ExclusiveOrExpression { Ctr__Expression__44 (rtkPosOf $1) $1 } |
+                       InclusiveOrEpression tok__pipe__48 ExclusiveOrExpression { Ctr__Expression__45 (rtkPosOf $1) $1 $3 }
 
-ConditionalAndExpression : InclusiveOrEpression { Ctr__Expression__44 (rtkPosOf $1) $1 } |
-                           ConditionalAndExpression tok__symbol__symbol__66 InclusiveOrEpression { Ctr__Expression__45 (rtkPosOf $1) $1 $3 }
+ConditionalAndExpression : InclusiveOrEpression { Ctr__Expression__46 (rtkPosOf $1) $1 } |
+                           ConditionalAndExpression tok__symbol__symbol__67 InclusiveOrEpression { Ctr__Expression__47 (rtkPosOf $1) $1 $3 }
 
-ConditionalOrExpression : ConditionalAndExpression { Ctr__Expression__46 (rtkPosOf $1) $1 } |
-                          ConditionalOrExpression tok__pipe__pipe__65 ConditionalAndExpression { Ctr__Expression__47 (rtkPosOf $1) $1 $3 }
+ConditionalOrExpression : ConditionalAndExpression { Ctr__Expression__48 (rtkPosOf $1) $1 } |
+                          ConditionalOrExpression tok__pipe__pipe__66 ConditionalAndExpression { Ctr__Expression__49 (rtkPosOf $1) $1 $3 }
 
-ConditionalExpression : ConditionalOrExpression { Ctr__Expression__48 (rtkPosOf $1) $1 } |
-                        ConditionalOrExpression tok__symbol__64 Expression tok__colon__37 ConditionalExpression { Ctr__Expression__49 (rtkPosOf $1) $1 $3 $5 }
+ConditionalExpression : ConditionalOrExpression { Ctr__Expression__50 (rtkPosOf $1) $1 } |
+                        ConditionalOrExpression tok__symbol__65 Expression tok__colon__37 ConditionalExpression { Ctr__Expression__51 (rtkPosOf $1) $1 $3 $5 }
 
-AssignmentExpression : ConditionalExpression Rule_76 { Ctr__Expression__50 (rtkPosOf $1) $1 $2 }
+AssignmentExpression : ConditionalExpression Rule_76 { Ctr__Expression__52 (rtkPosOf $1) $1 $2 } |
+                       id tok__minus__symbol__53 LambdaBody { Ctr__Expression__53 (rtkPosOf $1) (tkVal_id $1) $3 } |
+                       tok__lparen__7 tok__rparen__8 tok__minus__symbol__53 LambdaBody { Ctr__Expression__54 (rtkPosOf $1) $4 } |
+                       tok__lparen__7 id Rule_78 tok__rparen__8 tok__minus__symbol__53 LambdaBody { Ctr__Expression__55 (rtkPosOf $1) (tkVal_id $2) (reverse $3) $6 } |
+                       tok__lparen__7 Expression tok__rparen__8 tok__minus__symbol__53 LambdaBody { Ctr__Expression__56 (rtkPosOf $1) $2 $5 }
 
-Expression : AssignmentExpression { Ctr__Expression__51 (rtkPosOf $1) $1 }
+Expression : AssignmentExpression { Ctr__Expression__57 (rtkPosOf $1) $1 }
 
 ExtendsList : qq_ExtendsList { Anti_ExtendsList (tkVal_qq_ExtendsList $1) } |
               tok_extends_11 ClassOrInterfaceType Rule_12 { Ctr__ExtendsList__0 (rtkPosOf $1) $2 (reverse $3) }
@@ -620,14 +631,18 @@ ListElem_ImportList0 : qq_ImportList { Anti_ImportStatement (tkVal_qq_ImportList
 InterfaceDeclaration : qq_InterfaceDeclaration { Anti_InterfaceDeclaration (tkVal_qq_InterfaceDeclaration $1) } |
                        tok_interface_16 id TypeParameters Rule_18 tok__symbol__14 FieldDeclarationList tok__symbol__15 { Ctr__InterfaceDeclaration__0 (rtkPosOf $1) (tkVal_id $2) $3 $4 (reverse $6) }
 
+LambdaBody : qq_LambdaBody { Anti_LambdaBody (tkVal_qq_LambdaBody $1) } |
+             Expression { Ctr__LambdaBody__0 (rtkPosOf $1) $1 } |
+             StatementBlock { Ctr__LambdaBody__1 (rtkPosOf $1) $1 }
+
 Literal : qq_Literal { Anti_Literal (tkVal_qq_Literal $1) } |
           integerLiteral { Ctr__Literal__0 (rtkPosOf $1) (tkVal_integerLiteral $1) } |
           floatLiteral { Ctr__Literal__1 (rtkPosOf $1) (tkVal_floatLiteral $1) } |
-          tok_true_86 { Ctr__Literal__2 (rtkPosOf $1) } |
-          tok_false_87 { Ctr__Literal__3 (rtkPosOf $1) } |
+          tok_true_88 { Ctr__Literal__2 (rtkPosOf $1) } |
+          tok_false_89 { Ctr__Literal__3 (rtkPosOf $1) } |
           char { Ctr__Literal__4 (rtkPosOf $1) (tkVal_char $1) } |
           string { Ctr__Literal__5 (rtkPosOf $1) (tkVal_string $1) } |
-          tok_null_88 { Ctr__Literal__6 (rtkPosOf $1) }
+          tok_null_90 { Ctr__Literal__6 (rtkPosOf $1) }
 
 LocalModifierList1 : ListElem_LocalModifierList149 { [$1] } |
                      LocalModifierList1 ListElem_LocalModifierList149 { $2 : $1 }
@@ -646,16 +661,16 @@ MemberRest : qq_MemberRest { Anti_MemberRest (tkVal_qq_MemberRest $1) } |
              Dims OptVariableInitializer MoreVariableDeclarators tok__semi__1 { Ctr__MemberRest__1 (rtkPosOf (reverse $1)) (reverse $1) $2 (reverse $3) }
 
 Modifier : qq_Modifier { Anti_Modifier (tkVal_qq_Modifier $1) } |
-           tok_public_89 { Ctr__Modifier__0 (rtkPosOf $1) } |
-           tok_private_90 { Ctr__Modifier__1 (rtkPosOf $1) } |
-           tok_protected_91 { Ctr__Modifier__2 (rtkPosOf $1) } |
+           tok_public_91 { Ctr__Modifier__0 (rtkPosOf $1) } |
+           tok_private_92 { Ctr__Modifier__1 (rtkPosOf $1) } |
+           tok_protected_93 { Ctr__Modifier__2 (rtkPosOf $1) } |
            tok_static_3 { Ctr__Modifier__3 (rtkPosOf $1) } |
            tok_final_31 { Ctr__Modifier__4 (rtkPosOf $1) } |
-           tok_native_92 { Ctr__Modifier__5 (rtkPosOf $1) } |
+           tok_native_94 { Ctr__Modifier__5 (rtkPosOf $1) } |
            tok_synchronized_34 { Ctr__Modifier__6 (rtkPosOf $1) } |
-           tok_abstract_93 { Ctr__Modifier__7 (rtkPosOf $1) } |
-           tok_threadsafe_94 { Ctr__Modifier__8 (rtkPosOf $1) } |
-           tok_transient_95 { Ctr__Modifier__9 (rtkPosOf $1) }
+           tok_abstract_95 { Ctr__Modifier__7 (rtkPosOf $1) } |
+           tok_threadsafe_96 { Ctr__Modifier__8 (rtkPosOf $1) } |
+           tok_transient_97 { Ctr__Modifier__9 (rtkPosOf $1) }
 
 ModifierList : {- empty -} { [] } |
                ModifierList ListElem_ModifierList11 { $2 : $1 }
@@ -669,15 +684,15 @@ MoreVariableDeclarators : {- empty -} { [] } |
 
 MultiplicativeOp : qq_MultiplicativeOp { Anti_MultiplicativeOp (tkVal_qq_MultiplicativeOp $1) } |
                    tok__star__5 { Ctr__MultiplicativeOp__0 (rtkPosOf $1) } |
-                   tok__symbol__79 { Ctr__MultiplicativeOp__1 (rtkPosOf $1) } |
-                   tok__symbol__80 { Ctr__MultiplicativeOp__2 (rtkPosOf $1) }
+                   tok__symbol__80 { Ctr__MultiplicativeOp__1 (rtkPosOf $1) } |
+                   tok__symbol__81 { Ctr__MultiplicativeOp__2 (rtkPosOf $1) }
 
 NonEmptyDims : ListElem_NonEmptyDims34 { [$1] } |
                NonEmptyDims ListElem_NonEmptyDims34 { $2 : $1 }
 
 NonEmptyTypeArguments : qq_NonEmptyTypeArguments { Anti_NonEmptyTypeArguments (tkVal_qq_NonEmptyTypeArguments $1) } |
-                        tok__symbol__71 TypeArgument Rule_89 tok__symbol__72 { Ctr__NonEmptyTypeArguments__0 (rtkPosOf $1) $2 (reverse $3) } |
-                        tok__symbol__71 tok__symbol__72 { Ctr__NonEmptyTypeArguments__1 (rtkPosOf $1) }
+                        tok__symbol__72 TypeArgument Rule_91 tok__symbol__73 { Ctr__NonEmptyTypeArguments__0 (rtkPosOf $1) $2 (reverse $3) } |
+                        tok__symbol__72 tok__symbol__73 { Ctr__NonEmptyTypeArguments__1 (rtkPosOf $1) }
 
 OptDocComment : qq_OptDocComment { Anti_OptDocComment (tkVal_qq_OptDocComment $1) } |
                 { Ctr__OptDocComment__0 rtkNoPos } |
@@ -716,14 +731,14 @@ ParameterList : qq_ParameterList { Anti_ParameterList (tkVal_qq_ParameterList $1
                 Parameter Rule_55 { Ctr__ParameterList__0 (rtkPosOf $1) $1 (reverse $2) }
 
 PostfixOp : qq_PostfixOp { Anti_PostfixOp (tkVal_qq_PostfixOp $1) } |
-            tok__plus__plus__81 { Ctr__PostfixOp__0 (rtkPosOf $1) } |
-            tok__minus__minus__82 { Ctr__PostfixOp__1 (rtkPosOf $1) }
+            tok__plus__plus__82 { Ctr__PostfixOp__0 (rtkPosOf $1) } |
+            tok__minus__minus__83 { Ctr__PostfixOp__1 (rtkPosOf $1) }
 
 PrefixOp : qq_PrefixOp { Anti_PrefixOp (tkVal_qq_PrefixOp $1) } |
-           tok__plus__plus__81 { Ctr__PrefixOp__0 (rtkPosOf $1) } |
-           tok__minus__minus__82 { Ctr__PrefixOp__1 (rtkPosOf $1) } |
-           tok__plus__77 { Ctr__PrefixOp__2 (rtkPosOf $1) } |
-           tok__minus__78 { Ctr__PrefixOp__3 (rtkPosOf $1) }
+           tok__plus__plus__82 { Ctr__PrefixOp__0 (rtkPosOf $1) } |
+           tok__minus__minus__83 { Ctr__PrefixOp__1 (rtkPosOf $1) } |
+           tok__plus__78 { Ctr__PrefixOp__2 (rtkPosOf $1) } |
+           tok__minus__79 { Ctr__PrefixOp__3 (rtkPosOf $1) }
 
 PrimitiveTypeKeyword : qq_PrimitiveTypeKeyword { Anti_PrimitiveTypeKeyword (tkVal_qq_PrimitiveTypeKeyword $1) } |
                        tok_boolean_20 { Ctr__PrimitiveTypeKeyword__0 (rtkPosOf $1) } |
@@ -737,10 +752,10 @@ PrimitiveTypeKeyword : qq_PrimitiveTypeKeyword { Anti_PrimitiveTypeKeyword (tkVa
                        tok_void_28 { Ctr__PrimitiveTypeKeyword__8 (rtkPosOf $1) }
 
 RelationalOp : qq_RelationalOp { Anti_RelationalOp (tkVal_qq_RelationalOp $1) } |
-               tok__symbol__71 { Ctr__RelationalOp__0 (rtkPosOf $1) } |
-               tok__symbol__72 { Ctr__RelationalOp__1 (rtkPosOf $1) } |
-               tok__symbol__eql__73 { Ctr__RelationalOp__2 (rtkPosOf $1) } |
-               tok__symbol__eql__74 { Ctr__RelationalOp__3 (rtkPosOf $1) }
+               tok__symbol__72 { Ctr__RelationalOp__0 (rtkPosOf $1) } |
+               tok__symbol__73 { Ctr__RelationalOp__1 (rtkPosOf $1) } |
+               tok__symbol__eql__74 { Ctr__RelationalOp__2 (rtkPosOf $1) } |
+               tok__symbol__eql__75 { Ctr__RelationalOp__3 (rtkPosOf $1) }
 
 Resource : qq_Resource { Anti_Resource (tkVal_qq_Resource $1) } |
            ParamModifierList Type id tok__eql__10 Expression { Ctr__Resource__0 (rtkPosOf (reverse $1)) (reverse $1) $2 (tkVal_id $3) $5 }
@@ -756,6 +771,11 @@ ListElem_ModifierList11 : qq_ModifierList { Anti_Rule_10 (tkVal_qq_ModifierList 
 
 Rule_10 : Modifier { Ctr__Rule_10__1 (rtkPosOf $1) $1 } |
           Annotation { Ctr__Rule_10__2 (rtkPosOf $1) $1 }
+
+ListElem_CompoundNameTail101 : qq_CompoundNameTail { Anti_Rule_100 (tkVal_qq_CompoundNameTail $1) } |
+                               Rule_100 { $1 }
+
+Rule_100 : tok__dot__4 id { Ctr__Rule_100__1 (rtkPosOf $1) (tkVal_id $2) }
 
 Rule_12 : {- empty -} { [] } |
           Rule_12 Rule_13 { $2 : $1 }
@@ -944,10 +964,10 @@ Rule_76 : { Ctr__Rule_76__0 rtkNoPos } |
 
 Rule_77 : AssignmentOp AssignmentExpression { Ctr__Rule_77__0 (rtkPosOf $1) $1 $2 }
 
-Rule_78 : { Ctr__Rule_78__0 rtkNoPos } |
-          Rule_79 { Ctr__Rule_78__1 (rtkPosOf $1) $1 }
+Rule_78 : Rule_79 { [$1] } |
+          Rule_78 Rule_79 { $2 : $1 }
 
-Rule_79 : tok__lparen__7 Arglist tok__rparen__8 { Ctr__Rule_79__0 (rtkPosOf $1) $2 }
+Rule_79 : tok__coma__9 id { Ctr__Rule_79__0 (rtkPosOf $1) (tkVal_id $2) }
 
 Rule_8 : tok__coma__9 AnnotationElement { Ctr__Rule_8__0 (rtkPosOf $1) $2 }
 
@@ -956,55 +976,55 @@ Rule_80 : { Ctr__Rule_80__0 rtkNoPos } |
 
 Rule_81 : tok__lparen__7 Arglist tok__rparen__8 { Ctr__Rule_81__0 (rtkPosOf $1) $2 }
 
-Rule_82 : tok__lparen__7 Arglist tok__rparen__8 { Ctr__Rule_82__0 (rtkPosOf $1) $2 } |
-          DimExprs Rule_83 { Ctr__Rule_82__1 (rtkPosOf (reverse $1)) (reverse $1) $2 }
+Rule_82 : { Ctr__Rule_82__0 rtkNoPos } |
+          Rule_83 { Ctr__Rule_82__1 (rtkPosOf $1) $1 }
 
-Rule_83 : { Ctr__Rule_83__0 rtkNoPos } |
-          NonEmptyDims { Ctr__Rule_83__1 (rtkPosOf (reverse $1)) (reverse $1) }
+Rule_83 : tok__lparen__7 Arglist tok__rparen__8 { Ctr__Rule_83__0 (rtkPosOf $1) $2 }
 
-ListElem_DimExprs85 : qq_DimExprs { Anti_Rule_84 (tkVal_qq_DimExprs $1) } |
-                      Rule_84 { $1 }
+Rule_84 : tok__lparen__7 Arglist tok__rparen__8 { Ctr__Rule_84__0 (rtkPosOf $1) $2 } |
+          DimExprs Rule_85 { Ctr__Rule_84__1 (rtkPosOf (reverse $1)) (reverse $1) $2 }
 
-Rule_84 : tok__sq_bkt_l__18 Expression tok__sq_bkt_r__19 { Ctr__Rule_84__1 (rtkPosOf $1) $2 }
+Rule_85 : { Ctr__Rule_85__0 rtkNoPos } |
+          NonEmptyDims { Ctr__Rule_85__1 (rtkPosOf (reverse $1)) (reverse $1) }
 
-Rule_86 : Expression Rule_87 { Ctr__Rule_86__0 (rtkPosOf $1) $1 (reverse $2) }
+ListElem_DimExprs87 : qq_DimExprs { Anti_Rule_86 (tkVal_qq_DimExprs $1) } |
+                      Rule_86 { $1 }
 
-Rule_87 : {- empty -} { [] } |
-          Rule_87 Rule_88 { $2 : $1 }
+Rule_86 : tok__sq_bkt_l__18 Expression tok__sq_bkt_r__19 { Ctr__Rule_86__1 (rtkPosOf $1) $2 }
 
-Rule_88 : tok__coma__9 Expression { Ctr__Rule_88__0 (rtkPosOf $1) $2 }
+Rule_88 : Expression Rule_89 { Ctr__Rule_88__0 (rtkPosOf $1) $1 (reverse $2) }
 
 Rule_89 : {- empty -} { [] } |
           Rule_89 Rule_90 { $2 : $1 }
 
-Rule_90 : tok__coma__9 TypeArgument { Ctr__Rule_90__0 (rtkPosOf $1) $2 }
+Rule_90 : tok__coma__9 Expression { Ctr__Rule_90__0 (rtkPosOf $1) $2 }
 
-Rule_91 : tok__symbol__71 TypeParameter Rule_92 tok__symbol__72 { Ctr__Rule_91__0 (rtkPosOf $1) $2 (reverse $3) }
+Rule_91 : {- empty -} { [] } |
+          Rule_91 Rule_92 { $2 : $1 }
 
-Rule_92 : {- empty -} { [] } |
-          Rule_92 Rule_93 { $2 : $1 }
+Rule_92 : tok__coma__9 TypeArgument { Ctr__Rule_92__0 (rtkPosOf $1) $2 }
 
-Rule_93 : tok__coma__9 TypeParameter { Ctr__Rule_93__0 (rtkPosOf $1) $2 }
+Rule_93 : tok__symbol__72 TypeParameter Rule_94 tok__symbol__73 { Ctr__Rule_93__0 (rtkPosOf $1) $2 (reverse $3) }
 
-Rule_94 : { Ctr__Rule_94__0 rtkNoPos } |
-          Rule_95 { Ctr__Rule_94__1 (rtkPosOf $1) $1 }
+Rule_94 : {- empty -} { [] } |
+          Rule_94 Rule_95 { $2 : $1 }
 
-Rule_95 : tok_extends_11 Type Rule_96 { Ctr__Rule_95__0 (rtkPosOf $1) $2 (reverse $3) }
+Rule_95 : tok__coma__9 TypeParameter { Ctr__Rule_95__0 (rtkPosOf $1) $2 }
 
-Rule_96 : {- empty -} { [] } |
-          Rule_96 Rule_97 { $2 : $1 }
+Rule_96 : { Ctr__Rule_96__0 rtkNoPos } |
+          Rule_97 { Ctr__Rule_96__1 (rtkPosOf $1) $1 }
 
-Rule_97 : tok__symbol__68 Type { Ctr__Rule_97__0 (rtkPosOf $1) $2 }
+Rule_97 : tok_extends_11 Type Rule_98 { Ctr__Rule_97__0 (rtkPosOf $1) $2 (reverse $3) }
 
-ListElem_CompoundNameTail99 : qq_CompoundNameTail { Anti_Rule_98 (tkVal_qq_CompoundNameTail $1) } |
-                              Rule_98 { $1 }
+Rule_98 : {- empty -} { [] } |
+          Rule_98 Rule_99 { $2 : $1 }
 
-Rule_98 : tok__dot__4 id { Ctr__Rule_98__1 (rtkPosOf $1) (tkVal_id $2) }
+Rule_99 : tok__symbol__69 Type { Ctr__Rule_99__0 (rtkPosOf $1) $2 }
 
 ShiftOp : qq_ShiftOp { Anti_ShiftOp (tkVal_qq_ShiftOp $1) } |
-          tok__symbol__symbol__76 { Ctr__ShiftOp__0 (rtkPosOf $1) } |
-          tok__symbol__72 tok__symbol__72 { Ctr__ShiftOp__1 (rtkPosOf $1) } |
-          tok__symbol__72 tok__symbol__72 tok__symbol__72 { Ctr__ShiftOp__2 (rtkPosOf $1) }
+          tok__symbol__symbol__77 { Ctr__ShiftOp__0 (rtkPosOf $1) } |
+          tok__symbol__73 tok__symbol__73 { Ctr__ShiftOp__1 (rtkPosOf $1) } |
+          tok__symbol__73 tok__symbol__73 tok__symbol__73 { Ctr__ShiftOp__2 (rtkPosOf $1) }
 
 Statement : qq_Statement { Anti_Statement (tkVal_qq_Statement $1) } |
             VariableDeclaration { Ctr__Statement__0 (rtkPosOf $1) $1 } |
@@ -1075,11 +1095,11 @@ TypeDeclaration : qq_TypeDeclaration { Anti_TypeDeclaration (tkVal_qq_TypeDeclar
                   OptDocComment ModifierList TypeDeclRest { Ctr__TypeDeclaration__0 (rtkPosOf $1) $1 (reverse $2) $3 }
 
 TypeParameter : qq_TypeParameter { Anti_TypeParameter (tkVal_qq_TypeParameter $1) } |
-                id Rule_94 { Ctr__TypeParameter__0 (rtkPosOf $1) (tkVal_id $1) $2 }
+                id Rule_96 { Ctr__TypeParameter__0 (rtkPosOf $1) (tkVal_id $1) $2 }
 
 TypeParameters : qq_TypeParameters { Anti_TypeParameters (tkVal_qq_TypeParameters $1) } |
                  { Ctr__TypeParameters__0 rtkNoPos } |
-                 Rule_91 { Ctr__TypeParameters__1 (rtkPosOf $1) $1 }
+                 Rule_93 { Ctr__TypeParameters__1 (rtkPosOf $1) $1 }
 
 TypeSpecifier : qq_TypeSpecifier { Anti_TypeSpecifier (tkVal_qq_TypeSpecifier $1) } |
                 tok_boolean_20 { Ctr__TypeSpecifier__0 (rtkPosOf $1) } |
@@ -1115,9 +1135,9 @@ WhileStatement : qq_WhileStatement { Anti_WhileStatement (tkVal_qq_WhileStatemen
                  tok_while_45 tok__lparen__7 Expression tok__rparen__8 Statement { Ctr__WhileStatement__0 (rtkPosOf $1) $3 $5 }
 
 WildcardType : qq_WildcardType { Anti_WildcardType (tkVal_qq_WildcardType $1) } |
-               tok__symbol__64 { Ctr__WildcardType__0 (rtkPosOf $1) } |
-               tok__symbol__64 tok_extends_11 Type { Ctr__WildcardType__1 (rtkPosOf $1) $3 } |
-               tok__symbol__64 tok_super_40 Type { Ctr__WildcardType__2 (rtkPosOf $1) $3 }
+               tok__symbol__65 { Ctr__WildcardType__0 (rtkPosOf $1) } |
+               tok__symbol__65 tok_extends_11 Type { Ctr__WildcardType__1 (rtkPosOf $1) $3 } |
+               tok__symbol__65 tok_super_40 Type { Ctr__WildcardType__2 (rtkPosOf $1) $3 }
 
 
 {
@@ -1129,112 +1149,113 @@ parseError (L.PosToken (L.AlexPn _ line col) tok : _) =
 -- Render a token the way it appears in the source, for error messages
 showRtkToken :: L.Token -> String
 showRtkToken L.EndOfFile = "end of input"
-showRtkToken L.Tk__tok_AdditiveOp_dummy_190 = "'tok_AdditiveOp_dummy_190'"
-showRtkToken L.Tk__tok_Annotation_dummy_189 = "'tok_Annotation_dummy_189'"
-showRtkToken L.Tk__tok_AnnotationArguments_dummy_188 = "'tok_AnnotationArguments_dummy_188'"
-showRtkToken L.Tk__tok_AnnotationDeclaration_dummy_187 = "'tok_AnnotationDeclaration_dummy_187'"
-showRtkToken L.Tk__tok_AnnotationElement_dummy_186 = "'tok_AnnotationElement_dummy_186'"
-showRtkToken L.Tk__tok_AnnotationList_dummy_185 = "'tok_AnnotationList_dummy_185'"
-showRtkToken L.Tk__tok_AnnotationTypeElement_dummy_184 = "'tok_AnnotationTypeElement_dummy_184'"
-showRtkToken L.Tk__tok_AnnotationTypeElementList_dummy_183 = "'tok_AnnotationTypeElementList_dummy_183'"
-showRtkToken L.Tk__tok_Arglist_dummy_182 = "'tok_Arglist_dummy_182'"
-showRtkToken L.Tk__tok_AssignmentOp_dummy_181 = "'tok_AssignmentOp_dummy_181'"
-showRtkToken L.Tk__tok_CatchList_dummy_180 = "'tok_CatchList_dummy_180'"
-showRtkToken L.Tk__tok_CatchParameter_dummy_179 = "'tok_CatchParameter_dummy_179'"
-showRtkToken L.Tk__tok_ClassDeclaration_dummy_178 = "'tok_ClassDeclaration_dummy_178'"
-showRtkToken L.Tk__tok_ClassOrInterfaceType_dummy_177 = "'tok_ClassOrInterfaceType_dummy_177'"
-showRtkToken L.Tk__tok_CompilationUnit_dummy_176 = "'tok_CompilationUnit_dummy_176'"
-showRtkToken L.Tk__tok_CompoundName_dummy_175 = "'tok_CompoundName_dummy_175'"
-showRtkToken L.Tk__tok_CompoundNameTail_dummy_174 = "'tok_CompoundNameTail_dummy_174'"
-showRtkToken L.Tk__tok_CreationExpression_dummy_173 = "'tok_CreationExpression_dummy_173'"
-showRtkToken L.Tk__tok_DimExprs_dummy_172 = "'tok_DimExprs_dummy_172'"
-showRtkToken L.Tk__tok_Dims_dummy_171 = "'tok_Dims_dummy_171'"
-showRtkToken L.Tk__tok_DoStatement_dummy_170 = "'tok_DoStatement_dummy_170'"
-showRtkToken L.Tk__tok_DocComment_dummy_169 = "'tok_DocComment_dummy_169'"
-showRtkToken L.Tk__tok_EnumConstant_dummy_168 = "'tok_EnumConstant_dummy_168'"
-showRtkToken L.Tk__tok_EnumConstantList_dummy_167 = "'tok_EnumConstantList_dummy_167'"
-showRtkToken L.Tk__tok_EnumDeclaration_dummy_166 = "'tok_EnumDeclaration_dummy_166'"
-showRtkToken L.Tk__tok_EqualityOp_dummy_165 = "'tok_EqualityOp_dummy_165'"
-showRtkToken L.Tk__tok_Expression_dummy_164 = "'tok_Expression_dummy_164'"
-showRtkToken L.Tk__tok_ExtendsList_dummy_163 = "'tok_ExtendsList_dummy_163'"
-showRtkToken L.Tk__tok_FieldDeclaration_dummy_162 = "'tok_FieldDeclaration_dummy_162'"
-showRtkToken L.Tk__tok_FieldDeclarationList_dummy_161 = "'tok_FieldDeclarationList_dummy_161'"
-showRtkToken L.Tk__tok_ForEachHeader_dummy_160 = "'tok_ForEachHeader_dummy_160'"
-showRtkToken L.Tk__tok_ForStatement_dummy_159 = "'tok_ForStatement_dummy_159'"
-showRtkToken L.Tk__tok_IfStatement_dummy_158 = "'tok_IfStatement_dummy_158'"
-showRtkToken L.Tk__tok_ImplementsList_dummy_157 = "'tok_ImplementsList_dummy_157'"
-showRtkToken L.Tk__tok_ImportHead_dummy_156 = "'tok_ImportHead_dummy_156'"
-showRtkToken L.Tk__tok_ImportList_dummy_155 = "'tok_ImportList_dummy_155'"
-showRtkToken L.Tk__tok_ImportName_dummy_154 = "'tok_ImportName_dummy_154'"
-showRtkToken L.Tk__tok_ImportStatement_dummy_153 = "'tok_ImportStatement_dummy_153'"
-showRtkToken L.Tk__tok_InterfaceDeclaration_dummy_152 = "'tok_InterfaceDeclaration_dummy_152'"
-showRtkToken L.Tk__tok_Java_dummy_191 = "'tok_Java_dummy_191'"
-showRtkToken L.Tk__tok_Literal_dummy_151 = "'tok_Literal_dummy_151'"
-showRtkToken L.Tk__tok_LocalModifierList1_dummy_150 = "'tok_LocalModifierList1_dummy_150'"
-showRtkToken L.Tk__tok_MemberAfterFirstId_dummy_149 = "'tok_MemberAfterFirstId_dummy_149'"
-showRtkToken L.Tk__tok_MemberDeclaration_dummy_148 = "'tok_MemberDeclaration_dummy_148'"
-showRtkToken L.Tk__tok_MemberRest_dummy_147 = "'tok_MemberRest_dummy_147'"
-showRtkToken L.Tk__tok_Modifier_dummy_146 = "'tok_Modifier_dummy_146'"
-showRtkToken L.Tk__tok_ModifierList_dummy_145 = "'tok_ModifierList_dummy_145'"
-showRtkToken L.Tk__tok_MoreTypeSpecifier_dummy_144 = "'tok_MoreTypeSpecifier_dummy_144'"
-showRtkToken L.Tk__tok_MoreVariableDeclarators_dummy_143 = "'tok_MoreVariableDeclarators_dummy_143'"
-showRtkToken L.Tk__tok_MultiplicativeOp_dummy_142 = "'tok_MultiplicativeOp_dummy_142'"
-showRtkToken L.Tk__tok_NonEmptyDims_dummy_141 = "'tok_NonEmptyDims_dummy_141'"
-showRtkToken L.Tk__tok_NonEmptyTypeArguments_dummy_140 = "'tok_NonEmptyTypeArguments_dummy_140'"
-showRtkToken L.Tk__tok_OptDocComment_dummy_139 = "'tok_OptDocComment_dummy_139'"
-showRtkToken L.Tk__tok_OptElsePart_dummy_138 = "'tok_OptElsePart_dummy_138'"
-showRtkToken L.Tk__tok_OptExpression_dummy_137 = "'tok_OptExpression_dummy_137'"
-showRtkToken L.Tk__tok_OptFinally_dummy_136 = "'tok_OptFinally_dummy_136'"
-showRtkToken L.Tk__tok_OptId_dummy_135 = "'tok_OptId_dummy_135'"
-showRtkToken L.Tk__tok_OptVariableInitializer_dummy_134 = "'tok_OptVariableInitializer_dummy_134'"
-showRtkToken L.Tk__tok_Package_dummy_133 = "'tok_Package_dummy_133'"
-showRtkToken L.Tk__tok_ParamModifierList_dummy_132 = "'tok_ParamModifierList_dummy_132'"
-showRtkToken L.Tk__tok_Parameter_dummy_131 = "'tok_Parameter_dummy_131'"
-showRtkToken L.Tk__tok_ParameterList_dummy_130 = "'tok_ParameterList_dummy_130'"
-showRtkToken L.Tk__tok_PostfixOp_dummy_129 = "'tok_PostfixOp_dummy_129'"
-showRtkToken L.Tk__tok_PrefixOp_dummy_128 = "'tok_PrefixOp_dummy_128'"
-showRtkToken L.Tk__tok_PrimitiveTypeKeyword_dummy_127 = "'tok_PrimitiveTypeKeyword_dummy_127'"
-showRtkToken L.Tk__tok_RelationalOp_dummy_126 = "'tok_RelationalOp_dummy_126'"
-showRtkToken L.Tk__tok_Resource_dummy_125 = "'tok_Resource_dummy_125'"
-showRtkToken L.Tk__tok_ResourceSpec_dummy_124 = "'tok_ResourceSpec_dummy_124'"
-showRtkToken L.Tk__tok_ShiftOp_dummy_123 = "'tok_ShiftOp_dummy_123'"
-showRtkToken L.Tk__tok_Statement_dummy_122 = "'tok_Statement_dummy_122'"
-showRtkToken L.Tk__tok_StatementBlock_dummy_121 = "'tok_StatementBlock_dummy_121'"
-showRtkToken L.Tk__tok_StatementList_dummy_120 = "'tok_StatementList_dummy_120'"
-showRtkToken L.Tk__tok_StaticInitializer_dummy_119 = "'tok_StaticInitializer_dummy_119'"
-showRtkToken L.Tk__tok_SwitchCaseList_dummy_118 = "'tok_SwitchCaseList_dummy_118'"
-showRtkToken L.Tk__tok_SwitchStatement_dummy_117 = "'tok_SwitchStatement_dummy_117'"
-showRtkToken L.Tk__tok_ThrowsClause_dummy_116 = "'tok_ThrowsClause_dummy_116'"
-showRtkToken L.Tk__tok_TryStatement_dummy_115 = "'tok_TryStatement_dummy_115'"
-showRtkToken L.Tk__tok_Type_dummy_114 = "'tok_Type_dummy_114'"
-showRtkToken L.Tk__tok_TypeArgument_dummy_113 = "'tok_TypeArgument_dummy_113'"
-showRtkToken L.Tk__tok_TypeArguments_dummy_112 = "'tok_TypeArguments_dummy_112'"
-showRtkToken L.Tk__tok_TypeDeclRest_dummy_111 = "'tok_TypeDeclRest_dummy_111'"
-showRtkToken L.Tk__tok_TypeDeclaration_dummy_110 = "'tok_TypeDeclaration_dummy_110'"
-showRtkToken L.Tk__tok_TypeParameter_dummy_109 = "'tok_TypeParameter_dummy_109'"
-showRtkToken L.Tk__tok_TypeParameters_dummy_108 = "'tok_TypeParameters_dummy_108'"
-showRtkToken L.Tk__tok_TypeSpecifier_dummy_107 = "'tok_TypeSpecifier_dummy_107'"
-showRtkToken L.Tk__tok_VariableDeclaration_dummy_106 = "'tok_VariableDeclaration_dummy_106'"
-showRtkToken L.Tk__tok_VariableDeclarator_dummy_105 = "'tok_VariableDeclarator_dummy_105'"
-showRtkToken L.Tk__tok_VariableDeclaratorList_dummy_104 = "'tok_VariableDeclaratorList_dummy_104'"
-showRtkToken L.Tk__tok_VariableInitializer_dummy_103 = "'tok_VariableInitializer_dummy_103'"
-showRtkToken L.Tk__tok_VariableInitializerList_dummy_102 = "'tok_VariableInitializerList_dummy_102'"
-showRtkToken L.Tk__tok_WhileStatement_dummy_101 = "'tok_WhileStatement_dummy_101'"
-showRtkToken L.Tk__tok_WildcardType_dummy_100 = "'tok_WildcardType_dummy_100'"
-showRtkToken L.Tk__tok__tilde__83 = "'~'"
+showRtkToken L.Tk__tok_AdditiveOp_dummy_193 = "'tok_AdditiveOp_dummy_193'"
+showRtkToken L.Tk__tok_Annotation_dummy_192 = "'tok_Annotation_dummy_192'"
+showRtkToken L.Tk__tok_AnnotationArguments_dummy_191 = "'tok_AnnotationArguments_dummy_191'"
+showRtkToken L.Tk__tok_AnnotationDeclaration_dummy_190 = "'tok_AnnotationDeclaration_dummy_190'"
+showRtkToken L.Tk__tok_AnnotationElement_dummy_189 = "'tok_AnnotationElement_dummy_189'"
+showRtkToken L.Tk__tok_AnnotationList_dummy_188 = "'tok_AnnotationList_dummy_188'"
+showRtkToken L.Tk__tok_AnnotationTypeElement_dummy_187 = "'tok_AnnotationTypeElement_dummy_187'"
+showRtkToken L.Tk__tok_AnnotationTypeElementList_dummy_186 = "'tok_AnnotationTypeElementList_dummy_186'"
+showRtkToken L.Tk__tok_Arglist_dummy_185 = "'tok_Arglist_dummy_185'"
+showRtkToken L.Tk__tok_AssignmentOp_dummy_184 = "'tok_AssignmentOp_dummy_184'"
+showRtkToken L.Tk__tok_CatchList_dummy_183 = "'tok_CatchList_dummy_183'"
+showRtkToken L.Tk__tok_CatchParameter_dummy_182 = "'tok_CatchParameter_dummy_182'"
+showRtkToken L.Tk__tok_ClassDeclaration_dummy_181 = "'tok_ClassDeclaration_dummy_181'"
+showRtkToken L.Tk__tok_ClassOrInterfaceType_dummy_180 = "'tok_ClassOrInterfaceType_dummy_180'"
+showRtkToken L.Tk__tok_CompilationUnit_dummy_179 = "'tok_CompilationUnit_dummy_179'"
+showRtkToken L.Tk__tok_CompoundName_dummy_178 = "'tok_CompoundName_dummy_178'"
+showRtkToken L.Tk__tok_CompoundNameTail_dummy_177 = "'tok_CompoundNameTail_dummy_177'"
+showRtkToken L.Tk__tok_CreationExpression_dummy_176 = "'tok_CreationExpression_dummy_176'"
+showRtkToken L.Tk__tok_DimExprs_dummy_175 = "'tok_DimExprs_dummy_175'"
+showRtkToken L.Tk__tok_Dims_dummy_174 = "'tok_Dims_dummy_174'"
+showRtkToken L.Tk__tok_DoStatement_dummy_173 = "'tok_DoStatement_dummy_173'"
+showRtkToken L.Tk__tok_DocComment_dummy_172 = "'tok_DocComment_dummy_172'"
+showRtkToken L.Tk__tok_EnumConstant_dummy_171 = "'tok_EnumConstant_dummy_171'"
+showRtkToken L.Tk__tok_EnumConstantList_dummy_170 = "'tok_EnumConstantList_dummy_170'"
+showRtkToken L.Tk__tok_EnumDeclaration_dummy_169 = "'tok_EnumDeclaration_dummy_169'"
+showRtkToken L.Tk__tok_EqualityOp_dummy_168 = "'tok_EqualityOp_dummy_168'"
+showRtkToken L.Tk__tok_Expression_dummy_167 = "'tok_Expression_dummy_167'"
+showRtkToken L.Tk__tok_ExtendsList_dummy_166 = "'tok_ExtendsList_dummy_166'"
+showRtkToken L.Tk__tok_FieldDeclaration_dummy_165 = "'tok_FieldDeclaration_dummy_165'"
+showRtkToken L.Tk__tok_FieldDeclarationList_dummy_164 = "'tok_FieldDeclarationList_dummy_164'"
+showRtkToken L.Tk__tok_ForEachHeader_dummy_163 = "'tok_ForEachHeader_dummy_163'"
+showRtkToken L.Tk__tok_ForStatement_dummy_162 = "'tok_ForStatement_dummy_162'"
+showRtkToken L.Tk__tok_IfStatement_dummy_161 = "'tok_IfStatement_dummy_161'"
+showRtkToken L.Tk__tok_ImplementsList_dummy_160 = "'tok_ImplementsList_dummy_160'"
+showRtkToken L.Tk__tok_ImportHead_dummy_159 = "'tok_ImportHead_dummy_159'"
+showRtkToken L.Tk__tok_ImportList_dummy_158 = "'tok_ImportList_dummy_158'"
+showRtkToken L.Tk__tok_ImportName_dummy_157 = "'tok_ImportName_dummy_157'"
+showRtkToken L.Tk__tok_ImportStatement_dummy_156 = "'tok_ImportStatement_dummy_156'"
+showRtkToken L.Tk__tok_InterfaceDeclaration_dummy_155 = "'tok_InterfaceDeclaration_dummy_155'"
+showRtkToken L.Tk__tok_Java_dummy_194 = "'tok_Java_dummy_194'"
+showRtkToken L.Tk__tok_LambdaBody_dummy_154 = "'tok_LambdaBody_dummy_154'"
+showRtkToken L.Tk__tok_Literal_dummy_153 = "'tok_Literal_dummy_153'"
+showRtkToken L.Tk__tok_LocalModifierList1_dummy_152 = "'tok_LocalModifierList1_dummy_152'"
+showRtkToken L.Tk__tok_MemberAfterFirstId_dummy_151 = "'tok_MemberAfterFirstId_dummy_151'"
+showRtkToken L.Tk__tok_MemberDeclaration_dummy_150 = "'tok_MemberDeclaration_dummy_150'"
+showRtkToken L.Tk__tok_MemberRest_dummy_149 = "'tok_MemberRest_dummy_149'"
+showRtkToken L.Tk__tok_Modifier_dummy_148 = "'tok_Modifier_dummy_148'"
+showRtkToken L.Tk__tok_ModifierList_dummy_147 = "'tok_ModifierList_dummy_147'"
+showRtkToken L.Tk__tok_MoreTypeSpecifier_dummy_146 = "'tok_MoreTypeSpecifier_dummy_146'"
+showRtkToken L.Tk__tok_MoreVariableDeclarators_dummy_145 = "'tok_MoreVariableDeclarators_dummy_145'"
+showRtkToken L.Tk__tok_MultiplicativeOp_dummy_144 = "'tok_MultiplicativeOp_dummy_144'"
+showRtkToken L.Tk__tok_NonEmptyDims_dummy_143 = "'tok_NonEmptyDims_dummy_143'"
+showRtkToken L.Tk__tok_NonEmptyTypeArguments_dummy_142 = "'tok_NonEmptyTypeArguments_dummy_142'"
+showRtkToken L.Tk__tok_OptDocComment_dummy_141 = "'tok_OptDocComment_dummy_141'"
+showRtkToken L.Tk__tok_OptElsePart_dummy_140 = "'tok_OptElsePart_dummy_140'"
+showRtkToken L.Tk__tok_OptExpression_dummy_139 = "'tok_OptExpression_dummy_139'"
+showRtkToken L.Tk__tok_OptFinally_dummy_138 = "'tok_OptFinally_dummy_138'"
+showRtkToken L.Tk__tok_OptId_dummy_137 = "'tok_OptId_dummy_137'"
+showRtkToken L.Tk__tok_OptVariableInitializer_dummy_136 = "'tok_OptVariableInitializer_dummy_136'"
+showRtkToken L.Tk__tok_Package_dummy_135 = "'tok_Package_dummy_135'"
+showRtkToken L.Tk__tok_ParamModifierList_dummy_134 = "'tok_ParamModifierList_dummy_134'"
+showRtkToken L.Tk__tok_Parameter_dummy_133 = "'tok_Parameter_dummy_133'"
+showRtkToken L.Tk__tok_ParameterList_dummy_132 = "'tok_ParameterList_dummy_132'"
+showRtkToken L.Tk__tok_PostfixOp_dummy_131 = "'tok_PostfixOp_dummy_131'"
+showRtkToken L.Tk__tok_PrefixOp_dummy_130 = "'tok_PrefixOp_dummy_130'"
+showRtkToken L.Tk__tok_PrimitiveTypeKeyword_dummy_129 = "'tok_PrimitiveTypeKeyword_dummy_129'"
+showRtkToken L.Tk__tok_RelationalOp_dummy_128 = "'tok_RelationalOp_dummy_128'"
+showRtkToken L.Tk__tok_Resource_dummy_127 = "'tok_Resource_dummy_127'"
+showRtkToken L.Tk__tok_ResourceSpec_dummy_126 = "'tok_ResourceSpec_dummy_126'"
+showRtkToken L.Tk__tok_ShiftOp_dummy_125 = "'tok_ShiftOp_dummy_125'"
+showRtkToken L.Tk__tok_Statement_dummy_124 = "'tok_Statement_dummy_124'"
+showRtkToken L.Tk__tok_StatementBlock_dummy_123 = "'tok_StatementBlock_dummy_123'"
+showRtkToken L.Tk__tok_StatementList_dummy_122 = "'tok_StatementList_dummy_122'"
+showRtkToken L.Tk__tok_StaticInitializer_dummy_121 = "'tok_StaticInitializer_dummy_121'"
+showRtkToken L.Tk__tok_SwitchCaseList_dummy_120 = "'tok_SwitchCaseList_dummy_120'"
+showRtkToken L.Tk__tok_SwitchStatement_dummy_119 = "'tok_SwitchStatement_dummy_119'"
+showRtkToken L.Tk__tok_ThrowsClause_dummy_118 = "'tok_ThrowsClause_dummy_118'"
+showRtkToken L.Tk__tok_TryStatement_dummy_117 = "'tok_TryStatement_dummy_117'"
+showRtkToken L.Tk__tok_Type_dummy_116 = "'tok_Type_dummy_116'"
+showRtkToken L.Tk__tok_TypeArgument_dummy_115 = "'tok_TypeArgument_dummy_115'"
+showRtkToken L.Tk__tok_TypeArguments_dummy_114 = "'tok_TypeArguments_dummy_114'"
+showRtkToken L.Tk__tok_TypeDeclRest_dummy_113 = "'tok_TypeDeclRest_dummy_113'"
+showRtkToken L.Tk__tok_TypeDeclaration_dummy_112 = "'tok_TypeDeclaration_dummy_112'"
+showRtkToken L.Tk__tok_TypeParameter_dummy_111 = "'tok_TypeParameter_dummy_111'"
+showRtkToken L.Tk__tok_TypeParameters_dummy_110 = "'tok_TypeParameters_dummy_110'"
+showRtkToken L.Tk__tok_TypeSpecifier_dummy_109 = "'tok_TypeSpecifier_dummy_109'"
+showRtkToken L.Tk__tok_VariableDeclaration_dummy_108 = "'tok_VariableDeclaration_dummy_108'"
+showRtkToken L.Tk__tok_VariableDeclarator_dummy_107 = "'tok_VariableDeclarator_dummy_107'"
+showRtkToken L.Tk__tok_VariableDeclaratorList_dummy_106 = "'tok_VariableDeclaratorList_dummy_106'"
+showRtkToken L.Tk__tok_VariableInitializer_dummy_105 = "'tok_VariableInitializer_dummy_105'"
+showRtkToken L.Tk__tok_VariableInitializerList_dummy_104 = "'tok_VariableInitializerList_dummy_104'"
+showRtkToken L.Tk__tok_WhileStatement_dummy_103 = "'tok_WhileStatement_dummy_103'"
+showRtkToken L.Tk__tok_WildcardType_dummy_102 = "'tok_WildcardType_dummy_102'"
+showRtkToken L.Tk__tok__tilde__84 = "'~'"
 showRtkToken L.Tk__tok__symbol__15 = "'}'"
-showRtkToken L.Tk__tok__pipe__pipe__65 = "'||'"
-showRtkToken L.Tk__tok__pipe__eql__57 = "'|='"
+showRtkToken L.Tk__tok__pipe__pipe__66 = "'||'"
+showRtkToken L.Tk__tok__pipe__eql__58 = "'|='"
 showRtkToken L.Tk__tok__pipe__48 = "'|'"
 showRtkToken L.Tk__tok__symbol__14 = "'{'"
 showRtkToken L.Tk__tok_while_45 = "'while'"
 showRtkToken L.Tk__tok_void_28 = "'void'"
 showRtkToken L.Tk__tok_try_50 = "'try'"
-showRtkToken L.Tk__tok_true_86 = "'true'"
-showRtkToken L.Tk__tok_transient_95 = "'transient'"
+showRtkToken L.Tk__tok_true_88 = "'true'"
+showRtkToken L.Tk__tok_transient_97 = "'transient'"
 showRtkToken L.Tk__tok_throws_29 = "'throws'"
 showRtkToken L.Tk__tok_throw_35 = "'throw'"
-showRtkToken L.Tk__tok_threadsafe_94 = "'threadsafe'"
+showRtkToken L.Tk__tok_threadsafe_96 = "'threadsafe'"
 showRtkToken L.Tk__tok_this_41 = "'this'"
 showRtkToken L.Tk__tok_synchronized_34 = "'synchronized'"
 showRtkToken L.Tk__tok_switch_52 = "'switch'"
@@ -1242,17 +1263,17 @@ showRtkToken L.Tk__tok_super_40 = "'super'"
 showRtkToken L.Tk__tok_static_3 = "'static'"
 showRtkToken L.Tk__tok_short_23 = "'short'"
 showRtkToken L.Tk__tok_return_33 = "'return'"
-showRtkToken L.Tk__tok_public_89 = "'public'"
-showRtkToken L.Tk__tok_protected_91 = "'protected'"
-showRtkToken L.Tk__tok_private_90 = "'private'"
+showRtkToken L.Tk__tok_public_91 = "'public'"
+showRtkToken L.Tk__tok_protected_93 = "'protected'"
+showRtkToken L.Tk__tok_private_92 = "'private'"
 showRtkToken L.Tk__tok_package_0 = "'package'"
-showRtkToken L.Tk__tok_null_88 = "'null'"
-showRtkToken L.Tk__tok_new_85 = "'new'"
-showRtkToken L.Tk__tok_native_92 = "'native'"
+showRtkToken L.Tk__tok_null_90 = "'null'"
+showRtkToken L.Tk__tok_new_87 = "'new'"
+showRtkToken L.Tk__tok_native_94 = "'native'"
 showRtkToken L.Tk__tok_long_26 = "'long'"
 showRtkToken L.Tk__tok_interface_16 = "'interface'"
 showRtkToken L.Tk__tok_int_24 = "'int'"
-showRtkToken L.Tk__tok_instanceof_75 = "'instanceof'"
+showRtkToken L.Tk__tok_instanceof_76 = "'instanceof'"
 showRtkToken L.Tk__tok_import_2 = "'import'"
 showRtkToken L.Tk__tok_implements_12 = "'implements'"
 showRtkToken L.Tk__tok_if_43 = "'if'"
@@ -1260,7 +1281,7 @@ showRtkToken L.Tk__tok_for_46 = "'for'"
 showRtkToken L.Tk__tok_float_25 = "'float'"
 showRtkToken L.Tk__tok_finally_49 = "'finally'"
 showRtkToken L.Tk__tok_final_31 = "'final'"
-showRtkToken L.Tk__tok_false_87 = "'false'"
+showRtkToken L.Tk__tok_false_89 = "'false'"
 showRtkToken L.Tk__tok_extends_11 = "'extends'"
 showRtkToken L.Tk__tok_enum_17 = "'enum'"
 showRtkToken L.Tk__tok_else_42 = "'else'"
@@ -1276,47 +1297,49 @@ showRtkToken L.Tk__tok_byte_21 = "'byte'"
 showRtkToken L.Tk__tok_break_38 = "'break'"
 showRtkToken L.Tk__tok_boolean_20 = "'boolean'"
 showRtkToken L.Tk__tok_assert_36 = "'assert'"
-showRtkToken L.Tk__tok_abstract_93 = "'abstract'"
-showRtkToken L.Tk__tok__symbol__eql__59 = "'^='"
-showRtkToken L.Tk__tok__symbol__67 = "'^'"
+showRtkToken L.Tk__tok_abstract_95 = "'abstract'"
+showRtkToken L.Tk__tok__symbol__eql__60 = "'^='"
+showRtkToken L.Tk__tok__symbol__68 = "'^'"
 showRtkToken L.Tk__tok__sq_bkt_r__19 = "']'"
 showRtkToken L.Tk__tok__sq_bkt_l__18 = "'['"
 showRtkToken L.Tk__tok__symbol__6 = "'@'"
-showRtkToken L.Tk__tok__symbol__64 = "'?'"
-showRtkToken L.Tk__tok__symbol__symbol__symbol__eql__63 = "'>>>='"
-showRtkToken L.Tk__tok__symbol__symbol__eql__62 = "'>>='"
-showRtkToken L.Tk__tok__symbol__eql__74 = "'>='"
-showRtkToken L.Tk__tok__symbol__72 = "'>'"
-showRtkToken L.Tk__tok__eql__eql__69 = "'=='"
+showRtkToken L.Tk__tok__symbol__65 = "'?'"
+showRtkToken L.Tk__tok__symbol__symbol__symbol__eql__64 = "'>>>='"
+showRtkToken L.Tk__tok__symbol__symbol__eql__63 = "'>>='"
+showRtkToken L.Tk__tok__symbol__eql__75 = "'>='"
+showRtkToken L.Tk__tok__symbol__73 = "'>'"
+showRtkToken L.Tk__tok__eql__eql__70 = "'=='"
 showRtkToken L.Tk__tok__eql__10 = "'='"
-showRtkToken L.Tk__tok__symbol__eql__73 = "'<='"
-showRtkToken L.Tk__tok__symbol__symbol__eql__61 = "'<<='"
-showRtkToken L.Tk__tok__symbol__symbol__76 = "'<<'"
-showRtkToken L.Tk__tok__symbol__71 = "'<'"
+showRtkToken L.Tk__tok__symbol__eql__74 = "'<='"
+showRtkToken L.Tk__tok__symbol__symbol__eql__62 = "'<<='"
+showRtkToken L.Tk__tok__symbol__symbol__77 = "'<<'"
+showRtkToken L.Tk__tok__symbol__72 = "'<'"
 showRtkToken L.Tk__tok__semi__1 = "';'"
+showRtkToken L.Tk__tok__colon__colon__86 = "'::'"
 showRtkToken L.Tk__tok__colon__37 = "':'"
-showRtkToken L.Tk__tok__symbol__eql__56 = "'/='"
-showRtkToken L.Tk__tok__symbol__79 = "'/'"
+showRtkToken L.Tk__tok__symbol__eql__57 = "'/='"
+showRtkToken L.Tk__tok__symbol__80 = "'/'"
 showRtkToken L.Tk__tok__dot__dot__dot__32 = "'...'"
 showRtkToken L.Tk__tok__dot__4 = "'.'"
-showRtkToken L.Tk__tok__minus__eql__54 = "'-='"
-showRtkToken L.Tk__tok__minus__minus__82 = "'--'"
-showRtkToken L.Tk__tok__minus__78 = "'-'"
+showRtkToken L.Tk__tok__minus__symbol__53 = "'->'"
+showRtkToken L.Tk__tok__minus__eql__55 = "'-='"
+showRtkToken L.Tk__tok__minus__minus__83 = "'--'"
+showRtkToken L.Tk__tok__minus__79 = "'-'"
 showRtkToken L.Tk__tok__coma__9 = "','"
-showRtkToken L.Tk__tok__plus__eql__53 = "'+='"
-showRtkToken L.Tk__tok__plus__plus__81 = "'++'"
-showRtkToken L.Tk__tok__plus__77 = "'+'"
-showRtkToken L.Tk__tok__star__eql__55 = "'*='"
+showRtkToken L.Tk__tok__plus__eql__54 = "'+='"
+showRtkToken L.Tk__tok__plus__plus__82 = "'++'"
+showRtkToken L.Tk__tok__plus__78 = "'+'"
+showRtkToken L.Tk__tok__star__eql__56 = "'*='"
 showRtkToken L.Tk__tok__star__5 = "'*'"
 showRtkToken L.Tk__tok__rparen__8 = "')'"
 showRtkToken L.Tk__tok__lparen__7 = "'('"
-showRtkToken L.Tk__tok__symbol__eql__58 = "'&='"
-showRtkToken L.Tk__tok__symbol__symbol__66 = "'&&'"
-showRtkToken L.Tk__tok__symbol__68 = "'&'"
-showRtkToken L.Tk__tok__symbol__eql__60 = "'%='"
-showRtkToken L.Tk__tok__symbol__80 = "'%'"
-showRtkToken L.Tk__tok__exclamation__eql__70 = "'!='"
-showRtkToken L.Tk__tok__exclamation__84 = "'!'"
+showRtkToken L.Tk__tok__symbol__eql__59 = "'&='"
+showRtkToken L.Tk__tok__symbol__symbol__67 = "'&&'"
+showRtkToken L.Tk__tok__symbol__69 = "'&'"
+showRtkToken L.Tk__tok__symbol__eql__61 = "'%='"
+showRtkToken L.Tk__tok__symbol__81 = "'%'"
+showRtkToken L.Tk__tok__exclamation__eql__71 = "'!='"
+showRtkToken L.Tk__tok__exclamation__85 = "'!'"
 showRtkToken (L.Tk__doccomment v) = "doccomment " ++ show v
 showRtkToken (L.Tk__id v) = "id " ++ show v
 showRtkToken (L.Tk__string v) = "string " ++ show v
@@ -1348,6 +1371,7 @@ showRtkToken (L.Tk__qq_ShiftOp v) = "qq_ShiftOp " ++ show v
 showRtkToken (L.Tk__qq_RelationalOp v) = "qq_RelationalOp " ++ show v
 showRtkToken (L.Tk__qq_EqualityOp v) = "qq_EqualityOp " ++ show v
 showRtkToken (L.Tk__qq_AssignmentOp v) = "qq_AssignmentOp " ++ show v
+showRtkToken (L.Tk__qq_LambdaBody v) = "qq_LambdaBody " ++ show v
 showRtkToken (L.Tk__qq_Expression v) = "qq_Expression " ++ show v
 showRtkToken (L.Tk__qq_SwitchStatement v) = "qq_SwitchStatement " ++ show v
 showRtkToken (L.Tk__qq_SwitchCaseList v) = "qq_SwitchCaseList " ++ show v
@@ -1541,6 +1565,9 @@ tkVal_qq_EqualityOp t = error ("rtk internal error: token qq_EqualityOp expected
 tkVal_qq_AssignmentOp :: L.PosToken -> String
 tkVal_qq_AssignmentOp (L.PosToken _ (L.Tk__qq_AssignmentOp v)) = v
 tkVal_qq_AssignmentOp t = error ("rtk internal error: token qq_AssignmentOp expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_LambdaBody :: L.PosToken -> String
+tkVal_qq_LambdaBody (L.PosToken _ (L.Tk__qq_LambdaBody v)) = v
+tkVal_qq_LambdaBody t = error ("rtk internal error: token qq_LambdaBody expected, got " ++ showRtkToken (L.ptToken t))
 tkVal_qq_Expression :: L.PosToken -> String
 tkVal_qq_Expression (L.PosToken _ (L.Tk__qq_Expression v)) = v
 tkVal_qq_Expression t = error ("rtk internal error: token qq_Expression expected, got " ++ showRtkToken (L.ptToken t))
@@ -1789,60 +1816,61 @@ data Java = Ctr__Java__0 RtkPos Java |
             Ctr__Java__37 RtkPos ImportName |
             Ctr__Java__38 RtkPos ImportStatement |
             Ctr__Java__39 RtkPos InterfaceDeclaration |
-            Ctr__Java__40 RtkPos Literal |
-            Ctr__Java__41 RtkPos LocalModifierList1 |
-            Ctr__Java__42 RtkPos MemberAfterFirstId |
-            Ctr__Java__43 RtkPos MemberDeclaration |
-            Ctr__Java__44 RtkPos MemberRest |
-            Ctr__Java__45 RtkPos Modifier |
-            Ctr__Java__46 RtkPos ModifierList |
-            Ctr__Java__47 RtkPos MoreTypeSpecifier |
-            Ctr__Java__48 RtkPos MoreVariableDeclarators |
-            Ctr__Java__49 RtkPos MultiplicativeOp |
-            Ctr__Java__50 RtkPos NonEmptyDims |
-            Ctr__Java__51 RtkPos NonEmptyTypeArguments |
-            Ctr__Java__52 RtkPos OptDocComment |
-            Ctr__Java__53 RtkPos OptElsePart |
-            Ctr__Java__54 RtkPos OptExpression |
-            Ctr__Java__55 RtkPos OptFinally |
-            Ctr__Java__56 RtkPos OptId |
-            Ctr__Java__57 RtkPos OptVariableInitializer |
-            Ctr__Java__58 RtkPos Package |
-            Ctr__Java__59 RtkPos ParamModifierList |
-            Ctr__Java__60 RtkPos Parameter |
-            Ctr__Java__61 RtkPos ParameterList |
-            Ctr__Java__62 RtkPos PostfixOp |
-            Ctr__Java__63 RtkPos PrefixOp |
-            Ctr__Java__64 RtkPos PrimitiveTypeKeyword |
-            Ctr__Java__65 RtkPos RelationalOp |
-            Ctr__Java__66 RtkPos Resource |
-            Ctr__Java__67 RtkPos ResourceSpec |
-            Ctr__Java__68 RtkPos ShiftOp |
-            Ctr__Java__69 RtkPos Statement |
-            Ctr__Java__70 RtkPos StatementBlock |
-            Ctr__Java__71 RtkPos StatementList |
-            Ctr__Java__72 RtkPos StaticInitializer |
-            Ctr__Java__73 RtkPos SwitchCaseList |
-            Ctr__Java__74 RtkPos SwitchStatement |
-            Ctr__Java__75 RtkPos ThrowsClause |
-            Ctr__Java__76 RtkPos TryStatement |
-            Ctr__Java__77 RtkPos Type |
-            Ctr__Java__78 RtkPos TypeArgument |
-            Ctr__Java__79 RtkPos TypeArguments |
-            Ctr__Java__80 RtkPos TypeDeclRest |
-            Ctr__Java__81 RtkPos TypeDeclaration |
-            Ctr__Java__82 RtkPos TypeParameter |
-            Ctr__Java__83 RtkPos TypeParameters |
-            Ctr__Java__84 RtkPos TypeSpecifier |
-            Ctr__Java__85 RtkPos VariableDeclaration |
-            Ctr__Java__86 RtkPos VariableDeclarator |
-            Ctr__Java__87 RtkPos VariableDeclaratorList |
-            Ctr__Java__88 RtkPos VariableInitializer |
-            Ctr__Java__89 RtkPos VariableInitializerList |
-            Ctr__Java__90 RtkPos WhileStatement |
-            Ctr__Java__91 RtkPos WildcardType |
+            Ctr__Java__40 RtkPos LambdaBody |
+            Ctr__Java__41 RtkPos Literal |
+            Ctr__Java__42 RtkPos LocalModifierList1 |
+            Ctr__Java__43 RtkPos MemberAfterFirstId |
+            Ctr__Java__44 RtkPos MemberDeclaration |
+            Ctr__Java__45 RtkPos MemberRest |
+            Ctr__Java__46 RtkPos Modifier |
+            Ctr__Java__47 RtkPos ModifierList |
+            Ctr__Java__48 RtkPos MoreTypeSpecifier |
+            Ctr__Java__49 RtkPos MoreVariableDeclarators |
+            Ctr__Java__50 RtkPos MultiplicativeOp |
+            Ctr__Java__51 RtkPos NonEmptyDims |
+            Ctr__Java__52 RtkPos NonEmptyTypeArguments |
+            Ctr__Java__53 RtkPos OptDocComment |
+            Ctr__Java__54 RtkPos OptElsePart |
+            Ctr__Java__55 RtkPos OptExpression |
+            Ctr__Java__56 RtkPos OptFinally |
+            Ctr__Java__57 RtkPos OptId |
+            Ctr__Java__58 RtkPos OptVariableInitializer |
+            Ctr__Java__59 RtkPos Package |
+            Ctr__Java__60 RtkPos ParamModifierList |
+            Ctr__Java__61 RtkPos Parameter |
+            Ctr__Java__62 RtkPos ParameterList |
+            Ctr__Java__63 RtkPos PostfixOp |
+            Ctr__Java__64 RtkPos PrefixOp |
+            Ctr__Java__65 RtkPos PrimitiveTypeKeyword |
+            Ctr__Java__66 RtkPos RelationalOp |
+            Ctr__Java__67 RtkPos Resource |
+            Ctr__Java__68 RtkPos ResourceSpec |
+            Ctr__Java__69 RtkPos ShiftOp |
+            Ctr__Java__70 RtkPos Statement |
+            Ctr__Java__71 RtkPos StatementBlock |
+            Ctr__Java__72 RtkPos StatementList |
+            Ctr__Java__73 RtkPos StaticInitializer |
+            Ctr__Java__74 RtkPos SwitchCaseList |
+            Ctr__Java__75 RtkPos SwitchStatement |
+            Ctr__Java__76 RtkPos ThrowsClause |
+            Ctr__Java__77 RtkPos TryStatement |
+            Ctr__Java__78 RtkPos Type |
+            Ctr__Java__79 RtkPos TypeArgument |
+            Ctr__Java__80 RtkPos TypeArguments |
+            Ctr__Java__81 RtkPos TypeDeclRest |
+            Ctr__Java__82 RtkPos TypeDeclaration |
+            Ctr__Java__83 RtkPos TypeParameter |
+            Ctr__Java__84 RtkPos TypeParameters |
+            Ctr__Java__85 RtkPos TypeSpecifier |
+            Ctr__Java__86 RtkPos VariableDeclaration |
+            Ctr__Java__87 RtkPos VariableDeclarator |
+            Ctr__Java__88 RtkPos VariableDeclaratorList |
+            Ctr__Java__89 RtkPos VariableInitializer |
+            Ctr__Java__90 RtkPos VariableInitializerList |
+            Ctr__Java__91 RtkPos WhileStatement |
+            Ctr__Java__92 RtkPos WildcardType |
             Anti_Java String |
-            Ctr__Java__92 RtkPos CompilationUnit
+            Ctr__Java__93 RtkPos CompilationUnit
             deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Java where
     rtkPosOf (Ctr__Java__0 p _) = p
@@ -1937,8 +1965,9 @@ instance RtkPosOf Java where
     rtkPosOf (Ctr__Java__89 p _) = p
     rtkPosOf (Ctr__Java__90 p _) = p
     rtkPosOf (Ctr__Java__91 p _) = p
-    rtkPosOf (Anti_Java _) = rtkNoPos
     rtkPosOf (Ctr__Java__92 p _) = p
+    rtkPosOf (Anti_Java _) = rtkNoPos
+    rtkPosOf (Ctr__Java__93 p _) = p
 data AdditiveOp = Anti_AdditiveOp String |
                   Ctr__AdditiveOp__0 RtkPos |
                   Ctr__AdditiveOp__1 RtkPos
@@ -1983,7 +2012,7 @@ instance RtkPosOf AnnotationTypeElement where
 type AnnotationTypeElementList = [AnnotationTypeElement]
 data Arglist = Anti_Arglist String |
                Ctr__Arglist__0 RtkPos |
-               Ctr__Arglist__1 RtkPos Rule_86
+               Ctr__Arglist__1 RtkPos Rule_88
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Arglist where
     rtkPosOf (Anti_Arglist _) = rtkNoPos
@@ -2048,14 +2077,14 @@ data CompoundName = Anti_CompoundName String |
 instance RtkPosOf CompoundName where
     rtkPosOf (Anti_CompoundName _) = rtkNoPos
     rtkPosOf (Ctr__CompoundName__0 p _ _) = p
-type CompoundNameTail = [Rule_98]
+type CompoundNameTail = [Rule_100]
 data CreationExpression = Anti_CreationExpression String |
-                          Ctr__CreationExpression__0 RtkPos TypeSpecifier Rule_82
+                          Ctr__CreationExpression__0 RtkPos TypeSpecifier Rule_84
                           deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf CreationExpression where
     rtkPosOf (Anti_CreationExpression _) = rtkNoPos
     rtkPosOf (Ctr__CreationExpression__0 p _ _) = p
-type DimExprs = [Rule_84]
+type DimExprs = [Rule_86]
 type Dims = [Rule_31]
 data DoStatement = Anti_DoStatement String |
                    Ctr__DoStatement__0 RtkPos Statement Expression
@@ -2100,9 +2129,9 @@ data Expression = Anti_Expression String |
                   Ctr__Expression__1 RtkPos |
                   Ctr__Expression__2 RtkPos Expression |
                   Ctr__Expression__3 RtkPos CreationExpression |
-                  Ctr__Expression__4 RtkPos CompoundName Rule_78 |
+                  Ctr__Expression__4 RtkPos CompoundName Rule_80 |
                   Ctr__Expression__5 RtkPos CompoundName Expression |
-                  Ctr__Expression__6 RtkPos String Rule_80 |
+                  Ctr__Expression__6 RtkPos String Rule_82 |
                   Ctr__Expression__7 RtkPos String CompoundNameTail |
                   Ctr__Expression__8 RtkPos String CompoundNameTail |
                   Ctr__Expression__9 RtkPos String CompoundNameTail NonEmptyTypeArguments String Arglist |
@@ -2113,29 +2142,29 @@ data Expression = Anti_Expression String |
                   Ctr__Expression__14 RtkPos Expression String Arglist |
                   Ctr__Expression__15 RtkPos Expression NonEmptyTypeArguments String Arglist |
                   Ctr__Expression__16 RtkPos Expression Expression |
-                  Ctr__Expression__17 RtkPos Expression |
+                  Ctr__Expression__17 RtkPos Expression String |
                   Ctr__Expression__18 RtkPos Expression |
                   Ctr__Expression__19 RtkPos Expression |
                   Ctr__Expression__20 RtkPos Expression |
-                  Ctr__Expression__21 RtkPos PrefixOp Expression |
+                  Ctr__Expression__21 RtkPos Expression |
                   Ctr__Expression__22 RtkPos Expression |
-                  Ctr__Expression__23 RtkPos PrimitiveTypeKeyword Dims Expression |
-                  Ctr__Expression__24 RtkPos CompoundName NonEmptyTypeArguments Dims Expression |
-                  Ctr__Expression__25 RtkPos CompoundName NonEmptyDims Expression |
-                  Ctr__Expression__26 RtkPos Expression Expression |
-                  Ctr__Expression__27 RtkPos Expression |
-                  Ctr__Expression__28 RtkPos Expression MultiplicativeOp Expression |
+                  Ctr__Expression__23 RtkPos PrefixOp Expression |
+                  Ctr__Expression__24 RtkPos Expression |
+                  Ctr__Expression__25 RtkPos PrimitiveTypeKeyword Dims Expression |
+                  Ctr__Expression__26 RtkPos CompoundName NonEmptyTypeArguments Dims Expression |
+                  Ctr__Expression__27 RtkPos CompoundName NonEmptyDims Expression |
+                  Ctr__Expression__28 RtkPos Expression Expression |
                   Ctr__Expression__29 RtkPos Expression |
-                  Ctr__Expression__30 RtkPos Expression AdditiveOp Expression |
+                  Ctr__Expression__30 RtkPos Expression MultiplicativeOp Expression |
                   Ctr__Expression__31 RtkPos Expression |
-                  Ctr__Expression__32 RtkPos Expression ShiftOp Expression |
+                  Ctr__Expression__32 RtkPos Expression AdditiveOp Expression |
                   Ctr__Expression__33 RtkPos Expression |
-                  Ctr__Expression__34 RtkPos Expression RelationalOp Expression |
-                  Ctr__Expression__35 RtkPos Expression Type |
-                  Ctr__Expression__36 RtkPos Expression |
-                  Ctr__Expression__37 RtkPos Expression EqualityOp Expression |
+                  Ctr__Expression__34 RtkPos Expression ShiftOp Expression |
+                  Ctr__Expression__35 RtkPos Expression |
+                  Ctr__Expression__36 RtkPos Expression RelationalOp Expression |
+                  Ctr__Expression__37 RtkPos Expression Type |
                   Ctr__Expression__38 RtkPos Expression |
-                  Ctr__Expression__39 RtkPos Expression Expression |
+                  Ctr__Expression__39 RtkPos Expression EqualityOp Expression |
                   Ctr__Expression__40 RtkPos Expression |
                   Ctr__Expression__41 RtkPos Expression Expression |
                   Ctr__Expression__42 RtkPos Expression |
@@ -2145,9 +2174,15 @@ data Expression = Anti_Expression String |
                   Ctr__Expression__46 RtkPos Expression |
                   Ctr__Expression__47 RtkPos Expression Expression |
                   Ctr__Expression__48 RtkPos Expression |
-                  Ctr__Expression__49 RtkPos Expression Expression Expression |
-                  Ctr__Expression__50 RtkPos Expression Rule_76 |
-                  Ctr__Expression__51 RtkPos Expression
+                  Ctr__Expression__49 RtkPos Expression Expression |
+                  Ctr__Expression__50 RtkPos Expression |
+                  Ctr__Expression__51 RtkPos Expression Expression Expression |
+                  Ctr__Expression__52 RtkPos Expression Rule_76 |
+                  Ctr__Expression__53 RtkPos String LambdaBody |
+                  Ctr__Expression__54 RtkPos LambdaBody |
+                  Ctr__Expression__55 RtkPos String Rule_78 LambdaBody |
+                  Ctr__Expression__56 RtkPos Expression LambdaBody |
+                  Ctr__Expression__57 RtkPos Expression
                   deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Expression where
     rtkPosOf (Anti_Expression _) = rtkNoPos
@@ -2168,29 +2203,29 @@ instance RtkPosOf Expression where
     rtkPosOf (Ctr__Expression__14 p _ _ _) = p
     rtkPosOf (Ctr__Expression__15 p _ _ _ _) = p
     rtkPosOf (Ctr__Expression__16 p _ _) = p
-    rtkPosOf (Ctr__Expression__17 p _) = p
+    rtkPosOf (Ctr__Expression__17 p _ _) = p
     rtkPosOf (Ctr__Expression__18 p _) = p
     rtkPosOf (Ctr__Expression__19 p _) = p
     rtkPosOf (Ctr__Expression__20 p _) = p
-    rtkPosOf (Ctr__Expression__21 p _ _) = p
+    rtkPosOf (Ctr__Expression__21 p _) = p
     rtkPosOf (Ctr__Expression__22 p _) = p
-    rtkPosOf (Ctr__Expression__23 p _ _ _) = p
-    rtkPosOf (Ctr__Expression__24 p _ _ _ _) = p
+    rtkPosOf (Ctr__Expression__23 p _ _) = p
+    rtkPosOf (Ctr__Expression__24 p _) = p
     rtkPosOf (Ctr__Expression__25 p _ _ _) = p
-    rtkPosOf (Ctr__Expression__26 p _ _) = p
-    rtkPosOf (Ctr__Expression__27 p _) = p
-    rtkPosOf (Ctr__Expression__28 p _ _ _) = p
+    rtkPosOf (Ctr__Expression__26 p _ _ _ _) = p
+    rtkPosOf (Ctr__Expression__27 p _ _ _) = p
+    rtkPosOf (Ctr__Expression__28 p _ _) = p
     rtkPosOf (Ctr__Expression__29 p _) = p
     rtkPosOf (Ctr__Expression__30 p _ _ _) = p
     rtkPosOf (Ctr__Expression__31 p _) = p
     rtkPosOf (Ctr__Expression__32 p _ _ _) = p
     rtkPosOf (Ctr__Expression__33 p _) = p
     rtkPosOf (Ctr__Expression__34 p _ _ _) = p
-    rtkPosOf (Ctr__Expression__35 p _ _) = p
-    rtkPosOf (Ctr__Expression__36 p _) = p
-    rtkPosOf (Ctr__Expression__37 p _ _ _) = p
+    rtkPosOf (Ctr__Expression__35 p _) = p
+    rtkPosOf (Ctr__Expression__36 p _ _ _) = p
+    rtkPosOf (Ctr__Expression__37 p _ _) = p
     rtkPosOf (Ctr__Expression__38 p _) = p
-    rtkPosOf (Ctr__Expression__39 p _ _) = p
+    rtkPosOf (Ctr__Expression__39 p _ _ _) = p
     rtkPosOf (Ctr__Expression__40 p _) = p
     rtkPosOf (Ctr__Expression__41 p _ _) = p
     rtkPosOf (Ctr__Expression__42 p _) = p
@@ -2200,9 +2235,15 @@ instance RtkPosOf Expression where
     rtkPosOf (Ctr__Expression__46 p _) = p
     rtkPosOf (Ctr__Expression__47 p _ _) = p
     rtkPosOf (Ctr__Expression__48 p _) = p
-    rtkPosOf (Ctr__Expression__49 p _ _ _) = p
-    rtkPosOf (Ctr__Expression__50 p _ _) = p
-    rtkPosOf (Ctr__Expression__51 p _) = p
+    rtkPosOf (Ctr__Expression__49 p _ _) = p
+    rtkPosOf (Ctr__Expression__50 p _) = p
+    rtkPosOf (Ctr__Expression__51 p _ _ _) = p
+    rtkPosOf (Ctr__Expression__52 p _ _) = p
+    rtkPosOf (Ctr__Expression__53 p _ _) = p
+    rtkPosOf (Ctr__Expression__54 p _) = p
+    rtkPosOf (Ctr__Expression__55 p _ _ _) = p
+    rtkPosOf (Ctr__Expression__56 p _ _) = p
+    rtkPosOf (Ctr__Expression__57 p _) = p
 data ExtendsList = Anti_ExtendsList String |
                    Ctr__ExtendsList__0 RtkPos ClassOrInterfaceType Rule_12
                    deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
@@ -2275,6 +2316,14 @@ data InterfaceDeclaration = Anti_InterfaceDeclaration String |
 instance RtkPosOf InterfaceDeclaration where
     rtkPosOf (Anti_InterfaceDeclaration _) = rtkNoPos
     rtkPosOf (Ctr__InterfaceDeclaration__0 p _ _ _ _) = p
+data LambdaBody = Anti_LambdaBody String |
+                  Ctr__LambdaBody__0 RtkPos Expression |
+                  Ctr__LambdaBody__1 RtkPos StatementBlock
+                  deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf LambdaBody where
+    rtkPosOf (Anti_LambdaBody _) = rtkNoPos
+    rtkPosOf (Ctr__LambdaBody__0 p _) = p
+    rtkPosOf (Ctr__LambdaBody__1 p _) = p
 data Literal = Anti_Literal String |
                Ctr__Literal__0 RtkPos String |
                Ctr__Literal__1 RtkPos String |
@@ -2366,7 +2415,7 @@ instance RtkPosOf MultiplicativeOp where
     rtkPosOf (Ctr__MultiplicativeOp__2 p) = p
 type NonEmptyDims = [Rule_33]
 data NonEmptyTypeArguments = Anti_NonEmptyTypeArguments String |
-                             Ctr__NonEmptyTypeArguments__0 RtkPos TypeArgument Rule_89 |
+                             Ctr__NonEmptyTypeArguments__0 RtkPos TypeArgument Rule_91 |
                              Ctr__NonEmptyTypeArguments__1 RtkPos
                              deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf NonEmptyTypeArguments where
@@ -2520,6 +2569,12 @@ instance RtkPosOf Rule_10 where
     rtkPosOf (Anti_Rule_10 _) = rtkNoPos
     rtkPosOf (Ctr__Rule_10__1 p _) = p
     rtkPosOf (Ctr__Rule_10__2 p _) = p
+data Rule_100 = Anti_Rule_100 String |
+                Ctr__Rule_100__1 RtkPos String
+                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_100 where
+    rtkPosOf (Anti_Rule_100 _) = rtkNoPos
+    rtkPosOf (Ctr__Rule_100__1 p _) = p
 type Rule_12 = [Rule_13]
 data Rule_13 = Ctr__Rule_13__0 RtkPos ClassOrInterfaceType
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
@@ -2816,13 +2871,8 @@ data Rule_77 = Ctr__Rule_77__0 RtkPos AssignmentOp Expression
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_77 where
     rtkPosOf (Ctr__Rule_77__0 p _ _) = p
-data Rule_78 = Ctr__Rule_78__0 RtkPos |
-               Ctr__Rule_78__1 RtkPos Rule_79
-               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-instance RtkPosOf Rule_78 where
-    rtkPosOf (Ctr__Rule_78__0 p) = p
-    rtkPosOf (Ctr__Rule_78__1 p _) = p
-data Rule_79 = Ctr__Rule_79__0 RtkPos Arglist
+type Rule_78 = [Rule_79]
+data Rule_79 = Ctr__Rule_79__0 RtkPos String
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_79 where
     rtkPosOf (Ctr__Rule_79__0 p _) = p
@@ -2840,68 +2890,72 @@ data Rule_81 = Ctr__Rule_81__0 RtkPos Arglist
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_81 where
     rtkPosOf (Ctr__Rule_81__0 p _) = p
-data Rule_82 = Ctr__Rule_82__0 RtkPos Arglist |
-               Ctr__Rule_82__1 RtkPos DimExprs Rule_83
+data Rule_82 = Ctr__Rule_82__0 RtkPos |
+               Ctr__Rule_82__1 RtkPos Rule_83
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_82 where
-    rtkPosOf (Ctr__Rule_82__0 p _) = p
-    rtkPosOf (Ctr__Rule_82__1 p _ _) = p
-data Rule_83 = Ctr__Rule_83__0 RtkPos |
-               Ctr__Rule_83__1 RtkPos NonEmptyDims
+    rtkPosOf (Ctr__Rule_82__0 p) = p
+    rtkPosOf (Ctr__Rule_82__1 p _) = p
+data Rule_83 = Ctr__Rule_83__0 RtkPos Arglist
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_83 where
-    rtkPosOf (Ctr__Rule_83__0 p) = p
-    rtkPosOf (Ctr__Rule_83__1 p _) = p
-data Rule_84 = Anti_Rule_84 String |
-               Ctr__Rule_84__1 RtkPos Expression
+    rtkPosOf (Ctr__Rule_83__0 p _) = p
+data Rule_84 = Ctr__Rule_84__0 RtkPos Arglist |
+               Ctr__Rule_84__1 RtkPos DimExprs Rule_85
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_84 where
-    rtkPosOf (Anti_Rule_84 _) = rtkNoPos
-    rtkPosOf (Ctr__Rule_84__1 p _) = p
-data Rule_86 = Ctr__Rule_86__0 RtkPos Expression Rule_87
+    rtkPosOf (Ctr__Rule_84__0 p _) = p
+    rtkPosOf (Ctr__Rule_84__1 p _ _) = p
+data Rule_85 = Ctr__Rule_85__0 RtkPos |
+               Ctr__Rule_85__1 RtkPos NonEmptyDims
+               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_85 where
+    rtkPosOf (Ctr__Rule_85__0 p) = p
+    rtkPosOf (Ctr__Rule_85__1 p _) = p
+data Rule_86 = Anti_Rule_86 String |
+               Ctr__Rule_86__1 RtkPos Expression
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_86 where
-    rtkPosOf (Ctr__Rule_86__0 p _ _) = p
-type Rule_87 = [Rule_88]
-data Rule_88 = Ctr__Rule_88__0 RtkPos Expression
+    rtkPosOf (Anti_Rule_86 _) = rtkNoPos
+    rtkPosOf (Ctr__Rule_86__1 p _) = p
+data Rule_88 = Ctr__Rule_88__0 RtkPos Expression Rule_89
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_88 where
-    rtkPosOf (Ctr__Rule_88__0 p _) = p
+    rtkPosOf (Ctr__Rule_88__0 p _ _) = p
 type Rule_89 = [Rule_90]
-data Rule_90 = Ctr__Rule_90__0 RtkPos TypeArgument
+data Rule_90 = Ctr__Rule_90__0 RtkPos Expression
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_90 where
     rtkPosOf (Ctr__Rule_90__0 p _) = p
-data Rule_91 = Ctr__Rule_91__0 RtkPos TypeParameter Rule_92
+type Rule_91 = [Rule_92]
+data Rule_92 = Ctr__Rule_92__0 RtkPos TypeArgument
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-instance RtkPosOf Rule_91 where
-    rtkPosOf (Ctr__Rule_91__0 p _ _) = p
-type Rule_92 = [Rule_93]
-data Rule_93 = Ctr__Rule_93__0 RtkPos TypeParameter
+instance RtkPosOf Rule_92 where
+    rtkPosOf (Ctr__Rule_92__0 p _) = p
+data Rule_93 = Ctr__Rule_93__0 RtkPos TypeParameter Rule_94
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_93 where
-    rtkPosOf (Ctr__Rule_93__0 p _) = p
-data Rule_94 = Ctr__Rule_94__0 RtkPos |
-               Ctr__Rule_94__1 RtkPos Rule_95
-               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-instance RtkPosOf Rule_94 where
-    rtkPosOf (Ctr__Rule_94__0 p) = p
-    rtkPosOf (Ctr__Rule_94__1 p _) = p
-data Rule_95 = Ctr__Rule_95__0 RtkPos Type Rule_96
+    rtkPosOf (Ctr__Rule_93__0 p _ _) = p
+type Rule_94 = [Rule_95]
+data Rule_95 = Ctr__Rule_95__0 RtkPos TypeParameter
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_95 where
-    rtkPosOf (Ctr__Rule_95__0 p _ _) = p
-type Rule_96 = [Rule_97]
-data Rule_97 = Ctr__Rule_97__0 RtkPos Type
+    rtkPosOf (Ctr__Rule_95__0 p _) = p
+data Rule_96 = Ctr__Rule_96__0 RtkPos |
+               Ctr__Rule_96__1 RtkPos Rule_97
+               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_96 where
+    rtkPosOf (Ctr__Rule_96__0 p) = p
+    rtkPosOf (Ctr__Rule_96__1 p _) = p
+data Rule_97 = Ctr__Rule_97__0 RtkPos Type Rule_98
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_97 where
-    rtkPosOf (Ctr__Rule_97__0 p _) = p
-data Rule_98 = Anti_Rule_98 String |
-               Ctr__Rule_98__1 RtkPos String
+    rtkPosOf (Ctr__Rule_97__0 p _ _) = p
+type Rule_98 = [Rule_99]
+data Rule_99 = Ctr__Rule_99__0 RtkPos Type
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-instance RtkPosOf Rule_98 where
-    rtkPosOf (Anti_Rule_98 _) = rtkNoPos
-    rtkPosOf (Ctr__Rule_98__1 p _) = p
+instance RtkPosOf Rule_99 where
+    rtkPosOf (Ctr__Rule_99__0 p _) = p
 data ShiftOp = Anti_ShiftOp String |
                Ctr__ShiftOp__0 RtkPos |
                Ctr__ShiftOp__1 RtkPos |
@@ -3033,14 +3087,14 @@ instance RtkPosOf TypeDeclaration where
     rtkPosOf (Anti_TypeDeclaration _) = rtkNoPos
     rtkPosOf (Ctr__TypeDeclaration__0 p _ _ _) = p
 data TypeParameter = Anti_TypeParameter String |
-                     Ctr__TypeParameter__0 RtkPos String Rule_94
+                     Ctr__TypeParameter__0 RtkPos String Rule_96
                      deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf TypeParameter where
     rtkPosOf (Anti_TypeParameter _) = rtkNoPos
     rtkPosOf (Ctr__TypeParameter__0 p _ _) = p
 data TypeParameters = Anti_TypeParameters String |
                       Ctr__TypeParameters__0 RtkPos |
-                      Ctr__TypeParameters__1 RtkPos Rule_91
+                      Ctr__TypeParameters__1 RtkPos Rule_93
                       deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf TypeParameters where
     rtkPosOf (Anti_TypeParameters _) = rtkNoPos

--- a/test/golden/java/JavaQQ.hs
+++ b/test/golden/java/JavaQQ.hs
@@ -64,7 +64,7 @@ rtkRenderError err =
                 _ -> err
         _ -> err
 
-qqShortcuts = M.fromList [ ("java","Java"),("additiveOp","AdditiveOp"),("annotation","Annotation"),("annotationArguments","AnnotationArguments"),("annotationDeclaration","AnnotationDeclaration"),("annotationElement","AnnotationElement"),("annotationList","AnnotationList"),("annotationTypeElement","AnnotationTypeElement"),("annotationTypeElementList","AnnotationTypeElementList"),("arglist","Arglist"),("assignmentOp","AssignmentOp"),("catchList","CatchList"),("catchParameter","CatchParameter"),("classDeclaration","ClassDeclaration"),("classOrInterfaceType","ClassOrInterfaceType"),("compilationUnit","CompilationUnit"),("compoundName","CompoundName"),("compoundNameTail","CompoundNameTail"),("creationExpression","CreationExpression"),("dimExprs","DimExprs"),("dims","Dims"),("doStatement","DoStatement"),("docComment","DocComment"),("enumConstant","EnumConstant"),("enumConstantList","EnumConstantList"),("enumDeclaration","EnumDeclaration"),("equalityOp","EqualityOp"),("expression","Expression"),("extendsList","ExtendsList"),("fieldDeclaration","FieldDeclaration"),("fieldDeclarationList","FieldDeclarationList"),("forEachHeader","ForEachHeader"),("forStatement","ForStatement"),("ifStatement","IfStatement"),("implementsList","ImplementsList"),("importHead","ImportHead"),("importList","ImportList"),("importName","ImportName"),("importStatement","ImportStatement"),("interfaceDeclaration","InterfaceDeclaration"),("literal","Literal"),("localModifierList1","LocalModifierList1"),("memberAfterFirstId","MemberAfterFirstId"),("memberDeclaration","MemberDeclaration"),("memberRest","MemberRest"),("modifier","Modifier"),("modifierList","ModifierList"),("moreTypeSpecifier","MoreTypeSpecifier"),("moreVariableDeclarators","MoreVariableDeclarators"),("multiplicativeOp","MultiplicativeOp"),("nonEmptyDims","NonEmptyDims"),("nonEmptyTypeArguments","NonEmptyTypeArguments"),("optDocComment","OptDocComment"),("optElsePart","OptElsePart"),("optExpression","OptExpression"),("optFinally","OptFinally"),("optId","OptId"),("optVariableInitializer","OptVariableInitializer"),("package","Package"),("paramModifierList","ParamModifierList"),("parameter","Parameter"),("parameterList","ParameterList"),("postfixOp","PostfixOp"),("prefixOp","PrefixOp"),("primitiveTypeKeyword","PrimitiveTypeKeyword"),("relationalOp","RelationalOp"),("resource","Resource"),("resourceSpec","ResourceSpec"),("shiftOp","ShiftOp"),("statement","Statement"),("statementBlock","StatementBlock"),("statementList","StatementList"),("staticInitializer","StaticInitializer"),("switchCaseList","SwitchCaseList"),("switchStatement","SwitchStatement"),("throwsClause","ThrowsClause"),("tryStatement","TryStatement"),("type","Type"),("typeArgument","TypeArgument"),("typeArguments","TypeArguments"),("typeDeclRest","TypeDeclRest"),("typeDeclaration","TypeDeclaration"),("typeParameter","TypeParameter"),("typeParameters","TypeParameters"),("typeSpecifier","TypeSpecifier"),("variableDeclaration","VariableDeclaration"),("variableDeclarator","VariableDeclarator"),("variableDeclaratorList","VariableDeclaratorList"),("variableInitializer","VariableInitializer"),("variableInitializerList","VariableInitializerList"),("whileStatement","WhileStatement"),("wildcardType","WildcardType")]
+qqShortcuts = M.fromList [ ("java","Java"),("additiveOp","AdditiveOp"),("annotation","Annotation"),("annotationArguments","AnnotationArguments"),("annotationDeclaration","AnnotationDeclaration"),("annotationElement","AnnotationElement"),("annotationList","AnnotationList"),("annotationTypeElement","AnnotationTypeElement"),("annotationTypeElementList","AnnotationTypeElementList"),("arglist","Arglist"),("assignmentOp","AssignmentOp"),("catchList","CatchList"),("catchParameter","CatchParameter"),("classDeclaration","ClassDeclaration"),("classOrInterfaceType","ClassOrInterfaceType"),("compilationUnit","CompilationUnit"),("compoundName","CompoundName"),("compoundNameTail","CompoundNameTail"),("creationExpression","CreationExpression"),("dimExprs","DimExprs"),("dims","Dims"),("doStatement","DoStatement"),("docComment","DocComment"),("enumConstant","EnumConstant"),("enumConstantList","EnumConstantList"),("enumDeclaration","EnumDeclaration"),("equalityOp","EqualityOp"),("expression","Expression"),("extendsList","ExtendsList"),("fieldDeclaration","FieldDeclaration"),("fieldDeclarationList","FieldDeclarationList"),("forEachHeader","ForEachHeader"),("forStatement","ForStatement"),("ifStatement","IfStatement"),("implementsList","ImplementsList"),("importHead","ImportHead"),("importList","ImportList"),("importName","ImportName"),("importStatement","ImportStatement"),("interfaceDeclaration","InterfaceDeclaration"),("lambdaBody","LambdaBody"),("literal","Literal"),("localModifierList1","LocalModifierList1"),("memberAfterFirstId","MemberAfterFirstId"),("memberDeclaration","MemberDeclaration"),("memberRest","MemberRest"),("modifier","Modifier"),("modifierList","ModifierList"),("moreTypeSpecifier","MoreTypeSpecifier"),("moreVariableDeclarators","MoreVariableDeclarators"),("multiplicativeOp","MultiplicativeOp"),("nonEmptyDims","NonEmptyDims"),("nonEmptyTypeArguments","NonEmptyTypeArguments"),("optDocComment","OptDocComment"),("optElsePart","OptElsePart"),("optExpression","OptExpression"),("optFinally","OptFinally"),("optId","OptId"),("optVariableInitializer","OptVariableInitializer"),("package","Package"),("paramModifierList","ParamModifierList"),("parameter","Parameter"),("parameterList","ParameterList"),("postfixOp","PostfixOp"),("prefixOp","PrefixOp"),("primitiveTypeKeyword","PrimitiveTypeKeyword"),("relationalOp","RelationalOp"),("resource","Resource"),("resourceSpec","ResourceSpec"),("shiftOp","ShiftOp"),("statement","Statement"),("statementBlock","StatementBlock"),("statementList","StatementList"),("staticInitializer","StaticInitializer"),("switchCaseList","SwitchCaseList"),("switchStatement","SwitchStatement"),("throwsClause","ThrowsClause"),("tryStatement","TryStatement"),("type","Type"),("typeArgument","TypeArgument"),("typeArguments","TypeArguments"),("typeDeclRest","TypeDeclRest"),("typeDeclaration","TypeDeclaration"),("typeParameter","TypeParameter"),("typeParameters","TypeParameters"),("typeSpecifier","TypeSpecifier"),("variableDeclaration","VariableDeclaration"),("variableDeclarator","VariableDeclarator"),("variableDeclaratorList","VariableDeclaratorList"),("variableInitializer","VariableInitializer"),("variableInitializerList","VariableInitializerList"),("whileStatement","WhileStatement"),("wildcardType","WildcardType")]
 
 -- A quasi-quote pattern must match an AST parsed from anywhere in a source
 -- file, while the pattern itself was parsed from the quote body - so every
@@ -81,7 +81,7 @@ quoteJavaExp dummy func s = do
            Left err -> fail (rtkRenderError err)
            Right a -> return a
   let expr = func ast
-  dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiClassOrInterfaceTypeExp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiForEachHeaderExp `Generics.extQ` antiRule_65Exp `Generics.extQ` antiCatchParameterExp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiResourceSpecExp `Generics.extQ` antiResourceExp `Generics.extQ` antiRule_74Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_84Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiRule_98Exp `Generics.extQ` antiCompoundNameExp) expr
+  dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiClassOrInterfaceTypeExp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiForEachHeaderExp `Generics.extQ` antiRule_65Exp `Generics.extQ` antiCatchParameterExp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiResourceSpecExp `Generics.extQ` antiResourceExp `Generics.extQ` antiRule_74Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiLambdaBodyExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_86Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiRule_100Exp `Generics.extQ` antiCompoundNameExp) expr
 quoteJavaPat :: Data.Data a => String -> (Java -> a) -> String -> TH.PatQ
 quoteJavaPat dummy func s = do
   s1 <- either fail return (replaceAllPatterns s)
@@ -89,19 +89,19 @@ quoteJavaPat dummy func s = do
            Left err -> fail (rtkRenderError err)
            Right a -> return a
   let expr = func ast
-  dataToPatQ (const Nothing `Generics.extQ` rtkPosWildPat `Generics.extQ` antiJavaPat `Generics.extQ` antiOptDocCommentPat `Generics.extQ` antiTypeDeclarationPat `Generics.extQ` antiImportStatementPat `Generics.extQ` antiCompilationUnitPat `Generics.extQ` antiPackagePat `Generics.extQ` antiImportNamePat `Generics.extQ` antiImportHeadPat `Generics.extQ` antiDocCommentPat `Generics.extQ` antiAnnotationPat `Generics.extQ` antiAnnotationArgumentsPat `Generics.extQ` antiAnnotationElementPat `Generics.extQ` antiRule_10Pat `Generics.extQ` antiClassOrInterfaceTypePat `Generics.extQ` antiExtendsListPat `Generics.extQ` antiImplementsListPat `Generics.extQ` antiFieldDeclarationPat `Generics.extQ` antiClassDeclarationPat `Generics.extQ` antiInterfaceDeclarationPat `Generics.extQ` antiAnnotationDeclarationPat `Generics.extQ` antiAnnotationTypeElementPat `Generics.extQ` antiEnumConstantPat `Generics.extQ` antiEnumConstantListPat `Generics.extQ` antiEnumDeclarationPat `Generics.extQ` antiTypeDeclRestPat `Generics.extQ` antiRule_31Pat `Generics.extQ` antiRule_33Pat `Generics.extQ` antiMemberDeclarationPat `Generics.extQ` antiPrimitiveTypeKeywordPat `Generics.extQ` antiMemberAfterFirstIdPat `Generics.extQ` antiMoreTypeSpecifierPat `Generics.extQ` antiThrowsClausePat `Generics.extQ` antiMemberRestPat `Generics.extQ` antiRule_44Pat `Generics.extQ` antiStatementBlockPat `Generics.extQ` antiVariableDeclaratorListPat `Generics.extQ` antiVariableDeclarationPat `Generics.extQ` antiRule_48Pat `Generics.extQ` antiOptVariableInitializerPat `Generics.extQ` antiVariableDeclaratorPat `Generics.extQ` antiVariableInitializerListPat `Generics.extQ` antiVariableInitializerPat `Generics.extQ` antiStaticInitializerPat `Generics.extQ` antiParameterListPat `Generics.extQ` antiRule_57Pat `Generics.extQ` antiParameterPat `Generics.extQ` antiStatementPat `Generics.extQ` antiOptExpressionPat `Generics.extQ` antiOptIdPat `Generics.extQ` antiOptElsePartPat `Generics.extQ` antiIfStatementPat `Generics.extQ` antiDoStatementPat `Generics.extQ` antiWhileStatementPat `Generics.extQ` antiForStatementPat `Generics.extQ` antiForEachHeaderPat `Generics.extQ` antiRule_65Pat `Generics.extQ` antiCatchParameterPat `Generics.extQ` antiOptFinallyPat `Generics.extQ` antiTryStatementPat `Generics.extQ` antiResourceSpecPat `Generics.extQ` antiResourcePat `Generics.extQ` antiRule_74Pat `Generics.extQ` antiSwitchStatementPat `Generics.extQ` antiExpressionPat `Generics.extQ` antiAssignmentOpPat `Generics.extQ` antiEqualityOpPat `Generics.extQ` antiRelationalOpPat `Generics.extQ` antiShiftOpPat `Generics.extQ` antiAdditiveOpPat `Generics.extQ` antiMultiplicativeOpPat `Generics.extQ` antiPrefixOpPat `Generics.extQ` antiPostfixOpPat `Generics.extQ` antiCreationExpressionPat `Generics.extQ` antiRule_84Pat `Generics.extQ` antiLiteralPat `Generics.extQ` antiArglistPat `Generics.extQ` antiTypeArgumentsPat `Generics.extQ` antiNonEmptyTypeArgumentsPat `Generics.extQ` antiTypeArgumentPat `Generics.extQ` antiWildcardTypePat `Generics.extQ` antiTypeParametersPat `Generics.extQ` antiTypeParameterPat `Generics.extQ` antiTypePat `Generics.extQ` antiTypeSpecifierPat `Generics.extQ` antiModifierPat `Generics.extQ` antiRule_98Pat `Generics.extQ` antiCompoundNamePat) expr
+  dataToPatQ (const Nothing `Generics.extQ` rtkPosWildPat `Generics.extQ` antiJavaPat `Generics.extQ` antiOptDocCommentPat `Generics.extQ` antiTypeDeclarationPat `Generics.extQ` antiImportStatementPat `Generics.extQ` antiCompilationUnitPat `Generics.extQ` antiPackagePat `Generics.extQ` antiImportNamePat `Generics.extQ` antiImportHeadPat `Generics.extQ` antiDocCommentPat `Generics.extQ` antiAnnotationPat `Generics.extQ` antiAnnotationArgumentsPat `Generics.extQ` antiAnnotationElementPat `Generics.extQ` antiRule_10Pat `Generics.extQ` antiClassOrInterfaceTypePat `Generics.extQ` antiExtendsListPat `Generics.extQ` antiImplementsListPat `Generics.extQ` antiFieldDeclarationPat `Generics.extQ` antiClassDeclarationPat `Generics.extQ` antiInterfaceDeclarationPat `Generics.extQ` antiAnnotationDeclarationPat `Generics.extQ` antiAnnotationTypeElementPat `Generics.extQ` antiEnumConstantPat `Generics.extQ` antiEnumConstantListPat `Generics.extQ` antiEnumDeclarationPat `Generics.extQ` antiTypeDeclRestPat `Generics.extQ` antiRule_31Pat `Generics.extQ` antiRule_33Pat `Generics.extQ` antiMemberDeclarationPat `Generics.extQ` antiPrimitiveTypeKeywordPat `Generics.extQ` antiMemberAfterFirstIdPat `Generics.extQ` antiMoreTypeSpecifierPat `Generics.extQ` antiThrowsClausePat `Generics.extQ` antiMemberRestPat `Generics.extQ` antiRule_44Pat `Generics.extQ` antiStatementBlockPat `Generics.extQ` antiVariableDeclaratorListPat `Generics.extQ` antiVariableDeclarationPat `Generics.extQ` antiRule_48Pat `Generics.extQ` antiOptVariableInitializerPat `Generics.extQ` antiVariableDeclaratorPat `Generics.extQ` antiVariableInitializerListPat `Generics.extQ` antiVariableInitializerPat `Generics.extQ` antiStaticInitializerPat `Generics.extQ` antiParameterListPat `Generics.extQ` antiRule_57Pat `Generics.extQ` antiParameterPat `Generics.extQ` antiStatementPat `Generics.extQ` antiOptExpressionPat `Generics.extQ` antiOptIdPat `Generics.extQ` antiOptElsePartPat `Generics.extQ` antiIfStatementPat `Generics.extQ` antiDoStatementPat `Generics.extQ` antiWhileStatementPat `Generics.extQ` antiForStatementPat `Generics.extQ` antiForEachHeaderPat `Generics.extQ` antiRule_65Pat `Generics.extQ` antiCatchParameterPat `Generics.extQ` antiOptFinallyPat `Generics.extQ` antiTryStatementPat `Generics.extQ` antiResourceSpecPat `Generics.extQ` antiResourcePat `Generics.extQ` antiRule_74Pat `Generics.extQ` antiSwitchStatementPat `Generics.extQ` antiExpressionPat `Generics.extQ` antiLambdaBodyPat `Generics.extQ` antiAssignmentOpPat `Generics.extQ` antiEqualityOpPat `Generics.extQ` antiRelationalOpPat `Generics.extQ` antiShiftOpPat `Generics.extQ` antiAdditiveOpPat `Generics.extQ` antiMultiplicativeOpPat `Generics.extQ` antiPrefixOpPat `Generics.extQ` antiPostfixOpPat `Generics.extQ` antiCreationExpressionPat `Generics.extQ` antiRule_86Pat `Generics.extQ` antiLiteralPat `Generics.extQ` antiArglistPat `Generics.extQ` antiTypeArgumentsPat `Generics.extQ` antiNonEmptyTypeArgumentsPat `Generics.extQ` antiTypeArgumentPat `Generics.extQ` antiWildcardTypePat `Generics.extQ` antiTypeParametersPat `Generics.extQ` antiTypeParameterPat `Generics.extQ` antiTypePat `Generics.extQ` antiTypeSpecifierPat `Generics.extQ` antiModifierPat `Generics.extQ` antiRule_100Pat `Generics.extQ` antiCompoundNamePat) expr
 
 antiCompoundNameExp :: CompoundName -> Maybe (TH.Q TH.Exp )
 antiCompoundNameExp ( Anti_CompoundName v) = Just $ TH.varE (TH.mkName v)
 antiCompoundNameExp _ = Nothing
 
 
-antiRule_98Exp :: [ Rule_98 ] -> Maybe (TH.Q TH.Exp)
-antiRule_98Exp ((Anti_Rule_98 v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiClassOrInterfaceTypeExp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiForEachHeaderExp `Generics.extQ` antiRule_65Exp `Generics.extQ` antiCatchParameterExp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiResourceSpecExp `Generics.extQ` antiResourceExp `Generics.extQ` antiRule_74Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_84Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiRule_98Exp `Generics.extQ` antiCompoundNameExp) rest
+antiRule_100Exp :: [ Rule_100 ] -> Maybe (TH.Q TH.Exp)
+antiRule_100Exp ((Anti_Rule_100 v):rest) =
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiClassOrInterfaceTypeExp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiForEachHeaderExp `Generics.extQ` antiRule_65Exp `Generics.extQ` antiCatchParameterExp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiResourceSpecExp `Generics.extQ` antiResourceExp `Generics.extQ` antiRule_74Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiLambdaBodyExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_86Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiRule_100Exp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
-antiRule_98Exp _ = Nothing
+antiRule_100Exp _ = Nothing
 
 
 antiModifierExp :: Modifier -> Maybe (TH.Q TH.Exp )
@@ -159,12 +159,12 @@ antiLiteralExp ( Anti_Literal v) = Just $ TH.varE (TH.mkName v)
 antiLiteralExp _ = Nothing
 
 
-antiRule_84Exp :: [ Rule_84 ] -> Maybe (TH.Q TH.Exp)
-antiRule_84Exp ((Anti_Rule_84 v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiClassOrInterfaceTypeExp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiForEachHeaderExp `Generics.extQ` antiRule_65Exp `Generics.extQ` antiCatchParameterExp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiResourceSpecExp `Generics.extQ` antiResourceExp `Generics.extQ` antiRule_74Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_84Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiRule_98Exp `Generics.extQ` antiCompoundNameExp) rest
+antiRule_86Exp :: [ Rule_86 ] -> Maybe (TH.Q TH.Exp)
+antiRule_86Exp ((Anti_Rule_86 v):rest) =
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiClassOrInterfaceTypeExp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiForEachHeaderExp `Generics.extQ` antiRule_65Exp `Generics.extQ` antiCatchParameterExp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiResourceSpecExp `Generics.extQ` antiResourceExp `Generics.extQ` antiRule_74Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiLambdaBodyExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_86Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiRule_100Exp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
-antiRule_84Exp _ = Nothing
+antiRule_86Exp _ = Nothing
 
 
 antiCreationExpressionExp :: CreationExpression -> Maybe (TH.Q TH.Exp )
@@ -212,6 +212,11 @@ antiAssignmentOpExp ( Anti_AssignmentOp v) = Just $ TH.varE (TH.mkName v)
 antiAssignmentOpExp _ = Nothing
 
 
+antiLambdaBodyExp :: LambdaBody -> Maybe (TH.Q TH.Exp )
+antiLambdaBodyExp ( Anti_LambdaBody v) = Just $ TH.varE (TH.mkName v)
+antiLambdaBodyExp _ = Nothing
+
+
 antiExpressionExp :: Expression -> Maybe (TH.Q TH.Exp )
 antiExpressionExp ( Anti_Expression v) = Just $ TH.varE (TH.mkName v)
 antiExpressionExp _ = Nothing
@@ -224,7 +229,7 @@ antiSwitchStatementExp _ = Nothing
 
 antiRule_74Exp :: [ Rule_74 ] -> Maybe (TH.Q TH.Exp)
 antiRule_74Exp ((Anti_Rule_74 v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiClassOrInterfaceTypeExp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiForEachHeaderExp `Generics.extQ` antiRule_65Exp `Generics.extQ` antiCatchParameterExp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiResourceSpecExp `Generics.extQ` antiResourceExp `Generics.extQ` antiRule_74Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_84Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiRule_98Exp `Generics.extQ` antiCompoundNameExp) rest
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiClassOrInterfaceTypeExp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiForEachHeaderExp `Generics.extQ` antiRule_65Exp `Generics.extQ` antiCatchParameterExp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiResourceSpecExp `Generics.extQ` antiResourceExp `Generics.extQ` antiRule_74Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiLambdaBodyExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_86Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiRule_100Exp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
 antiRule_74Exp _ = Nothing
@@ -257,7 +262,7 @@ antiCatchParameterExp _ = Nothing
 
 antiRule_65Exp :: [ Rule_65 ] -> Maybe (TH.Q TH.Exp)
 antiRule_65Exp ((Anti_Rule_65 v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiClassOrInterfaceTypeExp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiForEachHeaderExp `Generics.extQ` antiRule_65Exp `Generics.extQ` antiCatchParameterExp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiResourceSpecExp `Generics.extQ` antiResourceExp `Generics.extQ` antiRule_74Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_84Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiRule_98Exp `Generics.extQ` antiCompoundNameExp) rest
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiClassOrInterfaceTypeExp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiForEachHeaderExp `Generics.extQ` antiRule_65Exp `Generics.extQ` antiCatchParameterExp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiResourceSpecExp `Generics.extQ` antiResourceExp `Generics.extQ` antiRule_74Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiLambdaBodyExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_86Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiRule_100Exp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
 antiRule_65Exp _ = Nothing
@@ -305,7 +310,7 @@ antiOptExpressionExp _ = Nothing
 
 antiStatementExp :: [ Statement ] -> Maybe (TH.Q TH.Exp)
 antiStatementExp ((Anti_Statement v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiClassOrInterfaceTypeExp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiForEachHeaderExp `Generics.extQ` antiRule_65Exp `Generics.extQ` antiCatchParameterExp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiResourceSpecExp `Generics.extQ` antiResourceExp `Generics.extQ` antiRule_74Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_84Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiRule_98Exp `Generics.extQ` antiCompoundNameExp) rest
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiClassOrInterfaceTypeExp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiForEachHeaderExp `Generics.extQ` antiRule_65Exp `Generics.extQ` antiCatchParameterExp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiResourceSpecExp `Generics.extQ` antiResourceExp `Generics.extQ` antiRule_74Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiLambdaBodyExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_86Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiRule_100Exp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
 antiStatementExp _ = Nothing
@@ -318,7 +323,7 @@ antiParameterExp _ = Nothing
 
 antiRule_57Exp :: [ Rule_57 ] -> Maybe (TH.Q TH.Exp)
 antiRule_57Exp ((Anti_Rule_57 v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiClassOrInterfaceTypeExp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiForEachHeaderExp `Generics.extQ` antiRule_65Exp `Generics.extQ` antiCatchParameterExp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiResourceSpecExp `Generics.extQ` antiResourceExp `Generics.extQ` antiRule_74Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_84Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiRule_98Exp `Generics.extQ` antiCompoundNameExp) rest
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiClassOrInterfaceTypeExp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiForEachHeaderExp `Generics.extQ` antiRule_65Exp `Generics.extQ` antiCatchParameterExp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiResourceSpecExp `Generics.extQ` antiResourceExp `Generics.extQ` antiRule_74Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiLambdaBodyExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_86Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiRule_100Exp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
 antiRule_57Exp _ = Nothing
@@ -356,7 +361,7 @@ antiOptVariableInitializerExp _ = Nothing
 
 antiRule_48Exp :: [ Rule_48 ] -> Maybe (TH.Q TH.Exp)
 antiRule_48Exp ((Anti_Rule_48 v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiClassOrInterfaceTypeExp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiForEachHeaderExp `Generics.extQ` antiRule_65Exp `Generics.extQ` antiCatchParameterExp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiResourceSpecExp `Generics.extQ` antiResourceExp `Generics.extQ` antiRule_74Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_84Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiRule_98Exp `Generics.extQ` antiCompoundNameExp) rest
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiClassOrInterfaceTypeExp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiForEachHeaderExp `Generics.extQ` antiRule_65Exp `Generics.extQ` antiCatchParameterExp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiResourceSpecExp `Generics.extQ` antiResourceExp `Generics.extQ` antiRule_74Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiLambdaBodyExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_86Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiRule_100Exp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
 antiRule_48Exp _ = Nothing
@@ -379,7 +384,7 @@ antiStatementBlockExp _ = Nothing
 
 antiRule_44Exp :: [ Rule_44 ] -> Maybe (TH.Q TH.Exp)
 antiRule_44Exp ((Anti_Rule_44 v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiClassOrInterfaceTypeExp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiForEachHeaderExp `Generics.extQ` antiRule_65Exp `Generics.extQ` antiCatchParameterExp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiResourceSpecExp `Generics.extQ` antiResourceExp `Generics.extQ` antiRule_74Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_84Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiRule_98Exp `Generics.extQ` antiCompoundNameExp) rest
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiClassOrInterfaceTypeExp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiForEachHeaderExp `Generics.extQ` antiRule_65Exp `Generics.extQ` antiCatchParameterExp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiResourceSpecExp `Generics.extQ` antiResourceExp `Generics.extQ` antiRule_74Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiLambdaBodyExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_86Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiRule_100Exp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
 antiRule_44Exp _ = Nothing
@@ -417,7 +422,7 @@ antiMemberDeclarationExp _ = Nothing
 
 antiRule_33Exp :: [ Rule_33 ] -> Maybe (TH.Q TH.Exp)
 antiRule_33Exp ((Anti_Rule_33 v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiClassOrInterfaceTypeExp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiForEachHeaderExp `Generics.extQ` antiRule_65Exp `Generics.extQ` antiCatchParameterExp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiResourceSpecExp `Generics.extQ` antiResourceExp `Generics.extQ` antiRule_74Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_84Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiRule_98Exp `Generics.extQ` antiCompoundNameExp) rest
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiClassOrInterfaceTypeExp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiForEachHeaderExp `Generics.extQ` antiRule_65Exp `Generics.extQ` antiCatchParameterExp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiResourceSpecExp `Generics.extQ` antiResourceExp `Generics.extQ` antiRule_74Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiLambdaBodyExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_86Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiRule_100Exp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
 antiRule_33Exp _ = Nothing
@@ -425,7 +430,7 @@ antiRule_33Exp _ = Nothing
 
 antiRule_31Exp :: [ Rule_31 ] -> Maybe (TH.Q TH.Exp)
 antiRule_31Exp ((Anti_Rule_31 v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiClassOrInterfaceTypeExp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiForEachHeaderExp `Generics.extQ` antiRule_65Exp `Generics.extQ` antiCatchParameterExp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiResourceSpecExp `Generics.extQ` antiResourceExp `Generics.extQ` antiRule_74Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_84Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiRule_98Exp `Generics.extQ` antiCompoundNameExp) rest
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiClassOrInterfaceTypeExp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiForEachHeaderExp `Generics.extQ` antiRule_65Exp `Generics.extQ` antiCatchParameterExp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiResourceSpecExp `Generics.extQ` antiResourceExp `Generics.extQ` antiRule_74Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiLambdaBodyExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_86Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiRule_100Exp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
 antiRule_31Exp _ = Nothing
@@ -453,7 +458,7 @@ antiEnumConstantExp _ = Nothing
 
 antiAnnotationTypeElementExp :: [ AnnotationTypeElement ] -> Maybe (TH.Q TH.Exp)
 antiAnnotationTypeElementExp ((Anti_AnnotationTypeElement v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiClassOrInterfaceTypeExp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiForEachHeaderExp `Generics.extQ` antiRule_65Exp `Generics.extQ` antiCatchParameterExp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiResourceSpecExp `Generics.extQ` antiResourceExp `Generics.extQ` antiRule_74Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_84Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiRule_98Exp `Generics.extQ` antiCompoundNameExp) rest
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiClassOrInterfaceTypeExp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiForEachHeaderExp `Generics.extQ` antiRule_65Exp `Generics.extQ` antiCatchParameterExp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiResourceSpecExp `Generics.extQ` antiResourceExp `Generics.extQ` antiRule_74Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiLambdaBodyExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_86Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiRule_100Exp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
 antiAnnotationTypeElementExp _ = Nothing
@@ -476,7 +481,7 @@ antiClassDeclarationExp _ = Nothing
 
 antiFieldDeclarationExp :: [ FieldDeclaration ] -> Maybe (TH.Q TH.Exp)
 antiFieldDeclarationExp ((Anti_FieldDeclaration v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiClassOrInterfaceTypeExp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiForEachHeaderExp `Generics.extQ` antiRule_65Exp `Generics.extQ` antiCatchParameterExp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiResourceSpecExp `Generics.extQ` antiResourceExp `Generics.extQ` antiRule_74Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_84Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiRule_98Exp `Generics.extQ` antiCompoundNameExp) rest
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiClassOrInterfaceTypeExp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiForEachHeaderExp `Generics.extQ` antiRule_65Exp `Generics.extQ` antiCatchParameterExp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiResourceSpecExp `Generics.extQ` antiResourceExp `Generics.extQ` antiRule_74Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiLambdaBodyExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_86Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiRule_100Exp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
 antiFieldDeclarationExp _ = Nothing
@@ -499,7 +504,7 @@ antiClassOrInterfaceTypeExp _ = Nothing
 
 antiRule_10Exp :: [ Rule_10 ] -> Maybe (TH.Q TH.Exp)
 antiRule_10Exp ((Anti_Rule_10 v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiClassOrInterfaceTypeExp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiForEachHeaderExp `Generics.extQ` antiRule_65Exp `Generics.extQ` antiCatchParameterExp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiResourceSpecExp `Generics.extQ` antiResourceExp `Generics.extQ` antiRule_74Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_84Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiRule_98Exp `Generics.extQ` antiCompoundNameExp) rest
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiClassOrInterfaceTypeExp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiForEachHeaderExp `Generics.extQ` antiRule_65Exp `Generics.extQ` antiCatchParameterExp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiResourceSpecExp `Generics.extQ` antiResourceExp `Generics.extQ` antiRule_74Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiLambdaBodyExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_86Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiRule_100Exp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
 antiRule_10Exp _ = Nothing
@@ -547,7 +552,7 @@ antiCompilationUnitExp _ = Nothing
 
 antiImportStatementExp :: [ ImportStatement ] -> Maybe (TH.Q TH.Exp)
 antiImportStatementExp ((Anti_ImportStatement v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiClassOrInterfaceTypeExp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiForEachHeaderExp `Generics.extQ` antiRule_65Exp `Generics.extQ` antiCatchParameterExp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiResourceSpecExp `Generics.extQ` antiResourceExp `Generics.extQ` antiRule_74Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_84Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiRule_98Exp `Generics.extQ` antiCompoundNameExp) rest
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiClassOrInterfaceTypeExp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiForEachHeaderExp `Generics.extQ` antiRule_65Exp `Generics.extQ` antiCatchParameterExp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiResourceSpecExp `Generics.extQ` antiResourceExp `Generics.extQ` antiRule_74Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiLambdaBodyExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_86Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiRule_100Exp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
 antiImportStatementExp _ = Nothing
@@ -574,9 +579,9 @@ antiCompoundNamePat ( Anti_CompoundName v) = Just $ TH.varP (TH.mkName v)
 antiCompoundNamePat _ = Nothing
 
 
-antiRule_98Pat :: [ Rule_98 ] -> Maybe (TH.Q TH.Pat)
-antiRule_98Pat [Anti_Rule_98 v] = Just $ TH.varP (TH.mkName v)
-antiRule_98Pat _ = Nothing
+antiRule_100Pat :: [ Rule_100 ] -> Maybe (TH.Q TH.Pat)
+antiRule_100Pat [Anti_Rule_100 v] = Just $ TH.varP (TH.mkName v)
+antiRule_100Pat _ = Nothing
 
 
 antiModifierPat :: Modifier -> Maybe (TH.Q TH.Pat )
@@ -634,9 +639,9 @@ antiLiteralPat ( Anti_Literal v) = Just $ TH.varP (TH.mkName v)
 antiLiteralPat _ = Nothing
 
 
-antiRule_84Pat :: [ Rule_84 ] -> Maybe (TH.Q TH.Pat)
-antiRule_84Pat [Anti_Rule_84 v] = Just $ TH.varP (TH.mkName v)
-antiRule_84Pat _ = Nothing
+antiRule_86Pat :: [ Rule_86 ] -> Maybe (TH.Q TH.Pat)
+antiRule_86Pat [Anti_Rule_86 v] = Just $ TH.varP (TH.mkName v)
+antiRule_86Pat _ = Nothing
 
 
 antiCreationExpressionPat :: CreationExpression -> Maybe (TH.Q TH.Pat )
@@ -682,6 +687,11 @@ antiEqualityOpPat _ = Nothing
 antiAssignmentOpPat :: AssignmentOp -> Maybe (TH.Q TH.Pat )
 antiAssignmentOpPat ( Anti_AssignmentOp v) = Just $ TH.varP (TH.mkName v)
 antiAssignmentOpPat _ = Nothing
+
+
+antiLambdaBodyPat :: LambdaBody -> Maybe (TH.Q TH.Pat )
+antiLambdaBodyPat ( Anti_LambdaBody v) = Just $ TH.varP (TH.mkName v)
+antiLambdaBodyPat _ = Nothing
 
 
 antiExpressionPat :: Expression -> Maybe (TH.Q TH.Pat )
@@ -1012,460 +1022,465 @@ quoteJavaDecs _ = fail "this quasi-quoter cannot be used in a declaration contex
 getJava ( Ctr__Java__0 _ s) = s
 
 java :: QuasiQuoter
-java = QuasiQuoter (quoteJavaExp "tok_Java_dummy_191" getJava ) (quoteJavaPat "tok_Java_dummy_191" getJava ) quoteJavaType quoteJavaDecs
+java = QuasiQuoter (quoteJavaExp "tok_Java_dummy_194" getJava ) (quoteJavaPat "tok_Java_dummy_194" getJava ) quoteJavaType quoteJavaDecs
 
 getAdditiveOp ( Ctr__Java__1 _ s) = s
 
 additiveOp :: QuasiQuoter
-additiveOp = QuasiQuoter (quoteJavaExp "tok_AdditiveOp_dummy_190" getAdditiveOp ) (quoteJavaPat "tok_AdditiveOp_dummy_190" getAdditiveOp ) quoteJavaType quoteJavaDecs
+additiveOp = QuasiQuoter (quoteJavaExp "tok_AdditiveOp_dummy_193" getAdditiveOp ) (quoteJavaPat "tok_AdditiveOp_dummy_193" getAdditiveOp ) quoteJavaType quoteJavaDecs
 
 getAnnotation ( Ctr__Java__2 _ s) = s
 
 annotation :: QuasiQuoter
-annotation = QuasiQuoter (quoteJavaExp "tok_Annotation_dummy_189" getAnnotation ) (quoteJavaPat "tok_Annotation_dummy_189" getAnnotation ) quoteJavaType quoteJavaDecs
+annotation = QuasiQuoter (quoteJavaExp "tok_Annotation_dummy_192" getAnnotation ) (quoteJavaPat "tok_Annotation_dummy_192" getAnnotation ) quoteJavaType quoteJavaDecs
 
 getAnnotationArguments ( Ctr__Java__3 _ s) = s
 
 annotationArguments :: QuasiQuoter
-annotationArguments = QuasiQuoter (quoteJavaExp "tok_AnnotationArguments_dummy_188" getAnnotationArguments ) (quoteJavaPat "tok_AnnotationArguments_dummy_188" getAnnotationArguments ) quoteJavaType quoteJavaDecs
+annotationArguments = QuasiQuoter (quoteJavaExp "tok_AnnotationArguments_dummy_191" getAnnotationArguments ) (quoteJavaPat "tok_AnnotationArguments_dummy_191" getAnnotationArguments ) quoteJavaType quoteJavaDecs
 
 getAnnotationDeclaration ( Ctr__Java__4 _ s) = s
 
 annotationDeclaration :: QuasiQuoter
-annotationDeclaration = QuasiQuoter (quoteJavaExp "tok_AnnotationDeclaration_dummy_187" getAnnotationDeclaration ) (quoteJavaPat "tok_AnnotationDeclaration_dummy_187" getAnnotationDeclaration ) quoteJavaType quoteJavaDecs
+annotationDeclaration = QuasiQuoter (quoteJavaExp "tok_AnnotationDeclaration_dummy_190" getAnnotationDeclaration ) (quoteJavaPat "tok_AnnotationDeclaration_dummy_190" getAnnotationDeclaration ) quoteJavaType quoteJavaDecs
 
 getAnnotationElement ( Ctr__Java__5 _ s) = s
 
 annotationElement :: QuasiQuoter
-annotationElement = QuasiQuoter (quoteJavaExp "tok_AnnotationElement_dummy_186" getAnnotationElement ) (quoteJavaPat "tok_AnnotationElement_dummy_186" getAnnotationElement ) quoteJavaType quoteJavaDecs
+annotationElement = QuasiQuoter (quoteJavaExp "tok_AnnotationElement_dummy_189" getAnnotationElement ) (quoteJavaPat "tok_AnnotationElement_dummy_189" getAnnotationElement ) quoteJavaType quoteJavaDecs
 
 getAnnotationList ( Ctr__Java__6 _ s) = s
 
 annotationList :: QuasiQuoter
-annotationList = QuasiQuoter (quoteJavaExp "tok_AnnotationList_dummy_185" getAnnotationList ) (quoteJavaPat "tok_AnnotationList_dummy_185" getAnnotationList ) quoteJavaType quoteJavaDecs
+annotationList = QuasiQuoter (quoteJavaExp "tok_AnnotationList_dummy_188" getAnnotationList ) (quoteJavaPat "tok_AnnotationList_dummy_188" getAnnotationList ) quoteJavaType quoteJavaDecs
 
 getAnnotationTypeElement ( Ctr__Java__7 _ s) = s
 
 annotationTypeElement :: QuasiQuoter
-annotationTypeElement = QuasiQuoter (quoteJavaExp "tok_AnnotationTypeElement_dummy_184" getAnnotationTypeElement ) (quoteJavaPat "tok_AnnotationTypeElement_dummy_184" getAnnotationTypeElement ) quoteJavaType quoteJavaDecs
+annotationTypeElement = QuasiQuoter (quoteJavaExp "tok_AnnotationTypeElement_dummy_187" getAnnotationTypeElement ) (quoteJavaPat "tok_AnnotationTypeElement_dummy_187" getAnnotationTypeElement ) quoteJavaType quoteJavaDecs
 
 getAnnotationTypeElementList ( Ctr__Java__8 _ s) = s
 
 annotationTypeElementList :: QuasiQuoter
-annotationTypeElementList = QuasiQuoter (quoteJavaExp "tok_AnnotationTypeElementList_dummy_183" getAnnotationTypeElementList ) (quoteJavaPat "tok_AnnotationTypeElementList_dummy_183" getAnnotationTypeElementList ) quoteJavaType quoteJavaDecs
+annotationTypeElementList = QuasiQuoter (quoteJavaExp "tok_AnnotationTypeElementList_dummy_186" getAnnotationTypeElementList ) (quoteJavaPat "tok_AnnotationTypeElementList_dummy_186" getAnnotationTypeElementList ) quoteJavaType quoteJavaDecs
 
 getArglist ( Ctr__Java__9 _ s) = s
 
 arglist :: QuasiQuoter
-arglist = QuasiQuoter (quoteJavaExp "tok_Arglist_dummy_182" getArglist ) (quoteJavaPat "tok_Arglist_dummy_182" getArglist ) quoteJavaType quoteJavaDecs
+arglist = QuasiQuoter (quoteJavaExp "tok_Arglist_dummy_185" getArglist ) (quoteJavaPat "tok_Arglist_dummy_185" getArglist ) quoteJavaType quoteJavaDecs
 
 getAssignmentOp ( Ctr__Java__10 _ s) = s
 
 assignmentOp :: QuasiQuoter
-assignmentOp = QuasiQuoter (quoteJavaExp "tok_AssignmentOp_dummy_181" getAssignmentOp ) (quoteJavaPat "tok_AssignmentOp_dummy_181" getAssignmentOp ) quoteJavaType quoteJavaDecs
+assignmentOp = QuasiQuoter (quoteJavaExp "tok_AssignmentOp_dummy_184" getAssignmentOp ) (quoteJavaPat "tok_AssignmentOp_dummy_184" getAssignmentOp ) quoteJavaType quoteJavaDecs
 
 getCatchList ( Ctr__Java__11 _ s) = s
 
 catchList :: QuasiQuoter
-catchList = QuasiQuoter (quoteJavaExp "tok_CatchList_dummy_180" getCatchList ) (quoteJavaPat "tok_CatchList_dummy_180" getCatchList ) quoteJavaType quoteJavaDecs
+catchList = QuasiQuoter (quoteJavaExp "tok_CatchList_dummy_183" getCatchList ) (quoteJavaPat "tok_CatchList_dummy_183" getCatchList ) quoteJavaType quoteJavaDecs
 
 getCatchParameter ( Ctr__Java__12 _ s) = s
 
 catchParameter :: QuasiQuoter
-catchParameter = QuasiQuoter (quoteJavaExp "tok_CatchParameter_dummy_179" getCatchParameter ) (quoteJavaPat "tok_CatchParameter_dummy_179" getCatchParameter ) quoteJavaType quoteJavaDecs
+catchParameter = QuasiQuoter (quoteJavaExp "tok_CatchParameter_dummy_182" getCatchParameter ) (quoteJavaPat "tok_CatchParameter_dummy_182" getCatchParameter ) quoteJavaType quoteJavaDecs
 
 getClassDeclaration ( Ctr__Java__13 _ s) = s
 
 classDeclaration :: QuasiQuoter
-classDeclaration = QuasiQuoter (quoteJavaExp "tok_ClassDeclaration_dummy_178" getClassDeclaration ) (quoteJavaPat "tok_ClassDeclaration_dummy_178" getClassDeclaration ) quoteJavaType quoteJavaDecs
+classDeclaration = QuasiQuoter (quoteJavaExp "tok_ClassDeclaration_dummy_181" getClassDeclaration ) (quoteJavaPat "tok_ClassDeclaration_dummy_181" getClassDeclaration ) quoteJavaType quoteJavaDecs
 
 getClassOrInterfaceType ( Ctr__Java__14 _ s) = s
 
 classOrInterfaceType :: QuasiQuoter
-classOrInterfaceType = QuasiQuoter (quoteJavaExp "tok_ClassOrInterfaceType_dummy_177" getClassOrInterfaceType ) (quoteJavaPat "tok_ClassOrInterfaceType_dummy_177" getClassOrInterfaceType ) quoteJavaType quoteJavaDecs
+classOrInterfaceType = QuasiQuoter (quoteJavaExp "tok_ClassOrInterfaceType_dummy_180" getClassOrInterfaceType ) (quoteJavaPat "tok_ClassOrInterfaceType_dummy_180" getClassOrInterfaceType ) quoteJavaType quoteJavaDecs
 
 getCompilationUnit ( Ctr__Java__15 _ s) = s
 
 compilationUnit :: QuasiQuoter
-compilationUnit = QuasiQuoter (quoteJavaExp "tok_CompilationUnit_dummy_176" getCompilationUnit ) (quoteJavaPat "tok_CompilationUnit_dummy_176" getCompilationUnit ) quoteJavaType quoteJavaDecs
+compilationUnit = QuasiQuoter (quoteJavaExp "tok_CompilationUnit_dummy_179" getCompilationUnit ) (quoteJavaPat "tok_CompilationUnit_dummy_179" getCompilationUnit ) quoteJavaType quoteJavaDecs
 
 getCompoundName ( Ctr__Java__16 _ s) = s
 
 compoundName :: QuasiQuoter
-compoundName = QuasiQuoter (quoteJavaExp "tok_CompoundName_dummy_175" getCompoundName ) (quoteJavaPat "tok_CompoundName_dummy_175" getCompoundName ) quoteJavaType quoteJavaDecs
+compoundName = QuasiQuoter (quoteJavaExp "tok_CompoundName_dummy_178" getCompoundName ) (quoteJavaPat "tok_CompoundName_dummy_178" getCompoundName ) quoteJavaType quoteJavaDecs
 
 getCompoundNameTail ( Ctr__Java__17 _ s) = s
 
 compoundNameTail :: QuasiQuoter
-compoundNameTail = QuasiQuoter (quoteJavaExp "tok_CompoundNameTail_dummy_174" getCompoundNameTail ) (quoteJavaPat "tok_CompoundNameTail_dummy_174" getCompoundNameTail ) quoteJavaType quoteJavaDecs
+compoundNameTail = QuasiQuoter (quoteJavaExp "tok_CompoundNameTail_dummy_177" getCompoundNameTail ) (quoteJavaPat "tok_CompoundNameTail_dummy_177" getCompoundNameTail ) quoteJavaType quoteJavaDecs
 
 getCreationExpression ( Ctr__Java__18 _ s) = s
 
 creationExpression :: QuasiQuoter
-creationExpression = QuasiQuoter (quoteJavaExp "tok_CreationExpression_dummy_173" getCreationExpression ) (quoteJavaPat "tok_CreationExpression_dummy_173" getCreationExpression ) quoteJavaType quoteJavaDecs
+creationExpression = QuasiQuoter (quoteJavaExp "tok_CreationExpression_dummy_176" getCreationExpression ) (quoteJavaPat "tok_CreationExpression_dummy_176" getCreationExpression ) quoteJavaType quoteJavaDecs
 
 getDimExprs ( Ctr__Java__19 _ s) = s
 
 dimExprs :: QuasiQuoter
-dimExprs = QuasiQuoter (quoteJavaExp "tok_DimExprs_dummy_172" getDimExprs ) (quoteJavaPat "tok_DimExprs_dummy_172" getDimExprs ) quoteJavaType quoteJavaDecs
+dimExprs = QuasiQuoter (quoteJavaExp "tok_DimExprs_dummy_175" getDimExprs ) (quoteJavaPat "tok_DimExprs_dummy_175" getDimExprs ) quoteJavaType quoteJavaDecs
 
 getDims ( Ctr__Java__20 _ s) = s
 
 dims :: QuasiQuoter
-dims = QuasiQuoter (quoteJavaExp "tok_Dims_dummy_171" getDims ) (quoteJavaPat "tok_Dims_dummy_171" getDims ) quoteJavaType quoteJavaDecs
+dims = QuasiQuoter (quoteJavaExp "tok_Dims_dummy_174" getDims ) (quoteJavaPat "tok_Dims_dummy_174" getDims ) quoteJavaType quoteJavaDecs
 
 getDoStatement ( Ctr__Java__21 _ s) = s
 
 doStatement :: QuasiQuoter
-doStatement = QuasiQuoter (quoteJavaExp "tok_DoStatement_dummy_170" getDoStatement ) (quoteJavaPat "tok_DoStatement_dummy_170" getDoStatement ) quoteJavaType quoteJavaDecs
+doStatement = QuasiQuoter (quoteJavaExp "tok_DoStatement_dummy_173" getDoStatement ) (quoteJavaPat "tok_DoStatement_dummy_173" getDoStatement ) quoteJavaType quoteJavaDecs
 
 getDocComment ( Ctr__Java__22 _ s) = s
 
 docComment :: QuasiQuoter
-docComment = QuasiQuoter (quoteJavaExp "tok_DocComment_dummy_169" getDocComment ) (quoteJavaPat "tok_DocComment_dummy_169" getDocComment ) quoteJavaType quoteJavaDecs
+docComment = QuasiQuoter (quoteJavaExp "tok_DocComment_dummy_172" getDocComment ) (quoteJavaPat "tok_DocComment_dummy_172" getDocComment ) quoteJavaType quoteJavaDecs
 
 getEnumConstant ( Ctr__Java__23 _ s) = s
 
 enumConstant :: QuasiQuoter
-enumConstant = QuasiQuoter (quoteJavaExp "tok_EnumConstant_dummy_168" getEnumConstant ) (quoteJavaPat "tok_EnumConstant_dummy_168" getEnumConstant ) quoteJavaType quoteJavaDecs
+enumConstant = QuasiQuoter (quoteJavaExp "tok_EnumConstant_dummy_171" getEnumConstant ) (quoteJavaPat "tok_EnumConstant_dummy_171" getEnumConstant ) quoteJavaType quoteJavaDecs
 
 getEnumConstantList ( Ctr__Java__24 _ s) = s
 
 enumConstantList :: QuasiQuoter
-enumConstantList = QuasiQuoter (quoteJavaExp "tok_EnumConstantList_dummy_167" getEnumConstantList ) (quoteJavaPat "tok_EnumConstantList_dummy_167" getEnumConstantList ) quoteJavaType quoteJavaDecs
+enumConstantList = QuasiQuoter (quoteJavaExp "tok_EnumConstantList_dummy_170" getEnumConstantList ) (quoteJavaPat "tok_EnumConstantList_dummy_170" getEnumConstantList ) quoteJavaType quoteJavaDecs
 
 getEnumDeclaration ( Ctr__Java__25 _ s) = s
 
 enumDeclaration :: QuasiQuoter
-enumDeclaration = QuasiQuoter (quoteJavaExp "tok_EnumDeclaration_dummy_166" getEnumDeclaration ) (quoteJavaPat "tok_EnumDeclaration_dummy_166" getEnumDeclaration ) quoteJavaType quoteJavaDecs
+enumDeclaration = QuasiQuoter (quoteJavaExp "tok_EnumDeclaration_dummy_169" getEnumDeclaration ) (quoteJavaPat "tok_EnumDeclaration_dummy_169" getEnumDeclaration ) quoteJavaType quoteJavaDecs
 
 getEqualityOp ( Ctr__Java__26 _ s) = s
 
 equalityOp :: QuasiQuoter
-equalityOp = QuasiQuoter (quoteJavaExp "tok_EqualityOp_dummy_165" getEqualityOp ) (quoteJavaPat "tok_EqualityOp_dummy_165" getEqualityOp ) quoteJavaType quoteJavaDecs
+equalityOp = QuasiQuoter (quoteJavaExp "tok_EqualityOp_dummy_168" getEqualityOp ) (quoteJavaPat "tok_EqualityOp_dummy_168" getEqualityOp ) quoteJavaType quoteJavaDecs
 
 getExpression ( Ctr__Java__27 _ s) = s
 
 expression :: QuasiQuoter
-expression = QuasiQuoter (quoteJavaExp "tok_Expression_dummy_164" getExpression ) (quoteJavaPat "tok_Expression_dummy_164" getExpression ) quoteJavaType quoteJavaDecs
+expression = QuasiQuoter (quoteJavaExp "tok_Expression_dummy_167" getExpression ) (quoteJavaPat "tok_Expression_dummy_167" getExpression ) quoteJavaType quoteJavaDecs
 
 getExtendsList ( Ctr__Java__28 _ s) = s
 
 extendsList :: QuasiQuoter
-extendsList = QuasiQuoter (quoteJavaExp "tok_ExtendsList_dummy_163" getExtendsList ) (quoteJavaPat "tok_ExtendsList_dummy_163" getExtendsList ) quoteJavaType quoteJavaDecs
+extendsList = QuasiQuoter (quoteJavaExp "tok_ExtendsList_dummy_166" getExtendsList ) (quoteJavaPat "tok_ExtendsList_dummy_166" getExtendsList ) quoteJavaType quoteJavaDecs
 
 getFieldDeclaration ( Ctr__Java__29 _ s) = s
 
 fieldDeclaration :: QuasiQuoter
-fieldDeclaration = QuasiQuoter (quoteJavaExp "tok_FieldDeclaration_dummy_162" getFieldDeclaration ) (quoteJavaPat "tok_FieldDeclaration_dummy_162" getFieldDeclaration ) quoteJavaType quoteJavaDecs
+fieldDeclaration = QuasiQuoter (quoteJavaExp "tok_FieldDeclaration_dummy_165" getFieldDeclaration ) (quoteJavaPat "tok_FieldDeclaration_dummy_165" getFieldDeclaration ) quoteJavaType quoteJavaDecs
 
 getFieldDeclarationList ( Ctr__Java__30 _ s) = s
 
 fieldDeclarationList :: QuasiQuoter
-fieldDeclarationList = QuasiQuoter (quoteJavaExp "tok_FieldDeclarationList_dummy_161" getFieldDeclarationList ) (quoteJavaPat "tok_FieldDeclarationList_dummy_161" getFieldDeclarationList ) quoteJavaType quoteJavaDecs
+fieldDeclarationList = QuasiQuoter (quoteJavaExp "tok_FieldDeclarationList_dummy_164" getFieldDeclarationList ) (quoteJavaPat "tok_FieldDeclarationList_dummy_164" getFieldDeclarationList ) quoteJavaType quoteJavaDecs
 
 getForEachHeader ( Ctr__Java__31 _ s) = s
 
 forEachHeader :: QuasiQuoter
-forEachHeader = QuasiQuoter (quoteJavaExp "tok_ForEachHeader_dummy_160" getForEachHeader ) (quoteJavaPat "tok_ForEachHeader_dummy_160" getForEachHeader ) quoteJavaType quoteJavaDecs
+forEachHeader = QuasiQuoter (quoteJavaExp "tok_ForEachHeader_dummy_163" getForEachHeader ) (quoteJavaPat "tok_ForEachHeader_dummy_163" getForEachHeader ) quoteJavaType quoteJavaDecs
 
 getForStatement ( Ctr__Java__32 _ s) = s
 
 forStatement :: QuasiQuoter
-forStatement = QuasiQuoter (quoteJavaExp "tok_ForStatement_dummy_159" getForStatement ) (quoteJavaPat "tok_ForStatement_dummy_159" getForStatement ) quoteJavaType quoteJavaDecs
+forStatement = QuasiQuoter (quoteJavaExp "tok_ForStatement_dummy_162" getForStatement ) (quoteJavaPat "tok_ForStatement_dummy_162" getForStatement ) quoteJavaType quoteJavaDecs
 
 getIfStatement ( Ctr__Java__33 _ s) = s
 
 ifStatement :: QuasiQuoter
-ifStatement = QuasiQuoter (quoteJavaExp "tok_IfStatement_dummy_158" getIfStatement ) (quoteJavaPat "tok_IfStatement_dummy_158" getIfStatement ) quoteJavaType quoteJavaDecs
+ifStatement = QuasiQuoter (quoteJavaExp "tok_IfStatement_dummy_161" getIfStatement ) (quoteJavaPat "tok_IfStatement_dummy_161" getIfStatement ) quoteJavaType quoteJavaDecs
 
 getImplementsList ( Ctr__Java__34 _ s) = s
 
 implementsList :: QuasiQuoter
-implementsList = QuasiQuoter (quoteJavaExp "tok_ImplementsList_dummy_157" getImplementsList ) (quoteJavaPat "tok_ImplementsList_dummy_157" getImplementsList ) quoteJavaType quoteJavaDecs
+implementsList = QuasiQuoter (quoteJavaExp "tok_ImplementsList_dummy_160" getImplementsList ) (quoteJavaPat "tok_ImplementsList_dummy_160" getImplementsList ) quoteJavaType quoteJavaDecs
 
 getImportHead ( Ctr__Java__35 _ s) = s
 
 importHead :: QuasiQuoter
-importHead = QuasiQuoter (quoteJavaExp "tok_ImportHead_dummy_156" getImportHead ) (quoteJavaPat "tok_ImportHead_dummy_156" getImportHead ) quoteJavaType quoteJavaDecs
+importHead = QuasiQuoter (quoteJavaExp "tok_ImportHead_dummy_159" getImportHead ) (quoteJavaPat "tok_ImportHead_dummy_159" getImportHead ) quoteJavaType quoteJavaDecs
 
 getImportList ( Ctr__Java__36 _ s) = s
 
 importList :: QuasiQuoter
-importList = QuasiQuoter (quoteJavaExp "tok_ImportList_dummy_155" getImportList ) (quoteJavaPat "tok_ImportList_dummy_155" getImportList ) quoteJavaType quoteJavaDecs
+importList = QuasiQuoter (quoteJavaExp "tok_ImportList_dummy_158" getImportList ) (quoteJavaPat "tok_ImportList_dummy_158" getImportList ) quoteJavaType quoteJavaDecs
 
 getImportName ( Ctr__Java__37 _ s) = s
 
 importName :: QuasiQuoter
-importName = QuasiQuoter (quoteJavaExp "tok_ImportName_dummy_154" getImportName ) (quoteJavaPat "tok_ImportName_dummy_154" getImportName ) quoteJavaType quoteJavaDecs
+importName = QuasiQuoter (quoteJavaExp "tok_ImportName_dummy_157" getImportName ) (quoteJavaPat "tok_ImportName_dummy_157" getImportName ) quoteJavaType quoteJavaDecs
 
 getImportStatement ( Ctr__Java__38 _ s) = s
 
 importStatement :: QuasiQuoter
-importStatement = QuasiQuoter (quoteJavaExp "tok_ImportStatement_dummy_153" getImportStatement ) (quoteJavaPat "tok_ImportStatement_dummy_153" getImportStatement ) quoteJavaType quoteJavaDecs
+importStatement = QuasiQuoter (quoteJavaExp "tok_ImportStatement_dummy_156" getImportStatement ) (quoteJavaPat "tok_ImportStatement_dummy_156" getImportStatement ) quoteJavaType quoteJavaDecs
 
 getInterfaceDeclaration ( Ctr__Java__39 _ s) = s
 
 interfaceDeclaration :: QuasiQuoter
-interfaceDeclaration = QuasiQuoter (quoteJavaExp "tok_InterfaceDeclaration_dummy_152" getInterfaceDeclaration ) (quoteJavaPat "tok_InterfaceDeclaration_dummy_152" getInterfaceDeclaration ) quoteJavaType quoteJavaDecs
+interfaceDeclaration = QuasiQuoter (quoteJavaExp "tok_InterfaceDeclaration_dummy_155" getInterfaceDeclaration ) (quoteJavaPat "tok_InterfaceDeclaration_dummy_155" getInterfaceDeclaration ) quoteJavaType quoteJavaDecs
 
-getLiteral ( Ctr__Java__40 _ s) = s
+getLambdaBody ( Ctr__Java__40 _ s) = s
+
+lambdaBody :: QuasiQuoter
+lambdaBody = QuasiQuoter (quoteJavaExp "tok_LambdaBody_dummy_154" getLambdaBody ) (quoteJavaPat "tok_LambdaBody_dummy_154" getLambdaBody ) quoteJavaType quoteJavaDecs
+
+getLiteral ( Ctr__Java__41 _ s) = s
 
 literal :: QuasiQuoter
-literal = QuasiQuoter (quoteJavaExp "tok_Literal_dummy_151" getLiteral ) (quoteJavaPat "tok_Literal_dummy_151" getLiteral ) quoteJavaType quoteJavaDecs
+literal = QuasiQuoter (quoteJavaExp "tok_Literal_dummy_153" getLiteral ) (quoteJavaPat "tok_Literal_dummy_153" getLiteral ) quoteJavaType quoteJavaDecs
 
-getLocalModifierList1 ( Ctr__Java__41 _ s) = s
+getLocalModifierList1 ( Ctr__Java__42 _ s) = s
 
 localModifierList1 :: QuasiQuoter
-localModifierList1 = QuasiQuoter (quoteJavaExp "tok_LocalModifierList1_dummy_150" getLocalModifierList1 ) (quoteJavaPat "tok_LocalModifierList1_dummy_150" getLocalModifierList1 ) quoteJavaType quoteJavaDecs
+localModifierList1 = QuasiQuoter (quoteJavaExp "tok_LocalModifierList1_dummy_152" getLocalModifierList1 ) (quoteJavaPat "tok_LocalModifierList1_dummy_152" getLocalModifierList1 ) quoteJavaType quoteJavaDecs
 
-getMemberAfterFirstId ( Ctr__Java__42 _ s) = s
+getMemberAfterFirstId ( Ctr__Java__43 _ s) = s
 
 memberAfterFirstId :: QuasiQuoter
-memberAfterFirstId = QuasiQuoter (quoteJavaExp "tok_MemberAfterFirstId_dummy_149" getMemberAfterFirstId ) (quoteJavaPat "tok_MemberAfterFirstId_dummy_149" getMemberAfterFirstId ) quoteJavaType quoteJavaDecs
+memberAfterFirstId = QuasiQuoter (quoteJavaExp "tok_MemberAfterFirstId_dummy_151" getMemberAfterFirstId ) (quoteJavaPat "tok_MemberAfterFirstId_dummy_151" getMemberAfterFirstId ) quoteJavaType quoteJavaDecs
 
-getMemberDeclaration ( Ctr__Java__43 _ s) = s
+getMemberDeclaration ( Ctr__Java__44 _ s) = s
 
 memberDeclaration :: QuasiQuoter
-memberDeclaration = QuasiQuoter (quoteJavaExp "tok_MemberDeclaration_dummy_148" getMemberDeclaration ) (quoteJavaPat "tok_MemberDeclaration_dummy_148" getMemberDeclaration ) quoteJavaType quoteJavaDecs
+memberDeclaration = QuasiQuoter (quoteJavaExp "tok_MemberDeclaration_dummy_150" getMemberDeclaration ) (quoteJavaPat "tok_MemberDeclaration_dummy_150" getMemberDeclaration ) quoteJavaType quoteJavaDecs
 
-getMemberRest ( Ctr__Java__44 _ s) = s
+getMemberRest ( Ctr__Java__45 _ s) = s
 
 memberRest :: QuasiQuoter
-memberRest = QuasiQuoter (quoteJavaExp "tok_MemberRest_dummy_147" getMemberRest ) (quoteJavaPat "tok_MemberRest_dummy_147" getMemberRest ) quoteJavaType quoteJavaDecs
+memberRest = QuasiQuoter (quoteJavaExp "tok_MemberRest_dummy_149" getMemberRest ) (quoteJavaPat "tok_MemberRest_dummy_149" getMemberRest ) quoteJavaType quoteJavaDecs
 
-getModifier ( Ctr__Java__45 _ s) = s
+getModifier ( Ctr__Java__46 _ s) = s
 
 modifier :: QuasiQuoter
-modifier = QuasiQuoter (quoteJavaExp "tok_Modifier_dummy_146" getModifier ) (quoteJavaPat "tok_Modifier_dummy_146" getModifier ) quoteJavaType quoteJavaDecs
+modifier = QuasiQuoter (quoteJavaExp "tok_Modifier_dummy_148" getModifier ) (quoteJavaPat "tok_Modifier_dummy_148" getModifier ) quoteJavaType quoteJavaDecs
 
-getModifierList ( Ctr__Java__46 _ s) = s
+getModifierList ( Ctr__Java__47 _ s) = s
 
 modifierList :: QuasiQuoter
-modifierList = QuasiQuoter (quoteJavaExp "tok_ModifierList_dummy_145" getModifierList ) (quoteJavaPat "tok_ModifierList_dummy_145" getModifierList ) quoteJavaType quoteJavaDecs
+modifierList = QuasiQuoter (quoteJavaExp "tok_ModifierList_dummy_147" getModifierList ) (quoteJavaPat "tok_ModifierList_dummy_147" getModifierList ) quoteJavaType quoteJavaDecs
 
-getMoreTypeSpecifier ( Ctr__Java__47 _ s) = s
+getMoreTypeSpecifier ( Ctr__Java__48 _ s) = s
 
 moreTypeSpecifier :: QuasiQuoter
-moreTypeSpecifier = QuasiQuoter (quoteJavaExp "tok_MoreTypeSpecifier_dummy_144" getMoreTypeSpecifier ) (quoteJavaPat "tok_MoreTypeSpecifier_dummy_144" getMoreTypeSpecifier ) quoteJavaType quoteJavaDecs
+moreTypeSpecifier = QuasiQuoter (quoteJavaExp "tok_MoreTypeSpecifier_dummy_146" getMoreTypeSpecifier ) (quoteJavaPat "tok_MoreTypeSpecifier_dummy_146" getMoreTypeSpecifier ) quoteJavaType quoteJavaDecs
 
-getMoreVariableDeclarators ( Ctr__Java__48 _ s) = s
+getMoreVariableDeclarators ( Ctr__Java__49 _ s) = s
 
 moreVariableDeclarators :: QuasiQuoter
-moreVariableDeclarators = QuasiQuoter (quoteJavaExp "tok_MoreVariableDeclarators_dummy_143" getMoreVariableDeclarators ) (quoteJavaPat "tok_MoreVariableDeclarators_dummy_143" getMoreVariableDeclarators ) quoteJavaType quoteJavaDecs
+moreVariableDeclarators = QuasiQuoter (quoteJavaExp "tok_MoreVariableDeclarators_dummy_145" getMoreVariableDeclarators ) (quoteJavaPat "tok_MoreVariableDeclarators_dummy_145" getMoreVariableDeclarators ) quoteJavaType quoteJavaDecs
 
-getMultiplicativeOp ( Ctr__Java__49 _ s) = s
+getMultiplicativeOp ( Ctr__Java__50 _ s) = s
 
 multiplicativeOp :: QuasiQuoter
-multiplicativeOp = QuasiQuoter (quoteJavaExp "tok_MultiplicativeOp_dummy_142" getMultiplicativeOp ) (quoteJavaPat "tok_MultiplicativeOp_dummy_142" getMultiplicativeOp ) quoteJavaType quoteJavaDecs
+multiplicativeOp = QuasiQuoter (quoteJavaExp "tok_MultiplicativeOp_dummy_144" getMultiplicativeOp ) (quoteJavaPat "tok_MultiplicativeOp_dummy_144" getMultiplicativeOp ) quoteJavaType quoteJavaDecs
 
-getNonEmptyDims ( Ctr__Java__50 _ s) = s
+getNonEmptyDims ( Ctr__Java__51 _ s) = s
 
 nonEmptyDims :: QuasiQuoter
-nonEmptyDims = QuasiQuoter (quoteJavaExp "tok_NonEmptyDims_dummy_141" getNonEmptyDims ) (quoteJavaPat "tok_NonEmptyDims_dummy_141" getNonEmptyDims ) quoteJavaType quoteJavaDecs
+nonEmptyDims = QuasiQuoter (quoteJavaExp "tok_NonEmptyDims_dummy_143" getNonEmptyDims ) (quoteJavaPat "tok_NonEmptyDims_dummy_143" getNonEmptyDims ) quoteJavaType quoteJavaDecs
 
-getNonEmptyTypeArguments ( Ctr__Java__51 _ s) = s
+getNonEmptyTypeArguments ( Ctr__Java__52 _ s) = s
 
 nonEmptyTypeArguments :: QuasiQuoter
-nonEmptyTypeArguments = QuasiQuoter (quoteJavaExp "tok_NonEmptyTypeArguments_dummy_140" getNonEmptyTypeArguments ) (quoteJavaPat "tok_NonEmptyTypeArguments_dummy_140" getNonEmptyTypeArguments ) quoteJavaType quoteJavaDecs
+nonEmptyTypeArguments = QuasiQuoter (quoteJavaExp "tok_NonEmptyTypeArguments_dummy_142" getNonEmptyTypeArguments ) (quoteJavaPat "tok_NonEmptyTypeArguments_dummy_142" getNonEmptyTypeArguments ) quoteJavaType quoteJavaDecs
 
-getOptDocComment ( Ctr__Java__52 _ s) = s
+getOptDocComment ( Ctr__Java__53 _ s) = s
 
 optDocComment :: QuasiQuoter
-optDocComment = QuasiQuoter (quoteJavaExp "tok_OptDocComment_dummy_139" getOptDocComment ) (quoteJavaPat "tok_OptDocComment_dummy_139" getOptDocComment ) quoteJavaType quoteJavaDecs
+optDocComment = QuasiQuoter (quoteJavaExp "tok_OptDocComment_dummy_141" getOptDocComment ) (quoteJavaPat "tok_OptDocComment_dummy_141" getOptDocComment ) quoteJavaType quoteJavaDecs
 
-getOptElsePart ( Ctr__Java__53 _ s) = s
+getOptElsePart ( Ctr__Java__54 _ s) = s
 
 optElsePart :: QuasiQuoter
-optElsePart = QuasiQuoter (quoteJavaExp "tok_OptElsePart_dummy_138" getOptElsePart ) (quoteJavaPat "tok_OptElsePart_dummy_138" getOptElsePart ) quoteJavaType quoteJavaDecs
+optElsePart = QuasiQuoter (quoteJavaExp "tok_OptElsePart_dummy_140" getOptElsePart ) (quoteJavaPat "tok_OptElsePart_dummy_140" getOptElsePart ) quoteJavaType quoteJavaDecs
 
-getOptExpression ( Ctr__Java__54 _ s) = s
+getOptExpression ( Ctr__Java__55 _ s) = s
 
 optExpression :: QuasiQuoter
-optExpression = QuasiQuoter (quoteJavaExp "tok_OptExpression_dummy_137" getOptExpression ) (quoteJavaPat "tok_OptExpression_dummy_137" getOptExpression ) quoteJavaType quoteJavaDecs
+optExpression = QuasiQuoter (quoteJavaExp "tok_OptExpression_dummy_139" getOptExpression ) (quoteJavaPat "tok_OptExpression_dummy_139" getOptExpression ) quoteJavaType quoteJavaDecs
 
-getOptFinally ( Ctr__Java__55 _ s) = s
+getOptFinally ( Ctr__Java__56 _ s) = s
 
 optFinally :: QuasiQuoter
-optFinally = QuasiQuoter (quoteJavaExp "tok_OptFinally_dummy_136" getOptFinally ) (quoteJavaPat "tok_OptFinally_dummy_136" getOptFinally ) quoteJavaType quoteJavaDecs
+optFinally = QuasiQuoter (quoteJavaExp "tok_OptFinally_dummy_138" getOptFinally ) (quoteJavaPat "tok_OptFinally_dummy_138" getOptFinally ) quoteJavaType quoteJavaDecs
 
-getOptId ( Ctr__Java__56 _ s) = s
+getOptId ( Ctr__Java__57 _ s) = s
 
 optId :: QuasiQuoter
-optId = QuasiQuoter (quoteJavaExp "tok_OptId_dummy_135" getOptId ) (quoteJavaPat "tok_OptId_dummy_135" getOptId ) quoteJavaType quoteJavaDecs
+optId = QuasiQuoter (quoteJavaExp "tok_OptId_dummy_137" getOptId ) (quoteJavaPat "tok_OptId_dummy_137" getOptId ) quoteJavaType quoteJavaDecs
 
-getOptVariableInitializer ( Ctr__Java__57 _ s) = s
+getOptVariableInitializer ( Ctr__Java__58 _ s) = s
 
 optVariableInitializer :: QuasiQuoter
-optVariableInitializer = QuasiQuoter (quoteJavaExp "tok_OptVariableInitializer_dummy_134" getOptVariableInitializer ) (quoteJavaPat "tok_OptVariableInitializer_dummy_134" getOptVariableInitializer ) quoteJavaType quoteJavaDecs
+optVariableInitializer = QuasiQuoter (quoteJavaExp "tok_OptVariableInitializer_dummy_136" getOptVariableInitializer ) (quoteJavaPat "tok_OptVariableInitializer_dummy_136" getOptVariableInitializer ) quoteJavaType quoteJavaDecs
 
-getPackage ( Ctr__Java__58 _ s) = s
+getPackage ( Ctr__Java__59 _ s) = s
 
 package :: QuasiQuoter
-package = QuasiQuoter (quoteJavaExp "tok_Package_dummy_133" getPackage ) (quoteJavaPat "tok_Package_dummy_133" getPackage ) quoteJavaType quoteJavaDecs
+package = QuasiQuoter (quoteJavaExp "tok_Package_dummy_135" getPackage ) (quoteJavaPat "tok_Package_dummy_135" getPackage ) quoteJavaType quoteJavaDecs
 
-getParamModifierList ( Ctr__Java__59 _ s) = s
+getParamModifierList ( Ctr__Java__60 _ s) = s
 
 paramModifierList :: QuasiQuoter
-paramModifierList = QuasiQuoter (quoteJavaExp "tok_ParamModifierList_dummy_132" getParamModifierList ) (quoteJavaPat "tok_ParamModifierList_dummy_132" getParamModifierList ) quoteJavaType quoteJavaDecs
+paramModifierList = QuasiQuoter (quoteJavaExp "tok_ParamModifierList_dummy_134" getParamModifierList ) (quoteJavaPat "tok_ParamModifierList_dummy_134" getParamModifierList ) quoteJavaType quoteJavaDecs
 
-getParameter ( Ctr__Java__60 _ s) = s
+getParameter ( Ctr__Java__61 _ s) = s
 
 parameter :: QuasiQuoter
-parameter = QuasiQuoter (quoteJavaExp "tok_Parameter_dummy_131" getParameter ) (quoteJavaPat "tok_Parameter_dummy_131" getParameter ) quoteJavaType quoteJavaDecs
+parameter = QuasiQuoter (quoteJavaExp "tok_Parameter_dummy_133" getParameter ) (quoteJavaPat "tok_Parameter_dummy_133" getParameter ) quoteJavaType quoteJavaDecs
 
-getParameterList ( Ctr__Java__61 _ s) = s
+getParameterList ( Ctr__Java__62 _ s) = s
 
 parameterList :: QuasiQuoter
-parameterList = QuasiQuoter (quoteJavaExp "tok_ParameterList_dummy_130" getParameterList ) (quoteJavaPat "tok_ParameterList_dummy_130" getParameterList ) quoteJavaType quoteJavaDecs
+parameterList = QuasiQuoter (quoteJavaExp "tok_ParameterList_dummy_132" getParameterList ) (quoteJavaPat "tok_ParameterList_dummy_132" getParameterList ) quoteJavaType quoteJavaDecs
 
-getPostfixOp ( Ctr__Java__62 _ s) = s
+getPostfixOp ( Ctr__Java__63 _ s) = s
 
 postfixOp :: QuasiQuoter
-postfixOp = QuasiQuoter (quoteJavaExp "tok_PostfixOp_dummy_129" getPostfixOp ) (quoteJavaPat "tok_PostfixOp_dummy_129" getPostfixOp ) quoteJavaType quoteJavaDecs
+postfixOp = QuasiQuoter (quoteJavaExp "tok_PostfixOp_dummy_131" getPostfixOp ) (quoteJavaPat "tok_PostfixOp_dummy_131" getPostfixOp ) quoteJavaType quoteJavaDecs
 
-getPrefixOp ( Ctr__Java__63 _ s) = s
+getPrefixOp ( Ctr__Java__64 _ s) = s
 
 prefixOp :: QuasiQuoter
-prefixOp = QuasiQuoter (quoteJavaExp "tok_PrefixOp_dummy_128" getPrefixOp ) (quoteJavaPat "tok_PrefixOp_dummy_128" getPrefixOp ) quoteJavaType quoteJavaDecs
+prefixOp = QuasiQuoter (quoteJavaExp "tok_PrefixOp_dummy_130" getPrefixOp ) (quoteJavaPat "tok_PrefixOp_dummy_130" getPrefixOp ) quoteJavaType quoteJavaDecs
 
-getPrimitiveTypeKeyword ( Ctr__Java__64 _ s) = s
+getPrimitiveTypeKeyword ( Ctr__Java__65 _ s) = s
 
 primitiveTypeKeyword :: QuasiQuoter
-primitiveTypeKeyword = QuasiQuoter (quoteJavaExp "tok_PrimitiveTypeKeyword_dummy_127" getPrimitiveTypeKeyword ) (quoteJavaPat "tok_PrimitiveTypeKeyword_dummy_127" getPrimitiveTypeKeyword ) quoteJavaType quoteJavaDecs
+primitiveTypeKeyword = QuasiQuoter (quoteJavaExp "tok_PrimitiveTypeKeyword_dummy_129" getPrimitiveTypeKeyword ) (quoteJavaPat "tok_PrimitiveTypeKeyword_dummy_129" getPrimitiveTypeKeyword ) quoteJavaType quoteJavaDecs
 
-getRelationalOp ( Ctr__Java__65 _ s) = s
+getRelationalOp ( Ctr__Java__66 _ s) = s
 
 relationalOp :: QuasiQuoter
-relationalOp = QuasiQuoter (quoteJavaExp "tok_RelationalOp_dummy_126" getRelationalOp ) (quoteJavaPat "tok_RelationalOp_dummy_126" getRelationalOp ) quoteJavaType quoteJavaDecs
+relationalOp = QuasiQuoter (quoteJavaExp "tok_RelationalOp_dummy_128" getRelationalOp ) (quoteJavaPat "tok_RelationalOp_dummy_128" getRelationalOp ) quoteJavaType quoteJavaDecs
 
-getResource ( Ctr__Java__66 _ s) = s
+getResource ( Ctr__Java__67 _ s) = s
 
 resource :: QuasiQuoter
-resource = QuasiQuoter (quoteJavaExp "tok_Resource_dummy_125" getResource ) (quoteJavaPat "tok_Resource_dummy_125" getResource ) quoteJavaType quoteJavaDecs
+resource = QuasiQuoter (quoteJavaExp "tok_Resource_dummy_127" getResource ) (quoteJavaPat "tok_Resource_dummy_127" getResource ) quoteJavaType quoteJavaDecs
 
-getResourceSpec ( Ctr__Java__67 _ s) = s
+getResourceSpec ( Ctr__Java__68 _ s) = s
 
 resourceSpec :: QuasiQuoter
-resourceSpec = QuasiQuoter (quoteJavaExp "tok_ResourceSpec_dummy_124" getResourceSpec ) (quoteJavaPat "tok_ResourceSpec_dummy_124" getResourceSpec ) quoteJavaType quoteJavaDecs
+resourceSpec = QuasiQuoter (quoteJavaExp "tok_ResourceSpec_dummy_126" getResourceSpec ) (quoteJavaPat "tok_ResourceSpec_dummy_126" getResourceSpec ) quoteJavaType quoteJavaDecs
 
-getShiftOp ( Ctr__Java__68 _ s) = s
+getShiftOp ( Ctr__Java__69 _ s) = s
 
 shiftOp :: QuasiQuoter
-shiftOp = QuasiQuoter (quoteJavaExp "tok_ShiftOp_dummy_123" getShiftOp ) (quoteJavaPat "tok_ShiftOp_dummy_123" getShiftOp ) quoteJavaType quoteJavaDecs
+shiftOp = QuasiQuoter (quoteJavaExp "tok_ShiftOp_dummy_125" getShiftOp ) (quoteJavaPat "tok_ShiftOp_dummy_125" getShiftOp ) quoteJavaType quoteJavaDecs
 
-getStatement ( Ctr__Java__69 _ s) = s
+getStatement ( Ctr__Java__70 _ s) = s
 
 statement :: QuasiQuoter
-statement = QuasiQuoter (quoteJavaExp "tok_Statement_dummy_122" getStatement ) (quoteJavaPat "tok_Statement_dummy_122" getStatement ) quoteJavaType quoteJavaDecs
+statement = QuasiQuoter (quoteJavaExp "tok_Statement_dummy_124" getStatement ) (quoteJavaPat "tok_Statement_dummy_124" getStatement ) quoteJavaType quoteJavaDecs
 
-getStatementBlock ( Ctr__Java__70 _ s) = s
+getStatementBlock ( Ctr__Java__71 _ s) = s
 
 statementBlock :: QuasiQuoter
-statementBlock = QuasiQuoter (quoteJavaExp "tok_StatementBlock_dummy_121" getStatementBlock ) (quoteJavaPat "tok_StatementBlock_dummy_121" getStatementBlock ) quoteJavaType quoteJavaDecs
+statementBlock = QuasiQuoter (quoteJavaExp "tok_StatementBlock_dummy_123" getStatementBlock ) (quoteJavaPat "tok_StatementBlock_dummy_123" getStatementBlock ) quoteJavaType quoteJavaDecs
 
-getStatementList ( Ctr__Java__71 _ s) = s
+getStatementList ( Ctr__Java__72 _ s) = s
 
 statementList :: QuasiQuoter
-statementList = QuasiQuoter (quoteJavaExp "tok_StatementList_dummy_120" getStatementList ) (quoteJavaPat "tok_StatementList_dummy_120" getStatementList ) quoteJavaType quoteJavaDecs
+statementList = QuasiQuoter (quoteJavaExp "tok_StatementList_dummy_122" getStatementList ) (quoteJavaPat "tok_StatementList_dummy_122" getStatementList ) quoteJavaType quoteJavaDecs
 
-getStaticInitializer ( Ctr__Java__72 _ s) = s
+getStaticInitializer ( Ctr__Java__73 _ s) = s
 
 staticInitializer :: QuasiQuoter
-staticInitializer = QuasiQuoter (quoteJavaExp "tok_StaticInitializer_dummy_119" getStaticInitializer ) (quoteJavaPat "tok_StaticInitializer_dummy_119" getStaticInitializer ) quoteJavaType quoteJavaDecs
+staticInitializer = QuasiQuoter (quoteJavaExp "tok_StaticInitializer_dummy_121" getStaticInitializer ) (quoteJavaPat "tok_StaticInitializer_dummy_121" getStaticInitializer ) quoteJavaType quoteJavaDecs
 
-getSwitchCaseList ( Ctr__Java__73 _ s) = s
+getSwitchCaseList ( Ctr__Java__74 _ s) = s
 
 switchCaseList :: QuasiQuoter
-switchCaseList = QuasiQuoter (quoteJavaExp "tok_SwitchCaseList_dummy_118" getSwitchCaseList ) (quoteJavaPat "tok_SwitchCaseList_dummy_118" getSwitchCaseList ) quoteJavaType quoteJavaDecs
+switchCaseList = QuasiQuoter (quoteJavaExp "tok_SwitchCaseList_dummy_120" getSwitchCaseList ) (quoteJavaPat "tok_SwitchCaseList_dummy_120" getSwitchCaseList ) quoteJavaType quoteJavaDecs
 
-getSwitchStatement ( Ctr__Java__74 _ s) = s
+getSwitchStatement ( Ctr__Java__75 _ s) = s
 
 switchStatement :: QuasiQuoter
-switchStatement = QuasiQuoter (quoteJavaExp "tok_SwitchStatement_dummy_117" getSwitchStatement ) (quoteJavaPat "tok_SwitchStatement_dummy_117" getSwitchStatement ) quoteJavaType quoteJavaDecs
+switchStatement = QuasiQuoter (quoteJavaExp "tok_SwitchStatement_dummy_119" getSwitchStatement ) (quoteJavaPat "tok_SwitchStatement_dummy_119" getSwitchStatement ) quoteJavaType quoteJavaDecs
 
-getThrowsClause ( Ctr__Java__75 _ s) = s
+getThrowsClause ( Ctr__Java__76 _ s) = s
 
 throwsClause :: QuasiQuoter
-throwsClause = QuasiQuoter (quoteJavaExp "tok_ThrowsClause_dummy_116" getThrowsClause ) (quoteJavaPat "tok_ThrowsClause_dummy_116" getThrowsClause ) quoteJavaType quoteJavaDecs
+throwsClause = QuasiQuoter (quoteJavaExp "tok_ThrowsClause_dummy_118" getThrowsClause ) (quoteJavaPat "tok_ThrowsClause_dummy_118" getThrowsClause ) quoteJavaType quoteJavaDecs
 
-getTryStatement ( Ctr__Java__76 _ s) = s
+getTryStatement ( Ctr__Java__77 _ s) = s
 
 tryStatement :: QuasiQuoter
-tryStatement = QuasiQuoter (quoteJavaExp "tok_TryStatement_dummy_115" getTryStatement ) (quoteJavaPat "tok_TryStatement_dummy_115" getTryStatement ) quoteJavaType quoteJavaDecs
+tryStatement = QuasiQuoter (quoteJavaExp "tok_TryStatement_dummy_117" getTryStatement ) (quoteJavaPat "tok_TryStatement_dummy_117" getTryStatement ) quoteJavaType quoteJavaDecs
 
-getType ( Ctr__Java__77 _ s) = s
+getType ( Ctr__Java__78 _ s) = s
 
 __type :: QuasiQuoter
-__type = QuasiQuoter (quoteJavaExp "tok_Type_dummy_114" getType ) (quoteJavaPat "tok_Type_dummy_114" getType ) quoteJavaType quoteJavaDecs
+__type = QuasiQuoter (quoteJavaExp "tok_Type_dummy_116" getType ) (quoteJavaPat "tok_Type_dummy_116" getType ) quoteJavaType quoteJavaDecs
 
-getTypeArgument ( Ctr__Java__78 _ s) = s
+getTypeArgument ( Ctr__Java__79 _ s) = s
 
 typeArgument :: QuasiQuoter
-typeArgument = QuasiQuoter (quoteJavaExp "tok_TypeArgument_dummy_113" getTypeArgument ) (quoteJavaPat "tok_TypeArgument_dummy_113" getTypeArgument ) quoteJavaType quoteJavaDecs
+typeArgument = QuasiQuoter (quoteJavaExp "tok_TypeArgument_dummy_115" getTypeArgument ) (quoteJavaPat "tok_TypeArgument_dummy_115" getTypeArgument ) quoteJavaType quoteJavaDecs
 
-getTypeArguments ( Ctr__Java__79 _ s) = s
+getTypeArguments ( Ctr__Java__80 _ s) = s
 
 typeArguments :: QuasiQuoter
-typeArguments = QuasiQuoter (quoteJavaExp "tok_TypeArguments_dummy_112" getTypeArguments ) (quoteJavaPat "tok_TypeArguments_dummy_112" getTypeArguments ) quoteJavaType quoteJavaDecs
+typeArguments = QuasiQuoter (quoteJavaExp "tok_TypeArguments_dummy_114" getTypeArguments ) (quoteJavaPat "tok_TypeArguments_dummy_114" getTypeArguments ) quoteJavaType quoteJavaDecs
 
-getTypeDeclRest ( Ctr__Java__80 _ s) = s
+getTypeDeclRest ( Ctr__Java__81 _ s) = s
 
 typeDeclRest :: QuasiQuoter
-typeDeclRest = QuasiQuoter (quoteJavaExp "tok_TypeDeclRest_dummy_111" getTypeDeclRest ) (quoteJavaPat "tok_TypeDeclRest_dummy_111" getTypeDeclRest ) quoteJavaType quoteJavaDecs
+typeDeclRest = QuasiQuoter (quoteJavaExp "tok_TypeDeclRest_dummy_113" getTypeDeclRest ) (quoteJavaPat "tok_TypeDeclRest_dummy_113" getTypeDeclRest ) quoteJavaType quoteJavaDecs
 
-getTypeDeclaration ( Ctr__Java__81 _ s) = s
+getTypeDeclaration ( Ctr__Java__82 _ s) = s
 
 typeDeclaration :: QuasiQuoter
-typeDeclaration = QuasiQuoter (quoteJavaExp "tok_TypeDeclaration_dummy_110" getTypeDeclaration ) (quoteJavaPat "tok_TypeDeclaration_dummy_110" getTypeDeclaration ) quoteJavaType quoteJavaDecs
+typeDeclaration = QuasiQuoter (quoteJavaExp "tok_TypeDeclaration_dummy_112" getTypeDeclaration ) (quoteJavaPat "tok_TypeDeclaration_dummy_112" getTypeDeclaration ) quoteJavaType quoteJavaDecs
 
-getTypeParameter ( Ctr__Java__82 _ s) = s
+getTypeParameter ( Ctr__Java__83 _ s) = s
 
 typeParameter :: QuasiQuoter
-typeParameter = QuasiQuoter (quoteJavaExp "tok_TypeParameter_dummy_109" getTypeParameter ) (quoteJavaPat "tok_TypeParameter_dummy_109" getTypeParameter ) quoteJavaType quoteJavaDecs
+typeParameter = QuasiQuoter (quoteJavaExp "tok_TypeParameter_dummy_111" getTypeParameter ) (quoteJavaPat "tok_TypeParameter_dummy_111" getTypeParameter ) quoteJavaType quoteJavaDecs
 
-getTypeParameters ( Ctr__Java__83 _ s) = s
+getTypeParameters ( Ctr__Java__84 _ s) = s
 
 typeParameters :: QuasiQuoter
-typeParameters = QuasiQuoter (quoteJavaExp "tok_TypeParameters_dummy_108" getTypeParameters ) (quoteJavaPat "tok_TypeParameters_dummy_108" getTypeParameters ) quoteJavaType quoteJavaDecs
+typeParameters = QuasiQuoter (quoteJavaExp "tok_TypeParameters_dummy_110" getTypeParameters ) (quoteJavaPat "tok_TypeParameters_dummy_110" getTypeParameters ) quoteJavaType quoteJavaDecs
 
-getTypeSpecifier ( Ctr__Java__84 _ s) = s
+getTypeSpecifier ( Ctr__Java__85 _ s) = s
 
 typeSpecifier :: QuasiQuoter
-typeSpecifier = QuasiQuoter (quoteJavaExp "tok_TypeSpecifier_dummy_107" getTypeSpecifier ) (quoteJavaPat "tok_TypeSpecifier_dummy_107" getTypeSpecifier ) quoteJavaType quoteJavaDecs
+typeSpecifier = QuasiQuoter (quoteJavaExp "tok_TypeSpecifier_dummy_109" getTypeSpecifier ) (quoteJavaPat "tok_TypeSpecifier_dummy_109" getTypeSpecifier ) quoteJavaType quoteJavaDecs
 
-getVariableDeclaration ( Ctr__Java__85 _ s) = s
+getVariableDeclaration ( Ctr__Java__86 _ s) = s
 
 variableDeclaration :: QuasiQuoter
-variableDeclaration = QuasiQuoter (quoteJavaExp "tok_VariableDeclaration_dummy_106" getVariableDeclaration ) (quoteJavaPat "tok_VariableDeclaration_dummy_106" getVariableDeclaration ) quoteJavaType quoteJavaDecs
+variableDeclaration = QuasiQuoter (quoteJavaExp "tok_VariableDeclaration_dummy_108" getVariableDeclaration ) (quoteJavaPat "tok_VariableDeclaration_dummy_108" getVariableDeclaration ) quoteJavaType quoteJavaDecs
 
-getVariableDeclarator ( Ctr__Java__86 _ s) = s
+getVariableDeclarator ( Ctr__Java__87 _ s) = s
 
 variableDeclarator :: QuasiQuoter
-variableDeclarator = QuasiQuoter (quoteJavaExp "tok_VariableDeclarator_dummy_105" getVariableDeclarator ) (quoteJavaPat "tok_VariableDeclarator_dummy_105" getVariableDeclarator ) quoteJavaType quoteJavaDecs
+variableDeclarator = QuasiQuoter (quoteJavaExp "tok_VariableDeclarator_dummy_107" getVariableDeclarator ) (quoteJavaPat "tok_VariableDeclarator_dummy_107" getVariableDeclarator ) quoteJavaType quoteJavaDecs
 
-getVariableDeclaratorList ( Ctr__Java__87 _ s) = s
+getVariableDeclaratorList ( Ctr__Java__88 _ s) = s
 
 variableDeclaratorList :: QuasiQuoter
-variableDeclaratorList = QuasiQuoter (quoteJavaExp "tok_VariableDeclaratorList_dummy_104" getVariableDeclaratorList ) (quoteJavaPat "tok_VariableDeclaratorList_dummy_104" getVariableDeclaratorList ) quoteJavaType quoteJavaDecs
+variableDeclaratorList = QuasiQuoter (quoteJavaExp "tok_VariableDeclaratorList_dummy_106" getVariableDeclaratorList ) (quoteJavaPat "tok_VariableDeclaratorList_dummy_106" getVariableDeclaratorList ) quoteJavaType quoteJavaDecs
 
-getVariableInitializer ( Ctr__Java__88 _ s) = s
+getVariableInitializer ( Ctr__Java__89 _ s) = s
 
 variableInitializer :: QuasiQuoter
-variableInitializer = QuasiQuoter (quoteJavaExp "tok_VariableInitializer_dummy_103" getVariableInitializer ) (quoteJavaPat "tok_VariableInitializer_dummy_103" getVariableInitializer ) quoteJavaType quoteJavaDecs
+variableInitializer = QuasiQuoter (quoteJavaExp "tok_VariableInitializer_dummy_105" getVariableInitializer ) (quoteJavaPat "tok_VariableInitializer_dummy_105" getVariableInitializer ) quoteJavaType quoteJavaDecs
 
-getVariableInitializerList ( Ctr__Java__89 _ s) = s
+getVariableInitializerList ( Ctr__Java__90 _ s) = s
 
 variableInitializerList :: QuasiQuoter
-variableInitializerList = QuasiQuoter (quoteJavaExp "tok_VariableInitializerList_dummy_102" getVariableInitializerList ) (quoteJavaPat "tok_VariableInitializerList_dummy_102" getVariableInitializerList ) quoteJavaType quoteJavaDecs
+variableInitializerList = QuasiQuoter (quoteJavaExp "tok_VariableInitializerList_dummy_104" getVariableInitializerList ) (quoteJavaPat "tok_VariableInitializerList_dummy_104" getVariableInitializerList ) quoteJavaType quoteJavaDecs
 
-getWhileStatement ( Ctr__Java__90 _ s) = s
+getWhileStatement ( Ctr__Java__91 _ s) = s
 
 whileStatement :: QuasiQuoter
-whileStatement = QuasiQuoter (quoteJavaExp "tok_WhileStatement_dummy_101" getWhileStatement ) (quoteJavaPat "tok_WhileStatement_dummy_101" getWhileStatement ) quoteJavaType quoteJavaDecs
+whileStatement = QuasiQuoter (quoteJavaExp "tok_WhileStatement_dummy_103" getWhileStatement ) (quoteJavaPat "tok_WhileStatement_dummy_103" getWhileStatement ) quoteJavaType quoteJavaDecs
 
-getWildcardType ( Ctr__Java__91 _ s) = s
+getWildcardType ( Ctr__Java__92 _ s) = s
 
 wildcardType :: QuasiQuoter
-wildcardType = QuasiQuoter (quoteJavaExp "tok_WildcardType_dummy_100" getWildcardType ) (quoteJavaPat "tok_WildcardType_dummy_100" getWildcardType ) quoteJavaType quoteJavaDecs
+wildcardType = QuasiQuoter (quoteJavaExp "tok_WildcardType_dummy_102" getWildcardType ) (quoteJavaPat "tok_WildcardType_dummy_102" getWildcardType ) quoteJavaType quoteJavaDecs
 


### PR DESCRIPTION
The two big Java 8 expression features, placed where the JLS puts them
and riding existing automaton decision points:

- method references (JLS 15.13): two PostfixExpression alternatives,
  PostfixExpression '::' id and PostfixExpression '::' 'new'. '::' is
  a fresh token, so the shift is unambiguous, and a bare-name base
  reduces CompoundName -> ... -> PostfixExpression on '::' without
  touching the greedy name-extension family. Covers Foo::bar,
  this::handle, obj.field::m, f()::m, (expr)::m, Foo::new. Not covered
  (rare): String[]::new, super::m, explicit type args on the reference.

- lambda expressions (JLS 15.27): four AssignmentExpression
  alternatives plus LambdaBody = Expression | StatementBlock.
  'id ->' shifts the fresh '->' token directly after the id (no reduce
  lookahead contains '->'); '( )' makes ')' a first-ever action for
  the operand-position '('; '( id (, id)+ )' commits on a ',' that no
  parenthesized expression can continue with; and the single
  parenthesized parameter '(x) -> e' rides the cast machinery's
  '(' Expression ')', with '->' joining the conflict-free
  one-token-after-')' decision (that the expression is a bare
  identifier is a semantic check, javac's job). The body extends as
  far right as an Expression can (JLS-correct); '{' starts a block
  body. A lambda parses in a conditional's TRUE branch; the FALSE
  branch (ConditionalExpression) excludes it - parenthesize, as the
  corpus does. KNOWN LIMITATIONS (documented at the rule, measured on
  commons-lang): typed parameter lists ((Foo a, Bar b) -> e, 0 corpus
  files) and a lambda directly under a cast ((Predicate<T>) t -> ...,
  2 corpus files) need cover-grammar machinery and are deferred.

Lexing: '->' and '::' are auto-collected literal tokens; maximal munch
keeps them whole, and 'a-->b' still lexes as '--' '>'. operators.java
grows arrow/coloncolon cases; its .tokens golden is verified
token-class identical line by line on the unchanged prefix.

Conflict inventory: UNCHANGED - 13 shift/reduce, 0 reduce/reduce, 10
states; happy's conflict states map 1:1 to the six documented families
before and after, so the features add ZERO conflicts (noted in the
header).

Goldens refreshed (test/golden/java/): the new tokens, productions, QQ
quoters and the LambdaBody type, plus mechanical renumbering.

commons-lang corpus: main 126 -> 182, tests 92 -> 172 passing (lexing
stays 526/526), zero regressions; the 136 newly passing files leave
the parser blacklists, whose headers drop lambdas/method references
from the blocker list (remaining: anonymous inner classes, doc comment
before package, <T> void methods, annotation-value/array-creation
initializers, cast-of-lambda).

https://claude.ai/code/session_01978hvfWEaToee2rfkKZHSV