### PR TITLE
Add support for Phase 4g Java language features

### DIFF
--- a/makefile
+++ b/makefile
@@ -188,6 +188,18 @@ $(eval $(call make-shared-test-rule,java-set-value,java,Java,test-grammars/java/
 $(eval $(call make-shared-test-rule,java-implements,java,Java,test-grammars/java/test-implements.java))
 $(eval $(call make-shared-test-rule,java-nested-if,java,Java,test-grammars/java/test-nested-if.java))
 
+# Phase 4g feature probes: anonymous classes, array initializers, 'default'
+# methods, annotation value arrays, package-info units, multiple top-level
+# types, enum-constant javadoc, generic primitive/void returns
+$(eval $(call make-shared-test-rule,java-anon-class,java,Java,test-grammars/java/test-anon-class.java))
+$(eval $(call make-shared-test-rule,java-array-init,java,Java,test-grammars/java/test-array-init.java))
+$(eval $(call make-shared-test-rule,java-default-method,java,Java,test-grammars/java/test-default-method.java))
+$(eval $(call make-shared-test-rule,java-annotation-array,java,Java,test-grammars/java/test-annotation-array.java))
+$(eval $(call make-shared-test-rule,java-package-info,java,Java,test-grammars/java/test-package-info.java))
+$(eval $(call make-shared-test-rule,java-multiple-types,java,Java,test-grammars/java/test-multiple-types.java))
+$(eval $(call make-shared-test-rule,java-enum-javadoc,java,Java,test-grammars/java/test-enum-javadoc.java))
+$(eval $(call make-shared-test-rule,java-generic-void,java,Java,test-grammars/java/test-generic-void.java))
+
 # JavaDoc comment tests (blank line + {@link Class#method()} regression tests)
 $(eval $(call make-shared-test-rule,java-javadoc-blank-link,java,Java,test-grammars/java/javadoc/test-blank-then-link.java))
 $(eval $(call make-shared-test-rule,java-javadoc-minimal-hash,java,Java,test-grammars/java/javadoc/test-minimal-hash.java))
@@ -207,7 +219,7 @@ accept-lex-java: test-out/java-main
 	ACCEPT=1 ./test-java-lexical.sh
 
 # Run all Java tests
-test-all-java: test-java test-java-simple test-java-minimal test-java-field test-java-field-public test-java-package test-java-string test-java-complex test-java-full test-java-generics test-java-enum test-java-annotations test-java-empty-method test-java-simple-return test-java-return-field test-java-very-simple test-java-parameter-only test-java-field-this test-java-simple-assignment test-java-compound-assignment test-java-set-value test-java-implements test-java-nested-if test-java-javadoc-blank-link test-java-javadoc-minimal-hash test-java-javadoc-minimal-fail test-java-javadoc-link-tag test-java-javadoc-just-hash
+test-all-java: test-java test-java-simple test-java-minimal test-java-field test-java-field-public test-java-package test-java-string test-java-complex test-java-full test-java-generics test-java-enum test-java-annotations test-java-empty-method test-java-simple-return test-java-return-field test-java-very-simple test-java-parameter-only test-java-field-this test-java-simple-assignment test-java-compound-assignment test-java-set-value test-java-implements test-java-nested-if test-java-anon-class test-java-array-init test-java-default-method test-java-annotation-array test-java-package-info test-java-multiple-types test-java-enum-javadoc test-java-generic-void test-java-javadoc-blank-link test-java-javadoc-minimal-hash test-java-javadoc-minimal-fail test-java-javadoc-link-tag test-java-javadoc-just-hash
 	@echo ""
 	@echo "=== All Java tests completed successfully! ==="
 

--- a/test-grammars/java.pg
+++ b/test-grammars/java.pg
@@ -75,10 +75,10 @@ grammar 'Java';
 # 6. QQ bootstrap dummy bracket - 1 state, 1 conflict. The quasi-quoter
 #    wraps a quote body in a per-rule dummy-token pair, and the whole-file
 #    entry 'Java -> DUMMY . Java DUMMY' lets a second opening DUMMY (shift)
-#    compete with deriving an empty CompilationUnit ((Package)? -> empty)
-#    right before the closing DUMMY (reduce). Only a completely empty
-#    [java| |] quote is affected (it fails to parse); any non-empty quote
-#    has a real token after the opening DUMMY.
+#    compete with deriving an empty CompilationUnit (OptDocComment -> empty,
+#    the unit's first nullable) right before the closing DUMMY (reduce).
+#    Only a completely empty [java| |] quote is affected (it fails to
+#    parse); any non-empty quote has a real token after the opening DUMMY.
 #
 # A seventh family - catch/finally attaching to the nearest try, 1 state,
 # 4 conflicts - dissolved when try/catch/finally bodies were tightened from
@@ -89,7 +89,14 @@ grammar 'Java';
 # references add ZERO conflicts: '->' and '::' are fresh tokens that no
 # reduce lookahead contains, so every lambda head and reference form is
 # decided by a plain shift - see the NOTEs at AssignmentExpression and
-# PostfixExpression.
+# PostfixExpression. The Phase 4g batch - anonymous class bodies, array
+# creation with initializers, the 'default' modifier, annotation value
+# arrays, generic members with primitive/void returns, enum-constant doc
+# comments, and the package-info/multi-type CompilationUnit left-factoring
+# - also adds ZERO conflicts; each construct's NOTE explains why (anchor
+# tokens, shared nonterminals, or '{' never following a complete
+# expression). Only the family-6 item moved: the empty unit's first
+# nullable is now OptDocComment instead of the retired (Package)? option.
 # ============================================================================
 
 Java = CompilationUnit ;
@@ -99,11 +106,33 @@ OptDocComment = (DocComment)? ;
 TypeDeclaration =
  OptDocComment ModifierList TypeDeclRest ;
 
+TypeDeclarationList = (TypeDeclaration)* ;
+
 ImportList = (ImportStatement)*;
+
+# A compilation unit may open with a doc comment and annotations that
+# belong to the 'package' line (package-info.java, JLS 7.4.1) - or, when
+# there is no package line, to the first type declaration. The two cannot
+# be told apart before the token after them, and giving each its own
+# nullable doc position would epsilon-reduce one against the other
+# (reduce/reduce). So the leading 'OptDocComment ModifierList' is parsed
+# ONCE, shared, and CompilationUnitRest's anchor token says what it
+# belongs to: 'package' (UnitPackageFirst - the package's), a type-start
+# token (UnitTypeFirst - the first type's, which therefore does NOT
+# re-parse its own leading doc/modifiers; types after the first are full
+# TypeDeclarations again), or 'import' (UnitImportsFirst - a dangling doc
+# nothing claims). Sharing ModifierList (not a bare AnnotationList) keeps
+# the '@'-extension machinery in one item set; that it also accepts
+# modifier keywords before 'package' is parser-level tolerance (javac's
+# job). TypeDeclarationList replaces the old (TypeDeclaration)?: a unit
+# may hold any number of top-level types (JLS 7.3).
 CompilationUnit  =
- (Package)?
- ImportList
- (TypeDeclaration)?  ;
+ OptDocComment ModifierList (CompilationUnitRest)?  ;
+
+CompilationUnitRest =
+ UnitPackageFirst: Package ImportList TypeDeclarationList
+ | UnitImportsFirst: ImportStatement ImportList TypeDeclarationList
+ | UnitTypeFirst: TypeDeclRest TypeDeclarationList ;
 
 Package  =
  'package' CompoundName  ';'  ;
@@ -133,11 +162,26 @@ Annotation = '@' CompoundName ('(' AnnotationArguments? ')')? ;
 
 AnnotationArguments = AnnotationElement (',' AnnotationElement)* ;
 
-# Explicit alternatives (not (id '=')? Expression) so LALR keeps both items
+# Explicit alternatives (not (id '=')? ElementValue) so LALR keeps both items
 # alive after shifting id; otherwise values starting with an identifier, e.g.
-# @Retention(RetentionPolicy.RUNTIME), fail. ConditionalExpression is the JLS
-# ElementValue level; full Expression would make @Foo(a = b) ambiguous.
-AnnotationElement = id '=' ConditionalExpression | ConditionalExpression ;
+# @Retention(RetentionPolicy.RUNTIME), fail.
+AnnotationElement = id '=' ElementValue | ElementValue ;
+
+# JLS 9.7.1 ElementValue: ConditionalExpression is the JLS expression level
+# (full Expression would make @Foo(a = b) ambiguous); a nested annotation
+# and the brace-enclosed value array are anchored on '@' and '{', tokens no
+# expression can start with, so the three alternatives never compete.
+ElementValue =
+ ConditionalExpression
+ | Annotation
+ | ElementValueArrayInitializer ;
+
+# '{' (values...)? '}' with an optional trailing comma (JLS 9.7.1), e.g.
+# @Target({ ElementType.METHOD, ElementType.FIELD }). After a ',' the next
+# token picks between another value and the closing '}' (the trailing-comma
+# case), the same deferred decision as EnumConstantList's trailing ','.
+ElementValueArrayInitializer =
+ '{' (ElementValue (',' ElementValue)* (',')?)? '}' ;
 
 AnnotationList = Annotation* ;
 
@@ -145,7 +189,7 @@ AnnotationList = Annotation* ;
 # declaration rule (TypeDeclaration at the top level, FieldDeclaration inside
 # a type body). The class/interface/enum/@interface rules must NOT start with
 # their own nullable ModifierList: after the enclosing list, every token that
-# can extend a ModifierList (the 10 modifier keywords, '@', and the splice
+# can extend a ModifierList (the 11 modifier keywords, '@', and the splice
 # tokens qq_Modifier/qq_Annotation/qq_ModifierList) used to conflict between
 # extending the outer list and epsilon-starting the inner one - 14
 # shift/reduce conflicts whose shift put all modifiers on the outer list and
@@ -192,8 +236,14 @@ AnnotationTypeElementList = AnnotationTypeElement* ;
 # ModifierList against FieldDeclaration's nullable OptDocComment → r/r).
 AnnotationTypeElement = FieldDeclaration ;
 
-# Enum declaration
-EnumConstant = AnnotationList id ('(' Arglist ')')? ('{' FieldDeclarationList '}')? ;
+# Enum declaration. A constant may carry a doc comment (JLS 8.9.1 puts
+# annotations there; the doc comment is standard style). The OptDocComment
+# is safe: inside an enum body every constant position (after '{' or a
+# separating ',') expects only an EnumConstant, so the doccomment shift and
+# the epsilon-reduce on '@'/id compete with nothing - the trailing-comma
+# branch reduces on '}'/';' only, and FieldDeclaration's own OptDocComment
+# sits behind the ';' that ends the constant list.
+EnumConstant = OptDocComment AnnotationList id ('(' Arglist ')')? ('{' FieldDeclarationList '}')? ;
 
 EnumConstantList = EnumConstant (',' EnumConstant)* (',')? ;
 
@@ -245,9 +295,20 @@ NonEmptyDims = ('[' ']')+ ;
 # - Primitive type keyword → definitely method/field
 # - TypeParameters → definitely method (generic)
 # - id → could be constructor or reference type method/field
+#
+# The primitive-return generic alternative ('<T> void m()', JLS 8.4) is
+# anchored on NON-nullable NonEmptyTypeParameters: with the nullable
+# TypeParameters it would put the 9 primitive keywords into the
+# empty-TypeParameters reduce lookahead, racing the first alternative's
+# shift in every member state (9 new conflicts per state). Anchored, the
+# branch is only entered through a real '<' - the same '<' shift the
+# reference-type generic alternative uses (TypeParameters derives the same
+# NonEmptyTypeParameters) - and after the closing '>' the next token picks
+# the branch: a primitive keyword shifts here, id reduces TypeParameters.
 MemberDeclaration =
  PrimitiveTypeKeyword Dims id MemberRest                       # Primitive type method/field
- | TypeParameters id MoreTypeSpecifier id MemberRest           # Generic method with any type
+ | TypeParameters id MoreTypeSpecifier id MemberRest           # Generic method with reference type
+ | NonEmptyTypeParameters PrimitiveTypeKeyword Dims id MemberRest # Generic method with primitive/void type
  | id MemberAfterFirstId ;                                     # Constructor or reference type
 
 # Primitive type keywords (from TypeSpecifier)
@@ -328,7 +389,11 @@ VariableInitializerList = (VariableInitializer (',' VariableInitializer)* (',')?
 
 VariableInitializer  =
 Expression
- |  '{'  VariableInitializerList  '}'  ;
+ |  ArrayInitializer  ;
+
+# Brace-enclosed initializer (JLS 10.6), shared by declarators
+# ('int[] a = {1, 2};') and array creation ('new int[] {1, 2}').
+ArrayInitializer  =  '{'  VariableInitializerList  '}'  ;
 
 StaticInitializer  =
  StatementBlock  ;
@@ -751,9 +816,27 @@ Expression : PrimaryNoPostfix =
 
 # Only array creation takes sizing expressions (DimExprs); trailing empty
 # pairs allow 'new int[3][]'. Uses TypeSpecifier, not Type, so the dims are
-# not consumed twice. 'new int[] {1,2}' (initializer syntax) is a separate
-# feature (Phase 4g).
-CreationExpression = 'new' TypeSpecifier ( '(' Arglist ')' | DimExprs (NonEmptyDims)? );
+# not consumed twice.
+#
+# The optional class body after the call form is an anonymous class
+# (JLS 15.9.5): 'new Foo() { ... }'. The '{' is a plain, conflict-FREE
+# shift: no production puts '{' directly after a complete expression, so
+# '{' is never in the lookahead of the empty-body reduce - after ')' the
+# parser either shifts '{' (anonymous body) or reduces on a real
+# expression-follower. (Array-initializer braces sit after NonEmptyDims,
+# never after a complete creation, and keep it that way.)
+#
+# The NonEmptyDims ArrayInitializer alternative is array creation with an
+# initializer (JLS 15.10.1): 'new int[] {1, 2}', 'new int[][] {{1}, {2}}'.
+# The initializer form takes only EMPTY bracket pairs (sizes and an
+# initializer are mutually exclusive in the JLS), so DimExprs keeps its
+# branch to itself: after 'new T [' the next token decides as before
+# (']' commits to the initializer form's empty pair, an expression start
+# to a sizing expression).
+CreationExpression = 'new' TypeSpecifier
+ ( '(' Arglist ')' ('{' FieldDeclarationList '}')?
+ | DimExprs (NonEmptyDims)?
+ | NonEmptyDims ArrayInitializer );
 
 DimExprs = ('[' Expression ']')+ ;
 
@@ -792,7 +875,15 @@ WildcardType =
  | '?' 'extends' Type
  | '?' 'super' Type ;
 
-TypeParameters = ('<' TypeParameter (',' TypeParameter)* '>')? ;
+# Split like TypeArguments/NonEmptyTypeArguments: the nullable wrapper for
+# positions where type parameters are optional (class/interface headers,
+# reference-type generic members), the non-empty core for
+# MemberDeclaration's primitive-return generic alternative, which must be
+# '<'-anchored (see the NOTE there). One shared core nonterminal, so both
+# uses ride the same '<' shift.
+TypeParameters = NonEmptyTypeParameters? ;
+
+NonEmptyTypeParameters = '<' TypeParameter (',' TypeParameter)* '>' ;
 
 TypeParameter = id ('extends' Type ('&' Type)*)? ;
 
@@ -824,6 +915,14 @@ TypeSpecifier =
  |  'void'
  | CompoundName TypeArguments ;
 
+# 'default' (JLS 9.4: interface default methods) is a Modifier even though
+# the JLS grammar gives it its own InterfaceMethodModifier production:
+# accepting it on classes too is parser-level tolerance (javac's job, like
+# 'default' values on ordinary methods - see MemberRest). It cannot clash
+# with the switch label ('default' ':' sits in a statement context where no
+# ModifierList is parsed) nor with the annotation-element default clause
+# (that 'default' follows a method header's ')' Dims ThrowsClause?, a
+# position with no ModifierList item either).
 Modifier =
  'public'
  |  'private'
@@ -834,7 +933,8 @@ Modifier =
  |  'synchronized'
  |  'abstract'
  |  'threadsafe'
- |  'transient'  ;
+ |  'transient'
+ |  'default'  ;
 
 # The tail of a dotted name, hoisted into a NAMED rule so that CompoundName
 # and the PrimaryNoPostfix alternatives anchored on 'id CompoundNameTail'

--- a/test-grammars/java/lexical/char-literals.tokens
+++ b/test-grammars/java/lexical/char-literals.tokens
@@ -1,6 +1,6 @@
-Tk__tok_class_13
+Tk__tok_class_15
 Tk__id "CharLiterals"
-Tk__tok__symbol__14
+Tk__tok__symbol__11
 Tk__tok_char_22
 Tk__id "simple"
 Tk__tok__eql__10
@@ -66,5 +66,5 @@ Tk__id "unicode"
 Tk__tok__eql__10
 Tk__char "'\\u0041'"
 Tk__tok__semi__1
-Tk__tok__symbol__15
+Tk__tok__symbol__12
 EndOfFile

--- a/test-grammars/java/lexical/comments.tokens
+++ b/test-grammars/java/lexical/comments.tokens
@@ -1,11 +1,11 @@
 Tk__doccomment "/** A doc comment with {@link Foo#bar()}.\n *\n * @param none\n */"
-Tk__tok_class_13
+Tk__tok_class_15
 Tk__id "Comments"
-Tk__tok__symbol__14
+Tk__tok__symbol__11
 Tk__tok_int_24
 Tk__id "x"
 Tk__tok__eql__10
 Tk__integerLiteral "1"
 Tk__tok__semi__1
-Tk__tok__symbol__15
+Tk__tok__symbol__12
 EndOfFile

--- a/test-grammars/java/lexical/float-literals.tokens
+++ b/test-grammars/java/lexical/float-literals.tokens
@@ -1,6 +1,6 @@
-Tk__tok_class_13
+Tk__tok_class_15
 Tk__id "FloatLiterals"
-Tk__tok__symbol__14
+Tk__tok__symbol__11
 Tk__tok_double_27
 Tk__id "plain"
 Tk__tok__eql__10
@@ -81,5 +81,5 @@ Tk__id "underscore"
 Tk__tok__eql__10
 Tk__floatLiteral "1_000.000_1"
 Tk__tok__semi__1
-Tk__tok__symbol__15
+Tk__tok__symbol__12
 EndOfFile

--- a/test-grammars/java/lexical/int-literals.tokens
+++ b/test-grammars/java/lexical/int-literals.tokens
@@ -1,6 +1,6 @@
-Tk__tok_class_13
+Tk__tok_class_15
 Tk__id "IntLiterals"
-Tk__tok__symbol__14
+Tk__tok__symbol__11
 Tk__tok_int_24
 Tk__id "dec"
 Tk__tok__eql__10
@@ -71,5 +71,5 @@ Tk__id "underscoreLong"
 Tk__tok__eql__10
 Tk__integerLiteral "9_999_999_999L"
 Tk__tok__semi__1
-Tk__tok__symbol__15
+Tk__tok__symbol__12
 EndOfFile

--- a/test-grammars/java/lexical/operators.tokens
+++ b/test-grammars/java/lexical/operators.tokens
@@ -1,11 +1,11 @@
-Tk__tok_class_13
+Tk__tok_class_15
 Tk__id "Operators"
-Tk__tok__symbol__14
+Tk__tok__symbol__11
 Tk__tok_void_28
 Tk__id "m"
 Tk__tok__lparen__7
 Tk__tok__rparen__8
-Tk__tok__symbol__14
+Tk__tok__symbol__11
 Tk__tok_int_24
 Tk__id "a"
 Tk__tok__eql__10
@@ -184,6 +184,6 @@ Tk__tok__minus__minus__83
 Tk__tok__symbol__73
 Tk__id "b"
 Tk__tok__semi__1
-Tk__tok__symbol__15
-Tk__tok__symbol__15
+Tk__tok__symbol__12
+Tk__tok__symbol__12
 EndOfFile

--- a/test-grammars/java/lexical/string-literals.tokens
+++ b/test-grammars/java/lexical/string-literals.tokens
@@ -1,6 +1,6 @@
-Tk__tok_class_13
+Tk__tok_class_15
 Tk__id "StringLiterals"
-Tk__tok__symbol__14
+Tk__tok__symbol__11
 Tk__id "String"
 Tk__id "empty"
 Tk__tok__eql__10
@@ -31,5 +31,5 @@ Tk__id "unicode"
 Tk__tok__eql__10
 Tk__string "\"\\u0041BC\""
 Tk__tok__semi__1
-Tk__tok__symbol__15
+Tk__tok__symbol__12
 EndOfFile

--- a/test-grammars/java/test-annotation-array.java
+++ b/test-grammars/java/test-annotation-array.java
@@ -1,0 +1,16 @@
+package test;
+
+@Target({ ElementType.METHOD, ElementType.FIELD })
+@interface T { }
+
+@Multi(value = {1, 2, 3}, names = {"a", "b"}, empty = {}, trailing = {1, 2,})
+class Annotated {
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    void m() { }
+
+    @Outer({ @Inner(1), @Inner(name = "x") })
+    int field;
+
+    @Wrap(@Inner(2))
+    int wrapped;
+}

--- a/test-grammars/java/test-anon-class.java
+++ b/test-grammars/java/test-anon-class.java
@@ -1,0 +1,26 @@
+package test;
+
+public class AnonClass {
+    private static final ToStringStyle STYLE = new ToStringStyle() { };
+
+    public void run() {
+        new ToStringStyle() { };
+        Runnable r = new Runnable() {
+            private int count = 0;
+
+            public void run() {
+                count = count + 1;
+            }
+        };
+        r.run();
+        helper(new java.util.ArrayList<String>() { });
+        new Thread(new Runnable() {
+            public void run() {
+                helper(null);
+            }
+        }).start();
+    }
+
+    private void helper(Object o) {
+    }
+}

--- a/test-grammars/java/test-array-init.java
+++ b/test-grammars/java/test-array-init.java
@@ -1,0 +1,18 @@
+package test;
+
+public class ArrayInit {
+    private static final char[] LETTERS = new char[] {'A', 'B'};
+    private static final int[][] GRID = new int[][] {{1}, {2}};
+
+    public int[] make() {
+        new char[] {'A'};
+        int[] empty = new int[] {};
+        long[] trailing = new long[] {1, 2, 3,};
+        String[] strings = new String[] {"a", "b"};
+        use(new Object[] {null, "x", 1});
+        return new int[] {1, 2};
+    }
+
+    private void use(Object[] os) {
+    }
+}

--- a/test-grammars/java/test-default-method.java
+++ b/test-grammars/java/test-default-method.java
@@ -1,0 +1,26 @@
+package test;
+
+interface I {
+    default int m() { return 1; }
+
+    default String greet(String name) {
+        return name;
+    }
+
+    int abstractOne();
+}
+
+class WithSwitch {
+    int pick(int x) {
+        switch (x) {
+            case 1:
+                return 10;
+            default:
+                return 0;
+        }
+    }
+}
+
+@interface WithDefault {
+    int value() default 5;
+}

--- a/test-grammars/java/test-enum-javadoc.java
+++ b/test-grammars/java/test-enum-javadoc.java
@@ -1,0 +1,24 @@
+package test;
+
+public enum Documented {
+    /** First constant. */
+    ALPHA,
+
+    /** Second constant, annotated, with arguments. */
+    @Deprecated
+    BETA(2),
+
+    /** Third, with a body. */
+    GAMMA {
+        void hook() { }
+    };
+
+    /** Field doc. */
+    private int value;
+
+    Documented() { }
+
+    Documented(int v) {
+        value = v;
+    }
+}

--- a/test-grammars/java/test-generic-void.java
+++ b/test-grammars/java/test-generic-void.java
@@ -1,0 +1,15 @@
+package test;
+
+class A {
+    <T> void m() { }
+
+    <K, V> int count(K k, V v) { return 0; }
+
+    <T> T id(T t) { return t; }
+
+    <T> int[] arr() { return null; }
+
+    static <E> void each(E[] items) { }
+
+    <T> boolean test(T t) { return true; }
+}

--- a/test-grammars/java/test-multiple-types.java
+++ b/test-grammars/java/test-multiple-types.java
@@ -1,0 +1,10 @@
+package test;
+
+class A { }
+
+class B { }
+
+/** Doc for C. */
+public class C { }
+
+interface D { }

--- a/test-grammars/java/test-package-info.java
+++ b/test-grammars/java/test-package-info.java
@@ -1,0 +1,7 @@
+/**
+ * Provides highly reusable static utility methods, chiefly concerned
+ * with adding value to the java.lang classes.
+ *
+ * @since 1.0
+ */
+package test.probe.util;

--- a/test-suites/commons-lang-parser-blacklist-tests.txt
+++ b/test-suites/commons-lang-parser-blacklist-tests.txt
@@ -1,106 +1,32 @@
 # Blacklist for full parsing tests (test sources)
 # These files use features not yet supported by the grammar, chiefly:
-# - anonymous inner classes (new Foo() { ... })
-# - array initializers in annotation values (@Foo({A, B})) and in array
-#   creation (new int[] {1, 2})
-# - generic methods with a void/primitive return type (<T> void m(...))
-# - a lambda directly under a cast ((Predicate<T>) t -> ...)
+# - array class literals (String[].class) and array-constructor method
+#   references (TimeUnit[]::new)
+# - lambdas with typed or modified parameter lists, under casts, and in a
+#   conditional's false branch
+# - comma-separated statement-expression lists in a for-update (i++, t += 1)
+# - the 'volatile' modifier
+# - type annotations in a generic return type (<T> @Nonnull T m())
+# - an empty enum body (enum E { })
 #
-# Total: 95 files blacklisted, 172 files passing
+# Total: 18 files blacklisted, 249 files passing
 # As grammar support is added, remove files from this list
 
 org/apache/commons/lang3/AnnotationUtilsTest.java
-org/apache/commons/lang3/AppendableJoinerTest.java
-org/apache/commons/lang3/ArrayUtilsAddTest.java
-org/apache/commons/lang3/ArrayUtilsInsertTest.java
-org/apache/commons/lang3/ArrayUtilsRemoveMultipleTest.java
-org/apache/commons/lang3/ArrayUtilsRemoveTest.java
 org/apache/commons/lang3/ArrayUtilsTest.java
-org/apache/commons/lang3/BooleanUtilsTest.java
-org/apache/commons/lang3/CachedRandomBitsTest.java
-org/apache/commons/lang3/CharSequenceUtilsTest.java
-org/apache/commons/lang3/CharSetTest.java
-org/apache/commons/lang3/ClassLoaderUtilsTest.java
 org/apache/commons/lang3/ClassUtilsTest.java
-org/apache/commons/lang3/ConversionTest.java
 org/apache/commons/lang3/EnumUtilsTest.java
-org/apache/commons/lang3/FunctionsTest.java
-org/apache/commons/lang3/LocaleUtilsTest.java
 org/apache/commons/lang3/ObjectUtilsTest.java
-org/apache/commons/lang3/RandomStringUtilsTest.java
-org/apache/commons/lang3/RangeTest.java
-org/apache/commons/lang3/RuntimeEnvironmentTest.java
-org/apache/commons/lang3/SerializationUtilsTest.java
-org/apache/commons/lang3/StringUtilsContainsTest.java
-org/apache/commons/lang3/StringUtilsEqualsIndexOfTest.java
 org/apache/commons/lang3/StringUtilsTest.java
-org/apache/commons/lang3/StringUtilsTrimStripTest.java
-org/apache/commons/lang3/StringUtilsValueOfTest.java
-org/apache/commons/lang3/SystemPropertiesTest.java
-org/apache/commons/lang3/ValidateTest.java
-org/apache/commons/lang3/builder/DefaultToStringStyleTest.java
-org/apache/commons/lang3/builder/DiffBuilderTest.java
-org/apache/commons/lang3/builder/EqualsBuilderReflectJreImplementationTest.java
 org/apache/commons/lang3/builder/JsonToStringStyleTest.java
-org/apache/commons/lang3/builder/MultiLineToStringStyleTest.java
-org/apache/commons/lang3/builder/MultilineRecursiveToStringStyleTest.java
-org/apache/commons/lang3/builder/NoClassNameToStringStyleTest.java
-org/apache/commons/lang3/builder/NoFieldNamesToStringStyleTest.java
-org/apache/commons/lang3/builder/RecursiveToStringStyleTest.java
-org/apache/commons/lang3/builder/ReflectionDiffBuilderTest.java
-org/apache/commons/lang3/builder/ReflectionToStringBuilderExcludeTest.java
-org/apache/commons/lang3/builder/ReflectionToStringBuilderIncludeTest.java
-org/apache/commons/lang3/builder/ShortPrefixToStringStyleTest.java
-org/apache/commons/lang3/builder/SimpleToStringStyleTest.java
-org/apache/commons/lang3/builder/StandardToStringStyleTest.java
-org/apache/commons/lang3/builder/TestClassBuilder.java
-org/apache/commons/lang3/builder/ToStringBuilderTest.java
-org/apache/commons/lang3/concurrent/AtomicInitializerNonObjectTest.java
-org/apache/commons/lang3/concurrent/AtomicInitializerObjectTest.java
-org/apache/commons/lang3/concurrent/AtomicSafeInitializerSupplierTest.java
-org/apache/commons/lang3/concurrent/AtomicSafeInitializerTest.java
 org/apache/commons/lang3/concurrent/BackgroundInitializerSupplierTest.java
-org/apache/commons/lang3/concurrent/BackgroundInitializerTest.java
 org/apache/commons/lang3/concurrent/EventCountCircuitBreakerTest.java
-org/apache/commons/lang3/concurrent/LazyInitializerAnonClassTest.java
 org/apache/commons/lang3/concurrent/MultiBackgroundInitializerSupplierTest.java
 org/apache/commons/lang3/concurrent/MultiBackgroundInitializerTest.java
 org/apache/commons/lang3/concurrent/TimedSemaphoreTest.java
-org/apache/commons/lang3/concurrent/UncheckedFutureTest.java
-org/apache/commons/lang3/concurrent/locks/LockingVisitorsTest.java
-org/apache/commons/lang3/event/EventListenerSupportTest.java
-org/apache/commons/lang3/event/EventUtilsTest.java
-org/apache/commons/lang3/exception/ContextedRuntimeExceptionTest.java
-org/apache/commons/lang3/exception/ExceptionUtilsTest.java
-org/apache/commons/lang3/function/AnnotationTestFixture.java
-org/apache/commons/lang3/function/ByteSupplierTest.java
-org/apache/commons/lang3/function/FailableTest.java
 org/apache/commons/lang3/function/MethodFixtures.java
 org/apache/commons/lang3/function/Objects.java
-org/apache/commons/lang3/math/FractionTest.java
 org/apache/commons/lang3/reflect/ConstructorUtilsTest.java
-org/apache/commons/lang3/reflect/FieldUtilsTest.java
 org/apache/commons/lang3/reflect/MethodUtilsTest.java
-org/apache/commons/lang3/reflect/TypeLiteralTest.java
 org/apache/commons/lang3/reflect/TypeUtilsTest.java
-org/apache/commons/lang3/reflect/testbed/Annotated.java
-org/apache/commons/lang3/reflect/testbed/PrivatelyShadowedChild.java
-org/apache/commons/lang3/stream/FailableStreamTest.java
-org/apache/commons/lang3/stream/IntStreamsTest.java
-org/apache/commons/lang3/stream/LangCollectorsTest.java
-org/apache/commons/lang3/text/CompositeFormatTest.java
-org/apache/commons/lang3/text/ExtendedMessageFormatTest.java
-org/apache/commons/lang3/text/StrBuilderAppendInsertTest.java
-org/apache/commons/lang3/text/StrBuilderTest.java
-org/apache/commons/lang3/text/StrSubstitutorTest.java
-org/apache/commons/lang3/text/StrTokenizerTest.java
-org/apache/commons/lang3/text/WordUtilsTest.java
-org/apache/commons/lang3/text/translate/LookupTranslatorTest.java
-org/apache/commons/lang3/time/DurationFormatUtilsTest.java
-org/apache/commons/lang3/time/DurationUtilsTest.java
-org/apache/commons/lang3/time/FastDateFormatTest.java
 org/apache/commons/lang3/time/FastDateParserTest.java
-org/apache/commons/lang3/time/FastDateParser_TimeZoneStrategyTest.java
-org/apache/commons/lang3/tuple/PairTest.java
-org/apache/commons/lang3/util/FluentBitSetTest.java
-org/apache/commons/lang3/util/IterableStringTokenizerTest.java

--- a/test-suites/commons-lang-parser-blacklist.txt
+++ b/test-suites/commons-lang-parser-blacklist.txt
@@ -1,89 +1,40 @@
 # Blacklist for full parsing tests (main sources)
 # These files use features not yet supported by the grammar, chiefly:
-# - anonymous inner classes (new Foo() { ... })
-# - a doc comment directly before 'package' (package-info.java)
-# - generic methods with a void/primitive return type (<T> void m(...))
-# - array initializers in annotation values (@Foo({A, B})) and in array
-#   creation (new int[] {1, 2})
-# - a lambda directly under a cast ((Predicate<T>) t -> ...)
+# - lambdas with typed or modified parameter lists ((final T t) -> ...),
+#   lambdas directly under a cast ((Predicate<T>) t -> ...), and lambdas in
+#   a conditional's false branch (cond ? x : (a, b) -> ...)
+# - array class literals (String[].class) and array-constructor method
+#   references (boolean[]::new)
+# - comma-separated statement-expression lists in a for-update (i++, pos++)
+# - the 'volatile' modifier
 #
-# Total: 77 files blacklisted, 182 files passing
+# Total: 27 files blacklisted, 232 files passing
 # As grammar support is added, remove files from this list
 
-org/apache/commons/lang3/AnnotationUtils.java
 org/apache/commons/lang3/AppendableJoiner.java
 org/apache/commons/lang3/ArrayUtils.java
-org/apache/commons/lang3/BooleanUtils.java
 org/apache/commons/lang3/CharSequenceUtils.java
-org/apache/commons/lang3/ClassUtils.java
-org/apache/commons/lang3/EnumUtils.java
-org/apache/commons/lang3/Functions.java
-org/apache/commons/lang3/JavaVersion.java
-org/apache/commons/lang3/ObjectUtils.java
-org/apache/commons/lang3/Range.java
-org/apache/commons/lang3/StringEscapeUtils.java
 org/apache/commons/lang3/StringUtils.java
 org/apache/commons/lang3/ThreadUtils.java
-org/apache/commons/lang3/Validate.java
-org/apache/commons/lang3/arch/Processor.java
-org/apache/commons/lang3/arch/package-info.java
 org/apache/commons/lang3/builder/DiffBuilder.java
-org/apache/commons/lang3/builder/HashCodeBuilder.java
 org/apache/commons/lang3/builder/ReflectionToStringBuilder.java
 org/apache/commons/lang3/builder/ToStringBuilder.java
-org/apache/commons/lang3/builder/package-info.java
-org/apache/commons/lang3/compare/package-info.java
-org/apache/commons/lang3/concurrent/AbstractCircuitBreaker.java
 org/apache/commons/lang3/concurrent/LazyInitializer.java
-org/apache/commons/lang3/concurrent/locks/package-info.java
-org/apache/commons/lang3/concurrent/package-info.java
-org/apache/commons/lang3/event/EventListenerSupport.java
-org/apache/commons/lang3/event/EventUtils.java
-org/apache/commons/lang3/event/package-info.java
-org/apache/commons/lang3/exception/package-info.java
 org/apache/commons/lang3/function/BooleanConsumer.java
 org/apache/commons/lang3/function/ByteConsumer.java
-org/apache/commons/lang3/function/Consumers.java
-org/apache/commons/lang3/function/Failable.java
-org/apache/commons/lang3/function/FailableBiConsumer.java
 org/apache/commons/lang3/function/FailableBiFunction.java
 org/apache/commons/lang3/function/FailableBiPredicate.java
 org/apache/commons/lang3/function/FailableByteConsumer.java
 org/apache/commons/lang3/function/FailableConsumer.java
 org/apache/commons/lang3/function/FailableDoubleConsumer.java
-org/apache/commons/lang3/function/FailableDoublePredicate.java
 org/apache/commons/lang3/function/FailableDoubleUnaryOperator.java
 org/apache/commons/lang3/function/FailableFunction.java
 org/apache/commons/lang3/function/FailableIntConsumer.java
-org/apache/commons/lang3/function/FailableIntPredicate.java
 org/apache/commons/lang3/function/FailableIntUnaryOperator.java
 org/apache/commons/lang3/function/FailableLongConsumer.java
-org/apache/commons/lang3/function/FailableLongPredicate.java
 org/apache/commons/lang3/function/FailableLongUnaryOperator.java
-org/apache/commons/lang3/function/FailablePredicate.java
-org/apache/commons/lang3/function/TriConsumer.java
 org/apache/commons/lang3/function/TriFunction.java
-org/apache/commons/lang3/function/package-info.java
-org/apache/commons/lang3/math/package-info.java
-org/apache/commons/lang3/mutable/Mutable.java
-org/apache/commons/lang3/mutable/package-info.java
-org/apache/commons/lang3/package-info.java
 org/apache/commons/lang3/reflect/TypeUtils.java
-org/apache/commons/lang3/reflect/package-info.java
-org/apache/commons/lang3/stream/package-info.java
 org/apache/commons/lang3/text/StrBuilder.java
 org/apache/commons/lang3/text/StrMatcher.java
 org/apache/commons/lang3/text/StrSubstitutor.java
-org/apache/commons/lang3/text/package-info.java
-org/apache/commons/lang3/text/translate/NumericEntityUnescaper.java
-org/apache/commons/lang3/text/translate/package-info.java
-org/apache/commons/lang3/time/DateUtils.java
-org/apache/commons/lang3/time/DurationUtils.java
-org/apache/commons/lang3/time/FastDateFormat.java
-org/apache/commons/lang3/time/FastDateParser.java
-org/apache/commons/lang3/time/StopWatch.java
-org/apache/commons/lang3/time/package-info.java
-org/apache/commons/lang3/tuple/Pair.java
-org/apache/commons/lang3/tuple/package-info.java
-org/apache/commons/lang3/util/IterableStringTokenizer.java
-org/apache/commons/lang3/util/package-info.java

--- a/test/golden/java/JavaLexer.x
+++ b/test/golden/java/JavaLexer.x
@@ -12,105 +12,111 @@ import Data.Data (Data)
 @floatTypeSuffix = ([fFdD])
 $backslash = [\\]
 
-tokens :- "tok_AdditiveOp_dummy_193" { simple Tk__tok_AdditiveOp_dummy_193 }
-          "tok_Annotation_dummy_192" { simple Tk__tok_Annotation_dummy_192 }
-          "tok_AnnotationArguments_dummy_191" { simple Tk__tok_AnnotationArguments_dummy_191 }
-          "tok_AnnotationDeclaration_dummy_190" { simple Tk__tok_AnnotationDeclaration_dummy_190 }
-          "tok_AnnotationElement_dummy_189" { simple Tk__tok_AnnotationElement_dummy_189 }
-          "tok_AnnotationList_dummy_188" { simple Tk__tok_AnnotationList_dummy_188 }
-          "tok_AnnotationTypeElement_dummy_187" { simple Tk__tok_AnnotationTypeElement_dummy_187 }
-          "tok_AnnotationTypeElementList_dummy_186" { simple Tk__tok_AnnotationTypeElementList_dummy_186 }
-          "tok_Arglist_dummy_185" { simple Tk__tok_Arglist_dummy_185 }
-          "tok_AssignmentOp_dummy_184" { simple Tk__tok_AssignmentOp_dummy_184 }
-          "tok_CatchList_dummy_183" { simple Tk__tok_CatchList_dummy_183 }
-          "tok_CatchParameter_dummy_182" { simple Tk__tok_CatchParameter_dummy_182 }
-          "tok_ClassDeclaration_dummy_181" { simple Tk__tok_ClassDeclaration_dummy_181 }
-          "tok_ClassOrInterfaceType_dummy_180" { simple Tk__tok_ClassOrInterfaceType_dummy_180 }
-          "tok_CompilationUnit_dummy_179" { simple Tk__tok_CompilationUnit_dummy_179 }
-          "tok_CompoundName_dummy_178" { simple Tk__tok_CompoundName_dummy_178 }
-          "tok_CompoundNameTail_dummy_177" { simple Tk__tok_CompoundNameTail_dummy_177 }
-          "tok_CreationExpression_dummy_176" { simple Tk__tok_CreationExpression_dummy_176 }
-          "tok_DimExprs_dummy_175" { simple Tk__tok_DimExprs_dummy_175 }
-          "tok_Dims_dummy_174" { simple Tk__tok_Dims_dummy_174 }
-          "tok_DoStatement_dummy_173" { simple Tk__tok_DoStatement_dummy_173 }
-          "tok_DocComment_dummy_172" { simple Tk__tok_DocComment_dummy_172 }
-          "tok_EnumConstant_dummy_171" { simple Tk__tok_EnumConstant_dummy_171 }
-          "tok_EnumConstantList_dummy_170" { simple Tk__tok_EnumConstantList_dummy_170 }
-          "tok_EnumDeclaration_dummy_169" { simple Tk__tok_EnumDeclaration_dummy_169 }
-          "tok_EqualityOp_dummy_168" { simple Tk__tok_EqualityOp_dummy_168 }
-          "tok_Expression_dummy_167" { simple Tk__tok_Expression_dummy_167 }
-          "tok_ExtendsList_dummy_166" { simple Tk__tok_ExtendsList_dummy_166 }
-          "tok_FieldDeclaration_dummy_165" { simple Tk__tok_FieldDeclaration_dummy_165 }
-          "tok_FieldDeclarationList_dummy_164" { simple Tk__tok_FieldDeclarationList_dummy_164 }
-          "tok_ForEachHeader_dummy_163" { simple Tk__tok_ForEachHeader_dummy_163 }
-          "tok_ForStatement_dummy_162" { simple Tk__tok_ForStatement_dummy_162 }
-          "tok_IfStatement_dummy_161" { simple Tk__tok_IfStatement_dummy_161 }
-          "tok_ImplementsList_dummy_160" { simple Tk__tok_ImplementsList_dummy_160 }
-          "tok_ImportHead_dummy_159" { simple Tk__tok_ImportHead_dummy_159 }
-          "tok_ImportList_dummy_158" { simple Tk__tok_ImportList_dummy_158 }
-          "tok_ImportName_dummy_157" { simple Tk__tok_ImportName_dummy_157 }
-          "tok_ImportStatement_dummy_156" { simple Tk__tok_ImportStatement_dummy_156 }
-          "tok_InterfaceDeclaration_dummy_155" { simple Tk__tok_InterfaceDeclaration_dummy_155 }
-          "tok_Java_dummy_194" { simple Tk__tok_Java_dummy_194 }
-          "tok_LambdaBody_dummy_154" { simple Tk__tok_LambdaBody_dummy_154 }
-          "tok_Literal_dummy_153" { simple Tk__tok_Literal_dummy_153 }
-          "tok_LocalModifierList1_dummy_152" { simple Tk__tok_LocalModifierList1_dummy_152 }
-          "tok_MemberAfterFirstId_dummy_151" { simple Tk__tok_MemberAfterFirstId_dummy_151 }
-          "tok_MemberDeclaration_dummy_150" { simple Tk__tok_MemberDeclaration_dummy_150 }
-          "tok_MemberRest_dummy_149" { simple Tk__tok_MemberRest_dummy_149 }
-          "tok_Modifier_dummy_148" { simple Tk__tok_Modifier_dummy_148 }
-          "tok_ModifierList_dummy_147" { simple Tk__tok_ModifierList_dummy_147 }
-          "tok_MoreTypeSpecifier_dummy_146" { simple Tk__tok_MoreTypeSpecifier_dummy_146 }
-          "tok_MoreVariableDeclarators_dummy_145" { simple Tk__tok_MoreVariableDeclarators_dummy_145 }
-          "tok_MultiplicativeOp_dummy_144" { simple Tk__tok_MultiplicativeOp_dummy_144 }
-          "tok_NonEmptyDims_dummy_143" { simple Tk__tok_NonEmptyDims_dummy_143 }
-          "tok_NonEmptyTypeArguments_dummy_142" { simple Tk__tok_NonEmptyTypeArguments_dummy_142 }
-          "tok_OptDocComment_dummy_141" { simple Tk__tok_OptDocComment_dummy_141 }
-          "tok_OptElsePart_dummy_140" { simple Tk__tok_OptElsePart_dummy_140 }
-          "tok_OptExpression_dummy_139" { simple Tk__tok_OptExpression_dummy_139 }
-          "tok_OptFinally_dummy_138" { simple Tk__tok_OptFinally_dummy_138 }
-          "tok_OptId_dummy_137" { simple Tk__tok_OptId_dummy_137 }
-          "tok_OptVariableInitializer_dummy_136" { simple Tk__tok_OptVariableInitializer_dummy_136 }
-          "tok_Package_dummy_135" { simple Tk__tok_Package_dummy_135 }
-          "tok_ParamModifierList_dummy_134" { simple Tk__tok_ParamModifierList_dummy_134 }
-          "tok_Parameter_dummy_133" { simple Tk__tok_Parameter_dummy_133 }
-          "tok_ParameterList_dummy_132" { simple Tk__tok_ParameterList_dummy_132 }
-          "tok_PostfixOp_dummy_131" { simple Tk__tok_PostfixOp_dummy_131 }
-          "tok_PrefixOp_dummy_130" { simple Tk__tok_PrefixOp_dummy_130 }
-          "tok_PrimitiveTypeKeyword_dummy_129" { simple Tk__tok_PrimitiveTypeKeyword_dummy_129 }
-          "tok_RelationalOp_dummy_128" { simple Tk__tok_RelationalOp_dummy_128 }
-          "tok_Resource_dummy_127" { simple Tk__tok_Resource_dummy_127 }
-          "tok_ResourceSpec_dummy_126" { simple Tk__tok_ResourceSpec_dummy_126 }
-          "tok_ShiftOp_dummy_125" { simple Tk__tok_ShiftOp_dummy_125 }
-          "tok_Statement_dummy_124" { simple Tk__tok_Statement_dummy_124 }
-          "tok_StatementBlock_dummy_123" { simple Tk__tok_StatementBlock_dummy_123 }
-          "tok_StatementList_dummy_122" { simple Tk__tok_StatementList_dummy_122 }
-          "tok_StaticInitializer_dummy_121" { simple Tk__tok_StaticInitializer_dummy_121 }
-          "tok_SwitchCaseList_dummy_120" { simple Tk__tok_SwitchCaseList_dummy_120 }
-          "tok_SwitchStatement_dummy_119" { simple Tk__tok_SwitchStatement_dummy_119 }
-          "tok_ThrowsClause_dummy_118" { simple Tk__tok_ThrowsClause_dummy_118 }
-          "tok_TryStatement_dummy_117" { simple Tk__tok_TryStatement_dummy_117 }
-          "tok_Type_dummy_116" { simple Tk__tok_Type_dummy_116 }
-          "tok_TypeArgument_dummy_115" { simple Tk__tok_TypeArgument_dummy_115 }
-          "tok_TypeArguments_dummy_114" { simple Tk__tok_TypeArguments_dummy_114 }
-          "tok_TypeDeclRest_dummy_113" { simple Tk__tok_TypeDeclRest_dummy_113 }
-          "tok_TypeDeclaration_dummy_112" { simple Tk__tok_TypeDeclaration_dummy_112 }
-          "tok_TypeParameter_dummy_111" { simple Tk__tok_TypeParameter_dummy_111 }
-          "tok_TypeParameters_dummy_110" { simple Tk__tok_TypeParameters_dummy_110 }
-          "tok_TypeSpecifier_dummy_109" { simple Tk__tok_TypeSpecifier_dummy_109 }
-          "tok_VariableDeclaration_dummy_108" { simple Tk__tok_VariableDeclaration_dummy_108 }
-          "tok_VariableDeclarator_dummy_107" { simple Tk__tok_VariableDeclarator_dummy_107 }
-          "tok_VariableDeclaratorList_dummy_106" { simple Tk__tok_VariableDeclaratorList_dummy_106 }
-          "tok_VariableInitializer_dummy_105" { simple Tk__tok_VariableInitializer_dummy_105 }
-          "tok_VariableInitializerList_dummy_104" { simple Tk__tok_VariableInitializerList_dummy_104 }
-          "tok_WhileStatement_dummy_103" { simple Tk__tok_WhileStatement_dummy_103 }
-          "tok_WildcardType_dummy_102" { simple Tk__tok_WildcardType_dummy_102 }
+tokens :- "tok_AdditiveOp_dummy_205" { simple Tk__tok_AdditiveOp_dummy_205 }
+          "tok_Annotation_dummy_204" { simple Tk__tok_Annotation_dummy_204 }
+          "tok_AnnotationArguments_dummy_203" { simple Tk__tok_AnnotationArguments_dummy_203 }
+          "tok_AnnotationDeclaration_dummy_202" { simple Tk__tok_AnnotationDeclaration_dummy_202 }
+          "tok_AnnotationElement_dummy_201" { simple Tk__tok_AnnotationElement_dummy_201 }
+          "tok_AnnotationList_dummy_200" { simple Tk__tok_AnnotationList_dummy_200 }
+          "tok_AnnotationTypeElement_dummy_199" { simple Tk__tok_AnnotationTypeElement_dummy_199 }
+          "tok_AnnotationTypeElementList_dummy_198" { simple Tk__tok_AnnotationTypeElementList_dummy_198 }
+          "tok_Arglist_dummy_197" { simple Tk__tok_Arglist_dummy_197 }
+          "tok_ArrayInitializer_dummy_196" { simple Tk__tok_ArrayInitializer_dummy_196 }
+          "tok_AssignmentOp_dummy_195" { simple Tk__tok_AssignmentOp_dummy_195 }
+          "tok_CatchList_dummy_194" { simple Tk__tok_CatchList_dummy_194 }
+          "tok_CatchParameter_dummy_193" { simple Tk__tok_CatchParameter_dummy_193 }
+          "tok_ClassDeclaration_dummy_192" { simple Tk__tok_ClassDeclaration_dummy_192 }
+          "tok_ClassOrInterfaceType_dummy_191" { simple Tk__tok_ClassOrInterfaceType_dummy_191 }
+          "tok_CompilationUnit_dummy_190" { simple Tk__tok_CompilationUnit_dummy_190 }
+          "tok_CompilationUnitRest_dummy_189" { simple Tk__tok_CompilationUnitRest_dummy_189 }
+          "tok_CompoundName_dummy_188" { simple Tk__tok_CompoundName_dummy_188 }
+          "tok_CompoundNameTail_dummy_187" { simple Tk__tok_CompoundNameTail_dummy_187 }
+          "tok_CreationExpression_dummy_186" { simple Tk__tok_CreationExpression_dummy_186 }
+          "tok_DimExprs_dummy_185" { simple Tk__tok_DimExprs_dummy_185 }
+          "tok_Dims_dummy_184" { simple Tk__tok_Dims_dummy_184 }
+          "tok_DoStatement_dummy_183" { simple Tk__tok_DoStatement_dummy_183 }
+          "tok_DocComment_dummy_182" { simple Tk__tok_DocComment_dummy_182 }
+          "tok_ElementValue_dummy_181" { simple Tk__tok_ElementValue_dummy_181 }
+          "tok_ElementValueArrayInitializer_dummy_180" { simple Tk__tok_ElementValueArrayInitializer_dummy_180 }
+          "tok_EnumConstant_dummy_179" { simple Tk__tok_EnumConstant_dummy_179 }
+          "tok_EnumConstantList_dummy_178" { simple Tk__tok_EnumConstantList_dummy_178 }
+          "tok_EnumDeclaration_dummy_177" { simple Tk__tok_EnumDeclaration_dummy_177 }
+          "tok_EqualityOp_dummy_176" { simple Tk__tok_EqualityOp_dummy_176 }
+          "tok_Expression_dummy_175" { simple Tk__tok_Expression_dummy_175 }
+          "tok_ExtendsList_dummy_174" { simple Tk__tok_ExtendsList_dummy_174 }
+          "tok_FieldDeclaration_dummy_173" { simple Tk__tok_FieldDeclaration_dummy_173 }
+          "tok_FieldDeclarationList_dummy_172" { simple Tk__tok_FieldDeclarationList_dummy_172 }
+          "tok_ForEachHeader_dummy_171" { simple Tk__tok_ForEachHeader_dummy_171 }
+          "tok_ForStatement_dummy_170" { simple Tk__tok_ForStatement_dummy_170 }
+          "tok_IfStatement_dummy_169" { simple Tk__tok_IfStatement_dummy_169 }
+          "tok_ImplementsList_dummy_168" { simple Tk__tok_ImplementsList_dummy_168 }
+          "tok_ImportHead_dummy_167" { simple Tk__tok_ImportHead_dummy_167 }
+          "tok_ImportList_dummy_166" { simple Tk__tok_ImportList_dummy_166 }
+          "tok_ImportName_dummy_165" { simple Tk__tok_ImportName_dummy_165 }
+          "tok_ImportStatement_dummy_164" { simple Tk__tok_ImportStatement_dummy_164 }
+          "tok_InterfaceDeclaration_dummy_163" { simple Tk__tok_InterfaceDeclaration_dummy_163 }
+          "tok_Java_dummy_206" { simple Tk__tok_Java_dummy_206 }
+          "tok_LambdaBody_dummy_162" { simple Tk__tok_LambdaBody_dummy_162 }
+          "tok_Literal_dummy_161" { simple Tk__tok_Literal_dummy_161 }
+          "tok_LocalModifierList1_dummy_160" { simple Tk__tok_LocalModifierList1_dummy_160 }
+          "tok_MemberAfterFirstId_dummy_159" { simple Tk__tok_MemberAfterFirstId_dummy_159 }
+          "tok_MemberDeclaration_dummy_158" { simple Tk__tok_MemberDeclaration_dummy_158 }
+          "tok_MemberRest_dummy_157" { simple Tk__tok_MemberRest_dummy_157 }
+          "tok_Modifier_dummy_156" { simple Tk__tok_Modifier_dummy_156 }
+          "tok_ModifierList_dummy_155" { simple Tk__tok_ModifierList_dummy_155 }
+          "tok_MoreTypeSpecifier_dummy_154" { simple Tk__tok_MoreTypeSpecifier_dummy_154 }
+          "tok_MoreVariableDeclarators_dummy_153" { simple Tk__tok_MoreVariableDeclarators_dummy_153 }
+          "tok_MultiplicativeOp_dummy_152" { simple Tk__tok_MultiplicativeOp_dummy_152 }
+          "tok_NonEmptyDims_dummy_151" { simple Tk__tok_NonEmptyDims_dummy_151 }
+          "tok_NonEmptyTypeArguments_dummy_150" { simple Tk__tok_NonEmptyTypeArguments_dummy_150 }
+          "tok_NonEmptyTypeParameters_dummy_149" { simple Tk__tok_NonEmptyTypeParameters_dummy_149 }
+          "tok_OptDocComment_dummy_148" { simple Tk__tok_OptDocComment_dummy_148 }
+          "tok_OptElsePart_dummy_147" { simple Tk__tok_OptElsePart_dummy_147 }
+          "tok_OptExpression_dummy_146" { simple Tk__tok_OptExpression_dummy_146 }
+          "tok_OptFinally_dummy_145" { simple Tk__tok_OptFinally_dummy_145 }
+          "tok_OptId_dummy_144" { simple Tk__tok_OptId_dummy_144 }
+          "tok_OptVariableInitializer_dummy_143" { simple Tk__tok_OptVariableInitializer_dummy_143 }
+          "tok_Package_dummy_142" { simple Tk__tok_Package_dummy_142 }
+          "tok_ParamModifierList_dummy_141" { simple Tk__tok_ParamModifierList_dummy_141 }
+          "tok_Parameter_dummy_140" { simple Tk__tok_Parameter_dummy_140 }
+          "tok_ParameterList_dummy_139" { simple Tk__tok_ParameterList_dummy_139 }
+          "tok_PostfixOp_dummy_138" { simple Tk__tok_PostfixOp_dummy_138 }
+          "tok_PrefixOp_dummy_137" { simple Tk__tok_PrefixOp_dummy_137 }
+          "tok_PrimitiveTypeKeyword_dummy_136" { simple Tk__tok_PrimitiveTypeKeyword_dummy_136 }
+          "tok_RelationalOp_dummy_135" { simple Tk__tok_RelationalOp_dummy_135 }
+          "tok_Resource_dummy_134" { simple Tk__tok_Resource_dummy_134 }
+          "tok_ResourceSpec_dummy_133" { simple Tk__tok_ResourceSpec_dummy_133 }
+          "tok_ShiftOp_dummy_132" { simple Tk__tok_ShiftOp_dummy_132 }
+          "tok_Statement_dummy_131" { simple Tk__tok_Statement_dummy_131 }
+          "tok_StatementBlock_dummy_130" { simple Tk__tok_StatementBlock_dummy_130 }
+          "tok_StatementList_dummy_129" { simple Tk__tok_StatementList_dummy_129 }
+          "tok_StaticInitializer_dummy_128" { simple Tk__tok_StaticInitializer_dummy_128 }
+          "tok_SwitchCaseList_dummy_127" { simple Tk__tok_SwitchCaseList_dummy_127 }
+          "tok_SwitchStatement_dummy_126" { simple Tk__tok_SwitchStatement_dummy_126 }
+          "tok_ThrowsClause_dummy_125" { simple Tk__tok_ThrowsClause_dummy_125 }
+          "tok_TryStatement_dummy_124" { simple Tk__tok_TryStatement_dummy_124 }
+          "tok_Type_dummy_123" { simple Tk__tok_Type_dummy_123 }
+          "tok_TypeArgument_dummy_122" { simple Tk__tok_TypeArgument_dummy_122 }
+          "tok_TypeArguments_dummy_121" { simple Tk__tok_TypeArguments_dummy_121 }
+          "tok_TypeDeclRest_dummy_120" { simple Tk__tok_TypeDeclRest_dummy_120 }
+          "tok_TypeDeclaration_dummy_119" { simple Tk__tok_TypeDeclaration_dummy_119 }
+          "tok_TypeDeclarationList_dummy_118" { simple Tk__tok_TypeDeclarationList_dummy_118 }
+          "tok_TypeParameter_dummy_117" { simple Tk__tok_TypeParameter_dummy_117 }
+          "tok_TypeParameters_dummy_116" { simple Tk__tok_TypeParameters_dummy_116 }
+          "tok_TypeSpecifier_dummy_115" { simple Tk__tok_TypeSpecifier_dummy_115 }
+          "tok_VariableDeclaration_dummy_114" { simple Tk__tok_VariableDeclaration_dummy_114 }
+          "tok_VariableDeclarator_dummy_113" { simple Tk__tok_VariableDeclarator_dummy_113 }
+          "tok_VariableDeclaratorList_dummy_112" { simple Tk__tok_VariableDeclaratorList_dummy_112 }
+          "tok_VariableInitializer_dummy_111" { simple Tk__tok_VariableInitializer_dummy_111 }
+          "tok_VariableInitializerList_dummy_110" { simple Tk__tok_VariableInitializerList_dummy_110 }
+          "tok_WhileStatement_dummy_109" { simple Tk__tok_WhileStatement_dummy_109 }
+          "tok_WildcardType_dummy_108" { simple Tk__tok_WildcardType_dummy_108 }
           "~" { simple Tk__tok__tilde__84 }
-          "}" { simple Tk__tok__symbol__15 }
+          "}" { simple Tk__tok__symbol__12 }
           "||" { simple Tk__tok__pipe__pipe__66 }
           "|=" { simple Tk__tok__pipe__eql__58 }
           "|" { simple Tk__tok__pipe__48 }
-          "{" { simple Tk__tok__symbol__14 }
+          "{" { simple Tk__tok__symbol__11 }
           "while" { simple Tk__tok_while_45 }
           "void" { simple Tk__tok_void_28 }
           "try" { simple Tk__tok_try_50 }
@@ -138,21 +144,21 @@ tokens :- "tok_AdditiveOp_dummy_193" { simple Tk__tok_AdditiveOp_dummy_193 }
           "int" { simple Tk__tok_int_24 }
           "instanceof" { simple Tk__tok_instanceof_76 }
           "import" { simple Tk__tok_import_2 }
-          "implements" { simple Tk__tok_implements_12 }
+          "implements" { simple Tk__tok_implements_14 }
           "if" { simple Tk__tok_if_43 }
           "for" { simple Tk__tok_for_46 }
           "float" { simple Tk__tok_float_25 }
           "finally" { simple Tk__tok_finally_49 }
           "final" { simple Tk__tok_final_31 }
           "false" { simple Tk__tok_false_89 }
-          "extends" { simple Tk__tok_extends_11 }
+          "extends" { simple Tk__tok_extends_13 }
           "enum" { simple Tk__tok_enum_17 }
           "else" { simple Tk__tok_else_42 }
           "double" { simple Tk__tok_double_27 }
           "do" { simple Tk__tok_do_44 }
           "default" { simple Tk__tok_default_30 }
           "continue" { simple Tk__tok_continue_39 }
-          "class" { simple Tk__tok_class_13 }
+          "class" { simple Tk__tok_class_15 }
           "char" { simple Tk__tok_char_22 }
           "catch" { simple Tk__tok_catch_47 }
           "case" { simple Tk__tok_case_51 }
@@ -220,6 +226,7 @@ tokens :- "tok_AdditiveOp_dummy_193" { simple Tk__tok_AdditiveOp_dummy_193 }
           ("$"  "TypeSpecifier"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_TypeSpecifier . ((tail . dropWhile (/= ':'))) }
           ("$"  "Type"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_Type . ((tail . dropWhile (/= ':'))) }
           ("$"  "TypeParameter"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_TypeParameter . ((tail . dropWhile (/= ':'))) }
+          ("$"  "NonEmptyTypeParameters"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_NonEmptyTypeParameters . ((tail . dropWhile (/= ':'))) }
           ("$"  "TypeParameters"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_TypeParameters . ((tail . dropWhile (/= ':'))) }
           ("$"  "WildcardType"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_WildcardType . ((tail . dropWhile (/= ':'))) }
           ("$"  "TypeArgument"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_TypeArgument . ((tail . dropWhile (/= ':'))) }
@@ -261,6 +268,7 @@ tokens :- "tok_AdditiveOp_dummy_193" { simple Tk__tok_AdditiveOp_dummy_193 }
           ("$"  "ParamModifierList"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_ParamModifierList . ((tail . dropWhile (/= ':'))) }
           ("$"  "ParameterList"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_ParameterList . ((tail . dropWhile (/= ':'))) }
           ("$"  "StaticInitializer"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_StaticInitializer . ((tail . dropWhile (/= ':'))) }
+          ("$"  "ArrayInitializer"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_ArrayInitializer . ((tail . dropWhile (/= ':'))) }
           ("$"  "VariableInitializer"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_VariableInitializer . ((tail . dropWhile (/= ':'))) }
           ("$"  "VariableInitializerList"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_VariableInitializerList . ((tail . dropWhile (/= ':'))) }
           ("$"  "VariableDeclarator"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_VariableDeclarator . ((tail . dropWhile (/= ':'))) }
@@ -294,6 +302,8 @@ tokens :- "tok_AdditiveOp_dummy_193" { simple Tk__tok_AdditiveOp_dummy_193 }
           ("$"  "ClassOrInterfaceType"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_ClassOrInterfaceType . ((tail . dropWhile (/= ':'))) }
           ("$"  "ModifierList"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_ModifierList . ((tail . dropWhile (/= ':'))) }
           ("$"  "AnnotationList"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_AnnotationList . ((tail . dropWhile (/= ':'))) }
+          ("$"  "ElementValueArrayInitializer"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_ElementValueArrayInitializer . ((tail . dropWhile (/= ':'))) }
+          ("$"  "ElementValue"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_ElementValue . ((tail . dropWhile (/= ':'))) }
           ("$"  "AnnotationElement"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_AnnotationElement . ((tail . dropWhile (/= ':'))) }
           ("$"  "AnnotationArguments"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_AnnotationArguments . ((tail . dropWhile (/= ':'))) }
           ("$"  "Annotation"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_Annotation . ((tail . dropWhile (/= ':'))) }
@@ -302,8 +312,10 @@ tokens :- "tok_AdditiveOp_dummy_193" { simple Tk__tok_AdditiveOp_dummy_193 }
           ("$"  "ImportName"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_ImportName . ((tail . dropWhile (/= ':'))) }
           ("$"  "ImportStatement"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_ImportStatement . ((tail . dropWhile (/= ':'))) }
           ("$"  "Package"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_Package . ((tail . dropWhile (/= ':'))) }
+          ("$"  "CompilationUnitRest"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_CompilationUnitRest . ((tail . dropWhile (/= ':'))) }
           ("$"  "CompilationUnit"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_CompilationUnit . ((tail . dropWhile (/= ':'))) }
           ("$"  "ImportList"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_ImportList . ((tail . dropWhile (/= ':'))) }
+          ("$"  "TypeDeclarationList"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_TypeDeclarationList . ((tail . dropWhile (/= ':'))) }
           ("$"  "TypeDeclaration"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_TypeDeclaration . ((tail . dropWhile (/= ':'))) }
           ("$"  "OptDocComment"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_OptDocComment . ((tail . dropWhile (/= ':'))) }
           ("$"  "Java"  ":"  [a-zA-Z_]  [A-Za-z0-9_]*) { simple1 $  Tk__qq_Java . ((tail . dropWhile (/= ':'))) }
@@ -311,105 +323,111 @@ tokens :- "tok_AdditiveOp_dummy_193" { simple Tk__tok_AdditiveOp_dummy_193 }
 
 {
 data Token = EndOfFile |
-             Tk__tok_AdditiveOp_dummy_193 |
-             Tk__tok_Annotation_dummy_192 |
-             Tk__tok_AnnotationArguments_dummy_191 |
-             Tk__tok_AnnotationDeclaration_dummy_190 |
-             Tk__tok_AnnotationElement_dummy_189 |
-             Tk__tok_AnnotationList_dummy_188 |
-             Tk__tok_AnnotationTypeElement_dummy_187 |
-             Tk__tok_AnnotationTypeElementList_dummy_186 |
-             Tk__tok_Arglist_dummy_185 |
-             Tk__tok_AssignmentOp_dummy_184 |
-             Tk__tok_CatchList_dummy_183 |
-             Tk__tok_CatchParameter_dummy_182 |
-             Tk__tok_ClassDeclaration_dummy_181 |
-             Tk__tok_ClassOrInterfaceType_dummy_180 |
-             Tk__tok_CompilationUnit_dummy_179 |
-             Tk__tok_CompoundName_dummy_178 |
-             Tk__tok_CompoundNameTail_dummy_177 |
-             Tk__tok_CreationExpression_dummy_176 |
-             Tk__tok_DimExprs_dummy_175 |
-             Tk__tok_Dims_dummy_174 |
-             Tk__tok_DoStatement_dummy_173 |
-             Tk__tok_DocComment_dummy_172 |
-             Tk__tok_EnumConstant_dummy_171 |
-             Tk__tok_EnumConstantList_dummy_170 |
-             Tk__tok_EnumDeclaration_dummy_169 |
-             Tk__tok_EqualityOp_dummy_168 |
-             Tk__tok_Expression_dummy_167 |
-             Tk__tok_ExtendsList_dummy_166 |
-             Tk__tok_FieldDeclaration_dummy_165 |
-             Tk__tok_FieldDeclarationList_dummy_164 |
-             Tk__tok_ForEachHeader_dummy_163 |
-             Tk__tok_ForStatement_dummy_162 |
-             Tk__tok_IfStatement_dummy_161 |
-             Tk__tok_ImplementsList_dummy_160 |
-             Tk__tok_ImportHead_dummy_159 |
-             Tk__tok_ImportList_dummy_158 |
-             Tk__tok_ImportName_dummy_157 |
-             Tk__tok_ImportStatement_dummy_156 |
-             Tk__tok_InterfaceDeclaration_dummy_155 |
-             Tk__tok_Java_dummy_194 |
-             Tk__tok_LambdaBody_dummy_154 |
-             Tk__tok_Literal_dummy_153 |
-             Tk__tok_LocalModifierList1_dummy_152 |
-             Tk__tok_MemberAfterFirstId_dummy_151 |
-             Tk__tok_MemberDeclaration_dummy_150 |
-             Tk__tok_MemberRest_dummy_149 |
-             Tk__tok_Modifier_dummy_148 |
-             Tk__tok_ModifierList_dummy_147 |
-             Tk__tok_MoreTypeSpecifier_dummy_146 |
-             Tk__tok_MoreVariableDeclarators_dummy_145 |
-             Tk__tok_MultiplicativeOp_dummy_144 |
-             Tk__tok_NonEmptyDims_dummy_143 |
-             Tk__tok_NonEmptyTypeArguments_dummy_142 |
-             Tk__tok_OptDocComment_dummy_141 |
-             Tk__tok_OptElsePart_dummy_140 |
-             Tk__tok_OptExpression_dummy_139 |
-             Tk__tok_OptFinally_dummy_138 |
-             Tk__tok_OptId_dummy_137 |
-             Tk__tok_OptVariableInitializer_dummy_136 |
-             Tk__tok_Package_dummy_135 |
-             Tk__tok_ParamModifierList_dummy_134 |
-             Tk__tok_Parameter_dummy_133 |
-             Tk__tok_ParameterList_dummy_132 |
-             Tk__tok_PostfixOp_dummy_131 |
-             Tk__tok_PrefixOp_dummy_130 |
-             Tk__tok_PrimitiveTypeKeyword_dummy_129 |
-             Tk__tok_RelationalOp_dummy_128 |
-             Tk__tok_Resource_dummy_127 |
-             Tk__tok_ResourceSpec_dummy_126 |
-             Tk__tok_ShiftOp_dummy_125 |
-             Tk__tok_Statement_dummy_124 |
-             Tk__tok_StatementBlock_dummy_123 |
-             Tk__tok_StatementList_dummy_122 |
-             Tk__tok_StaticInitializer_dummy_121 |
-             Tk__tok_SwitchCaseList_dummy_120 |
-             Tk__tok_SwitchStatement_dummy_119 |
-             Tk__tok_ThrowsClause_dummy_118 |
-             Tk__tok_TryStatement_dummy_117 |
-             Tk__tok_Type_dummy_116 |
-             Tk__tok_TypeArgument_dummy_115 |
-             Tk__tok_TypeArguments_dummy_114 |
-             Tk__tok_TypeDeclRest_dummy_113 |
-             Tk__tok_TypeDeclaration_dummy_112 |
-             Tk__tok_TypeParameter_dummy_111 |
-             Tk__tok_TypeParameters_dummy_110 |
-             Tk__tok_TypeSpecifier_dummy_109 |
-             Tk__tok_VariableDeclaration_dummy_108 |
-             Tk__tok_VariableDeclarator_dummy_107 |
-             Tk__tok_VariableDeclaratorList_dummy_106 |
-             Tk__tok_VariableInitializer_dummy_105 |
-             Tk__tok_VariableInitializerList_dummy_104 |
-             Tk__tok_WhileStatement_dummy_103 |
-             Tk__tok_WildcardType_dummy_102 |
+             Tk__tok_AdditiveOp_dummy_205 |
+             Tk__tok_Annotation_dummy_204 |
+             Tk__tok_AnnotationArguments_dummy_203 |
+             Tk__tok_AnnotationDeclaration_dummy_202 |
+             Tk__tok_AnnotationElement_dummy_201 |
+             Tk__tok_AnnotationList_dummy_200 |
+             Tk__tok_AnnotationTypeElement_dummy_199 |
+             Tk__tok_AnnotationTypeElementList_dummy_198 |
+             Tk__tok_Arglist_dummy_197 |
+             Tk__tok_ArrayInitializer_dummy_196 |
+             Tk__tok_AssignmentOp_dummy_195 |
+             Tk__tok_CatchList_dummy_194 |
+             Tk__tok_CatchParameter_dummy_193 |
+             Tk__tok_ClassDeclaration_dummy_192 |
+             Tk__tok_ClassOrInterfaceType_dummy_191 |
+             Tk__tok_CompilationUnit_dummy_190 |
+             Tk__tok_CompilationUnitRest_dummy_189 |
+             Tk__tok_CompoundName_dummy_188 |
+             Tk__tok_CompoundNameTail_dummy_187 |
+             Tk__tok_CreationExpression_dummy_186 |
+             Tk__tok_DimExprs_dummy_185 |
+             Tk__tok_Dims_dummy_184 |
+             Tk__tok_DoStatement_dummy_183 |
+             Tk__tok_DocComment_dummy_182 |
+             Tk__tok_ElementValue_dummy_181 |
+             Tk__tok_ElementValueArrayInitializer_dummy_180 |
+             Tk__tok_EnumConstant_dummy_179 |
+             Tk__tok_EnumConstantList_dummy_178 |
+             Tk__tok_EnumDeclaration_dummy_177 |
+             Tk__tok_EqualityOp_dummy_176 |
+             Tk__tok_Expression_dummy_175 |
+             Tk__tok_ExtendsList_dummy_174 |
+             Tk__tok_FieldDeclaration_dummy_173 |
+             Tk__tok_FieldDeclarationList_dummy_172 |
+             Tk__tok_ForEachHeader_dummy_171 |
+             Tk__tok_ForStatement_dummy_170 |
+             Tk__tok_IfStatement_dummy_169 |
+             Tk__tok_ImplementsList_dummy_168 |
+             Tk__tok_ImportHead_dummy_167 |
+             Tk__tok_ImportList_dummy_166 |
+             Tk__tok_ImportName_dummy_165 |
+             Tk__tok_ImportStatement_dummy_164 |
+             Tk__tok_InterfaceDeclaration_dummy_163 |
+             Tk__tok_Java_dummy_206 |
+             Tk__tok_LambdaBody_dummy_162 |
+             Tk__tok_Literal_dummy_161 |
+             Tk__tok_LocalModifierList1_dummy_160 |
+             Tk__tok_MemberAfterFirstId_dummy_159 |
+             Tk__tok_MemberDeclaration_dummy_158 |
+             Tk__tok_MemberRest_dummy_157 |
+             Tk__tok_Modifier_dummy_156 |
+             Tk__tok_ModifierList_dummy_155 |
+             Tk__tok_MoreTypeSpecifier_dummy_154 |
+             Tk__tok_MoreVariableDeclarators_dummy_153 |
+             Tk__tok_MultiplicativeOp_dummy_152 |
+             Tk__tok_NonEmptyDims_dummy_151 |
+             Tk__tok_NonEmptyTypeArguments_dummy_150 |
+             Tk__tok_NonEmptyTypeParameters_dummy_149 |
+             Tk__tok_OptDocComment_dummy_148 |
+             Tk__tok_OptElsePart_dummy_147 |
+             Tk__tok_OptExpression_dummy_146 |
+             Tk__tok_OptFinally_dummy_145 |
+             Tk__tok_OptId_dummy_144 |
+             Tk__tok_OptVariableInitializer_dummy_143 |
+             Tk__tok_Package_dummy_142 |
+             Tk__tok_ParamModifierList_dummy_141 |
+             Tk__tok_Parameter_dummy_140 |
+             Tk__tok_ParameterList_dummy_139 |
+             Tk__tok_PostfixOp_dummy_138 |
+             Tk__tok_PrefixOp_dummy_137 |
+             Tk__tok_PrimitiveTypeKeyword_dummy_136 |
+             Tk__tok_RelationalOp_dummy_135 |
+             Tk__tok_Resource_dummy_134 |
+             Tk__tok_ResourceSpec_dummy_133 |
+             Tk__tok_ShiftOp_dummy_132 |
+             Tk__tok_Statement_dummy_131 |
+             Tk__tok_StatementBlock_dummy_130 |
+             Tk__tok_StatementList_dummy_129 |
+             Tk__tok_StaticInitializer_dummy_128 |
+             Tk__tok_SwitchCaseList_dummy_127 |
+             Tk__tok_SwitchStatement_dummy_126 |
+             Tk__tok_ThrowsClause_dummy_125 |
+             Tk__tok_TryStatement_dummy_124 |
+             Tk__tok_Type_dummy_123 |
+             Tk__tok_TypeArgument_dummy_122 |
+             Tk__tok_TypeArguments_dummy_121 |
+             Tk__tok_TypeDeclRest_dummy_120 |
+             Tk__tok_TypeDeclaration_dummy_119 |
+             Tk__tok_TypeDeclarationList_dummy_118 |
+             Tk__tok_TypeParameter_dummy_117 |
+             Tk__tok_TypeParameters_dummy_116 |
+             Tk__tok_TypeSpecifier_dummy_115 |
+             Tk__tok_VariableDeclaration_dummy_114 |
+             Tk__tok_VariableDeclarator_dummy_113 |
+             Tk__tok_VariableDeclaratorList_dummy_112 |
+             Tk__tok_VariableInitializer_dummy_111 |
+             Tk__tok_VariableInitializerList_dummy_110 |
+             Tk__tok_WhileStatement_dummy_109 |
+             Tk__tok_WildcardType_dummy_108 |
              Tk__tok__tilde__84 |
-             Tk__tok__symbol__15 |
+             Tk__tok__symbol__12 |
              Tk__tok__pipe__pipe__66 |
              Tk__tok__pipe__eql__58 |
              Tk__tok__pipe__48 |
-             Tk__tok__symbol__14 |
+             Tk__tok__symbol__11 |
              Tk__tok_while_45 |
              Tk__tok_void_28 |
              Tk__tok_try_50 |
@@ -437,21 +455,21 @@ data Token = EndOfFile |
              Tk__tok_int_24 |
              Tk__tok_instanceof_76 |
              Tk__tok_import_2 |
-             Tk__tok_implements_12 |
+             Tk__tok_implements_14 |
              Tk__tok_if_43 |
              Tk__tok_for_46 |
              Tk__tok_float_25 |
              Tk__tok_finally_49 |
              Tk__tok_final_31 |
              Tk__tok_false_89 |
-             Tk__tok_extends_11 |
+             Tk__tok_extends_13 |
              Tk__tok_enum_17 |
              Tk__tok_else_42 |
              Tk__tok_double_27 |
              Tk__tok_do_44 |
              Tk__tok_default_30 |
              Tk__tok_continue_39 |
-             Tk__tok_class_13 |
+             Tk__tok_class_15 |
              Tk__tok_char_22 |
              Tk__tok_catch_47 |
              Tk__tok_case_51 |
@@ -516,6 +534,7 @@ data Token = EndOfFile |
              Tk__qq_TypeSpecifier String |
              Tk__qq_Type String |
              Tk__qq_TypeParameter String |
+             Tk__qq_NonEmptyTypeParameters String |
              Tk__qq_TypeParameters String |
              Tk__qq_WildcardType String |
              Tk__qq_TypeArgument String |
@@ -557,6 +576,7 @@ data Token = EndOfFile |
              Tk__qq_ParamModifierList String |
              Tk__qq_ParameterList String |
              Tk__qq_StaticInitializer String |
+             Tk__qq_ArrayInitializer String |
              Tk__qq_VariableInitializer String |
              Tk__qq_VariableInitializerList String |
              Tk__qq_VariableDeclarator String |
@@ -590,6 +610,8 @@ data Token = EndOfFile |
              Tk__qq_ClassOrInterfaceType String |
              Tk__qq_ModifierList String |
              Tk__qq_AnnotationList String |
+             Tk__qq_ElementValueArrayInitializer String |
+             Tk__qq_ElementValue String |
              Tk__qq_AnnotationElement String |
              Tk__qq_AnnotationArguments String |
              Tk__qq_Annotation String |
@@ -598,8 +620,10 @@ data Token = EndOfFile |
              Tk__qq_ImportName String |
              Tk__qq_ImportStatement String |
              Tk__qq_Package String |
+             Tk__qq_CompilationUnitRest String |
              Tk__qq_CompilationUnit String |
              Tk__qq_ImportList String |
+             Tk__qq_TypeDeclarationList String |
              Tk__qq_TypeDeclaration String |
              Tk__qq_OptDocComment String |
              Tk__qq_Java String

--- a/test/golden/java/JavaParser.y
+++ b/test/golden/java/JavaParser.y
@@ -14,105 +14,111 @@ import qualified JavaLexer as L (Token(..), PosToken(..), AlexPosn(..), alexScan
 %token
 
 rtk__eof { L.PosToken _ L.EndOfFile }
-tok_AdditiveOp_dummy_193 { L.PosToken _ L.Tk__tok_AdditiveOp_dummy_193 }
-tok_Annotation_dummy_192 { L.PosToken _ L.Tk__tok_Annotation_dummy_192 }
-tok_AnnotationArguments_dummy_191 { L.PosToken _ L.Tk__tok_AnnotationArguments_dummy_191 }
-tok_AnnotationDeclaration_dummy_190 { L.PosToken _ L.Tk__tok_AnnotationDeclaration_dummy_190 }
-tok_AnnotationElement_dummy_189 { L.PosToken _ L.Tk__tok_AnnotationElement_dummy_189 }
-tok_AnnotationList_dummy_188 { L.PosToken _ L.Tk__tok_AnnotationList_dummy_188 }
-tok_AnnotationTypeElement_dummy_187 { L.PosToken _ L.Tk__tok_AnnotationTypeElement_dummy_187 }
-tok_AnnotationTypeElementList_dummy_186 { L.PosToken _ L.Tk__tok_AnnotationTypeElementList_dummy_186 }
-tok_Arglist_dummy_185 { L.PosToken _ L.Tk__tok_Arglist_dummy_185 }
-tok_AssignmentOp_dummy_184 { L.PosToken _ L.Tk__tok_AssignmentOp_dummy_184 }
-tok_CatchList_dummy_183 { L.PosToken _ L.Tk__tok_CatchList_dummy_183 }
-tok_CatchParameter_dummy_182 { L.PosToken _ L.Tk__tok_CatchParameter_dummy_182 }
-tok_ClassDeclaration_dummy_181 { L.PosToken _ L.Tk__tok_ClassDeclaration_dummy_181 }
-tok_ClassOrInterfaceType_dummy_180 { L.PosToken _ L.Tk__tok_ClassOrInterfaceType_dummy_180 }
-tok_CompilationUnit_dummy_179 { L.PosToken _ L.Tk__tok_CompilationUnit_dummy_179 }
-tok_CompoundName_dummy_178 { L.PosToken _ L.Tk__tok_CompoundName_dummy_178 }
-tok_CompoundNameTail_dummy_177 { L.PosToken _ L.Tk__tok_CompoundNameTail_dummy_177 }
-tok_CreationExpression_dummy_176 { L.PosToken _ L.Tk__tok_CreationExpression_dummy_176 }
-tok_DimExprs_dummy_175 { L.PosToken _ L.Tk__tok_DimExprs_dummy_175 }
-tok_Dims_dummy_174 { L.PosToken _ L.Tk__tok_Dims_dummy_174 }
-tok_DoStatement_dummy_173 { L.PosToken _ L.Tk__tok_DoStatement_dummy_173 }
-tok_DocComment_dummy_172 { L.PosToken _ L.Tk__tok_DocComment_dummy_172 }
-tok_EnumConstant_dummy_171 { L.PosToken _ L.Tk__tok_EnumConstant_dummy_171 }
-tok_EnumConstantList_dummy_170 { L.PosToken _ L.Tk__tok_EnumConstantList_dummy_170 }
-tok_EnumDeclaration_dummy_169 { L.PosToken _ L.Tk__tok_EnumDeclaration_dummy_169 }
-tok_EqualityOp_dummy_168 { L.PosToken _ L.Tk__tok_EqualityOp_dummy_168 }
-tok_Expression_dummy_167 { L.PosToken _ L.Tk__tok_Expression_dummy_167 }
-tok_ExtendsList_dummy_166 { L.PosToken _ L.Tk__tok_ExtendsList_dummy_166 }
-tok_FieldDeclaration_dummy_165 { L.PosToken _ L.Tk__tok_FieldDeclaration_dummy_165 }
-tok_FieldDeclarationList_dummy_164 { L.PosToken _ L.Tk__tok_FieldDeclarationList_dummy_164 }
-tok_ForEachHeader_dummy_163 { L.PosToken _ L.Tk__tok_ForEachHeader_dummy_163 }
-tok_ForStatement_dummy_162 { L.PosToken _ L.Tk__tok_ForStatement_dummy_162 }
-tok_IfStatement_dummy_161 { L.PosToken _ L.Tk__tok_IfStatement_dummy_161 }
-tok_ImplementsList_dummy_160 { L.PosToken _ L.Tk__tok_ImplementsList_dummy_160 }
-tok_ImportHead_dummy_159 { L.PosToken _ L.Tk__tok_ImportHead_dummy_159 }
-tok_ImportList_dummy_158 { L.PosToken _ L.Tk__tok_ImportList_dummy_158 }
-tok_ImportName_dummy_157 { L.PosToken _ L.Tk__tok_ImportName_dummy_157 }
-tok_ImportStatement_dummy_156 { L.PosToken _ L.Tk__tok_ImportStatement_dummy_156 }
-tok_InterfaceDeclaration_dummy_155 { L.PosToken _ L.Tk__tok_InterfaceDeclaration_dummy_155 }
-tok_Java_dummy_194 { L.PosToken _ L.Tk__tok_Java_dummy_194 }
-tok_LambdaBody_dummy_154 { L.PosToken _ L.Tk__tok_LambdaBody_dummy_154 }
-tok_Literal_dummy_153 { L.PosToken _ L.Tk__tok_Literal_dummy_153 }
-tok_LocalModifierList1_dummy_152 { L.PosToken _ L.Tk__tok_LocalModifierList1_dummy_152 }
-tok_MemberAfterFirstId_dummy_151 { L.PosToken _ L.Tk__tok_MemberAfterFirstId_dummy_151 }
-tok_MemberDeclaration_dummy_150 { L.PosToken _ L.Tk__tok_MemberDeclaration_dummy_150 }
-tok_MemberRest_dummy_149 { L.PosToken _ L.Tk__tok_MemberRest_dummy_149 }
-tok_Modifier_dummy_148 { L.PosToken _ L.Tk__tok_Modifier_dummy_148 }
-tok_ModifierList_dummy_147 { L.PosToken _ L.Tk__tok_ModifierList_dummy_147 }
-tok_MoreTypeSpecifier_dummy_146 { L.PosToken _ L.Tk__tok_MoreTypeSpecifier_dummy_146 }
-tok_MoreVariableDeclarators_dummy_145 { L.PosToken _ L.Tk__tok_MoreVariableDeclarators_dummy_145 }
-tok_MultiplicativeOp_dummy_144 { L.PosToken _ L.Tk__tok_MultiplicativeOp_dummy_144 }
-tok_NonEmptyDims_dummy_143 { L.PosToken _ L.Tk__tok_NonEmptyDims_dummy_143 }
-tok_NonEmptyTypeArguments_dummy_142 { L.PosToken _ L.Tk__tok_NonEmptyTypeArguments_dummy_142 }
-tok_OptDocComment_dummy_141 { L.PosToken _ L.Tk__tok_OptDocComment_dummy_141 }
-tok_OptElsePart_dummy_140 { L.PosToken _ L.Tk__tok_OptElsePart_dummy_140 }
-tok_OptExpression_dummy_139 { L.PosToken _ L.Tk__tok_OptExpression_dummy_139 }
-tok_OptFinally_dummy_138 { L.PosToken _ L.Tk__tok_OptFinally_dummy_138 }
-tok_OptId_dummy_137 { L.PosToken _ L.Tk__tok_OptId_dummy_137 }
-tok_OptVariableInitializer_dummy_136 { L.PosToken _ L.Tk__tok_OptVariableInitializer_dummy_136 }
-tok_Package_dummy_135 { L.PosToken _ L.Tk__tok_Package_dummy_135 }
-tok_ParamModifierList_dummy_134 { L.PosToken _ L.Tk__tok_ParamModifierList_dummy_134 }
-tok_Parameter_dummy_133 { L.PosToken _ L.Tk__tok_Parameter_dummy_133 }
-tok_ParameterList_dummy_132 { L.PosToken _ L.Tk__tok_ParameterList_dummy_132 }
-tok_PostfixOp_dummy_131 { L.PosToken _ L.Tk__tok_PostfixOp_dummy_131 }
-tok_PrefixOp_dummy_130 { L.PosToken _ L.Tk__tok_PrefixOp_dummy_130 }
-tok_PrimitiveTypeKeyword_dummy_129 { L.PosToken _ L.Tk__tok_PrimitiveTypeKeyword_dummy_129 }
-tok_RelationalOp_dummy_128 { L.PosToken _ L.Tk__tok_RelationalOp_dummy_128 }
-tok_Resource_dummy_127 { L.PosToken _ L.Tk__tok_Resource_dummy_127 }
-tok_ResourceSpec_dummy_126 { L.PosToken _ L.Tk__tok_ResourceSpec_dummy_126 }
-tok_ShiftOp_dummy_125 { L.PosToken _ L.Tk__tok_ShiftOp_dummy_125 }
-tok_Statement_dummy_124 { L.PosToken _ L.Tk__tok_Statement_dummy_124 }
-tok_StatementBlock_dummy_123 { L.PosToken _ L.Tk__tok_StatementBlock_dummy_123 }
-tok_StatementList_dummy_122 { L.PosToken _ L.Tk__tok_StatementList_dummy_122 }
-tok_StaticInitializer_dummy_121 { L.PosToken _ L.Tk__tok_StaticInitializer_dummy_121 }
-tok_SwitchCaseList_dummy_120 { L.PosToken _ L.Tk__tok_SwitchCaseList_dummy_120 }
-tok_SwitchStatement_dummy_119 { L.PosToken _ L.Tk__tok_SwitchStatement_dummy_119 }
-tok_ThrowsClause_dummy_118 { L.PosToken _ L.Tk__tok_ThrowsClause_dummy_118 }
-tok_TryStatement_dummy_117 { L.PosToken _ L.Tk__tok_TryStatement_dummy_117 }
-tok_Type_dummy_116 { L.PosToken _ L.Tk__tok_Type_dummy_116 }
-tok_TypeArgument_dummy_115 { L.PosToken _ L.Tk__tok_TypeArgument_dummy_115 }
-tok_TypeArguments_dummy_114 { L.PosToken _ L.Tk__tok_TypeArguments_dummy_114 }
-tok_TypeDeclRest_dummy_113 { L.PosToken _ L.Tk__tok_TypeDeclRest_dummy_113 }
-tok_TypeDeclaration_dummy_112 { L.PosToken _ L.Tk__tok_TypeDeclaration_dummy_112 }
-tok_TypeParameter_dummy_111 { L.PosToken _ L.Tk__tok_TypeParameter_dummy_111 }
-tok_TypeParameters_dummy_110 { L.PosToken _ L.Tk__tok_TypeParameters_dummy_110 }
-tok_TypeSpecifier_dummy_109 { L.PosToken _ L.Tk__tok_TypeSpecifier_dummy_109 }
-tok_VariableDeclaration_dummy_108 { L.PosToken _ L.Tk__tok_VariableDeclaration_dummy_108 }
-tok_VariableDeclarator_dummy_107 { L.PosToken _ L.Tk__tok_VariableDeclarator_dummy_107 }
-tok_VariableDeclaratorList_dummy_106 { L.PosToken _ L.Tk__tok_VariableDeclaratorList_dummy_106 }
-tok_VariableInitializer_dummy_105 { L.PosToken _ L.Tk__tok_VariableInitializer_dummy_105 }
-tok_VariableInitializerList_dummy_104 { L.PosToken _ L.Tk__tok_VariableInitializerList_dummy_104 }
-tok_WhileStatement_dummy_103 { L.PosToken _ L.Tk__tok_WhileStatement_dummy_103 }
-tok_WildcardType_dummy_102 { L.PosToken _ L.Tk__tok_WildcardType_dummy_102 }
+tok_AdditiveOp_dummy_205 { L.PosToken _ L.Tk__tok_AdditiveOp_dummy_205 }
+tok_Annotation_dummy_204 { L.PosToken _ L.Tk__tok_Annotation_dummy_204 }
+tok_AnnotationArguments_dummy_203 { L.PosToken _ L.Tk__tok_AnnotationArguments_dummy_203 }
+tok_AnnotationDeclaration_dummy_202 { L.PosToken _ L.Tk__tok_AnnotationDeclaration_dummy_202 }
+tok_AnnotationElement_dummy_201 { L.PosToken _ L.Tk__tok_AnnotationElement_dummy_201 }
+tok_AnnotationList_dummy_200 { L.PosToken _ L.Tk__tok_AnnotationList_dummy_200 }
+tok_AnnotationTypeElement_dummy_199 { L.PosToken _ L.Tk__tok_AnnotationTypeElement_dummy_199 }
+tok_AnnotationTypeElementList_dummy_198 { L.PosToken _ L.Tk__tok_AnnotationTypeElementList_dummy_198 }
+tok_Arglist_dummy_197 { L.PosToken _ L.Tk__tok_Arglist_dummy_197 }
+tok_ArrayInitializer_dummy_196 { L.PosToken _ L.Tk__tok_ArrayInitializer_dummy_196 }
+tok_AssignmentOp_dummy_195 { L.PosToken _ L.Tk__tok_AssignmentOp_dummy_195 }
+tok_CatchList_dummy_194 { L.PosToken _ L.Tk__tok_CatchList_dummy_194 }
+tok_CatchParameter_dummy_193 { L.PosToken _ L.Tk__tok_CatchParameter_dummy_193 }
+tok_ClassDeclaration_dummy_192 { L.PosToken _ L.Tk__tok_ClassDeclaration_dummy_192 }
+tok_ClassOrInterfaceType_dummy_191 { L.PosToken _ L.Tk__tok_ClassOrInterfaceType_dummy_191 }
+tok_CompilationUnit_dummy_190 { L.PosToken _ L.Tk__tok_CompilationUnit_dummy_190 }
+tok_CompilationUnitRest_dummy_189 { L.PosToken _ L.Tk__tok_CompilationUnitRest_dummy_189 }
+tok_CompoundName_dummy_188 { L.PosToken _ L.Tk__tok_CompoundName_dummy_188 }
+tok_CompoundNameTail_dummy_187 { L.PosToken _ L.Tk__tok_CompoundNameTail_dummy_187 }
+tok_CreationExpression_dummy_186 { L.PosToken _ L.Tk__tok_CreationExpression_dummy_186 }
+tok_DimExprs_dummy_185 { L.PosToken _ L.Tk__tok_DimExprs_dummy_185 }
+tok_Dims_dummy_184 { L.PosToken _ L.Tk__tok_Dims_dummy_184 }
+tok_DoStatement_dummy_183 { L.PosToken _ L.Tk__tok_DoStatement_dummy_183 }
+tok_DocComment_dummy_182 { L.PosToken _ L.Tk__tok_DocComment_dummy_182 }
+tok_ElementValue_dummy_181 { L.PosToken _ L.Tk__tok_ElementValue_dummy_181 }
+tok_ElementValueArrayInitializer_dummy_180 { L.PosToken _ L.Tk__tok_ElementValueArrayInitializer_dummy_180 }
+tok_EnumConstant_dummy_179 { L.PosToken _ L.Tk__tok_EnumConstant_dummy_179 }
+tok_EnumConstantList_dummy_178 { L.PosToken _ L.Tk__tok_EnumConstantList_dummy_178 }
+tok_EnumDeclaration_dummy_177 { L.PosToken _ L.Tk__tok_EnumDeclaration_dummy_177 }
+tok_EqualityOp_dummy_176 { L.PosToken _ L.Tk__tok_EqualityOp_dummy_176 }
+tok_Expression_dummy_175 { L.PosToken _ L.Tk__tok_Expression_dummy_175 }
+tok_ExtendsList_dummy_174 { L.PosToken _ L.Tk__tok_ExtendsList_dummy_174 }
+tok_FieldDeclaration_dummy_173 { L.PosToken _ L.Tk__tok_FieldDeclaration_dummy_173 }
+tok_FieldDeclarationList_dummy_172 { L.PosToken _ L.Tk__tok_FieldDeclarationList_dummy_172 }
+tok_ForEachHeader_dummy_171 { L.PosToken _ L.Tk__tok_ForEachHeader_dummy_171 }
+tok_ForStatement_dummy_170 { L.PosToken _ L.Tk__tok_ForStatement_dummy_170 }
+tok_IfStatement_dummy_169 { L.PosToken _ L.Tk__tok_IfStatement_dummy_169 }
+tok_ImplementsList_dummy_168 { L.PosToken _ L.Tk__tok_ImplementsList_dummy_168 }
+tok_ImportHead_dummy_167 { L.PosToken _ L.Tk__tok_ImportHead_dummy_167 }
+tok_ImportList_dummy_166 { L.PosToken _ L.Tk__tok_ImportList_dummy_166 }
+tok_ImportName_dummy_165 { L.PosToken _ L.Tk__tok_ImportName_dummy_165 }
+tok_ImportStatement_dummy_164 { L.PosToken _ L.Tk__tok_ImportStatement_dummy_164 }
+tok_InterfaceDeclaration_dummy_163 { L.PosToken _ L.Tk__tok_InterfaceDeclaration_dummy_163 }
+tok_Java_dummy_206 { L.PosToken _ L.Tk__tok_Java_dummy_206 }
+tok_LambdaBody_dummy_162 { L.PosToken _ L.Tk__tok_LambdaBody_dummy_162 }
+tok_Literal_dummy_161 { L.PosToken _ L.Tk__tok_Literal_dummy_161 }
+tok_LocalModifierList1_dummy_160 { L.PosToken _ L.Tk__tok_LocalModifierList1_dummy_160 }
+tok_MemberAfterFirstId_dummy_159 { L.PosToken _ L.Tk__tok_MemberAfterFirstId_dummy_159 }
+tok_MemberDeclaration_dummy_158 { L.PosToken _ L.Tk__tok_MemberDeclaration_dummy_158 }
+tok_MemberRest_dummy_157 { L.PosToken _ L.Tk__tok_MemberRest_dummy_157 }
+tok_Modifier_dummy_156 { L.PosToken _ L.Tk__tok_Modifier_dummy_156 }
+tok_ModifierList_dummy_155 { L.PosToken _ L.Tk__tok_ModifierList_dummy_155 }
+tok_MoreTypeSpecifier_dummy_154 { L.PosToken _ L.Tk__tok_MoreTypeSpecifier_dummy_154 }
+tok_MoreVariableDeclarators_dummy_153 { L.PosToken _ L.Tk__tok_MoreVariableDeclarators_dummy_153 }
+tok_MultiplicativeOp_dummy_152 { L.PosToken _ L.Tk__tok_MultiplicativeOp_dummy_152 }
+tok_NonEmptyDims_dummy_151 { L.PosToken _ L.Tk__tok_NonEmptyDims_dummy_151 }
+tok_NonEmptyTypeArguments_dummy_150 { L.PosToken _ L.Tk__tok_NonEmptyTypeArguments_dummy_150 }
+tok_NonEmptyTypeParameters_dummy_149 { L.PosToken _ L.Tk__tok_NonEmptyTypeParameters_dummy_149 }
+tok_OptDocComment_dummy_148 { L.PosToken _ L.Tk__tok_OptDocComment_dummy_148 }
+tok_OptElsePart_dummy_147 { L.PosToken _ L.Tk__tok_OptElsePart_dummy_147 }
+tok_OptExpression_dummy_146 { L.PosToken _ L.Tk__tok_OptExpression_dummy_146 }
+tok_OptFinally_dummy_145 { L.PosToken _ L.Tk__tok_OptFinally_dummy_145 }
+tok_OptId_dummy_144 { L.PosToken _ L.Tk__tok_OptId_dummy_144 }
+tok_OptVariableInitializer_dummy_143 { L.PosToken _ L.Tk__tok_OptVariableInitializer_dummy_143 }
+tok_Package_dummy_142 { L.PosToken _ L.Tk__tok_Package_dummy_142 }
+tok_ParamModifierList_dummy_141 { L.PosToken _ L.Tk__tok_ParamModifierList_dummy_141 }
+tok_Parameter_dummy_140 { L.PosToken _ L.Tk__tok_Parameter_dummy_140 }
+tok_ParameterList_dummy_139 { L.PosToken _ L.Tk__tok_ParameterList_dummy_139 }
+tok_PostfixOp_dummy_138 { L.PosToken _ L.Tk__tok_PostfixOp_dummy_138 }
+tok_PrefixOp_dummy_137 { L.PosToken _ L.Tk__tok_PrefixOp_dummy_137 }
+tok_PrimitiveTypeKeyword_dummy_136 { L.PosToken _ L.Tk__tok_PrimitiveTypeKeyword_dummy_136 }
+tok_RelationalOp_dummy_135 { L.PosToken _ L.Tk__tok_RelationalOp_dummy_135 }
+tok_Resource_dummy_134 { L.PosToken _ L.Tk__tok_Resource_dummy_134 }
+tok_ResourceSpec_dummy_133 { L.PosToken _ L.Tk__tok_ResourceSpec_dummy_133 }
+tok_ShiftOp_dummy_132 { L.PosToken _ L.Tk__tok_ShiftOp_dummy_132 }
+tok_Statement_dummy_131 { L.PosToken _ L.Tk__tok_Statement_dummy_131 }
+tok_StatementBlock_dummy_130 { L.PosToken _ L.Tk__tok_StatementBlock_dummy_130 }
+tok_StatementList_dummy_129 { L.PosToken _ L.Tk__tok_StatementList_dummy_129 }
+tok_StaticInitializer_dummy_128 { L.PosToken _ L.Tk__tok_StaticInitializer_dummy_128 }
+tok_SwitchCaseList_dummy_127 { L.PosToken _ L.Tk__tok_SwitchCaseList_dummy_127 }
+tok_SwitchStatement_dummy_126 { L.PosToken _ L.Tk__tok_SwitchStatement_dummy_126 }
+tok_ThrowsClause_dummy_125 { L.PosToken _ L.Tk__tok_ThrowsClause_dummy_125 }
+tok_TryStatement_dummy_124 { L.PosToken _ L.Tk__tok_TryStatement_dummy_124 }
+tok_Type_dummy_123 { L.PosToken _ L.Tk__tok_Type_dummy_123 }
+tok_TypeArgument_dummy_122 { L.PosToken _ L.Tk__tok_TypeArgument_dummy_122 }
+tok_TypeArguments_dummy_121 { L.PosToken _ L.Tk__tok_TypeArguments_dummy_121 }
+tok_TypeDeclRest_dummy_120 { L.PosToken _ L.Tk__tok_TypeDeclRest_dummy_120 }
+tok_TypeDeclaration_dummy_119 { L.PosToken _ L.Tk__tok_TypeDeclaration_dummy_119 }
+tok_TypeDeclarationList_dummy_118 { L.PosToken _ L.Tk__tok_TypeDeclarationList_dummy_118 }
+tok_TypeParameter_dummy_117 { L.PosToken _ L.Tk__tok_TypeParameter_dummy_117 }
+tok_TypeParameters_dummy_116 { L.PosToken _ L.Tk__tok_TypeParameters_dummy_116 }
+tok_TypeSpecifier_dummy_115 { L.PosToken _ L.Tk__tok_TypeSpecifier_dummy_115 }
+tok_VariableDeclaration_dummy_114 { L.PosToken _ L.Tk__tok_VariableDeclaration_dummy_114 }
+tok_VariableDeclarator_dummy_113 { L.PosToken _ L.Tk__tok_VariableDeclarator_dummy_113 }
+tok_VariableDeclaratorList_dummy_112 { L.PosToken _ L.Tk__tok_VariableDeclaratorList_dummy_112 }
+tok_VariableInitializer_dummy_111 { L.PosToken _ L.Tk__tok_VariableInitializer_dummy_111 }
+tok_VariableInitializerList_dummy_110 { L.PosToken _ L.Tk__tok_VariableInitializerList_dummy_110 }
+tok_WhileStatement_dummy_109 { L.PosToken _ L.Tk__tok_WhileStatement_dummy_109 }
+tok_WildcardType_dummy_108 { L.PosToken _ L.Tk__tok_WildcardType_dummy_108 }
 tok__tilde__84 { L.PosToken _ L.Tk__tok__tilde__84 }
-tok__symbol__15 { L.PosToken _ L.Tk__tok__symbol__15 }
+tok__symbol__12 { L.PosToken _ L.Tk__tok__symbol__12 }
 tok__pipe__pipe__66 { L.PosToken _ L.Tk__tok__pipe__pipe__66 }
 tok__pipe__eql__58 { L.PosToken _ L.Tk__tok__pipe__eql__58 }
 tok__pipe__48 { L.PosToken _ L.Tk__tok__pipe__48 }
-tok__symbol__14 { L.PosToken _ L.Tk__tok__symbol__14 }
+tok__symbol__11 { L.PosToken _ L.Tk__tok__symbol__11 }
 tok_while_45 { L.PosToken _ L.Tk__tok_while_45 }
 tok_void_28 { L.PosToken _ L.Tk__tok_void_28 }
 tok_try_50 { L.PosToken _ L.Tk__tok_try_50 }
@@ -140,21 +146,21 @@ tok_interface_16 { L.PosToken _ L.Tk__tok_interface_16 }
 tok_int_24 { L.PosToken _ L.Tk__tok_int_24 }
 tok_instanceof_76 { L.PosToken _ L.Tk__tok_instanceof_76 }
 tok_import_2 { L.PosToken _ L.Tk__tok_import_2 }
-tok_implements_12 { L.PosToken _ L.Tk__tok_implements_12 }
+tok_implements_14 { L.PosToken _ L.Tk__tok_implements_14 }
 tok_if_43 { L.PosToken _ L.Tk__tok_if_43 }
 tok_for_46 { L.PosToken _ L.Tk__tok_for_46 }
 tok_float_25 { L.PosToken _ L.Tk__tok_float_25 }
 tok_finally_49 { L.PosToken _ L.Tk__tok_finally_49 }
 tok_final_31 { L.PosToken _ L.Tk__tok_final_31 }
 tok_false_89 { L.PosToken _ L.Tk__tok_false_89 }
-tok_extends_11 { L.PosToken _ L.Tk__tok_extends_11 }
+tok_extends_13 { L.PosToken _ L.Tk__tok_extends_13 }
 tok_enum_17 { L.PosToken _ L.Tk__tok_enum_17 }
 tok_else_42 { L.PosToken _ L.Tk__tok_else_42 }
 tok_double_27 { L.PosToken _ L.Tk__tok_double_27 }
 tok_do_44 { L.PosToken _ L.Tk__tok_do_44 }
 tok_default_30 { L.PosToken _ L.Tk__tok_default_30 }
 tok_continue_39 { L.PosToken _ L.Tk__tok_continue_39 }
-tok_class_13 { L.PosToken _ L.Tk__tok_class_13 }
+tok_class_15 { L.PosToken _ L.Tk__tok_class_15 }
 tok_char_22 { L.PosToken _ L.Tk__tok_char_22 }
 tok_catch_47 { L.PosToken _ L.Tk__tok_catch_47 }
 tok_case_51 { L.PosToken _ L.Tk__tok_case_51 }
@@ -219,6 +225,7 @@ qq_Modifier { L.PosToken _ (L.Tk__qq_Modifier _) }
 qq_TypeSpecifier { L.PosToken _ (L.Tk__qq_TypeSpecifier _) }
 qq_Type { L.PosToken _ (L.Tk__qq_Type _) }
 qq_TypeParameter { L.PosToken _ (L.Tk__qq_TypeParameter _) }
+qq_NonEmptyTypeParameters { L.PosToken _ (L.Tk__qq_NonEmptyTypeParameters _) }
 qq_TypeParameters { L.PosToken _ (L.Tk__qq_TypeParameters _) }
 qq_WildcardType { L.PosToken _ (L.Tk__qq_WildcardType _) }
 qq_TypeArgument { L.PosToken _ (L.Tk__qq_TypeArgument _) }
@@ -260,6 +267,7 @@ qq_Parameter { L.PosToken _ (L.Tk__qq_Parameter _) }
 qq_ParamModifierList { L.PosToken _ (L.Tk__qq_ParamModifierList _) }
 qq_ParameterList { L.PosToken _ (L.Tk__qq_ParameterList _) }
 qq_StaticInitializer { L.PosToken _ (L.Tk__qq_StaticInitializer _) }
+qq_ArrayInitializer { L.PosToken _ (L.Tk__qq_ArrayInitializer _) }
 qq_VariableInitializer { L.PosToken _ (L.Tk__qq_VariableInitializer _) }
 qq_VariableInitializerList { L.PosToken _ (L.Tk__qq_VariableInitializerList _) }
 qq_VariableDeclarator { L.PosToken _ (L.Tk__qq_VariableDeclarator _) }
@@ -293,6 +301,8 @@ qq_ExtendsList { L.PosToken _ (L.Tk__qq_ExtendsList _) }
 qq_ClassOrInterfaceType { L.PosToken _ (L.Tk__qq_ClassOrInterfaceType _) }
 qq_ModifierList { L.PosToken _ (L.Tk__qq_ModifierList _) }
 qq_AnnotationList { L.PosToken _ (L.Tk__qq_AnnotationList _) }
+qq_ElementValueArrayInitializer { L.PosToken _ (L.Tk__qq_ElementValueArrayInitializer _) }
+qq_ElementValue { L.PosToken _ (L.Tk__qq_ElementValue _) }
 qq_AnnotationElement { L.PosToken _ (L.Tk__qq_AnnotationElement _) }
 qq_AnnotationArguments { L.PosToken _ (L.Tk__qq_AnnotationArguments _) }
 qq_Annotation { L.PosToken _ (L.Tk__qq_Annotation _) }
@@ -301,8 +311,10 @@ qq_ImportHead { L.PosToken _ (L.Tk__qq_ImportHead _) }
 qq_ImportName { L.PosToken _ (L.Tk__qq_ImportName _) }
 qq_ImportStatement { L.PosToken _ (L.Tk__qq_ImportStatement _) }
 qq_Package { L.PosToken _ (L.Tk__qq_Package _) }
+qq_CompilationUnitRest { L.PosToken _ (L.Tk__qq_CompilationUnitRest _) }
 qq_CompilationUnit { L.PosToken _ (L.Tk__qq_CompilationUnit _) }
 qq_ImportList { L.PosToken _ (L.Tk__qq_ImportList _) }
+qq_TypeDeclarationList { L.PosToken _ (L.Tk__qq_TypeDeclarationList _) }
 qq_TypeDeclaration { L.PosToken _ (L.Tk__qq_TypeDeclaration _) }
 qq_OptDocComment { L.PosToken _ (L.Tk__qq_OptDocComment _) }
 qq_Java { L.PosToken _ (L.Tk__qq_Java _) }
@@ -311,109 +323,115 @@ qq_Java { L.PosToken _ (L.Tk__qq_Java _) }
 
 Java__top : Java rtk__eof { $1 }
 
-Java : tok_Java_dummy_194 Java tok_Java_dummy_194 { Ctr__Java__0 (rtkPosOf $1) $2 } |
-       tok_AdditiveOp_dummy_193 AdditiveOp tok_AdditiveOp_dummy_193 { Ctr__Java__1 (rtkPosOf $1) $2 } |
-       tok_Annotation_dummy_192 Annotation tok_Annotation_dummy_192 { Ctr__Java__2 (rtkPosOf $1) $2 } |
-       tok_AnnotationArguments_dummy_191 AnnotationArguments tok_AnnotationArguments_dummy_191 { Ctr__Java__3 (rtkPosOf $1) $2 } |
-       tok_AnnotationDeclaration_dummy_190 AnnotationDeclaration tok_AnnotationDeclaration_dummy_190 { Ctr__Java__4 (rtkPosOf $1) $2 } |
-       tok_AnnotationElement_dummy_189 AnnotationElement tok_AnnotationElement_dummy_189 { Ctr__Java__5 (rtkPosOf $1) $2 } |
-       tok_AnnotationList_dummy_188 AnnotationList tok_AnnotationList_dummy_188 { Ctr__Java__6 (rtkPosOf $1) (reverse $2) } |
-       tok_AnnotationTypeElement_dummy_187 AnnotationTypeElement tok_AnnotationTypeElement_dummy_187 { Ctr__Java__7 (rtkPosOf $1) $2 } |
-       tok_AnnotationTypeElementList_dummy_186 AnnotationTypeElementList tok_AnnotationTypeElementList_dummy_186 { Ctr__Java__8 (rtkPosOf $1) (reverse $2) } |
-       tok_Arglist_dummy_185 Arglist tok_Arglist_dummy_185 { Ctr__Java__9 (rtkPosOf $1) $2 } |
-       tok_AssignmentOp_dummy_184 AssignmentOp tok_AssignmentOp_dummy_184 { Ctr__Java__10 (rtkPosOf $1) $2 } |
-       tok_CatchList_dummy_183 CatchList tok_CatchList_dummy_183 { Ctr__Java__11 (rtkPosOf $1) (reverse $2) } |
-       tok_CatchParameter_dummy_182 CatchParameter tok_CatchParameter_dummy_182 { Ctr__Java__12 (rtkPosOf $1) $2 } |
-       tok_ClassDeclaration_dummy_181 ClassDeclaration tok_ClassDeclaration_dummy_181 { Ctr__Java__13 (rtkPosOf $1) $2 } |
-       tok_ClassOrInterfaceType_dummy_180 ClassOrInterfaceType tok_ClassOrInterfaceType_dummy_180 { Ctr__Java__14 (rtkPosOf $1) $2 } |
-       tok_CompilationUnit_dummy_179 CompilationUnit tok_CompilationUnit_dummy_179 { Ctr__Java__15 (rtkPosOf $1) $2 } |
-       tok_CompoundName_dummy_178 CompoundName tok_CompoundName_dummy_178 { Ctr__Java__16 (rtkPosOf $1) $2 } |
-       tok_CompoundNameTail_dummy_177 CompoundNameTail tok_CompoundNameTail_dummy_177 { Ctr__Java__17 (rtkPosOf $1) (reverse $2) } |
-       tok_CreationExpression_dummy_176 CreationExpression tok_CreationExpression_dummy_176 { Ctr__Java__18 (rtkPosOf $1) $2 } |
-       tok_DimExprs_dummy_175 DimExprs tok_DimExprs_dummy_175 { Ctr__Java__19 (rtkPosOf $1) (reverse $2) } |
-       tok_Dims_dummy_174 Dims tok_Dims_dummy_174 { Ctr__Java__20 (rtkPosOf $1) (reverse $2) } |
-       tok_DoStatement_dummy_173 DoStatement tok_DoStatement_dummy_173 { Ctr__Java__21 (rtkPosOf $1) $2 } |
-       tok_DocComment_dummy_172 DocComment tok_DocComment_dummy_172 { Ctr__Java__22 (rtkPosOf $1) $2 } |
-       tok_EnumConstant_dummy_171 EnumConstant tok_EnumConstant_dummy_171 { Ctr__Java__23 (rtkPosOf $1) $2 } |
-       tok_EnumConstantList_dummy_170 EnumConstantList tok_EnumConstantList_dummy_170 { Ctr__Java__24 (rtkPosOf $1) $2 } |
-       tok_EnumDeclaration_dummy_169 EnumDeclaration tok_EnumDeclaration_dummy_169 { Ctr__Java__25 (rtkPosOf $1) $2 } |
-       tok_EqualityOp_dummy_168 EqualityOp tok_EqualityOp_dummy_168 { Ctr__Java__26 (rtkPosOf $1) $2 } |
-       tok_Expression_dummy_167 Expression tok_Expression_dummy_167 { Ctr__Java__27 (rtkPosOf $1) $2 } |
-       tok_ExtendsList_dummy_166 ExtendsList tok_ExtendsList_dummy_166 { Ctr__Java__28 (rtkPosOf $1) $2 } |
-       tok_FieldDeclaration_dummy_165 FieldDeclaration tok_FieldDeclaration_dummy_165 { Ctr__Java__29 (rtkPosOf $1) $2 } |
-       tok_FieldDeclarationList_dummy_164 FieldDeclarationList tok_FieldDeclarationList_dummy_164 { Ctr__Java__30 (rtkPosOf $1) (reverse $2) } |
-       tok_ForEachHeader_dummy_163 ForEachHeader tok_ForEachHeader_dummy_163 { Ctr__Java__31 (rtkPosOf $1) $2 } |
-       tok_ForStatement_dummy_162 ForStatement tok_ForStatement_dummy_162 { Ctr__Java__32 (rtkPosOf $1) $2 } |
-       tok_IfStatement_dummy_161 IfStatement tok_IfStatement_dummy_161 { Ctr__Java__33 (rtkPosOf $1) $2 } |
-       tok_ImplementsList_dummy_160 ImplementsList tok_ImplementsList_dummy_160 { Ctr__Java__34 (rtkPosOf $1) $2 } |
-       tok_ImportHead_dummy_159 ImportHead tok_ImportHead_dummy_159 { Ctr__Java__35 (rtkPosOf $1) $2 } |
-       tok_ImportList_dummy_158 ImportList tok_ImportList_dummy_158 { Ctr__Java__36 (rtkPosOf $1) (reverse $2) } |
-       tok_ImportName_dummy_157 ImportName tok_ImportName_dummy_157 { Ctr__Java__37 (rtkPosOf $1) $2 } |
-       tok_ImportStatement_dummy_156 ImportStatement tok_ImportStatement_dummy_156 { Ctr__Java__38 (rtkPosOf $1) $2 } |
-       tok_InterfaceDeclaration_dummy_155 InterfaceDeclaration tok_InterfaceDeclaration_dummy_155 { Ctr__Java__39 (rtkPosOf $1) $2 } |
-       tok_LambdaBody_dummy_154 LambdaBody tok_LambdaBody_dummy_154 { Ctr__Java__40 (rtkPosOf $1) $2 } |
-       tok_Literal_dummy_153 Literal tok_Literal_dummy_153 { Ctr__Java__41 (rtkPosOf $1) $2 } |
-       tok_LocalModifierList1_dummy_152 LocalModifierList1 tok_LocalModifierList1_dummy_152 { Ctr__Java__42 (rtkPosOf $1) (reverse $2) } |
-       tok_MemberAfterFirstId_dummy_151 MemberAfterFirstId tok_MemberAfterFirstId_dummy_151 { Ctr__Java__43 (rtkPosOf $1) $2 } |
-       tok_MemberDeclaration_dummy_150 MemberDeclaration tok_MemberDeclaration_dummy_150 { Ctr__Java__44 (rtkPosOf $1) $2 } |
-       tok_MemberRest_dummy_149 MemberRest tok_MemberRest_dummy_149 { Ctr__Java__45 (rtkPosOf $1) $2 } |
-       tok_Modifier_dummy_148 Modifier tok_Modifier_dummy_148 { Ctr__Java__46 (rtkPosOf $1) $2 } |
-       tok_ModifierList_dummy_147 ModifierList tok_ModifierList_dummy_147 { Ctr__Java__47 (rtkPosOf $1) (reverse $2) } |
-       tok_MoreTypeSpecifier_dummy_146 MoreTypeSpecifier tok_MoreTypeSpecifier_dummy_146 { Ctr__Java__48 (rtkPosOf $1) $2 } |
-       tok_MoreVariableDeclarators_dummy_145 MoreVariableDeclarators tok_MoreVariableDeclarators_dummy_145 { Ctr__Java__49 (rtkPosOf $1) (reverse $2) } |
-       tok_MultiplicativeOp_dummy_144 MultiplicativeOp tok_MultiplicativeOp_dummy_144 { Ctr__Java__50 (rtkPosOf $1) $2 } |
-       tok_NonEmptyDims_dummy_143 NonEmptyDims tok_NonEmptyDims_dummy_143 { Ctr__Java__51 (rtkPosOf $1) (reverse $2) } |
-       tok_NonEmptyTypeArguments_dummy_142 NonEmptyTypeArguments tok_NonEmptyTypeArguments_dummy_142 { Ctr__Java__52 (rtkPosOf $1) $2 } |
-       tok_OptDocComment_dummy_141 OptDocComment tok_OptDocComment_dummy_141 { Ctr__Java__53 (rtkPosOf $1) $2 } |
-       tok_OptElsePart_dummy_140 OptElsePart tok_OptElsePart_dummy_140 { Ctr__Java__54 (rtkPosOf $1) $2 } |
-       tok_OptExpression_dummy_139 OptExpression tok_OptExpression_dummy_139 { Ctr__Java__55 (rtkPosOf $1) $2 } |
-       tok_OptFinally_dummy_138 OptFinally tok_OptFinally_dummy_138 { Ctr__Java__56 (rtkPosOf $1) $2 } |
-       tok_OptId_dummy_137 OptId tok_OptId_dummy_137 { Ctr__Java__57 (rtkPosOf $1) $2 } |
-       tok_OptVariableInitializer_dummy_136 OptVariableInitializer tok_OptVariableInitializer_dummy_136 { Ctr__Java__58 (rtkPosOf $1) $2 } |
-       tok_Package_dummy_135 Package tok_Package_dummy_135 { Ctr__Java__59 (rtkPosOf $1) $2 } |
-       tok_ParamModifierList_dummy_134 ParamModifierList tok_ParamModifierList_dummy_134 { Ctr__Java__60 (rtkPosOf $1) (reverse $2) } |
-       tok_Parameter_dummy_133 Parameter tok_Parameter_dummy_133 { Ctr__Java__61 (rtkPosOf $1) $2 } |
-       tok_ParameterList_dummy_132 ParameterList tok_ParameterList_dummy_132 { Ctr__Java__62 (rtkPosOf $1) $2 } |
-       tok_PostfixOp_dummy_131 PostfixOp tok_PostfixOp_dummy_131 { Ctr__Java__63 (rtkPosOf $1) $2 } |
-       tok_PrefixOp_dummy_130 PrefixOp tok_PrefixOp_dummy_130 { Ctr__Java__64 (rtkPosOf $1) $2 } |
-       tok_PrimitiveTypeKeyword_dummy_129 PrimitiveTypeKeyword tok_PrimitiveTypeKeyword_dummy_129 { Ctr__Java__65 (rtkPosOf $1) $2 } |
-       tok_RelationalOp_dummy_128 RelationalOp tok_RelationalOp_dummy_128 { Ctr__Java__66 (rtkPosOf $1) $2 } |
-       tok_Resource_dummy_127 Resource tok_Resource_dummy_127 { Ctr__Java__67 (rtkPosOf $1) $2 } |
-       tok_ResourceSpec_dummy_126 ResourceSpec tok_ResourceSpec_dummy_126 { Ctr__Java__68 (rtkPosOf $1) $2 } |
-       tok_ShiftOp_dummy_125 ShiftOp tok_ShiftOp_dummy_125 { Ctr__Java__69 (rtkPosOf $1) $2 } |
-       tok_Statement_dummy_124 Statement tok_Statement_dummy_124 { Ctr__Java__70 (rtkPosOf $1) $2 } |
-       tok_StatementBlock_dummy_123 StatementBlock tok_StatementBlock_dummy_123 { Ctr__Java__71 (rtkPosOf $1) $2 } |
-       tok_StatementList_dummy_122 StatementList tok_StatementList_dummy_122 { Ctr__Java__72 (rtkPosOf $1) (reverse $2) } |
-       tok_StaticInitializer_dummy_121 StaticInitializer tok_StaticInitializer_dummy_121 { Ctr__Java__73 (rtkPosOf $1) $2 } |
-       tok_SwitchCaseList_dummy_120 SwitchCaseList tok_SwitchCaseList_dummy_120 { Ctr__Java__74 (rtkPosOf $1) (reverse $2) } |
-       tok_SwitchStatement_dummy_119 SwitchStatement tok_SwitchStatement_dummy_119 { Ctr__Java__75 (rtkPosOf $1) $2 } |
-       tok_ThrowsClause_dummy_118 ThrowsClause tok_ThrowsClause_dummy_118 { Ctr__Java__76 (rtkPosOf $1) $2 } |
-       tok_TryStatement_dummy_117 TryStatement tok_TryStatement_dummy_117 { Ctr__Java__77 (rtkPosOf $1) $2 } |
-       tok_Type_dummy_116 Type tok_Type_dummy_116 { Ctr__Java__78 (rtkPosOf $1) $2 } |
-       tok_TypeArgument_dummy_115 TypeArgument tok_TypeArgument_dummy_115 { Ctr__Java__79 (rtkPosOf $1) $2 } |
-       tok_TypeArguments_dummy_114 TypeArguments tok_TypeArguments_dummy_114 { Ctr__Java__80 (rtkPosOf $1) $2 } |
-       tok_TypeDeclRest_dummy_113 TypeDeclRest tok_TypeDeclRest_dummy_113 { Ctr__Java__81 (rtkPosOf $1) $2 } |
-       tok_TypeDeclaration_dummy_112 TypeDeclaration tok_TypeDeclaration_dummy_112 { Ctr__Java__82 (rtkPosOf $1) $2 } |
-       tok_TypeParameter_dummy_111 TypeParameter tok_TypeParameter_dummy_111 { Ctr__Java__83 (rtkPosOf $1) $2 } |
-       tok_TypeParameters_dummy_110 TypeParameters tok_TypeParameters_dummy_110 { Ctr__Java__84 (rtkPosOf $1) $2 } |
-       tok_TypeSpecifier_dummy_109 TypeSpecifier tok_TypeSpecifier_dummy_109 { Ctr__Java__85 (rtkPosOf $1) $2 } |
-       tok_VariableDeclaration_dummy_108 VariableDeclaration tok_VariableDeclaration_dummy_108 { Ctr__Java__86 (rtkPosOf $1) $2 } |
-       tok_VariableDeclarator_dummy_107 VariableDeclarator tok_VariableDeclarator_dummy_107 { Ctr__Java__87 (rtkPosOf $1) $2 } |
-       tok_VariableDeclaratorList_dummy_106 VariableDeclaratorList tok_VariableDeclaratorList_dummy_106 { Ctr__Java__88 (rtkPosOf $1) $2 } |
-       tok_VariableInitializer_dummy_105 VariableInitializer tok_VariableInitializer_dummy_105 { Ctr__Java__89 (rtkPosOf $1) $2 } |
-       tok_VariableInitializerList_dummy_104 VariableInitializerList tok_VariableInitializerList_dummy_104 { Ctr__Java__90 (rtkPosOf $1) $2 } |
-       tok_WhileStatement_dummy_103 WhileStatement tok_WhileStatement_dummy_103 { Ctr__Java__91 (rtkPosOf $1) $2 } |
-       tok_WildcardType_dummy_102 WildcardType tok_WildcardType_dummy_102 { Ctr__Java__92 (rtkPosOf $1) $2 }
+Java : tok_Java_dummy_206 Java tok_Java_dummy_206 { Ctr__Java__0 (rtkPosOf $1) $2 } |
+       tok_AdditiveOp_dummy_205 AdditiveOp tok_AdditiveOp_dummy_205 { Ctr__Java__1 (rtkPosOf $1) $2 } |
+       tok_Annotation_dummy_204 Annotation tok_Annotation_dummy_204 { Ctr__Java__2 (rtkPosOf $1) $2 } |
+       tok_AnnotationArguments_dummy_203 AnnotationArguments tok_AnnotationArguments_dummy_203 { Ctr__Java__3 (rtkPosOf $1) $2 } |
+       tok_AnnotationDeclaration_dummy_202 AnnotationDeclaration tok_AnnotationDeclaration_dummy_202 { Ctr__Java__4 (rtkPosOf $1) $2 } |
+       tok_AnnotationElement_dummy_201 AnnotationElement tok_AnnotationElement_dummy_201 { Ctr__Java__5 (rtkPosOf $1) $2 } |
+       tok_AnnotationList_dummy_200 AnnotationList tok_AnnotationList_dummy_200 { Ctr__Java__6 (rtkPosOf $1) (reverse $2) } |
+       tok_AnnotationTypeElement_dummy_199 AnnotationTypeElement tok_AnnotationTypeElement_dummy_199 { Ctr__Java__7 (rtkPosOf $1) $2 } |
+       tok_AnnotationTypeElementList_dummy_198 AnnotationTypeElementList tok_AnnotationTypeElementList_dummy_198 { Ctr__Java__8 (rtkPosOf $1) (reverse $2) } |
+       tok_Arglist_dummy_197 Arglist tok_Arglist_dummy_197 { Ctr__Java__9 (rtkPosOf $1) $2 } |
+       tok_ArrayInitializer_dummy_196 ArrayInitializer tok_ArrayInitializer_dummy_196 { Ctr__Java__10 (rtkPosOf $1) $2 } |
+       tok_AssignmentOp_dummy_195 AssignmentOp tok_AssignmentOp_dummy_195 { Ctr__Java__11 (rtkPosOf $1) $2 } |
+       tok_CatchList_dummy_194 CatchList tok_CatchList_dummy_194 { Ctr__Java__12 (rtkPosOf $1) (reverse $2) } |
+       tok_CatchParameter_dummy_193 CatchParameter tok_CatchParameter_dummy_193 { Ctr__Java__13 (rtkPosOf $1) $2 } |
+       tok_ClassDeclaration_dummy_192 ClassDeclaration tok_ClassDeclaration_dummy_192 { Ctr__Java__14 (rtkPosOf $1) $2 } |
+       tok_ClassOrInterfaceType_dummy_191 ClassOrInterfaceType tok_ClassOrInterfaceType_dummy_191 { Ctr__Java__15 (rtkPosOf $1) $2 } |
+       tok_CompilationUnit_dummy_190 CompilationUnit tok_CompilationUnit_dummy_190 { Ctr__Java__16 (rtkPosOf $1) $2 } |
+       tok_CompilationUnitRest_dummy_189 CompilationUnitRest tok_CompilationUnitRest_dummy_189 { Ctr__Java__17 (rtkPosOf $1) $2 } |
+       tok_CompoundName_dummy_188 CompoundName tok_CompoundName_dummy_188 { Ctr__Java__18 (rtkPosOf $1) $2 } |
+       tok_CompoundNameTail_dummy_187 CompoundNameTail tok_CompoundNameTail_dummy_187 { Ctr__Java__19 (rtkPosOf $1) (reverse $2) } |
+       tok_CreationExpression_dummy_186 CreationExpression tok_CreationExpression_dummy_186 { Ctr__Java__20 (rtkPosOf $1) $2 } |
+       tok_DimExprs_dummy_185 DimExprs tok_DimExprs_dummy_185 { Ctr__Java__21 (rtkPosOf $1) (reverse $2) } |
+       tok_Dims_dummy_184 Dims tok_Dims_dummy_184 { Ctr__Java__22 (rtkPosOf $1) (reverse $2) } |
+       tok_DoStatement_dummy_183 DoStatement tok_DoStatement_dummy_183 { Ctr__Java__23 (rtkPosOf $1) $2 } |
+       tok_DocComment_dummy_182 DocComment tok_DocComment_dummy_182 { Ctr__Java__24 (rtkPosOf $1) $2 } |
+       tok_ElementValue_dummy_181 ElementValue tok_ElementValue_dummy_181 { Ctr__Java__25 (rtkPosOf $1) $2 } |
+       tok_ElementValueArrayInitializer_dummy_180 ElementValueArrayInitializer tok_ElementValueArrayInitializer_dummy_180 { Ctr__Java__26 (rtkPosOf $1) $2 } |
+       tok_EnumConstant_dummy_179 EnumConstant tok_EnumConstant_dummy_179 { Ctr__Java__27 (rtkPosOf $1) $2 } |
+       tok_EnumConstantList_dummy_178 EnumConstantList tok_EnumConstantList_dummy_178 { Ctr__Java__28 (rtkPosOf $1) $2 } |
+       tok_EnumDeclaration_dummy_177 EnumDeclaration tok_EnumDeclaration_dummy_177 { Ctr__Java__29 (rtkPosOf $1) $2 } |
+       tok_EqualityOp_dummy_176 EqualityOp tok_EqualityOp_dummy_176 { Ctr__Java__30 (rtkPosOf $1) $2 } |
+       tok_Expression_dummy_175 Expression tok_Expression_dummy_175 { Ctr__Java__31 (rtkPosOf $1) $2 } |
+       tok_ExtendsList_dummy_174 ExtendsList tok_ExtendsList_dummy_174 { Ctr__Java__32 (rtkPosOf $1) $2 } |
+       tok_FieldDeclaration_dummy_173 FieldDeclaration tok_FieldDeclaration_dummy_173 { Ctr__Java__33 (rtkPosOf $1) $2 } |
+       tok_FieldDeclarationList_dummy_172 FieldDeclarationList tok_FieldDeclarationList_dummy_172 { Ctr__Java__34 (rtkPosOf $1) (reverse $2) } |
+       tok_ForEachHeader_dummy_171 ForEachHeader tok_ForEachHeader_dummy_171 { Ctr__Java__35 (rtkPosOf $1) $2 } |
+       tok_ForStatement_dummy_170 ForStatement tok_ForStatement_dummy_170 { Ctr__Java__36 (rtkPosOf $1) $2 } |
+       tok_IfStatement_dummy_169 IfStatement tok_IfStatement_dummy_169 { Ctr__Java__37 (rtkPosOf $1) $2 } |
+       tok_ImplementsList_dummy_168 ImplementsList tok_ImplementsList_dummy_168 { Ctr__Java__38 (rtkPosOf $1) $2 } |
+       tok_ImportHead_dummy_167 ImportHead tok_ImportHead_dummy_167 { Ctr__Java__39 (rtkPosOf $1) $2 } |
+       tok_ImportList_dummy_166 ImportList tok_ImportList_dummy_166 { Ctr__Java__40 (rtkPosOf $1) (reverse $2) } |
+       tok_ImportName_dummy_165 ImportName tok_ImportName_dummy_165 { Ctr__Java__41 (rtkPosOf $1) $2 } |
+       tok_ImportStatement_dummy_164 ImportStatement tok_ImportStatement_dummy_164 { Ctr__Java__42 (rtkPosOf $1) $2 } |
+       tok_InterfaceDeclaration_dummy_163 InterfaceDeclaration tok_InterfaceDeclaration_dummy_163 { Ctr__Java__43 (rtkPosOf $1) $2 } |
+       tok_LambdaBody_dummy_162 LambdaBody tok_LambdaBody_dummy_162 { Ctr__Java__44 (rtkPosOf $1) $2 } |
+       tok_Literal_dummy_161 Literal tok_Literal_dummy_161 { Ctr__Java__45 (rtkPosOf $1) $2 } |
+       tok_LocalModifierList1_dummy_160 LocalModifierList1 tok_LocalModifierList1_dummy_160 { Ctr__Java__46 (rtkPosOf $1) (reverse $2) } |
+       tok_MemberAfterFirstId_dummy_159 MemberAfterFirstId tok_MemberAfterFirstId_dummy_159 { Ctr__Java__47 (rtkPosOf $1) $2 } |
+       tok_MemberDeclaration_dummy_158 MemberDeclaration tok_MemberDeclaration_dummy_158 { Ctr__Java__48 (rtkPosOf $1) $2 } |
+       tok_MemberRest_dummy_157 MemberRest tok_MemberRest_dummy_157 { Ctr__Java__49 (rtkPosOf $1) $2 } |
+       tok_Modifier_dummy_156 Modifier tok_Modifier_dummy_156 { Ctr__Java__50 (rtkPosOf $1) $2 } |
+       tok_ModifierList_dummy_155 ModifierList tok_ModifierList_dummy_155 { Ctr__Java__51 (rtkPosOf $1) (reverse $2) } |
+       tok_MoreTypeSpecifier_dummy_154 MoreTypeSpecifier tok_MoreTypeSpecifier_dummy_154 { Ctr__Java__52 (rtkPosOf $1) $2 } |
+       tok_MoreVariableDeclarators_dummy_153 MoreVariableDeclarators tok_MoreVariableDeclarators_dummy_153 { Ctr__Java__53 (rtkPosOf $1) (reverse $2) } |
+       tok_MultiplicativeOp_dummy_152 MultiplicativeOp tok_MultiplicativeOp_dummy_152 { Ctr__Java__54 (rtkPosOf $1) $2 } |
+       tok_NonEmptyDims_dummy_151 NonEmptyDims tok_NonEmptyDims_dummy_151 { Ctr__Java__55 (rtkPosOf $1) (reverse $2) } |
+       tok_NonEmptyTypeArguments_dummy_150 NonEmptyTypeArguments tok_NonEmptyTypeArguments_dummy_150 { Ctr__Java__56 (rtkPosOf $1) $2 } |
+       tok_NonEmptyTypeParameters_dummy_149 NonEmptyTypeParameters tok_NonEmptyTypeParameters_dummy_149 { Ctr__Java__57 (rtkPosOf $1) $2 } |
+       tok_OptDocComment_dummy_148 OptDocComment tok_OptDocComment_dummy_148 { Ctr__Java__58 (rtkPosOf $1) $2 } |
+       tok_OptElsePart_dummy_147 OptElsePart tok_OptElsePart_dummy_147 { Ctr__Java__59 (rtkPosOf $1) $2 } |
+       tok_OptExpression_dummy_146 OptExpression tok_OptExpression_dummy_146 { Ctr__Java__60 (rtkPosOf $1) $2 } |
+       tok_OptFinally_dummy_145 OptFinally tok_OptFinally_dummy_145 { Ctr__Java__61 (rtkPosOf $1) $2 } |
+       tok_OptId_dummy_144 OptId tok_OptId_dummy_144 { Ctr__Java__62 (rtkPosOf $1) $2 } |
+       tok_OptVariableInitializer_dummy_143 OptVariableInitializer tok_OptVariableInitializer_dummy_143 { Ctr__Java__63 (rtkPosOf $1) $2 } |
+       tok_Package_dummy_142 Package tok_Package_dummy_142 { Ctr__Java__64 (rtkPosOf $1) $2 } |
+       tok_ParamModifierList_dummy_141 ParamModifierList tok_ParamModifierList_dummy_141 { Ctr__Java__65 (rtkPosOf $1) (reverse $2) } |
+       tok_Parameter_dummy_140 Parameter tok_Parameter_dummy_140 { Ctr__Java__66 (rtkPosOf $1) $2 } |
+       tok_ParameterList_dummy_139 ParameterList tok_ParameterList_dummy_139 { Ctr__Java__67 (rtkPosOf $1) $2 } |
+       tok_PostfixOp_dummy_138 PostfixOp tok_PostfixOp_dummy_138 { Ctr__Java__68 (rtkPosOf $1) $2 } |
+       tok_PrefixOp_dummy_137 PrefixOp tok_PrefixOp_dummy_137 { Ctr__Java__69 (rtkPosOf $1) $2 } |
+       tok_PrimitiveTypeKeyword_dummy_136 PrimitiveTypeKeyword tok_PrimitiveTypeKeyword_dummy_136 { Ctr__Java__70 (rtkPosOf $1) $2 } |
+       tok_RelationalOp_dummy_135 RelationalOp tok_RelationalOp_dummy_135 { Ctr__Java__71 (rtkPosOf $1) $2 } |
+       tok_Resource_dummy_134 Resource tok_Resource_dummy_134 { Ctr__Java__72 (rtkPosOf $1) $2 } |
+       tok_ResourceSpec_dummy_133 ResourceSpec tok_ResourceSpec_dummy_133 { Ctr__Java__73 (rtkPosOf $1) $2 } |
+       tok_ShiftOp_dummy_132 ShiftOp tok_ShiftOp_dummy_132 { Ctr__Java__74 (rtkPosOf $1) $2 } |
+       tok_Statement_dummy_131 Statement tok_Statement_dummy_131 { Ctr__Java__75 (rtkPosOf $1) $2 } |
+       tok_StatementBlock_dummy_130 StatementBlock tok_StatementBlock_dummy_130 { Ctr__Java__76 (rtkPosOf $1) $2 } |
+       tok_StatementList_dummy_129 StatementList tok_StatementList_dummy_129 { Ctr__Java__77 (rtkPosOf $1) (reverse $2) } |
+       tok_StaticInitializer_dummy_128 StaticInitializer tok_StaticInitializer_dummy_128 { Ctr__Java__78 (rtkPosOf $1) $2 } |
+       tok_SwitchCaseList_dummy_127 SwitchCaseList tok_SwitchCaseList_dummy_127 { Ctr__Java__79 (rtkPosOf $1) (reverse $2) } |
+       tok_SwitchStatement_dummy_126 SwitchStatement tok_SwitchStatement_dummy_126 { Ctr__Java__80 (rtkPosOf $1) $2 } |
+       tok_ThrowsClause_dummy_125 ThrowsClause tok_ThrowsClause_dummy_125 { Ctr__Java__81 (rtkPosOf $1) $2 } |
+       tok_TryStatement_dummy_124 TryStatement tok_TryStatement_dummy_124 { Ctr__Java__82 (rtkPosOf $1) $2 } |
+       tok_Type_dummy_123 Type tok_Type_dummy_123 { Ctr__Java__83 (rtkPosOf $1) $2 } |
+       tok_TypeArgument_dummy_122 TypeArgument tok_TypeArgument_dummy_122 { Ctr__Java__84 (rtkPosOf $1) $2 } |
+       tok_TypeArguments_dummy_121 TypeArguments tok_TypeArguments_dummy_121 { Ctr__Java__85 (rtkPosOf $1) $2 } |
+       tok_TypeDeclRest_dummy_120 TypeDeclRest tok_TypeDeclRest_dummy_120 { Ctr__Java__86 (rtkPosOf $1) $2 } |
+       tok_TypeDeclaration_dummy_119 TypeDeclaration tok_TypeDeclaration_dummy_119 { Ctr__Java__87 (rtkPosOf $1) $2 } |
+       tok_TypeDeclarationList_dummy_118 TypeDeclarationList tok_TypeDeclarationList_dummy_118 { Ctr__Java__88 (rtkPosOf $1) (reverse $2) } |
+       tok_TypeParameter_dummy_117 TypeParameter tok_TypeParameter_dummy_117 { Ctr__Java__89 (rtkPosOf $1) $2 } |
+       tok_TypeParameters_dummy_116 TypeParameters tok_TypeParameters_dummy_116 { Ctr__Java__90 (rtkPosOf $1) $2 } |
+       tok_TypeSpecifier_dummy_115 TypeSpecifier tok_TypeSpecifier_dummy_115 { Ctr__Java__91 (rtkPosOf $1) $2 } |
+       tok_VariableDeclaration_dummy_114 VariableDeclaration tok_VariableDeclaration_dummy_114 { Ctr__Java__92 (rtkPosOf $1) $2 } |
+       tok_VariableDeclarator_dummy_113 VariableDeclarator tok_VariableDeclarator_dummy_113 { Ctr__Java__93 (rtkPosOf $1) $2 } |
+       tok_VariableDeclaratorList_dummy_112 VariableDeclaratorList tok_VariableDeclaratorList_dummy_112 { Ctr__Java__94 (rtkPosOf $1) $2 } |
+       tok_VariableInitializer_dummy_111 VariableInitializer tok_VariableInitializer_dummy_111 { Ctr__Java__95 (rtkPosOf $1) $2 } |
+       tok_VariableInitializerList_dummy_110 VariableInitializerList tok_VariableInitializerList_dummy_110 { Ctr__Java__96 (rtkPosOf $1) $2 } |
+       tok_WhileStatement_dummy_109 WhileStatement tok_WhileStatement_dummy_109 { Ctr__Java__97 (rtkPosOf $1) $2 } |
+       tok_WildcardType_dummy_108 WildcardType tok_WildcardType_dummy_108 { Ctr__Java__98 (rtkPosOf $1) $2 }
 
 Java : qq_Java { Anti_Java (tkVal_qq_Java $1) } |
-       CompilationUnit { Ctr__Java__93 (rtkPosOf $1) $1 }
+       CompilationUnit { Ctr__Java__99 (rtkPosOf $1) $1 }
 
 AdditiveOp : qq_AdditiveOp { Anti_AdditiveOp (tkVal_qq_AdditiveOp $1) } |
              tok__plus__78 { Ctr__AdditiveOp__0 (rtkPosOf $1) } |
              tok__minus__79 { Ctr__AdditiveOp__1 (rtkPosOf $1) }
 
-ListElem_AnnotationList9 : qq_AnnotationList { Anti_Annotation (tkVal_qq_AnnotationList $1) } |
-                           Annotation { $1 }
+ListElem_AnnotationList14 : qq_AnnotationList { Anti_Annotation (tkVal_qq_AnnotationList $1) } |
+                            Annotation { $1 }
 
 Annotation : qq_Annotation { Anti_Annotation (tkVal_qq_Annotation $1) } |
              tok__symbol__6 CompoundName Rule_4 { Ctr__Annotation__1 (rtkPosOf $1) $2 $3 }
@@ -422,27 +440,30 @@ AnnotationArguments : qq_AnnotationArguments { Anti_AnnotationArguments (tkVal_q
                       AnnotationElement Rule_7 { Ctr__AnnotationArguments__0 (rtkPosOf $1) $1 (reverse $2) }
 
 AnnotationDeclaration : qq_AnnotationDeclaration { Anti_AnnotationDeclaration (tkVal_qq_AnnotationDeclaration $1) } |
-                        tok__symbol__6 tok_interface_16 id tok__symbol__14 AnnotationTypeElementList tok__symbol__15 { Ctr__AnnotationDeclaration__0 (rtkPosOf $1) (tkVal_id $3) (reverse $5) }
+                        tok__symbol__6 tok_interface_16 id tok__symbol__11 AnnotationTypeElementList tok__symbol__12 { Ctr__AnnotationDeclaration__0 (rtkPosOf $1) (tkVal_id $3) (reverse $5) }
 
 AnnotationElement : qq_AnnotationElement { Anti_AnnotationElement (tkVal_qq_AnnotationElement $1) } |
-                    id tok__eql__10 ConditionalExpression { Ctr__AnnotationElement__0 (rtkPosOf $1) (tkVal_id $1) $3 } |
-                    ConditionalExpression { Ctr__AnnotationElement__1 (rtkPosOf $1) $1 }
+                    id tok__eql__10 ElementValue { Ctr__AnnotationElement__0 (rtkPosOf $1) (tkVal_id $1) $3 } |
+                    ElementValue { Ctr__AnnotationElement__1 (rtkPosOf $1) $1 }
 
 AnnotationList : {- empty -} { [] } |
-                 AnnotationList ListElem_AnnotationList9 { $2 : $1 }
+                 AnnotationList ListElem_AnnotationList14 { $2 : $1 }
 
 AnnotationTypeElement : qq_AnnotationTypeElement { Anti_AnnotationTypeElement (tkVal_qq_AnnotationTypeElement $1) } |
                         FieldDeclaration { Ctr__AnnotationTypeElement__0 (rtkPosOf $1) $1 }
 
-ListElem_AnnotationTypeElementList19 : qq_AnnotationTypeElementList { Anti_AnnotationTypeElement (tkVal_qq_AnnotationTypeElementList $1) } |
+ListElem_AnnotationTypeElementList24 : qq_AnnotationTypeElementList { Anti_AnnotationTypeElement (tkVal_qq_AnnotationTypeElementList $1) } |
                                        AnnotationTypeElement { $1 }
 
 AnnotationTypeElementList : {- empty -} { [] } |
-                            AnnotationTypeElementList ListElem_AnnotationTypeElementList19 { $2 : $1 }
+                            AnnotationTypeElementList ListElem_AnnotationTypeElementList24 { $2 : $1 }
 
 Arglist : qq_Arglist { Anti_Arglist (tkVal_qq_Arglist $1) } |
           { Ctr__Arglist__0 rtkNoPos } |
-          Rule_88 { Ctr__Arglist__1 (rtkPosOf $1) $1 }
+          Rule_95 { Ctr__Arglist__1 (rtkPosOf $1) $1 }
+
+ArrayInitializer : qq_ArrayInitializer { Anti_ArrayInitializer (tkVal_qq_ArrayInitializer $1) } |
+                   tok__symbol__11 VariableInitializerList tok__symbol__12 { Ctr__ArrayInitializer__0 (rtkPosOf $1) $2 }
 
 AssignmentOp : qq_AssignmentOp { Anti_AssignmentOp (tkVal_qq_AssignmentOp $1) } |
                tok__eql__10 { Ctr__AssignmentOp__0 (rtkPosOf $1) } |
@@ -459,34 +480,39 @@ AssignmentOp : qq_AssignmentOp { Anti_AssignmentOp (tkVal_qq_AssignmentOp $1) } 
                tok__symbol__symbol__symbol__eql__64 { Ctr__AssignmentOp__11 (rtkPosOf $1) }
 
 CatchList : {- empty -} { [] } |
-            CatchList ListElem_CatchList66 { $2 : $1 }
+            CatchList ListElem_CatchList71 { $2 : $1 }
 
 CatchParameter : qq_CatchParameter { Anti_CatchParameter (tkVal_qq_CatchParameter $1) } |
-                 ParamModifierList Type Rule_67 id { Ctr__CatchParameter__0 (rtkPosOf (reverse $1)) (reverse $1) $2 (reverse $3) (tkVal_id $4) }
+                 ParamModifierList Type Rule_72 id { Ctr__CatchParameter__0 (rtkPosOf (reverse $1)) (reverse $1) $2 (reverse $3) (tkVal_id $4) }
 
 ClassDeclaration : qq_ClassDeclaration { Anti_ClassDeclaration (tkVal_qq_ClassDeclaration $1) } |
-                   tok_class_13 id TypeParameters Rule_16 Rule_17 tok__symbol__14 FieldDeclarationList tok__symbol__15 { Ctr__ClassDeclaration__0 (rtkPosOf $1) (tkVal_id $2) $3 $4 $5 (reverse $7) }
+                   tok_class_15 id TypeParameters Rule_21 Rule_22 tok__symbol__11 FieldDeclarationList tok__symbol__12 { Ctr__ClassDeclaration__0 (rtkPosOf $1) (tkVal_id $2) $3 $4 $5 (reverse $7) }
 
 ClassOrInterfaceType : qq_ClassOrInterfaceType { Anti_ClassOrInterfaceType (tkVal_qq_ClassOrInterfaceType $1) } |
                        CompoundName TypeArguments { Ctr__ClassOrInterfaceType__0 (rtkPosOf $1) $1 $2 }
 
 CompilationUnit : qq_CompilationUnit { Anti_CompilationUnit (tkVal_qq_CompilationUnit $1) } |
-                  Rule_1 ImportList Rule_2 { Ctr__CompilationUnit__0 (rtkPosOf $1) $1 (reverse $2) $3 }
+                  OptDocComment ModifierList Rule_2 { Ctr__CompilationUnit__0 (rtkPosOf $1) $1 (reverse $2) $3 }
+
+CompilationUnitRest : qq_CompilationUnitRest { Anti_CompilationUnitRest (tkVal_qq_CompilationUnitRest $1) } |
+                      Package ImportList TypeDeclarationList { UnitPackageFirst (rtkPosOf $1) $1 (reverse $2) (reverse $3) } |
+                      ImportStatement ImportList TypeDeclarationList { UnitImportsFirst (rtkPosOf $1) $1 (reverse $2) (reverse $3) } |
+                      TypeDeclRest TypeDeclarationList { UnitTypeFirst (rtkPosOf $1) $1 (reverse $2) }
 
 CompoundName : qq_CompoundName { Anti_CompoundName (tkVal_qq_CompoundName $1) } |
                id CompoundNameTail { Ctr__CompoundName__0 (rtkPosOf $1) (tkVal_id $1) (reverse $2) }
 
 CompoundNameTail : {- empty -} { [] } |
-                   CompoundNameTail ListElem_CompoundNameTail101 { $2 : $1 }
+                   CompoundNameTail ListElem_CompoundNameTail107 { $2 : $1 }
 
 CreationExpression : qq_CreationExpression { Anti_CreationExpression (tkVal_qq_CreationExpression $1) } |
-                     tok_new_87 TypeSpecifier Rule_84 { Ctr__CreationExpression__0 (rtkPosOf $1) $2 $3 }
+                     tok_new_87 TypeSpecifier Rule_89 { Ctr__CreationExpression__0 (rtkPosOf $1) $2 $3 }
 
-DimExprs : ListElem_DimExprs87 { [$1] } |
-           DimExprs ListElem_DimExprs87 { $2 : $1 }
+DimExprs : ListElem_DimExprs94 { [$1] } |
+           DimExprs ListElem_DimExprs94 { $2 : $1 }
 
 Dims : {- empty -} { [] } |
-       Dims ListElem_Dims32 { $2 : $1 }
+       Dims ListElem_Dims37 { $2 : $1 }
 
 DoStatement : qq_DoStatement { Anti_DoStatement (tkVal_qq_DoStatement $1) } |
               tok_do_44 Statement tok_while_45 tok__lparen__7 Expression tok__rparen__8 tok__semi__1 { Ctr__DoStatement__0 (rtkPosOf $1) $2 $5 }
@@ -494,14 +520,22 @@ DoStatement : qq_DoStatement { Anti_DoStatement (tkVal_qq_DoStatement $1) } |
 DocComment : qq_DocComment { Anti_DocComment (tkVal_qq_DocComment $1) } |
              doccomment { Ctr__DocComment__0 (rtkPosOf $1) (tkVal_doccomment $1) }
 
+ElementValue : qq_ElementValue { Anti_ElementValue (tkVal_qq_ElementValue $1) } |
+               ConditionalExpression { Ctr__ElementValue__0 (rtkPosOf $1) $1 } |
+               Annotation { Ctr__ElementValue__1 (rtkPosOf $1) $1 } |
+               ElementValueArrayInitializer { Ctr__ElementValue__2 (rtkPosOf $1) $1 }
+
+ElementValueArrayInitializer : qq_ElementValueArrayInitializer { Anti_ElementValueArrayInitializer (tkVal_qq_ElementValueArrayInitializer $1) } |
+                               tok__symbol__11 Rule_9 tok__symbol__12 { Ctr__ElementValueArrayInitializer__0 (rtkPosOf $1) $2 }
+
 EnumConstant : qq_EnumConstant { Anti_EnumConstant (tkVal_qq_EnumConstant $1) } |
-               AnnotationList id Rule_20 Rule_22 { Ctr__EnumConstant__0 (rtkPosOf (reverse $1)) (reverse $1) (tkVal_id $2) $3 $4 }
+               OptDocComment AnnotationList id Rule_25 Rule_27 { Ctr__EnumConstant__0 (rtkPosOf $1) $1 (reverse $2) (tkVal_id $3) $4 $5 }
 
 EnumConstantList : qq_EnumConstantList { Anti_EnumConstantList (tkVal_qq_EnumConstantList $1) } |
-                   EnumConstant Rule_24 Rule_26 { Ctr__EnumConstantList__0 (rtkPosOf $1) $1 (reverse $2) $3 }
+                   EnumConstant Rule_29 Rule_31 { Ctr__EnumConstantList__0 (rtkPosOf $1) $1 (reverse $2) $3 }
 
 EnumDeclaration : qq_EnumDeclaration { Anti_EnumDeclaration (tkVal_qq_EnumDeclaration $1) } |
-                  tok_enum_17 id Rule_27 tok__symbol__14 EnumConstantList Rule_28 tok__symbol__15 { Ctr__EnumDeclaration__0 (rtkPosOf $1) (tkVal_id $2) $3 $5 $6 }
+                  tok_enum_17 id Rule_32 tok__symbol__11 EnumConstantList Rule_33 tok__symbol__12 { Ctr__EnumDeclaration__0 (rtkPosOf $1) (tkVal_id $2) $3 $5 $6 }
 
 EqualityOp : qq_EqualityOp { Anti_EqualityOp (tkVal_qq_EqualityOp $1) } |
              tok__eql__eql__70 { Ctr__EqualityOp__0 (rtkPosOf $1) } |
@@ -512,13 +546,13 @@ PrimaryNoPostfix : qq_Expression { Anti_Expression (tkVal_qq_Expression $1) } |
                    tok_this_41 { Ctr__Expression__1 (rtkPosOf $1) } |
                    tok__lparen__7 Expression tok__rparen__8 { Ctr__Expression__2 (rtkPosOf $1) $2 } |
                    CreationExpression { Ctr__Expression__3 (rtkPosOf $1) $1 } |
-                   CompoundName Rule_80 { Ctr__Expression__4 (rtkPosOf $1) $1 $2 } |
+                   CompoundName Rule_85 { Ctr__Expression__4 (rtkPosOf $1) $1 $2 } |
                    CompoundName tok__sq_bkt_l__18 Expression tok__sq_bkt_r__19 { Ctr__Expression__5 (rtkPosOf $1) $1 $3 } |
-                   tok_super_40 tok__dot__4 id Rule_82 { Ctr__Expression__6 (rtkPosOf $1) (tkVal_id $3) $4 } |
-                   id CompoundNameTail tok__dot__4 tok_class_13 { Ctr__Expression__7 (rtkPosOf $1) (tkVal_id $1) (reverse $2) } |
+                   tok_super_40 tok__dot__4 id Rule_87 { Ctr__Expression__6 (rtkPosOf $1) (tkVal_id $3) $4 } |
+                   id CompoundNameTail tok__dot__4 tok_class_15 { Ctr__Expression__7 (rtkPosOf $1) (tkVal_id $1) (reverse $2) } |
                    id CompoundNameTail tok__dot__4 tok_this_41 { Ctr__Expression__8 (rtkPosOf $1) (tkVal_id $1) (reverse $2) } |
                    id CompoundNameTail tok__dot__4 NonEmptyTypeArguments id tok__lparen__7 Arglist tok__rparen__8 { Ctr__Expression__9 (rtkPosOf $1) (tkVal_id $1) (reverse $2) $4 (tkVal_id $5) $7 } |
-                   PrimitiveTypeKeyword tok__dot__4 tok_class_13 { Ctr__Expression__10 (rtkPosOf $1) $1 }
+                   PrimitiveTypeKeyword tok__dot__4 tok_class_15 { Ctr__Expression__10 (rtkPosOf $1) $1 }
 
 PostfixExpression : PrimaryNoPostfix { Ctr__Expression__11 (rtkPosOf $1) $1 } |
                     PostfixExpression PostfixOp { Ctr__Expression__12 (rtkPosOf $1) $1 $2 } |
@@ -576,47 +610,47 @@ ConditionalOrExpression : ConditionalAndExpression { Ctr__Expression__48 (rtkPos
 ConditionalExpression : ConditionalOrExpression { Ctr__Expression__50 (rtkPosOf $1) $1 } |
                         ConditionalOrExpression tok__symbol__65 Expression tok__colon__37 ConditionalExpression { Ctr__Expression__51 (rtkPosOf $1) $1 $3 $5 }
 
-AssignmentExpression : ConditionalExpression Rule_76 { Ctr__Expression__52 (rtkPosOf $1) $1 $2 } |
+AssignmentExpression : ConditionalExpression Rule_81 { Ctr__Expression__52 (rtkPosOf $1) $1 $2 } |
                        id tok__minus__symbol__53 LambdaBody { Ctr__Expression__53 (rtkPosOf $1) (tkVal_id $1) $3 } |
                        tok__lparen__7 tok__rparen__8 tok__minus__symbol__53 LambdaBody { Ctr__Expression__54 (rtkPosOf $1) $4 } |
-                       tok__lparen__7 id Rule_78 tok__rparen__8 tok__minus__symbol__53 LambdaBody { Ctr__Expression__55 (rtkPosOf $1) (tkVal_id $2) (reverse $3) $6 } |
+                       tok__lparen__7 id Rule_83 tok__rparen__8 tok__minus__symbol__53 LambdaBody { Ctr__Expression__55 (rtkPosOf $1) (tkVal_id $2) (reverse $3) $6 } |
                        tok__lparen__7 Expression tok__rparen__8 tok__minus__symbol__53 LambdaBody { Ctr__Expression__56 (rtkPosOf $1) $2 $5 }
 
 Expression : AssignmentExpression { Ctr__Expression__57 (rtkPosOf $1) $1 }
 
 ExtendsList : qq_ExtendsList { Anti_ExtendsList (tkVal_qq_ExtendsList $1) } |
-              tok_extends_11 ClassOrInterfaceType Rule_12 { Ctr__ExtendsList__0 (rtkPosOf $1) $2 (reverse $3) }
+              tok_extends_13 ClassOrInterfaceType Rule_17 { Ctr__ExtendsList__0 (rtkPosOf $1) $2 (reverse $3) }
 
 FieldDeclaration : qq_FieldDeclaration { Anti_FieldDeclaration (tkVal_qq_FieldDeclaration $1) } |
-                   OptDocComment ModifierList Rule_30 { Ctr__FieldDeclaration__0 (rtkPosOf $1) $1 (reverse $2) $3 } |
+                   OptDocComment ModifierList Rule_35 { Ctr__FieldDeclaration__0 (rtkPosOf $1) $1 (reverse $2) $3 } |
                    tok__semi__1 { Ctr__FieldDeclaration__1 (rtkPosOf $1) }
 
-ListElem_FieldDeclarationList15 : qq_FieldDeclarationList { Anti_FieldDeclaration (tkVal_qq_FieldDeclarationList $1) } |
+ListElem_FieldDeclarationList20 : qq_FieldDeclarationList { Anti_FieldDeclaration (tkVal_qq_FieldDeclarationList $1) } |
                                   FieldDeclaration { $1 }
 
 FieldDeclarationList : {- empty -} { [] } |
-                       FieldDeclarationList ListElem_FieldDeclarationList15 { $2 : $1 }
+                       FieldDeclarationList ListElem_FieldDeclarationList20 { $2 : $1 }
 
 ForEachHeader : qq_ForEachHeader { Anti_ForEachHeader (tkVal_qq_ForEachHeader $1) } |
                 Type id tok__colon__37 Expression { Ctr__ForEachHeader__0 (rtkPosOf $1) $1 (tkVal_id $2) $4 } |
                 LocalModifierList1 Type id tok__colon__37 Expression { Ctr__ForEachHeader__1 (rtkPosOf (reverse $1)) (reverse $1) $2 (tkVal_id $3) $5 }
 
 ForStatement : qq_ForStatement { Anti_ForStatement (tkVal_qq_ForStatement $1) } |
-               tok_for_46 tok__lparen__7 Rule_64 OptExpression tok__semi__1 OptExpression tok__rparen__8 Statement { Ctr__ForStatement__0 (rtkPosOf $1) $3 $4 $6 $8 } |
+               tok_for_46 tok__lparen__7 Rule_69 OptExpression tok__semi__1 OptExpression tok__rparen__8 Statement { Ctr__ForStatement__0 (rtkPosOf $1) $3 $4 $6 $8 } |
                tok_for_46 tok__lparen__7 ForEachHeader tok__rparen__8 Statement { Ctr__ForStatement__1 (rtkPosOf $1) $3 $5 }
 
 IfStatement : qq_IfStatement { Anti_IfStatement (tkVal_qq_IfStatement $1) } |
               tok_if_43 tok__lparen__7 Expression tok__rparen__8 Statement OptElsePart { Ctr__IfStatement__0 (rtkPosOf $1) $3 $5 $6 }
 
 ImplementsList : qq_ImplementsList { Anti_ImplementsList (tkVal_qq_ImplementsList $1) } |
-                 tok_implements_12 Rule_14 { Ctr__ImplementsList__0 (rtkPosOf $1) (reverse $2) }
+                 tok_implements_14 Rule_19 { Ctr__ImplementsList__0 (rtkPosOf $1) (reverse $2) }
 
 ImportHead : qq_ImportHead { Anti_ImportHead (tkVal_qq_ImportHead $1) } |
              id { Ctr__ImportHead__0 (rtkPosOf $1) (tkVal_id $1) } |
              ImportHead tok__dot__4 id { Ctr__ImportHead__1 (rtkPosOf $1) $1 (tkVal_id $3) }
 
 ImportList : {- empty -} { [] } |
-             ImportList ListElem_ImportList0 { $2 : $1 }
+             ImportList ListElem_ImportList1 { $2 : $1 }
 
 ImportName : qq_ImportName { Anti_ImportName (tkVal_qq_ImportName $1) } |
              ImportHead { Ctr__ImportName__0 (rtkPosOf $1) $1 } |
@@ -625,11 +659,11 @@ ImportName : qq_ImportName { Anti_ImportName (tkVal_qq_ImportName $1) } |
 ImportStatement : qq_ImportStatement { Anti_ImportStatement (tkVal_qq_ImportStatement $1) } |
                   tok_import_2 Rule_3 ImportName tok__semi__1 { Ctr__ImportStatement__0 (rtkPosOf $1) $2 $3 }
 
-ListElem_ImportList0 : qq_ImportList { Anti_ImportStatement (tkVal_qq_ImportList $1) } |
+ListElem_ImportList1 : qq_ImportList { Anti_ImportStatement (tkVal_qq_ImportList $1) } |
                        ImportStatement { $1 }
 
 InterfaceDeclaration : qq_InterfaceDeclaration { Anti_InterfaceDeclaration (tkVal_qq_InterfaceDeclaration $1) } |
-                       tok_interface_16 id TypeParameters Rule_18 tok__symbol__14 FieldDeclarationList tok__symbol__15 { Ctr__InterfaceDeclaration__0 (rtkPosOf $1) (tkVal_id $2) $3 $4 (reverse $6) }
+                       tok_interface_16 id TypeParameters Rule_23 tok__symbol__11 FieldDeclarationList tok__symbol__12 { Ctr__InterfaceDeclaration__0 (rtkPosOf $1) (tkVal_id $2) $3 $4 (reverse $6) }
 
 LambdaBody : qq_LambdaBody { Anti_LambdaBody (tkVal_qq_LambdaBody $1) } |
              Expression { Ctr__LambdaBody__0 (rtkPosOf $1) $1 } |
@@ -644,20 +678,21 @@ Literal : qq_Literal { Anti_Literal (tkVal_qq_Literal $1) } |
           string { Ctr__Literal__5 (rtkPosOf $1) (tkVal_string $1) } |
           tok_null_90 { Ctr__Literal__6 (rtkPosOf $1) }
 
-LocalModifierList1 : ListElem_LocalModifierList149 { [$1] } |
-                     LocalModifierList1 ListElem_LocalModifierList149 { $2 : $1 }
+LocalModifierList1 : ListElem_LocalModifierList154 { [$1] } |
+                     LocalModifierList1 ListElem_LocalModifierList154 { $2 : $1 }
 
 MemberAfterFirstId : qq_MemberAfterFirstId { Anti_MemberAfterFirstId (tkVal_qq_MemberAfterFirstId $1) } |
-                     tok__lparen__7 Rule_35 tok__rparen__8 Rule_36 StatementBlock { Ctr__MemberAfterFirstId__0 (rtkPosOf $1) $2 $4 $5 } |
+                     tok__lparen__7 Rule_40 tok__rparen__8 Rule_41 StatementBlock { Ctr__MemberAfterFirstId__0 (rtkPosOf $1) $2 $4 $5 } |
                      MoreTypeSpecifier id MemberRest { Ctr__MemberAfterFirstId__1 (rtkPosOf $1) $1 (tkVal_id $2) $3 }
 
 MemberDeclaration : qq_MemberDeclaration { Anti_MemberDeclaration (tkVal_qq_MemberDeclaration $1) } |
                     PrimitiveTypeKeyword Dims id MemberRest { Ctr__MemberDeclaration__0 (rtkPosOf $1) $1 (reverse $2) (tkVal_id $3) $4 } |
                     TypeParameters id MoreTypeSpecifier id MemberRest { Ctr__MemberDeclaration__1 (rtkPosOf $1) $1 (tkVal_id $2) $3 (tkVal_id $4) $5 } |
-                    id MemberAfterFirstId { Ctr__MemberDeclaration__2 (rtkPosOf $1) (tkVal_id $1) $2 }
+                    NonEmptyTypeParameters PrimitiveTypeKeyword Dims id MemberRest { Ctr__MemberDeclaration__2 (rtkPosOf $1) $1 $2 (reverse $3) (tkVal_id $4) $5 } |
+                    id MemberAfterFirstId { Ctr__MemberDeclaration__3 (rtkPosOf $1) (tkVal_id $1) $2 }
 
 MemberRest : qq_MemberRest { Anti_MemberRest (tkVal_qq_MemberRest $1) } |
-             tok__lparen__7 Rule_39 tok__rparen__8 Dims Rule_40 Rule_41 { Ctr__MemberRest__0 (rtkPosOf $1) $2 (reverse $4) $5 $6 } |
+             tok__lparen__7 Rule_44 tok__rparen__8 Dims Rule_45 Rule_46 { Ctr__MemberRest__0 (rtkPosOf $1) $2 (reverse $4) $5 $6 } |
              Dims OptVariableInitializer MoreVariableDeclarators tok__semi__1 { Ctr__MemberRest__1 (rtkPosOf (reverse $1)) (reverse $1) $2 (reverse $3) }
 
 Modifier : qq_Modifier { Anti_Modifier (tkVal_qq_Modifier $1) } |
@@ -670,29 +705,33 @@ Modifier : qq_Modifier { Anti_Modifier (tkVal_qq_Modifier $1) } |
            tok_synchronized_34 { Ctr__Modifier__6 (rtkPosOf $1) } |
            tok_abstract_95 { Ctr__Modifier__7 (rtkPosOf $1) } |
            tok_threadsafe_96 { Ctr__Modifier__8 (rtkPosOf $1) } |
-           tok_transient_97 { Ctr__Modifier__9 (rtkPosOf $1) }
+           tok_transient_97 { Ctr__Modifier__9 (rtkPosOf $1) } |
+           tok_default_30 { Ctr__Modifier__10 (rtkPosOf $1) }
 
 ModifierList : {- empty -} { [] } |
-               ModifierList ListElem_ModifierList11 { $2 : $1 }
+               ModifierList ListElem_ModifierList16 { $2 : $1 }
 
 MoreTypeSpecifier : qq_MoreTypeSpecifier { Anti_MoreTypeSpecifier (tkVal_qq_MoreTypeSpecifier $1) } |
                     tok__dot__4 id MoreTypeSpecifier { Ctr__MoreTypeSpecifier__0 (rtkPosOf $1) (tkVal_id $2) $3 } |
                     TypeArguments Dims { Ctr__MoreTypeSpecifier__1 (rtkPosOf $1) $1 (reverse $2) }
 
 MoreVariableDeclarators : {- empty -} { [] } |
-                          MoreVariableDeclarators ListElem_MoreVariableDeclarators45 { $2 : $1 }
+                          MoreVariableDeclarators ListElem_MoreVariableDeclarators50 { $2 : $1 }
 
 MultiplicativeOp : qq_MultiplicativeOp { Anti_MultiplicativeOp (tkVal_qq_MultiplicativeOp $1) } |
                    tok__star__5 { Ctr__MultiplicativeOp__0 (rtkPosOf $1) } |
                    tok__symbol__80 { Ctr__MultiplicativeOp__1 (rtkPosOf $1) } |
                    tok__symbol__81 { Ctr__MultiplicativeOp__2 (rtkPosOf $1) }
 
-NonEmptyDims : ListElem_NonEmptyDims34 { [$1] } |
-               NonEmptyDims ListElem_NonEmptyDims34 { $2 : $1 }
+NonEmptyDims : ListElem_NonEmptyDims39 { [$1] } |
+               NonEmptyDims ListElem_NonEmptyDims39 { $2 : $1 }
 
 NonEmptyTypeArguments : qq_NonEmptyTypeArguments { Anti_NonEmptyTypeArguments (tkVal_qq_NonEmptyTypeArguments $1) } |
-                        tok__symbol__72 TypeArgument Rule_91 tok__symbol__73 { Ctr__NonEmptyTypeArguments__0 (rtkPosOf $1) $2 (reverse $3) } |
+                        tok__symbol__72 TypeArgument Rule_98 tok__symbol__73 { Ctr__NonEmptyTypeArguments__0 (rtkPosOf $1) $2 (reverse $3) } |
                         tok__symbol__72 tok__symbol__73 { Ctr__NonEmptyTypeArguments__1 (rtkPosOf $1) }
+
+NonEmptyTypeParameters : qq_NonEmptyTypeParameters { Anti_NonEmptyTypeParameters (tkVal_qq_NonEmptyTypeParameters $1) } |
+                         tok__symbol__72 TypeParameter Rule_100 tok__symbol__73 { Ctr__NonEmptyTypeParameters__0 (rtkPosOf $1) $2 (reverse $3) }
 
 OptDocComment : qq_OptDocComment { Anti_OptDocComment (tkVal_qq_OptDocComment $1) } |
                 { Ctr__OptDocComment__0 rtkNoPos } |
@@ -700,7 +739,7 @@ OptDocComment : qq_OptDocComment { Anti_OptDocComment (tkVal_qq_OptDocComment $1
 
 OptElsePart : qq_OptElsePart { Anti_OptElsePart (tkVal_qq_OptElsePart $1) } |
               { Ctr__OptElsePart__0 rtkNoPos } |
-              Rule_63 { Ctr__OptElsePart__1 (rtkPosOf $1) $1 }
+              Rule_68 { Ctr__OptElsePart__1 (rtkPosOf $1) $1 }
 
 OptExpression : qq_OptExpression { Anti_OptExpression (tkVal_qq_OptExpression $1) } |
                 { Ctr__OptExpression__0 rtkNoPos } |
@@ -708,7 +747,7 @@ OptExpression : qq_OptExpression { Anti_OptExpression (tkVal_qq_OptExpression $1
 
 OptFinally : qq_OptFinally { Anti_OptFinally (tkVal_qq_OptFinally $1) } |
              { Ctr__OptFinally__0 rtkNoPos } |
-             Rule_69 { Ctr__OptFinally__1 (rtkPosOf $1) $1 }
+             Rule_74 { Ctr__OptFinally__1 (rtkPosOf $1) $1 }
 
 OptId : qq_OptId { Anti_OptId (tkVal_qq_OptId $1) } |
         { Ctr__OptId__0 rtkNoPos } |
@@ -716,19 +755,19 @@ OptId : qq_OptId { Anti_OptId (tkVal_qq_OptId $1) } |
 
 OptVariableInitializer : qq_OptVariableInitializer { Anti_OptVariableInitializer (tkVal_qq_OptVariableInitializer $1) } |
                          { Ctr__OptVariableInitializer__0 rtkNoPos } |
-                         Rule_50 { Ctr__OptVariableInitializer__1 (rtkPosOf $1) $1 }
+                         Rule_55 { Ctr__OptVariableInitializer__1 (rtkPosOf $1) $1 }
 
 Package : qq_Package { Anti_Package (tkVal_qq_Package $1) } |
           tok_package_0 CompoundName tok__semi__1 { Ctr__Package__0 (rtkPosOf $1) $2 }
 
 ParamModifierList : {- empty -} { [] } |
-                    ParamModifierList ListElem_ParamModifierList58 { $2 : $1 }
+                    ParamModifierList ListElem_ParamModifierList63 { $2 : $1 }
 
 Parameter : qq_Parameter { Anti_Parameter (tkVal_qq_Parameter $1) } |
-            ParamModifierList Type Rule_59 id Dims { Ctr__Parameter__0 (rtkPosOf (reverse $1)) (reverse $1) $2 $3 (tkVal_id $4) (reverse $5) }
+            ParamModifierList Type Rule_64 id Dims { Ctr__Parameter__0 (rtkPosOf (reverse $1)) (reverse $1) $2 $3 (tkVal_id $4) (reverse $5) }
 
 ParameterList : qq_ParameterList { Anti_ParameterList (tkVal_qq_ParameterList $1) } |
-                Parameter Rule_55 { Ctr__ParameterList__0 (rtkPosOf $1) $1 (reverse $2) }
+                Parameter Rule_60 { Ctr__ParameterList__0 (rtkPosOf $1) $1 (reverse $2) }
 
 PostfixOp : qq_PostfixOp { Anti_PostfixOp (tkVal_qq_PostfixOp $1) } |
             tok__plus__plus__82 { Ctr__PostfixOp__0 (rtkPosOf $1) } |
@@ -761,265 +800,279 @@ Resource : qq_Resource { Anti_Resource (tkVal_qq_Resource $1) } |
            ParamModifierList Type id tok__eql__10 Expression { Ctr__Resource__0 (rtkPosOf (reverse $1)) (reverse $1) $2 (tkVal_id $3) $5 }
 
 ResourceSpec : qq_ResourceSpec { Anti_ResourceSpec (tkVal_qq_ResourceSpec $1) } |
-               tok__lparen__7 Resource Rule_71 Rule_73 tok__rparen__8 { Ctr__ResourceSpec__0 (rtkPosOf $1) $2 (reverse $3) $4 }
+               tok__lparen__7 Resource Rule_76 Rule_78 tok__rparen__8 { Ctr__ResourceSpec__0 (rtkPosOf $1) $2 (reverse $3) $4 }
 
-Rule_1 : { Ctr__Rule_1__0 rtkNoPos } |
-         Package { Ctr__Rule_1__1 (rtkPosOf $1) $1 }
+Rule_10 : ElementValue Rule_11 Rule_13 { Ctr__Rule_10__0 (rtkPosOf $1) $1 (reverse $2) $3 }
 
-ListElem_ModifierList11 : qq_ModifierList { Anti_Rule_10 (tkVal_qq_ModifierList $1) } |
-                          Rule_10 { $1 }
+Rule_100 : {- empty -} { [] } |
+           Rule_100 Rule_101 { $2 : $1 }
 
-Rule_10 : Modifier { Ctr__Rule_10__1 (rtkPosOf $1) $1 } |
-          Annotation { Ctr__Rule_10__2 (rtkPosOf $1) $1 }
+Rule_101 : tok__coma__9 TypeParameter { Ctr__Rule_101__0 (rtkPosOf $1) $2 }
 
-ListElem_CompoundNameTail101 : qq_CompoundNameTail { Anti_Rule_100 (tkVal_qq_CompoundNameTail $1) } |
-                               Rule_100 { $1 }
+Rule_102 : { Ctr__Rule_102__0 rtkNoPos } |
+           Rule_103 { Ctr__Rule_102__1 (rtkPosOf $1) $1 }
 
-Rule_100 : tok__dot__4 id { Ctr__Rule_100__1 (rtkPosOf $1) (tkVal_id $2) }
+Rule_103 : tok_extends_13 Type Rule_104 { Ctr__Rule_103__0 (rtkPosOf $1) $2 (reverse $3) }
 
-Rule_12 : {- empty -} { [] } |
-          Rule_12 Rule_13 { $2 : $1 }
+Rule_104 : {- empty -} { [] } |
+           Rule_104 Rule_105 { $2 : $1 }
 
-Rule_13 : tok__coma__9 ClassOrInterfaceType { Ctr__Rule_13__0 (rtkPosOf $1) $2 }
+Rule_105 : tok__symbol__69 Type { Ctr__Rule_105__0 (rtkPosOf $1) $2 }
 
-Rule_14 : ClassOrInterfaceType { [$1] } |
-          Rule_14 tok__coma__9 ClassOrInterfaceType { $3 : $1 }
+ListElem_CompoundNameTail107 : qq_CompoundNameTail { Anti_Rule_106 (tkVal_qq_CompoundNameTail $1) } |
+                               Rule_106 { $1 }
 
-Rule_16 : { Ctr__Rule_16__0 rtkNoPos } |
-          ExtendsList { Ctr__Rule_16__1 (rtkPosOf $1) $1 }
+Rule_106 : tok__dot__4 id { Ctr__Rule_106__1 (rtkPosOf $1) (tkVal_id $2) }
 
-Rule_17 : { Ctr__Rule_17__0 rtkNoPos } |
-          ImplementsList { Ctr__Rule_17__1 (rtkPosOf $1) $1 }
+Rule_11 : {- empty -} { [] } |
+          Rule_11 Rule_12 { $2 : $1 }
 
-Rule_18 : { Ctr__Rule_18__0 rtkNoPos } |
-          ExtendsList { Ctr__Rule_18__1 (rtkPosOf $1) $1 }
+Rule_12 : tok__coma__9 ElementValue { Ctr__Rule_12__0 (rtkPosOf $1) $2 }
+
+Rule_13 : { Ctr__Rule_13__0 rtkNoPos } |
+          tok__coma__9 { Ctr__Rule_13__1 (rtkPosOf $1) }
+
+ListElem_ModifierList16 : qq_ModifierList { Anti_Rule_15 (tkVal_qq_ModifierList $1) } |
+                          Rule_15 { $1 }
+
+Rule_15 : Modifier { Ctr__Rule_15__1 (rtkPosOf $1) $1 } |
+          Annotation { Ctr__Rule_15__2 (rtkPosOf $1) $1 }
+
+Rule_17 : {- empty -} { [] } |
+          Rule_17 Rule_18 { $2 : $1 }
+
+Rule_18 : tok__coma__9 ClassOrInterfaceType { Ctr__Rule_18__0 (rtkPosOf $1) $2 }
+
+Rule_19 : ClassOrInterfaceType { [$1] } |
+          Rule_19 tok__coma__9 ClassOrInterfaceType { $3 : $1 }
 
 Rule_2 : { Ctr__Rule_2__0 rtkNoPos } |
-         TypeDeclaration { Ctr__Rule_2__1 (rtkPosOf $1) $1 }
+         CompilationUnitRest { Ctr__Rule_2__1 (rtkPosOf $1) $1 }
 
-Rule_20 : { Ctr__Rule_20__0 rtkNoPos } |
-          Rule_21 { Ctr__Rule_20__1 (rtkPosOf $1) $1 }
-
-Rule_21 : tok__lparen__7 Arglist tok__rparen__8 { Ctr__Rule_21__0 (rtkPosOf $1) $2 }
+Rule_21 : { Ctr__Rule_21__0 rtkNoPos } |
+          ExtendsList { Ctr__Rule_21__1 (rtkPosOf $1) $1 }
 
 Rule_22 : { Ctr__Rule_22__0 rtkNoPos } |
-          Rule_23 { Ctr__Rule_22__1 (rtkPosOf $1) $1 }
+          ImplementsList { Ctr__Rule_22__1 (rtkPosOf $1) $1 }
 
-Rule_23 : tok__symbol__14 FieldDeclarationList tok__symbol__15 { Ctr__Rule_23__0 (rtkPosOf $1) (reverse $2) }
+Rule_23 : { Ctr__Rule_23__0 rtkNoPos } |
+          ExtendsList { Ctr__Rule_23__1 (rtkPosOf $1) $1 }
 
-Rule_24 : {- empty -} { [] } |
-          Rule_24 Rule_25 { $2 : $1 }
+Rule_25 : { Ctr__Rule_25__0 rtkNoPos } |
+          Rule_26 { Ctr__Rule_25__1 (rtkPosOf $1) $1 }
 
-Rule_25 : tok__coma__9 EnumConstant { Ctr__Rule_25__0 (rtkPosOf $1) $2 }
-
-Rule_26 : { Ctr__Rule_26__0 rtkNoPos } |
-          tok__coma__9 { Ctr__Rule_26__1 (rtkPosOf $1) }
+Rule_26 : tok__lparen__7 Arglist tok__rparen__8 { Ctr__Rule_26__0 (rtkPosOf $1) $2 }
 
 Rule_27 : { Ctr__Rule_27__0 rtkNoPos } |
-          ImplementsList { Ctr__Rule_27__1 (rtkPosOf $1) $1 }
+          Rule_28 { Ctr__Rule_27__1 (rtkPosOf $1) $1 }
 
-Rule_28 : { Ctr__Rule_28__0 rtkNoPos } |
-          Rule_29 { Ctr__Rule_28__1 (rtkPosOf $1) $1 }
+Rule_28 : tok__symbol__11 FieldDeclarationList tok__symbol__12 { Ctr__Rule_28__0 (rtkPosOf $1) (reverse $2) }
 
-Rule_29 : tok__semi__1 FieldDeclarationList { Ctr__Rule_29__0 (rtkPosOf $1) (reverse $2) }
+Rule_29 : {- empty -} { [] } |
+          Rule_29 Rule_30 { $2 : $1 }
 
 Rule_3 : { Ctr__Rule_3__0 rtkNoPos } |
          tok_static_3 { Ctr__Rule_3__1 (rtkPosOf $1) }
 
-Rule_30 : MemberDeclaration { Ctr__Rule_30__0 (rtkPosOf $1) $1 } |
-          TypeDeclRest { Ctr__Rule_30__1 (rtkPosOf $1) $1 } |
-          StaticInitializer { Ctr__Rule_30__2 (rtkPosOf $1) $1 }
+Rule_30 : tok__coma__9 EnumConstant { Ctr__Rule_30__0 (rtkPosOf $1) $2 }
 
-ListElem_Dims32 : qq_Dims { Anti_Rule_31 (tkVal_qq_Dims $1) } |
-                  Rule_31 { $1 }
+Rule_31 : { Ctr__Rule_31__0 rtkNoPos } |
+          tok__coma__9 { Ctr__Rule_31__1 (rtkPosOf $1) }
 
-Rule_31 : tok__sq_bkt_l__18 tok__sq_bkt_r__19 { Ctr__Rule_31__1 (rtkPosOf $1) }
+Rule_32 : { Ctr__Rule_32__0 rtkNoPos } |
+          ImplementsList { Ctr__Rule_32__1 (rtkPosOf $1) $1 }
 
-ListElem_NonEmptyDims34 : qq_NonEmptyDims { Anti_Rule_33 (tkVal_qq_NonEmptyDims $1) } |
-                          Rule_33 { $1 }
+Rule_33 : { Ctr__Rule_33__0 rtkNoPos } |
+          Rule_34 { Ctr__Rule_33__1 (rtkPosOf $1) $1 }
 
-Rule_33 : tok__sq_bkt_l__18 tok__sq_bkt_r__19 { Ctr__Rule_33__1 (rtkPosOf $1) }
+Rule_34 : tok__semi__1 FieldDeclarationList { Ctr__Rule_34__0 (rtkPosOf $1) (reverse $2) }
 
-Rule_35 : { Ctr__Rule_35__0 rtkNoPos } |
-          ParameterList { Ctr__Rule_35__1 (rtkPosOf $1) $1 }
+Rule_35 : MemberDeclaration { Ctr__Rule_35__0 (rtkPosOf $1) $1 } |
+          TypeDeclRest { Ctr__Rule_35__1 (rtkPosOf $1) $1 } |
+          StaticInitializer { Ctr__Rule_35__2 (rtkPosOf $1) $1 }
 
-Rule_36 : { Ctr__Rule_36__0 rtkNoPos } |
-          ThrowsClause { Ctr__Rule_36__1 (rtkPosOf $1) $1 }
+ListElem_Dims37 : qq_Dims { Anti_Rule_36 (tkVal_qq_Dims $1) } |
+                  Rule_36 { $1 }
 
-Rule_37 : {- empty -} { [] } |
-          Rule_37 Rule_38 { $2 : $1 }
+Rule_36 : tok__sq_bkt_l__18 tok__sq_bkt_r__19 { Ctr__Rule_36__1 (rtkPosOf $1) }
 
-Rule_38 : tok__coma__9 CompoundName { Ctr__Rule_38__0 (rtkPosOf $1) $2 }
+ListElem_NonEmptyDims39 : qq_NonEmptyDims { Anti_Rule_38 (tkVal_qq_NonEmptyDims $1) } |
+                          Rule_38 { $1 }
 
-Rule_39 : { Ctr__Rule_39__0 rtkNoPos } |
-          ParameterList { Ctr__Rule_39__1 (rtkPosOf $1) $1 }
+Rule_38 : tok__sq_bkt_l__18 tok__sq_bkt_r__19 { Ctr__Rule_38__1 (rtkPosOf $1) }
 
 Rule_4 : { Ctr__Rule_4__0 rtkNoPos } |
          Rule_5 { Ctr__Rule_4__1 (rtkPosOf $1) $1 }
 
 Rule_40 : { Ctr__Rule_40__0 rtkNoPos } |
-          ThrowsClause { Ctr__Rule_40__1 (rtkPosOf $1) $1 }
+          ParameterList { Ctr__Rule_40__1 (rtkPosOf $1) $1 }
 
-Rule_41 : StatementBlock { Ctr__Rule_41__0 (rtkPosOf $1) $1 } |
-          Rule_42 tok__semi__1 { Ctr__Rule_41__1 (rtkPosOf $1) $1 }
+Rule_41 : { Ctr__Rule_41__0 rtkNoPos } |
+          ThrowsClause { Ctr__Rule_41__1 (rtkPosOf $1) $1 }
 
-Rule_42 : { Ctr__Rule_42__0 rtkNoPos } |
-          Rule_43 { Ctr__Rule_42__1 (rtkPosOf $1) $1 }
+Rule_42 : {- empty -} { [] } |
+          Rule_42 Rule_43 { $2 : $1 }
 
-Rule_43 : tok_default_30 Expression { Ctr__Rule_43__0 (rtkPosOf $1) $2 }
+Rule_43 : tok__coma__9 CompoundName { Ctr__Rule_43__0 (rtkPosOf $1) $2 }
 
-ListElem_MoreVariableDeclarators45 : qq_MoreVariableDeclarators { Anti_Rule_44 (tkVal_qq_MoreVariableDeclarators $1) } |
-                                     Rule_44 { $1 }
+Rule_44 : { Ctr__Rule_44__0 rtkNoPos } |
+          ParameterList { Ctr__Rule_44__1 (rtkPosOf $1) $1 }
 
-Rule_44 : tok__coma__9 VariableDeclarator { Ctr__Rule_44__1 (rtkPosOf $1) $2 }
+Rule_45 : { Ctr__Rule_45__0 rtkNoPos } |
+          ThrowsClause { Ctr__Rule_45__1 (rtkPosOf $1) $1 }
 
-Rule_46 : {- empty -} { [] } |
-          Rule_46 Rule_47 { $2 : $1 }
+Rule_46 : StatementBlock { Ctr__Rule_46__0 (rtkPosOf $1) $1 } |
+          Rule_47 tok__semi__1 { Ctr__Rule_46__1 (rtkPosOf $1) $1 }
 
-Rule_47 : tok__coma__9 VariableDeclarator { Ctr__Rule_47__0 (rtkPosOf $1) $2 }
+Rule_47 : { Ctr__Rule_47__0 rtkNoPos } |
+          Rule_48 { Ctr__Rule_47__1 (rtkPosOf $1) $1 }
 
-ListElem_LocalModifierList149 : qq_LocalModifierList1 { Anti_Rule_48 (tkVal_qq_LocalModifierList1 $1) } |
-                                Rule_48 { $1 }
+Rule_48 : tok_default_30 Expression { Ctr__Rule_48__0 (rtkPosOf $1) $2 }
 
-Rule_48 : tok_final_31 { Ctr__Rule_48__1 (rtkPosOf $1) } |
-          Annotation { Ctr__Rule_48__2 (rtkPosOf $1) $1 }
+ListElem_MoreVariableDeclarators50 : qq_MoreVariableDeclarators { Anti_Rule_49 (tkVal_qq_MoreVariableDeclarators $1) } |
+                                     Rule_49 { $1 }
+
+Rule_49 : tok__coma__9 VariableDeclarator { Ctr__Rule_49__1 (rtkPosOf $1) $2 }
 
 Rule_5 : tok__lparen__7 Rule_6 tok__rparen__8 { Ctr__Rule_5__0 (rtkPosOf $1) $2 }
 
-Rule_50 : tok__eql__10 VariableInitializer { Ctr__Rule_50__0 (rtkPosOf $1) $2 }
+Rule_51 : {- empty -} { [] } |
+          Rule_51 Rule_52 { $2 : $1 }
 
-Rule_51 : VariableInitializer Rule_52 Rule_54 { Ctr__Rule_51__0 (rtkPosOf $1) $1 (reverse $2) $3 }
+Rule_52 : tok__coma__9 VariableDeclarator { Ctr__Rule_52__0 (rtkPosOf $1) $2 }
 
-Rule_52 : {- empty -} { [] } |
-          Rule_52 Rule_53 { $2 : $1 }
+ListElem_LocalModifierList154 : qq_LocalModifierList1 { Anti_Rule_53 (tkVal_qq_LocalModifierList1 $1) } |
+                                Rule_53 { $1 }
 
-Rule_53 : tok__coma__9 VariableInitializer { Ctr__Rule_53__0 (rtkPosOf $1) $2 }
+Rule_53 : tok_final_31 { Ctr__Rule_53__1 (rtkPosOf $1) } |
+          Annotation { Ctr__Rule_53__2 (rtkPosOf $1) $1 }
 
-Rule_54 : { Ctr__Rule_54__0 rtkNoPos } |
-          tok__coma__9 { Ctr__Rule_54__1 (rtkPosOf $1) }
+Rule_55 : tok__eql__10 VariableInitializer { Ctr__Rule_55__0 (rtkPosOf $1) $2 }
 
-Rule_55 : {- empty -} { [] } |
-          Rule_55 Rule_56 { $2 : $1 }
+Rule_56 : VariableInitializer Rule_57 Rule_59 { Ctr__Rule_56__0 (rtkPosOf $1) $1 (reverse $2) $3 }
 
-Rule_56 : tok__coma__9 Parameter { Ctr__Rule_56__0 (rtkPosOf $1) $2 }
+Rule_57 : {- empty -} { [] } |
+          Rule_57 Rule_58 { $2 : $1 }
 
-ListElem_ParamModifierList58 : qq_ParamModifierList { Anti_Rule_57 (tkVal_qq_ParamModifierList $1) } |
-                               Rule_57 { $1 }
-
-Rule_57 : tok_final_31 { Ctr__Rule_57__1 (rtkPosOf $1) } |
-          Annotation { Ctr__Rule_57__2 (rtkPosOf $1) $1 }
+Rule_58 : tok__coma__9 VariableInitializer { Ctr__Rule_58__0 (rtkPosOf $1) $2 }
 
 Rule_59 : { Ctr__Rule_59__0 rtkNoPos } |
-          tok__dot__dot__dot__32 { Ctr__Rule_59__1 (rtkPosOf $1) }
+          tok__coma__9 { Ctr__Rule_59__1 (rtkPosOf $1) }
 
 Rule_6 : { Ctr__Rule_6__0 rtkNoPos } |
          AnnotationArguments { Ctr__Rule_6__1 (rtkPosOf $1) $1 }
 
-Rule_61 : { Ctr__Rule_61__0 rtkNoPos } |
-          Rule_62 { Ctr__Rule_61__1 (rtkPosOf $1) $1 }
+Rule_60 : {- empty -} { [] } |
+          Rule_60 Rule_61 { $2 : $1 }
 
-Rule_62 : tok__colon__37 Expression { Ctr__Rule_62__0 (rtkPosOf $1) $2 }
+Rule_61 : tok__coma__9 Parameter { Ctr__Rule_61__0 (rtkPosOf $1) $2 }
 
-Rule_63 : tok_else_42 Statement { Ctr__Rule_63__0 (rtkPosOf $1) $2 }
+ListElem_ParamModifierList63 : qq_ParamModifierList { Anti_Rule_62 (tkVal_qq_ParamModifierList $1) } |
+                               Rule_62 { $1 }
 
-Rule_64 : VariableDeclaration { Ctr__Rule_64__0 (rtkPosOf $1) $1 } |
-          Expression tok__semi__1 { Ctr__Rule_64__1 (rtkPosOf $1) $1 } |
-          tok__semi__1 { Ctr__Rule_64__2 (rtkPosOf $1) }
+Rule_62 : tok_final_31 { Ctr__Rule_62__1 (rtkPosOf $1) } |
+          Annotation { Ctr__Rule_62__2 (rtkPosOf $1) $1 }
 
-ListElem_CatchList66 : qq_CatchList { Anti_Rule_65 (tkVal_qq_CatchList $1) } |
-                       Rule_65 { $1 }
+Rule_64 : { Ctr__Rule_64__0 rtkNoPos } |
+          tok__dot__dot__dot__32 { Ctr__Rule_64__1 (rtkPosOf $1) }
 
-Rule_65 : tok_catch_47 tok__lparen__7 CatchParameter tok__rparen__8 StatementBlock { Ctr__Rule_65__1 (rtkPosOf $1) $3 $5 }
+Rule_66 : { Ctr__Rule_66__0 rtkNoPos } |
+          Rule_67 { Ctr__Rule_66__1 (rtkPosOf $1) $1 }
 
-Rule_67 : {- empty -} { [] } |
-          Rule_67 Rule_68 { $2 : $1 }
+Rule_67 : tok__colon__37 Expression { Ctr__Rule_67__0 (rtkPosOf $1) $2 }
 
-Rule_68 : tok__pipe__48 Type { Ctr__Rule_68__0 (rtkPosOf $1) $2 }
+Rule_68 : tok_else_42 Statement { Ctr__Rule_68__0 (rtkPosOf $1) $2 }
 
-Rule_69 : tok_finally_49 StatementBlock { Ctr__Rule_69__0 (rtkPosOf $1) $2 }
+Rule_69 : VariableDeclaration { Ctr__Rule_69__0 (rtkPosOf $1) $1 } |
+          Expression tok__semi__1 { Ctr__Rule_69__1 (rtkPosOf $1) $1 } |
+          tok__semi__1 { Ctr__Rule_69__2 (rtkPosOf $1) }
 
 Rule_7 : {- empty -} { [] } |
          Rule_7 Rule_8 { $2 : $1 }
 
-Rule_70 : { Ctr__Rule_70__0 rtkNoPos } |
-          ResourceSpec { Ctr__Rule_70__1 (rtkPosOf $1) $1 }
+ListElem_CatchList71 : qq_CatchList { Anti_Rule_70 (tkVal_qq_CatchList $1) } |
+                       Rule_70 { $1 }
 
-Rule_71 : {- empty -} { [] } |
-          Rule_71 Rule_72 { $2 : $1 }
+Rule_70 : tok_catch_47 tok__lparen__7 CatchParameter tok__rparen__8 StatementBlock { Ctr__Rule_70__1 (rtkPosOf $1) $3 $5 }
 
-Rule_72 : tok__semi__1 Resource { Ctr__Rule_72__0 (rtkPosOf $1) $2 }
+Rule_72 : {- empty -} { [] } |
+          Rule_72 Rule_73 { $2 : $1 }
 
-Rule_73 : { Ctr__Rule_73__0 rtkNoPos } |
-          tok__semi__1 { Ctr__Rule_73__1 (rtkPosOf $1) }
+Rule_73 : tok__pipe__48 Type { Ctr__Rule_73__0 (rtkPosOf $1) $2 }
 
-ListElem_SwitchCaseList75 : qq_SwitchCaseList { Anti_Rule_74 (tkVal_qq_SwitchCaseList $1) } |
-                            Rule_74 { $1 }
+Rule_74 : tok_finally_49 StatementBlock { Ctr__Rule_74__0 (rtkPosOf $1) $2 }
 
-Rule_74 : tok_case_51 Expression tok__colon__37 { Ctr__Rule_74__1 (rtkPosOf $1) $2 } |
-          tok_default_30 tok__colon__37 { Ctr__Rule_74__2 (rtkPosOf $1) } |
-          Statement { Ctr__Rule_74__3 (rtkPosOf $1) $1 }
+Rule_75 : { Ctr__Rule_75__0 rtkNoPos } |
+          ResourceSpec { Ctr__Rule_75__1 (rtkPosOf $1) $1 }
 
-Rule_76 : { Ctr__Rule_76__0 rtkNoPos } |
-          Rule_77 { Ctr__Rule_76__1 (rtkPosOf $1) $1 }
+Rule_76 : {- empty -} { [] } |
+          Rule_76 Rule_77 { $2 : $1 }
 
-Rule_77 : AssignmentOp AssignmentExpression { Ctr__Rule_77__0 (rtkPosOf $1) $1 $2 }
+Rule_77 : tok__semi__1 Resource { Ctr__Rule_77__0 (rtkPosOf $1) $2 }
 
-Rule_78 : Rule_79 { [$1] } |
-          Rule_78 Rule_79 { $2 : $1 }
+Rule_78 : { Ctr__Rule_78__0 rtkNoPos } |
+          tok__semi__1 { Ctr__Rule_78__1 (rtkPosOf $1) }
 
-Rule_79 : tok__coma__9 id { Ctr__Rule_79__0 (rtkPosOf $1) (tkVal_id $2) }
+ListElem_SwitchCaseList80 : qq_SwitchCaseList { Anti_Rule_79 (tkVal_qq_SwitchCaseList $1) } |
+                            Rule_79 { $1 }
+
+Rule_79 : tok_case_51 Expression tok__colon__37 { Ctr__Rule_79__1 (rtkPosOf $1) $2 } |
+          tok_default_30 tok__colon__37 { Ctr__Rule_79__2 (rtkPosOf $1) } |
+          Statement { Ctr__Rule_79__3 (rtkPosOf $1) $1 }
 
 Rule_8 : tok__coma__9 AnnotationElement { Ctr__Rule_8__0 (rtkPosOf $1) $2 }
 
-Rule_80 : { Ctr__Rule_80__0 rtkNoPos } |
-          Rule_81 { Ctr__Rule_80__1 (rtkPosOf $1) $1 }
+Rule_81 : { Ctr__Rule_81__0 rtkNoPos } |
+          Rule_82 { Ctr__Rule_81__1 (rtkPosOf $1) $1 }
 
-Rule_81 : tok__lparen__7 Arglist tok__rparen__8 { Ctr__Rule_81__0 (rtkPosOf $1) $2 }
+Rule_82 : AssignmentOp AssignmentExpression { Ctr__Rule_82__0 (rtkPosOf $1) $1 $2 }
 
-Rule_82 : { Ctr__Rule_82__0 rtkNoPos } |
-          Rule_83 { Ctr__Rule_82__1 (rtkPosOf $1) $1 }
+Rule_83 : Rule_84 { [$1] } |
+          Rule_83 Rule_84 { $2 : $1 }
 
-Rule_83 : tok__lparen__7 Arglist tok__rparen__8 { Ctr__Rule_83__0 (rtkPosOf $1) $2 }
-
-Rule_84 : tok__lparen__7 Arglist tok__rparen__8 { Ctr__Rule_84__0 (rtkPosOf $1) $2 } |
-          DimExprs Rule_85 { Ctr__Rule_84__1 (rtkPosOf (reverse $1)) (reverse $1) $2 }
+Rule_84 : tok__coma__9 id { Ctr__Rule_84__0 (rtkPosOf $1) (tkVal_id $2) }
 
 Rule_85 : { Ctr__Rule_85__0 rtkNoPos } |
-          NonEmptyDims { Ctr__Rule_85__1 (rtkPosOf (reverse $1)) (reverse $1) }
+          Rule_86 { Ctr__Rule_85__1 (rtkPosOf $1) $1 }
 
-ListElem_DimExprs87 : qq_DimExprs { Anti_Rule_86 (tkVal_qq_DimExprs $1) } |
-                      Rule_86 { $1 }
+Rule_86 : tok__lparen__7 Arglist tok__rparen__8 { Ctr__Rule_86__0 (rtkPosOf $1) $2 }
 
-Rule_86 : tok__sq_bkt_l__18 Expression tok__sq_bkt_r__19 { Ctr__Rule_86__1 (rtkPosOf $1) $2 }
+Rule_87 : { Ctr__Rule_87__0 rtkNoPos } |
+          Rule_88 { Ctr__Rule_87__1 (rtkPosOf $1) $1 }
 
-Rule_88 : Expression Rule_89 { Ctr__Rule_88__0 (rtkPosOf $1) $1 (reverse $2) }
+Rule_88 : tok__lparen__7 Arglist tok__rparen__8 { Ctr__Rule_88__0 (rtkPosOf $1) $2 }
 
-Rule_89 : {- empty -} { [] } |
-          Rule_89 Rule_90 { $2 : $1 }
+Rule_89 : tok__lparen__7 Arglist tok__rparen__8 Rule_90 { Ctr__Rule_89__0 (rtkPosOf $1) $2 $4 } |
+          DimExprs Rule_92 { Ctr__Rule_89__1 (rtkPosOf (reverse $1)) (reverse $1) $2 } |
+          NonEmptyDims ArrayInitializer { Ctr__Rule_89__2 (rtkPosOf (reverse $1)) (reverse $1) $2 }
 
-Rule_90 : tok__coma__9 Expression { Ctr__Rule_90__0 (rtkPosOf $1) $2 }
+Rule_9 : { Ctr__Rule_9__0 rtkNoPos } |
+         Rule_10 { Ctr__Rule_9__1 (rtkPosOf $1) $1 }
 
-Rule_91 : {- empty -} { [] } |
-          Rule_91 Rule_92 { $2 : $1 }
+Rule_90 : { Ctr__Rule_90__0 rtkNoPos } |
+          Rule_91 { Ctr__Rule_90__1 (rtkPosOf $1) $1 }
 
-Rule_92 : tok__coma__9 TypeArgument { Ctr__Rule_92__0 (rtkPosOf $1) $2 }
+Rule_91 : tok__symbol__11 FieldDeclarationList tok__symbol__12 { Ctr__Rule_91__0 (rtkPosOf $1) (reverse $2) }
 
-Rule_93 : tok__symbol__72 TypeParameter Rule_94 tok__symbol__73 { Ctr__Rule_93__0 (rtkPosOf $1) $2 (reverse $3) }
+Rule_92 : { Ctr__Rule_92__0 rtkNoPos } |
+          NonEmptyDims { Ctr__Rule_92__1 (rtkPosOf (reverse $1)) (reverse $1) }
 
-Rule_94 : {- empty -} { [] } |
-          Rule_94 Rule_95 { $2 : $1 }
+ListElem_DimExprs94 : qq_DimExprs { Anti_Rule_93 (tkVal_qq_DimExprs $1) } |
+                      Rule_93 { $1 }
 
-Rule_95 : tok__coma__9 TypeParameter { Ctr__Rule_95__0 (rtkPosOf $1) $2 }
+Rule_93 : tok__sq_bkt_l__18 Expression tok__sq_bkt_r__19 { Ctr__Rule_93__1 (rtkPosOf $1) $2 }
 
-Rule_96 : { Ctr__Rule_96__0 rtkNoPos } |
-          Rule_97 { Ctr__Rule_96__1 (rtkPosOf $1) $1 }
+Rule_95 : Expression Rule_96 { Ctr__Rule_95__0 (rtkPosOf $1) $1 (reverse $2) }
 
-Rule_97 : tok_extends_11 Type Rule_98 { Ctr__Rule_97__0 (rtkPosOf $1) $2 (reverse $3) }
+Rule_96 : {- empty -} { [] } |
+          Rule_96 Rule_97 { $2 : $1 }
+
+Rule_97 : tok__coma__9 Expression { Ctr__Rule_97__0 (rtkPosOf $1) $2 }
 
 Rule_98 : {- empty -} { [] } |
           Rule_98 Rule_99 { $2 : $1 }
 
-Rule_99 : tok__symbol__69 Type { Ctr__Rule_99__0 (rtkPosOf $1) $2 }
+Rule_99 : tok__coma__9 TypeArgument { Ctr__Rule_99__0 (rtkPosOf $1) $2 }
 
 ShiftOp : qq_ShiftOp { Anti_ShiftOp (tkVal_qq_ShiftOp $1) } |
           tok__symbol__symbol__77 { Ctr__ShiftOp__0 (rtkPosOf $1) } |
@@ -1039,7 +1092,7 @@ Statement : qq_Statement { Anti_Statement (tkVal_qq_Statement $1) } |
             SwitchStatement { Ctr__Statement__9 (rtkPosOf $1) $1 } |
             tok_synchronized_34 tok__lparen__7 Expression tok__rparen__8 Statement { Ctr__Statement__10 (rtkPosOf $1) $3 $5 } |
             tok_throw_35 Expression tok__semi__1 { Ctr__Statement__11 (rtkPosOf $1) $2 } |
-            tok_assert_36 Expression Rule_61 tok__semi__1 { Ctr__Statement__12 (rtkPosOf $1) $2 $3 } |
+            tok_assert_36 Expression Rule_66 tok__semi__1 { Ctr__Statement__12 (rtkPosOf $1) $2 $3 } |
             id tok__colon__37 Statement { Ctr__Statement__13 (rtkPosOf $1) (tkVal_id $1) $3 } |
             tok_break_38 OptId tok__semi__1 { Ctr__Statement__14 (rtkPosOf $1) $2 } |
             tok_continue_39 OptId tok__semi__1 { Ctr__Statement__15 (rtkPosOf $1) $2 } |
@@ -1047,29 +1100,29 @@ Statement : qq_Statement { Anti_Statement (tkVal_qq_Statement $1) } |
             tok_this_41 tok__lparen__7 Arglist tok__rparen__8 tok__semi__1 { Ctr__Statement__17 (rtkPosOf $1) $3 } |
             tok__semi__1 { Ctr__Statement__18 (rtkPosOf $1) }
 
-ListElem_StatementList60 : qq_StatementList { Anti_Statement (tkVal_qq_StatementList $1) } |
+ListElem_StatementList65 : qq_StatementList { Anti_Statement (tkVal_qq_StatementList $1) } |
                            Statement { $1 }
 
 StatementBlock : qq_StatementBlock { Anti_StatementBlock (tkVal_qq_StatementBlock $1) } |
-                 tok__symbol__14 StatementList tok__symbol__15 { Ctr__StatementBlock__0 (rtkPosOf $1) (reverse $2) }
+                 tok__symbol__11 StatementList tok__symbol__12 { Ctr__StatementBlock__0 (rtkPosOf $1) (reverse $2) }
 
 StatementList : {- empty -} { [] } |
-                StatementList ListElem_StatementList60 { $2 : $1 }
+                StatementList ListElem_StatementList65 { $2 : $1 }
 
 StaticInitializer : qq_StaticInitializer { Anti_StaticInitializer (tkVal_qq_StaticInitializer $1) } |
                     StatementBlock { Ctr__StaticInitializer__0 (rtkPosOf $1) $1 }
 
 SwitchCaseList : {- empty -} { [] } |
-                 SwitchCaseList ListElem_SwitchCaseList75 { $2 : $1 }
+                 SwitchCaseList ListElem_SwitchCaseList80 { $2 : $1 }
 
 SwitchStatement : qq_SwitchStatement { Anti_SwitchStatement (tkVal_qq_SwitchStatement $1) } |
-                  tok_switch_52 tok__lparen__7 Expression tok__rparen__8 tok__symbol__14 SwitchCaseList tok__symbol__15 { Ctr__SwitchStatement__0 (rtkPosOf $1) $3 (reverse $6) }
+                  tok_switch_52 tok__lparen__7 Expression tok__rparen__8 tok__symbol__11 SwitchCaseList tok__symbol__12 { Ctr__SwitchStatement__0 (rtkPosOf $1) $3 (reverse $6) }
 
 ThrowsClause : qq_ThrowsClause { Anti_ThrowsClause (tkVal_qq_ThrowsClause $1) } |
-               tok_throws_29 CompoundName Rule_37 { Ctr__ThrowsClause__0 (rtkPosOf $1) $2 (reverse $3) }
+               tok_throws_29 CompoundName Rule_42 { Ctr__ThrowsClause__0 (rtkPosOf $1) $2 (reverse $3) }
 
 TryStatement : qq_TryStatement { Anti_TryStatement (tkVal_qq_TryStatement $1) } |
-               tok_try_50 Rule_70 StatementBlock CatchList OptFinally { Ctr__TryStatement__0 (rtkPosOf $1) $2 $3 (reverse $4) $5 }
+               tok_try_50 Rule_75 StatementBlock CatchList OptFinally { Ctr__TryStatement__0 (rtkPosOf $1) $2 $3 (reverse $4) $5 }
 
 Type : qq_Type { Anti_Type (tkVal_qq_Type $1) } |
        PrimitiveTypeKeyword Dims { Ctr__Type__0 (rtkPosOf $1) $1 (reverse $2) } |
@@ -1091,15 +1144,21 @@ TypeDeclRest : qq_TypeDeclRest { Anti_TypeDeclRest (tkVal_qq_TypeDeclRest $1) } 
                EnumDeclaration { Ctr__TypeDeclRest__2 (rtkPosOf $1) $1 } |
                AnnotationDeclaration { Ctr__TypeDeclRest__3 (rtkPosOf $1) $1 }
 
+ListElem_TypeDeclarationList0 : qq_TypeDeclarationList { Anti_TypeDeclaration (tkVal_qq_TypeDeclarationList $1) } |
+                                TypeDeclaration { $1 }
+
 TypeDeclaration : qq_TypeDeclaration { Anti_TypeDeclaration (tkVal_qq_TypeDeclaration $1) } |
-                  OptDocComment ModifierList TypeDeclRest { Ctr__TypeDeclaration__0 (rtkPosOf $1) $1 (reverse $2) $3 }
+                  OptDocComment ModifierList TypeDeclRest { Ctr__TypeDeclaration__1 (rtkPosOf $1) $1 (reverse $2) $3 }
+
+TypeDeclarationList : {- empty -} { [] } |
+                      TypeDeclarationList ListElem_TypeDeclarationList0 { $2 : $1 }
 
 TypeParameter : qq_TypeParameter { Anti_TypeParameter (tkVal_qq_TypeParameter $1) } |
-                id Rule_96 { Ctr__TypeParameter__0 (rtkPosOf $1) (tkVal_id $1) $2 }
+                id Rule_102 { Ctr__TypeParameter__0 (rtkPosOf $1) (tkVal_id $1) $2 }
 
 TypeParameters : qq_TypeParameters { Anti_TypeParameters (tkVal_qq_TypeParameters $1) } |
                  { Ctr__TypeParameters__0 rtkNoPos } |
-                 Rule_93 { Ctr__TypeParameters__1 (rtkPosOf $1) $1 }
+                 NonEmptyTypeParameters { Ctr__TypeParameters__1 (rtkPosOf $1) $1 }
 
 TypeSpecifier : qq_TypeSpecifier { Anti_TypeSpecifier (tkVal_qq_TypeSpecifier $1) } |
                 tok_boolean_20 { Ctr__TypeSpecifier__0 (rtkPosOf $1) } |
@@ -1121,22 +1180,22 @@ VariableDeclarator : qq_VariableDeclarator { Anti_VariableDeclarator (tkVal_qq_V
                      id Dims OptVariableInitializer { Ctr__VariableDeclarator__0 (rtkPosOf $1) (tkVal_id $1) (reverse $2) $3 }
 
 VariableDeclaratorList : qq_VariableDeclaratorList { Anti_VariableDeclaratorList (tkVal_qq_VariableDeclaratorList $1) } |
-                         VariableDeclarator Rule_46 { Ctr__VariableDeclaratorList__0 (rtkPosOf $1) $1 (reverse $2) }
+                         VariableDeclarator Rule_51 { Ctr__VariableDeclaratorList__0 (rtkPosOf $1) $1 (reverse $2) }
 
 VariableInitializer : qq_VariableInitializer { Anti_VariableInitializer (tkVal_qq_VariableInitializer $1) } |
                       Expression { Ctr__VariableInitializer__0 (rtkPosOf $1) $1 } |
-                      tok__symbol__14 VariableInitializerList tok__symbol__15 { Ctr__VariableInitializer__1 (rtkPosOf $1) $2 }
+                      ArrayInitializer { Ctr__VariableInitializer__1 (rtkPosOf $1) $1 }
 
 VariableInitializerList : qq_VariableInitializerList { Anti_VariableInitializerList (tkVal_qq_VariableInitializerList $1) } |
                           { Ctr__VariableInitializerList__0 rtkNoPos } |
-                          Rule_51 { Ctr__VariableInitializerList__1 (rtkPosOf $1) $1 }
+                          Rule_56 { Ctr__VariableInitializerList__1 (rtkPosOf $1) $1 }
 
 WhileStatement : qq_WhileStatement { Anti_WhileStatement (tkVal_qq_WhileStatement $1) } |
                  tok_while_45 tok__lparen__7 Expression tok__rparen__8 Statement { Ctr__WhileStatement__0 (rtkPosOf $1) $3 $5 }
 
 WildcardType : qq_WildcardType { Anti_WildcardType (tkVal_qq_WildcardType $1) } |
                tok__symbol__65 { Ctr__WildcardType__0 (rtkPosOf $1) } |
-               tok__symbol__65 tok_extends_11 Type { Ctr__WildcardType__1 (rtkPosOf $1) $3 } |
+               tok__symbol__65 tok_extends_13 Type { Ctr__WildcardType__1 (rtkPosOf $1) $3 } |
                tok__symbol__65 tok_super_40 Type { Ctr__WildcardType__2 (rtkPosOf $1) $3 }
 
 
@@ -1149,105 +1208,111 @@ parseError (L.PosToken (L.AlexPn _ line col) tok : _) =
 -- Render a token the way it appears in the source, for error messages
 showRtkToken :: L.Token -> String
 showRtkToken L.EndOfFile = "end of input"
-showRtkToken L.Tk__tok_AdditiveOp_dummy_193 = "'tok_AdditiveOp_dummy_193'"
-showRtkToken L.Tk__tok_Annotation_dummy_192 = "'tok_Annotation_dummy_192'"
-showRtkToken L.Tk__tok_AnnotationArguments_dummy_191 = "'tok_AnnotationArguments_dummy_191'"
-showRtkToken L.Tk__tok_AnnotationDeclaration_dummy_190 = "'tok_AnnotationDeclaration_dummy_190'"
-showRtkToken L.Tk__tok_AnnotationElement_dummy_189 = "'tok_AnnotationElement_dummy_189'"
-showRtkToken L.Tk__tok_AnnotationList_dummy_188 = "'tok_AnnotationList_dummy_188'"
-showRtkToken L.Tk__tok_AnnotationTypeElement_dummy_187 = "'tok_AnnotationTypeElement_dummy_187'"
-showRtkToken L.Tk__tok_AnnotationTypeElementList_dummy_186 = "'tok_AnnotationTypeElementList_dummy_186'"
-showRtkToken L.Tk__tok_Arglist_dummy_185 = "'tok_Arglist_dummy_185'"
-showRtkToken L.Tk__tok_AssignmentOp_dummy_184 = "'tok_AssignmentOp_dummy_184'"
-showRtkToken L.Tk__tok_CatchList_dummy_183 = "'tok_CatchList_dummy_183'"
-showRtkToken L.Tk__tok_CatchParameter_dummy_182 = "'tok_CatchParameter_dummy_182'"
-showRtkToken L.Tk__tok_ClassDeclaration_dummy_181 = "'tok_ClassDeclaration_dummy_181'"
-showRtkToken L.Tk__tok_ClassOrInterfaceType_dummy_180 = "'tok_ClassOrInterfaceType_dummy_180'"
-showRtkToken L.Tk__tok_CompilationUnit_dummy_179 = "'tok_CompilationUnit_dummy_179'"
-showRtkToken L.Tk__tok_CompoundName_dummy_178 = "'tok_CompoundName_dummy_178'"
-showRtkToken L.Tk__tok_CompoundNameTail_dummy_177 = "'tok_CompoundNameTail_dummy_177'"
-showRtkToken L.Tk__tok_CreationExpression_dummy_176 = "'tok_CreationExpression_dummy_176'"
-showRtkToken L.Tk__tok_DimExprs_dummy_175 = "'tok_DimExprs_dummy_175'"
-showRtkToken L.Tk__tok_Dims_dummy_174 = "'tok_Dims_dummy_174'"
-showRtkToken L.Tk__tok_DoStatement_dummy_173 = "'tok_DoStatement_dummy_173'"
-showRtkToken L.Tk__tok_DocComment_dummy_172 = "'tok_DocComment_dummy_172'"
-showRtkToken L.Tk__tok_EnumConstant_dummy_171 = "'tok_EnumConstant_dummy_171'"
-showRtkToken L.Tk__tok_EnumConstantList_dummy_170 = "'tok_EnumConstantList_dummy_170'"
-showRtkToken L.Tk__tok_EnumDeclaration_dummy_169 = "'tok_EnumDeclaration_dummy_169'"
-showRtkToken L.Tk__tok_EqualityOp_dummy_168 = "'tok_EqualityOp_dummy_168'"
-showRtkToken L.Tk__tok_Expression_dummy_167 = "'tok_Expression_dummy_167'"
-showRtkToken L.Tk__tok_ExtendsList_dummy_166 = "'tok_ExtendsList_dummy_166'"
-showRtkToken L.Tk__tok_FieldDeclaration_dummy_165 = "'tok_FieldDeclaration_dummy_165'"
-showRtkToken L.Tk__tok_FieldDeclarationList_dummy_164 = "'tok_FieldDeclarationList_dummy_164'"
-showRtkToken L.Tk__tok_ForEachHeader_dummy_163 = "'tok_ForEachHeader_dummy_163'"
-showRtkToken L.Tk__tok_ForStatement_dummy_162 = "'tok_ForStatement_dummy_162'"
-showRtkToken L.Tk__tok_IfStatement_dummy_161 = "'tok_IfStatement_dummy_161'"
-showRtkToken L.Tk__tok_ImplementsList_dummy_160 = "'tok_ImplementsList_dummy_160'"
-showRtkToken L.Tk__tok_ImportHead_dummy_159 = "'tok_ImportHead_dummy_159'"
-showRtkToken L.Tk__tok_ImportList_dummy_158 = "'tok_ImportList_dummy_158'"
-showRtkToken L.Tk__tok_ImportName_dummy_157 = "'tok_ImportName_dummy_157'"
-showRtkToken L.Tk__tok_ImportStatement_dummy_156 = "'tok_ImportStatement_dummy_156'"
-showRtkToken L.Tk__tok_InterfaceDeclaration_dummy_155 = "'tok_InterfaceDeclaration_dummy_155'"
-showRtkToken L.Tk__tok_Java_dummy_194 = "'tok_Java_dummy_194'"
-showRtkToken L.Tk__tok_LambdaBody_dummy_154 = "'tok_LambdaBody_dummy_154'"
-showRtkToken L.Tk__tok_Literal_dummy_153 = "'tok_Literal_dummy_153'"
-showRtkToken L.Tk__tok_LocalModifierList1_dummy_152 = "'tok_LocalModifierList1_dummy_152'"
-showRtkToken L.Tk__tok_MemberAfterFirstId_dummy_151 = "'tok_MemberAfterFirstId_dummy_151'"
-showRtkToken L.Tk__tok_MemberDeclaration_dummy_150 = "'tok_MemberDeclaration_dummy_150'"
-showRtkToken L.Tk__tok_MemberRest_dummy_149 = "'tok_MemberRest_dummy_149'"
-showRtkToken L.Tk__tok_Modifier_dummy_148 = "'tok_Modifier_dummy_148'"
-showRtkToken L.Tk__tok_ModifierList_dummy_147 = "'tok_ModifierList_dummy_147'"
-showRtkToken L.Tk__tok_MoreTypeSpecifier_dummy_146 = "'tok_MoreTypeSpecifier_dummy_146'"
-showRtkToken L.Tk__tok_MoreVariableDeclarators_dummy_145 = "'tok_MoreVariableDeclarators_dummy_145'"
-showRtkToken L.Tk__tok_MultiplicativeOp_dummy_144 = "'tok_MultiplicativeOp_dummy_144'"
-showRtkToken L.Tk__tok_NonEmptyDims_dummy_143 = "'tok_NonEmptyDims_dummy_143'"
-showRtkToken L.Tk__tok_NonEmptyTypeArguments_dummy_142 = "'tok_NonEmptyTypeArguments_dummy_142'"
-showRtkToken L.Tk__tok_OptDocComment_dummy_141 = "'tok_OptDocComment_dummy_141'"
-showRtkToken L.Tk__tok_OptElsePart_dummy_140 = "'tok_OptElsePart_dummy_140'"
-showRtkToken L.Tk__tok_OptExpression_dummy_139 = "'tok_OptExpression_dummy_139'"
-showRtkToken L.Tk__tok_OptFinally_dummy_138 = "'tok_OptFinally_dummy_138'"
-showRtkToken L.Tk__tok_OptId_dummy_137 = "'tok_OptId_dummy_137'"
-showRtkToken L.Tk__tok_OptVariableInitializer_dummy_136 = "'tok_OptVariableInitializer_dummy_136'"
-showRtkToken L.Tk__tok_Package_dummy_135 = "'tok_Package_dummy_135'"
-showRtkToken L.Tk__tok_ParamModifierList_dummy_134 = "'tok_ParamModifierList_dummy_134'"
-showRtkToken L.Tk__tok_Parameter_dummy_133 = "'tok_Parameter_dummy_133'"
-showRtkToken L.Tk__tok_ParameterList_dummy_132 = "'tok_ParameterList_dummy_132'"
-showRtkToken L.Tk__tok_PostfixOp_dummy_131 = "'tok_PostfixOp_dummy_131'"
-showRtkToken L.Tk__tok_PrefixOp_dummy_130 = "'tok_PrefixOp_dummy_130'"
-showRtkToken L.Tk__tok_PrimitiveTypeKeyword_dummy_129 = "'tok_PrimitiveTypeKeyword_dummy_129'"
-showRtkToken L.Tk__tok_RelationalOp_dummy_128 = "'tok_RelationalOp_dummy_128'"
-showRtkToken L.Tk__tok_Resource_dummy_127 = "'tok_Resource_dummy_127'"
-showRtkToken L.Tk__tok_ResourceSpec_dummy_126 = "'tok_ResourceSpec_dummy_126'"
-showRtkToken L.Tk__tok_ShiftOp_dummy_125 = "'tok_ShiftOp_dummy_125'"
-showRtkToken L.Tk__tok_Statement_dummy_124 = "'tok_Statement_dummy_124'"
-showRtkToken L.Tk__tok_StatementBlock_dummy_123 = "'tok_StatementBlock_dummy_123'"
-showRtkToken L.Tk__tok_StatementList_dummy_122 = "'tok_StatementList_dummy_122'"
-showRtkToken L.Tk__tok_StaticInitializer_dummy_121 = "'tok_StaticInitializer_dummy_121'"
-showRtkToken L.Tk__tok_SwitchCaseList_dummy_120 = "'tok_SwitchCaseList_dummy_120'"
-showRtkToken L.Tk__tok_SwitchStatement_dummy_119 = "'tok_SwitchStatement_dummy_119'"
-showRtkToken L.Tk__tok_ThrowsClause_dummy_118 = "'tok_ThrowsClause_dummy_118'"
-showRtkToken L.Tk__tok_TryStatement_dummy_117 = "'tok_TryStatement_dummy_117'"
-showRtkToken L.Tk__tok_Type_dummy_116 = "'tok_Type_dummy_116'"
-showRtkToken L.Tk__tok_TypeArgument_dummy_115 = "'tok_TypeArgument_dummy_115'"
-showRtkToken L.Tk__tok_TypeArguments_dummy_114 = "'tok_TypeArguments_dummy_114'"
-showRtkToken L.Tk__tok_TypeDeclRest_dummy_113 = "'tok_TypeDeclRest_dummy_113'"
-showRtkToken L.Tk__tok_TypeDeclaration_dummy_112 = "'tok_TypeDeclaration_dummy_112'"
-showRtkToken L.Tk__tok_TypeParameter_dummy_111 = "'tok_TypeParameter_dummy_111'"
-showRtkToken L.Tk__tok_TypeParameters_dummy_110 = "'tok_TypeParameters_dummy_110'"
-showRtkToken L.Tk__tok_TypeSpecifier_dummy_109 = "'tok_TypeSpecifier_dummy_109'"
-showRtkToken L.Tk__tok_VariableDeclaration_dummy_108 = "'tok_VariableDeclaration_dummy_108'"
-showRtkToken L.Tk__tok_VariableDeclarator_dummy_107 = "'tok_VariableDeclarator_dummy_107'"
-showRtkToken L.Tk__tok_VariableDeclaratorList_dummy_106 = "'tok_VariableDeclaratorList_dummy_106'"
-showRtkToken L.Tk__tok_VariableInitializer_dummy_105 = "'tok_VariableInitializer_dummy_105'"
-showRtkToken L.Tk__tok_VariableInitializerList_dummy_104 = "'tok_VariableInitializerList_dummy_104'"
-showRtkToken L.Tk__tok_WhileStatement_dummy_103 = "'tok_WhileStatement_dummy_103'"
-showRtkToken L.Tk__tok_WildcardType_dummy_102 = "'tok_WildcardType_dummy_102'"
+showRtkToken L.Tk__tok_AdditiveOp_dummy_205 = "'tok_AdditiveOp_dummy_205'"
+showRtkToken L.Tk__tok_Annotation_dummy_204 = "'tok_Annotation_dummy_204'"
+showRtkToken L.Tk__tok_AnnotationArguments_dummy_203 = "'tok_AnnotationArguments_dummy_203'"
+showRtkToken L.Tk__tok_AnnotationDeclaration_dummy_202 = "'tok_AnnotationDeclaration_dummy_202'"
+showRtkToken L.Tk__tok_AnnotationElement_dummy_201 = "'tok_AnnotationElement_dummy_201'"
+showRtkToken L.Tk__tok_AnnotationList_dummy_200 = "'tok_AnnotationList_dummy_200'"
+showRtkToken L.Tk__tok_AnnotationTypeElement_dummy_199 = "'tok_AnnotationTypeElement_dummy_199'"
+showRtkToken L.Tk__tok_AnnotationTypeElementList_dummy_198 = "'tok_AnnotationTypeElementList_dummy_198'"
+showRtkToken L.Tk__tok_Arglist_dummy_197 = "'tok_Arglist_dummy_197'"
+showRtkToken L.Tk__tok_ArrayInitializer_dummy_196 = "'tok_ArrayInitializer_dummy_196'"
+showRtkToken L.Tk__tok_AssignmentOp_dummy_195 = "'tok_AssignmentOp_dummy_195'"
+showRtkToken L.Tk__tok_CatchList_dummy_194 = "'tok_CatchList_dummy_194'"
+showRtkToken L.Tk__tok_CatchParameter_dummy_193 = "'tok_CatchParameter_dummy_193'"
+showRtkToken L.Tk__tok_ClassDeclaration_dummy_192 = "'tok_ClassDeclaration_dummy_192'"
+showRtkToken L.Tk__tok_ClassOrInterfaceType_dummy_191 = "'tok_ClassOrInterfaceType_dummy_191'"
+showRtkToken L.Tk__tok_CompilationUnit_dummy_190 = "'tok_CompilationUnit_dummy_190'"
+showRtkToken L.Tk__tok_CompilationUnitRest_dummy_189 = "'tok_CompilationUnitRest_dummy_189'"
+showRtkToken L.Tk__tok_CompoundName_dummy_188 = "'tok_CompoundName_dummy_188'"
+showRtkToken L.Tk__tok_CompoundNameTail_dummy_187 = "'tok_CompoundNameTail_dummy_187'"
+showRtkToken L.Tk__tok_CreationExpression_dummy_186 = "'tok_CreationExpression_dummy_186'"
+showRtkToken L.Tk__tok_DimExprs_dummy_185 = "'tok_DimExprs_dummy_185'"
+showRtkToken L.Tk__tok_Dims_dummy_184 = "'tok_Dims_dummy_184'"
+showRtkToken L.Tk__tok_DoStatement_dummy_183 = "'tok_DoStatement_dummy_183'"
+showRtkToken L.Tk__tok_DocComment_dummy_182 = "'tok_DocComment_dummy_182'"
+showRtkToken L.Tk__tok_ElementValue_dummy_181 = "'tok_ElementValue_dummy_181'"
+showRtkToken L.Tk__tok_ElementValueArrayInitializer_dummy_180 = "'tok_ElementValueArrayInitializer_dummy_180'"
+showRtkToken L.Tk__tok_EnumConstant_dummy_179 = "'tok_EnumConstant_dummy_179'"
+showRtkToken L.Tk__tok_EnumConstantList_dummy_178 = "'tok_EnumConstantList_dummy_178'"
+showRtkToken L.Tk__tok_EnumDeclaration_dummy_177 = "'tok_EnumDeclaration_dummy_177'"
+showRtkToken L.Tk__tok_EqualityOp_dummy_176 = "'tok_EqualityOp_dummy_176'"
+showRtkToken L.Tk__tok_Expression_dummy_175 = "'tok_Expression_dummy_175'"
+showRtkToken L.Tk__tok_ExtendsList_dummy_174 = "'tok_ExtendsList_dummy_174'"
+showRtkToken L.Tk__tok_FieldDeclaration_dummy_173 = "'tok_FieldDeclaration_dummy_173'"
+showRtkToken L.Tk__tok_FieldDeclarationList_dummy_172 = "'tok_FieldDeclarationList_dummy_172'"
+showRtkToken L.Tk__tok_ForEachHeader_dummy_171 = "'tok_ForEachHeader_dummy_171'"
+showRtkToken L.Tk__tok_ForStatement_dummy_170 = "'tok_ForStatement_dummy_170'"
+showRtkToken L.Tk__tok_IfStatement_dummy_169 = "'tok_IfStatement_dummy_169'"
+showRtkToken L.Tk__tok_ImplementsList_dummy_168 = "'tok_ImplementsList_dummy_168'"
+showRtkToken L.Tk__tok_ImportHead_dummy_167 = "'tok_ImportHead_dummy_167'"
+showRtkToken L.Tk__tok_ImportList_dummy_166 = "'tok_ImportList_dummy_166'"
+showRtkToken L.Tk__tok_ImportName_dummy_165 = "'tok_ImportName_dummy_165'"
+showRtkToken L.Tk__tok_ImportStatement_dummy_164 = "'tok_ImportStatement_dummy_164'"
+showRtkToken L.Tk__tok_InterfaceDeclaration_dummy_163 = "'tok_InterfaceDeclaration_dummy_163'"
+showRtkToken L.Tk__tok_Java_dummy_206 = "'tok_Java_dummy_206'"
+showRtkToken L.Tk__tok_LambdaBody_dummy_162 = "'tok_LambdaBody_dummy_162'"
+showRtkToken L.Tk__tok_Literal_dummy_161 = "'tok_Literal_dummy_161'"
+showRtkToken L.Tk__tok_LocalModifierList1_dummy_160 = "'tok_LocalModifierList1_dummy_160'"
+showRtkToken L.Tk__tok_MemberAfterFirstId_dummy_159 = "'tok_MemberAfterFirstId_dummy_159'"
+showRtkToken L.Tk__tok_MemberDeclaration_dummy_158 = "'tok_MemberDeclaration_dummy_158'"
+showRtkToken L.Tk__tok_MemberRest_dummy_157 = "'tok_MemberRest_dummy_157'"
+showRtkToken L.Tk__tok_Modifier_dummy_156 = "'tok_Modifier_dummy_156'"
+showRtkToken L.Tk__tok_ModifierList_dummy_155 = "'tok_ModifierList_dummy_155'"
+showRtkToken L.Tk__tok_MoreTypeSpecifier_dummy_154 = "'tok_MoreTypeSpecifier_dummy_154'"
+showRtkToken L.Tk__tok_MoreVariableDeclarators_dummy_153 = "'tok_MoreVariableDeclarators_dummy_153'"
+showRtkToken L.Tk__tok_MultiplicativeOp_dummy_152 = "'tok_MultiplicativeOp_dummy_152'"
+showRtkToken L.Tk__tok_NonEmptyDims_dummy_151 = "'tok_NonEmptyDims_dummy_151'"
+showRtkToken L.Tk__tok_NonEmptyTypeArguments_dummy_150 = "'tok_NonEmptyTypeArguments_dummy_150'"
+showRtkToken L.Tk__tok_NonEmptyTypeParameters_dummy_149 = "'tok_NonEmptyTypeParameters_dummy_149'"
+showRtkToken L.Tk__tok_OptDocComment_dummy_148 = "'tok_OptDocComment_dummy_148'"
+showRtkToken L.Tk__tok_OptElsePart_dummy_147 = "'tok_OptElsePart_dummy_147'"
+showRtkToken L.Tk__tok_OptExpression_dummy_146 = "'tok_OptExpression_dummy_146'"
+showRtkToken L.Tk__tok_OptFinally_dummy_145 = "'tok_OptFinally_dummy_145'"
+showRtkToken L.Tk__tok_OptId_dummy_144 = "'tok_OptId_dummy_144'"
+showRtkToken L.Tk__tok_OptVariableInitializer_dummy_143 = "'tok_OptVariableInitializer_dummy_143'"
+showRtkToken L.Tk__tok_Package_dummy_142 = "'tok_Package_dummy_142'"
+showRtkToken L.Tk__tok_ParamModifierList_dummy_141 = "'tok_ParamModifierList_dummy_141'"
+showRtkToken L.Tk__tok_Parameter_dummy_140 = "'tok_Parameter_dummy_140'"
+showRtkToken L.Tk__tok_ParameterList_dummy_139 = "'tok_ParameterList_dummy_139'"
+showRtkToken L.Tk__tok_PostfixOp_dummy_138 = "'tok_PostfixOp_dummy_138'"
+showRtkToken L.Tk__tok_PrefixOp_dummy_137 = "'tok_PrefixOp_dummy_137'"
+showRtkToken L.Tk__tok_PrimitiveTypeKeyword_dummy_136 = "'tok_PrimitiveTypeKeyword_dummy_136'"
+showRtkToken L.Tk__tok_RelationalOp_dummy_135 = "'tok_RelationalOp_dummy_135'"
+showRtkToken L.Tk__tok_Resource_dummy_134 = "'tok_Resource_dummy_134'"
+showRtkToken L.Tk__tok_ResourceSpec_dummy_133 = "'tok_ResourceSpec_dummy_133'"
+showRtkToken L.Tk__tok_ShiftOp_dummy_132 = "'tok_ShiftOp_dummy_132'"
+showRtkToken L.Tk__tok_Statement_dummy_131 = "'tok_Statement_dummy_131'"
+showRtkToken L.Tk__tok_StatementBlock_dummy_130 = "'tok_StatementBlock_dummy_130'"
+showRtkToken L.Tk__tok_StatementList_dummy_129 = "'tok_StatementList_dummy_129'"
+showRtkToken L.Tk__tok_StaticInitializer_dummy_128 = "'tok_StaticInitializer_dummy_128'"
+showRtkToken L.Tk__tok_SwitchCaseList_dummy_127 = "'tok_SwitchCaseList_dummy_127'"
+showRtkToken L.Tk__tok_SwitchStatement_dummy_126 = "'tok_SwitchStatement_dummy_126'"
+showRtkToken L.Tk__tok_ThrowsClause_dummy_125 = "'tok_ThrowsClause_dummy_125'"
+showRtkToken L.Tk__tok_TryStatement_dummy_124 = "'tok_TryStatement_dummy_124'"
+showRtkToken L.Tk__tok_Type_dummy_123 = "'tok_Type_dummy_123'"
+showRtkToken L.Tk__tok_TypeArgument_dummy_122 = "'tok_TypeArgument_dummy_122'"
+showRtkToken L.Tk__tok_TypeArguments_dummy_121 = "'tok_TypeArguments_dummy_121'"
+showRtkToken L.Tk__tok_TypeDeclRest_dummy_120 = "'tok_TypeDeclRest_dummy_120'"
+showRtkToken L.Tk__tok_TypeDeclaration_dummy_119 = "'tok_TypeDeclaration_dummy_119'"
+showRtkToken L.Tk__tok_TypeDeclarationList_dummy_118 = "'tok_TypeDeclarationList_dummy_118'"
+showRtkToken L.Tk__tok_TypeParameter_dummy_117 = "'tok_TypeParameter_dummy_117'"
+showRtkToken L.Tk__tok_TypeParameters_dummy_116 = "'tok_TypeParameters_dummy_116'"
+showRtkToken L.Tk__tok_TypeSpecifier_dummy_115 = "'tok_TypeSpecifier_dummy_115'"
+showRtkToken L.Tk__tok_VariableDeclaration_dummy_114 = "'tok_VariableDeclaration_dummy_114'"
+showRtkToken L.Tk__tok_VariableDeclarator_dummy_113 = "'tok_VariableDeclarator_dummy_113'"
+showRtkToken L.Tk__tok_VariableDeclaratorList_dummy_112 = "'tok_VariableDeclaratorList_dummy_112'"
+showRtkToken L.Tk__tok_VariableInitializer_dummy_111 = "'tok_VariableInitializer_dummy_111'"
+showRtkToken L.Tk__tok_VariableInitializerList_dummy_110 = "'tok_VariableInitializerList_dummy_110'"
+showRtkToken L.Tk__tok_WhileStatement_dummy_109 = "'tok_WhileStatement_dummy_109'"
+showRtkToken L.Tk__tok_WildcardType_dummy_108 = "'tok_WildcardType_dummy_108'"
 showRtkToken L.Tk__tok__tilde__84 = "'~'"
-showRtkToken L.Tk__tok__symbol__15 = "'}'"
+showRtkToken L.Tk__tok__symbol__12 = "'}'"
 showRtkToken L.Tk__tok__pipe__pipe__66 = "'||'"
 showRtkToken L.Tk__tok__pipe__eql__58 = "'|='"
 showRtkToken L.Tk__tok__pipe__48 = "'|'"
-showRtkToken L.Tk__tok__symbol__14 = "'{'"
+showRtkToken L.Tk__tok__symbol__11 = "'{'"
 showRtkToken L.Tk__tok_while_45 = "'while'"
 showRtkToken L.Tk__tok_void_28 = "'void'"
 showRtkToken L.Tk__tok_try_50 = "'try'"
@@ -1275,21 +1340,21 @@ showRtkToken L.Tk__tok_interface_16 = "'interface'"
 showRtkToken L.Tk__tok_int_24 = "'int'"
 showRtkToken L.Tk__tok_instanceof_76 = "'instanceof'"
 showRtkToken L.Tk__tok_import_2 = "'import'"
-showRtkToken L.Tk__tok_implements_12 = "'implements'"
+showRtkToken L.Tk__tok_implements_14 = "'implements'"
 showRtkToken L.Tk__tok_if_43 = "'if'"
 showRtkToken L.Tk__tok_for_46 = "'for'"
 showRtkToken L.Tk__tok_float_25 = "'float'"
 showRtkToken L.Tk__tok_finally_49 = "'finally'"
 showRtkToken L.Tk__tok_final_31 = "'final'"
 showRtkToken L.Tk__tok_false_89 = "'false'"
-showRtkToken L.Tk__tok_extends_11 = "'extends'"
+showRtkToken L.Tk__tok_extends_13 = "'extends'"
 showRtkToken L.Tk__tok_enum_17 = "'enum'"
 showRtkToken L.Tk__tok_else_42 = "'else'"
 showRtkToken L.Tk__tok_double_27 = "'double'"
 showRtkToken L.Tk__tok_do_44 = "'do'"
 showRtkToken L.Tk__tok_default_30 = "'default'"
 showRtkToken L.Tk__tok_continue_39 = "'continue'"
-showRtkToken L.Tk__tok_class_13 = "'class'"
+showRtkToken L.Tk__tok_class_15 = "'class'"
 showRtkToken L.Tk__tok_char_22 = "'char'"
 showRtkToken L.Tk__tok_catch_47 = "'catch'"
 showRtkToken L.Tk__tok_case_51 = "'case'"
@@ -1354,6 +1419,7 @@ showRtkToken (L.Tk__qq_Modifier v) = "qq_Modifier " ++ show v
 showRtkToken (L.Tk__qq_TypeSpecifier v) = "qq_TypeSpecifier " ++ show v
 showRtkToken (L.Tk__qq_Type v) = "qq_Type " ++ show v
 showRtkToken (L.Tk__qq_TypeParameter v) = "qq_TypeParameter " ++ show v
+showRtkToken (L.Tk__qq_NonEmptyTypeParameters v) = "qq_NonEmptyTypeParameters " ++ show v
 showRtkToken (L.Tk__qq_TypeParameters v) = "qq_TypeParameters " ++ show v
 showRtkToken (L.Tk__qq_WildcardType v) = "qq_WildcardType " ++ show v
 showRtkToken (L.Tk__qq_TypeArgument v) = "qq_TypeArgument " ++ show v
@@ -1395,6 +1461,7 @@ showRtkToken (L.Tk__qq_Parameter v) = "qq_Parameter " ++ show v
 showRtkToken (L.Tk__qq_ParamModifierList v) = "qq_ParamModifierList " ++ show v
 showRtkToken (L.Tk__qq_ParameterList v) = "qq_ParameterList " ++ show v
 showRtkToken (L.Tk__qq_StaticInitializer v) = "qq_StaticInitializer " ++ show v
+showRtkToken (L.Tk__qq_ArrayInitializer v) = "qq_ArrayInitializer " ++ show v
 showRtkToken (L.Tk__qq_VariableInitializer v) = "qq_VariableInitializer " ++ show v
 showRtkToken (L.Tk__qq_VariableInitializerList v) = "qq_VariableInitializerList " ++ show v
 showRtkToken (L.Tk__qq_VariableDeclarator v) = "qq_VariableDeclarator " ++ show v
@@ -1428,6 +1495,8 @@ showRtkToken (L.Tk__qq_ExtendsList v) = "qq_ExtendsList " ++ show v
 showRtkToken (L.Tk__qq_ClassOrInterfaceType v) = "qq_ClassOrInterfaceType " ++ show v
 showRtkToken (L.Tk__qq_ModifierList v) = "qq_ModifierList " ++ show v
 showRtkToken (L.Tk__qq_AnnotationList v) = "qq_AnnotationList " ++ show v
+showRtkToken (L.Tk__qq_ElementValueArrayInitializer v) = "qq_ElementValueArrayInitializer " ++ show v
+showRtkToken (L.Tk__qq_ElementValue v) = "qq_ElementValue " ++ show v
 showRtkToken (L.Tk__qq_AnnotationElement v) = "qq_AnnotationElement " ++ show v
 showRtkToken (L.Tk__qq_AnnotationArguments v) = "qq_AnnotationArguments " ++ show v
 showRtkToken (L.Tk__qq_Annotation v) = "qq_Annotation " ++ show v
@@ -1436,8 +1505,10 @@ showRtkToken (L.Tk__qq_ImportHead v) = "qq_ImportHead " ++ show v
 showRtkToken (L.Tk__qq_ImportName v) = "qq_ImportName " ++ show v
 showRtkToken (L.Tk__qq_ImportStatement v) = "qq_ImportStatement " ++ show v
 showRtkToken (L.Tk__qq_Package v) = "qq_Package " ++ show v
+showRtkToken (L.Tk__qq_CompilationUnitRest v) = "qq_CompilationUnitRest " ++ show v
 showRtkToken (L.Tk__qq_CompilationUnit v) = "qq_CompilationUnit " ++ show v
 showRtkToken (L.Tk__qq_ImportList v) = "qq_ImportList " ++ show v
+showRtkToken (L.Tk__qq_TypeDeclarationList v) = "qq_TypeDeclarationList " ++ show v
 showRtkToken (L.Tk__qq_TypeDeclaration v) = "qq_TypeDeclaration " ++ show v
 showRtkToken (L.Tk__qq_OptDocComment v) = "qq_OptDocComment " ++ show v
 showRtkToken (L.Tk__qq_Java v) = "qq_Java " ++ show v
@@ -1514,6 +1585,9 @@ tkVal_qq_Type t = error ("rtk internal error: token qq_Type expected, got " ++ s
 tkVal_qq_TypeParameter :: L.PosToken -> String
 tkVal_qq_TypeParameter (L.PosToken _ (L.Tk__qq_TypeParameter v)) = v
 tkVal_qq_TypeParameter t = error ("rtk internal error: token qq_TypeParameter expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_NonEmptyTypeParameters :: L.PosToken -> String
+tkVal_qq_NonEmptyTypeParameters (L.PosToken _ (L.Tk__qq_NonEmptyTypeParameters v)) = v
+tkVal_qq_NonEmptyTypeParameters t = error ("rtk internal error: token qq_NonEmptyTypeParameters expected, got " ++ showRtkToken (L.ptToken t))
 tkVal_qq_TypeParameters :: L.PosToken -> String
 tkVal_qq_TypeParameters (L.PosToken _ (L.Tk__qq_TypeParameters v)) = v
 tkVal_qq_TypeParameters t = error ("rtk internal error: token qq_TypeParameters expected, got " ++ showRtkToken (L.ptToken t))
@@ -1637,6 +1711,9 @@ tkVal_qq_ParameterList t = error ("rtk internal error: token qq_ParameterList ex
 tkVal_qq_StaticInitializer :: L.PosToken -> String
 tkVal_qq_StaticInitializer (L.PosToken _ (L.Tk__qq_StaticInitializer v)) = v
 tkVal_qq_StaticInitializer t = error ("rtk internal error: token qq_StaticInitializer expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_ArrayInitializer :: L.PosToken -> String
+tkVal_qq_ArrayInitializer (L.PosToken _ (L.Tk__qq_ArrayInitializer v)) = v
+tkVal_qq_ArrayInitializer t = error ("rtk internal error: token qq_ArrayInitializer expected, got " ++ showRtkToken (L.ptToken t))
 tkVal_qq_VariableInitializer :: L.PosToken -> String
 tkVal_qq_VariableInitializer (L.PosToken _ (L.Tk__qq_VariableInitializer v)) = v
 tkVal_qq_VariableInitializer t = error ("rtk internal error: token qq_VariableInitializer expected, got " ++ showRtkToken (L.ptToken t))
@@ -1736,6 +1813,12 @@ tkVal_qq_ModifierList t = error ("rtk internal error: token qq_ModifierList expe
 tkVal_qq_AnnotationList :: L.PosToken -> String
 tkVal_qq_AnnotationList (L.PosToken _ (L.Tk__qq_AnnotationList v)) = v
 tkVal_qq_AnnotationList t = error ("rtk internal error: token qq_AnnotationList expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_ElementValueArrayInitializer :: L.PosToken -> String
+tkVal_qq_ElementValueArrayInitializer (L.PosToken _ (L.Tk__qq_ElementValueArrayInitializer v)) = v
+tkVal_qq_ElementValueArrayInitializer t = error ("rtk internal error: token qq_ElementValueArrayInitializer expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_ElementValue :: L.PosToken -> String
+tkVal_qq_ElementValue (L.PosToken _ (L.Tk__qq_ElementValue v)) = v
+tkVal_qq_ElementValue t = error ("rtk internal error: token qq_ElementValue expected, got " ++ showRtkToken (L.ptToken t))
 tkVal_qq_AnnotationElement :: L.PosToken -> String
 tkVal_qq_AnnotationElement (L.PosToken _ (L.Tk__qq_AnnotationElement v)) = v
 tkVal_qq_AnnotationElement t = error ("rtk internal error: token qq_AnnotationElement expected, got " ++ showRtkToken (L.ptToken t))
@@ -1760,12 +1843,18 @@ tkVal_qq_ImportStatement t = error ("rtk internal error: token qq_ImportStatemen
 tkVal_qq_Package :: L.PosToken -> String
 tkVal_qq_Package (L.PosToken _ (L.Tk__qq_Package v)) = v
 tkVal_qq_Package t = error ("rtk internal error: token qq_Package expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_CompilationUnitRest :: L.PosToken -> String
+tkVal_qq_CompilationUnitRest (L.PosToken _ (L.Tk__qq_CompilationUnitRest v)) = v
+tkVal_qq_CompilationUnitRest t = error ("rtk internal error: token qq_CompilationUnitRest expected, got " ++ showRtkToken (L.ptToken t))
 tkVal_qq_CompilationUnit :: L.PosToken -> String
 tkVal_qq_CompilationUnit (L.PosToken _ (L.Tk__qq_CompilationUnit v)) = v
 tkVal_qq_CompilationUnit t = error ("rtk internal error: token qq_CompilationUnit expected, got " ++ showRtkToken (L.ptToken t))
 tkVal_qq_ImportList :: L.PosToken -> String
 tkVal_qq_ImportList (L.PosToken _ (L.Tk__qq_ImportList v)) = v
 tkVal_qq_ImportList t = error ("rtk internal error: token qq_ImportList expected, got " ++ showRtkToken (L.ptToken t))
+tkVal_qq_TypeDeclarationList :: L.PosToken -> String
+tkVal_qq_TypeDeclarationList (L.PosToken _ (L.Tk__qq_TypeDeclarationList v)) = v
+tkVal_qq_TypeDeclarationList t = error ("rtk internal error: token qq_TypeDeclarationList expected, got " ++ showRtkToken (L.ptToken t))
 tkVal_qq_TypeDeclaration :: L.PosToken -> String
 tkVal_qq_TypeDeclaration (L.PosToken _ (L.Tk__qq_TypeDeclaration v)) = v
 tkVal_qq_TypeDeclaration t = error ("rtk internal error: token qq_TypeDeclaration expected, got " ++ showRtkToken (L.ptToken t))
@@ -1786,91 +1875,97 @@ data Java = Ctr__Java__0 RtkPos Java |
             Ctr__Java__7 RtkPos AnnotationTypeElement |
             Ctr__Java__8 RtkPos AnnotationTypeElementList |
             Ctr__Java__9 RtkPos Arglist |
-            Ctr__Java__10 RtkPos AssignmentOp |
-            Ctr__Java__11 RtkPos CatchList |
-            Ctr__Java__12 RtkPos CatchParameter |
-            Ctr__Java__13 RtkPos ClassDeclaration |
-            Ctr__Java__14 RtkPos ClassOrInterfaceType |
-            Ctr__Java__15 RtkPos CompilationUnit |
-            Ctr__Java__16 RtkPos CompoundName |
-            Ctr__Java__17 RtkPos CompoundNameTail |
-            Ctr__Java__18 RtkPos CreationExpression |
-            Ctr__Java__19 RtkPos DimExprs |
-            Ctr__Java__20 RtkPos Dims |
-            Ctr__Java__21 RtkPos DoStatement |
-            Ctr__Java__22 RtkPos DocComment |
-            Ctr__Java__23 RtkPos EnumConstant |
-            Ctr__Java__24 RtkPos EnumConstantList |
-            Ctr__Java__25 RtkPos EnumDeclaration |
-            Ctr__Java__26 RtkPos EqualityOp |
-            Ctr__Java__27 RtkPos Expression |
-            Ctr__Java__28 RtkPos ExtendsList |
-            Ctr__Java__29 RtkPos FieldDeclaration |
-            Ctr__Java__30 RtkPos FieldDeclarationList |
-            Ctr__Java__31 RtkPos ForEachHeader |
-            Ctr__Java__32 RtkPos ForStatement |
-            Ctr__Java__33 RtkPos IfStatement |
-            Ctr__Java__34 RtkPos ImplementsList |
-            Ctr__Java__35 RtkPos ImportHead |
-            Ctr__Java__36 RtkPos ImportList |
-            Ctr__Java__37 RtkPos ImportName |
-            Ctr__Java__38 RtkPos ImportStatement |
-            Ctr__Java__39 RtkPos InterfaceDeclaration |
-            Ctr__Java__40 RtkPos LambdaBody |
-            Ctr__Java__41 RtkPos Literal |
-            Ctr__Java__42 RtkPos LocalModifierList1 |
-            Ctr__Java__43 RtkPos MemberAfterFirstId |
-            Ctr__Java__44 RtkPos MemberDeclaration |
-            Ctr__Java__45 RtkPos MemberRest |
-            Ctr__Java__46 RtkPos Modifier |
-            Ctr__Java__47 RtkPos ModifierList |
-            Ctr__Java__48 RtkPos MoreTypeSpecifier |
-            Ctr__Java__49 RtkPos MoreVariableDeclarators |
-            Ctr__Java__50 RtkPos MultiplicativeOp |
-            Ctr__Java__51 RtkPos NonEmptyDims |
-            Ctr__Java__52 RtkPos NonEmptyTypeArguments |
-            Ctr__Java__53 RtkPos OptDocComment |
-            Ctr__Java__54 RtkPos OptElsePart |
-            Ctr__Java__55 RtkPos OptExpression |
-            Ctr__Java__56 RtkPos OptFinally |
-            Ctr__Java__57 RtkPos OptId |
-            Ctr__Java__58 RtkPos OptVariableInitializer |
-            Ctr__Java__59 RtkPos Package |
-            Ctr__Java__60 RtkPos ParamModifierList |
-            Ctr__Java__61 RtkPos Parameter |
-            Ctr__Java__62 RtkPos ParameterList |
-            Ctr__Java__63 RtkPos PostfixOp |
-            Ctr__Java__64 RtkPos PrefixOp |
-            Ctr__Java__65 RtkPos PrimitiveTypeKeyword |
-            Ctr__Java__66 RtkPos RelationalOp |
-            Ctr__Java__67 RtkPos Resource |
-            Ctr__Java__68 RtkPos ResourceSpec |
-            Ctr__Java__69 RtkPos ShiftOp |
-            Ctr__Java__70 RtkPos Statement |
-            Ctr__Java__71 RtkPos StatementBlock |
-            Ctr__Java__72 RtkPos StatementList |
-            Ctr__Java__73 RtkPos StaticInitializer |
-            Ctr__Java__74 RtkPos SwitchCaseList |
-            Ctr__Java__75 RtkPos SwitchStatement |
-            Ctr__Java__76 RtkPos ThrowsClause |
-            Ctr__Java__77 RtkPos TryStatement |
-            Ctr__Java__78 RtkPos Type |
-            Ctr__Java__79 RtkPos TypeArgument |
-            Ctr__Java__80 RtkPos TypeArguments |
-            Ctr__Java__81 RtkPos TypeDeclRest |
-            Ctr__Java__82 RtkPos TypeDeclaration |
-            Ctr__Java__83 RtkPos TypeParameter |
-            Ctr__Java__84 RtkPos TypeParameters |
-            Ctr__Java__85 RtkPos TypeSpecifier |
-            Ctr__Java__86 RtkPos VariableDeclaration |
-            Ctr__Java__87 RtkPos VariableDeclarator |
-            Ctr__Java__88 RtkPos VariableDeclaratorList |
-            Ctr__Java__89 RtkPos VariableInitializer |
-            Ctr__Java__90 RtkPos VariableInitializerList |
-            Ctr__Java__91 RtkPos WhileStatement |
-            Ctr__Java__92 RtkPos WildcardType |
+            Ctr__Java__10 RtkPos ArrayInitializer |
+            Ctr__Java__11 RtkPos AssignmentOp |
+            Ctr__Java__12 RtkPos CatchList |
+            Ctr__Java__13 RtkPos CatchParameter |
+            Ctr__Java__14 RtkPos ClassDeclaration |
+            Ctr__Java__15 RtkPos ClassOrInterfaceType |
+            Ctr__Java__16 RtkPos CompilationUnit |
+            Ctr__Java__17 RtkPos CompilationUnitRest |
+            Ctr__Java__18 RtkPos CompoundName |
+            Ctr__Java__19 RtkPos CompoundNameTail |
+            Ctr__Java__20 RtkPos CreationExpression |
+            Ctr__Java__21 RtkPos DimExprs |
+            Ctr__Java__22 RtkPos Dims |
+            Ctr__Java__23 RtkPos DoStatement |
+            Ctr__Java__24 RtkPos DocComment |
+            Ctr__Java__25 RtkPos ElementValue |
+            Ctr__Java__26 RtkPos ElementValueArrayInitializer |
+            Ctr__Java__27 RtkPos EnumConstant |
+            Ctr__Java__28 RtkPos EnumConstantList |
+            Ctr__Java__29 RtkPos EnumDeclaration |
+            Ctr__Java__30 RtkPos EqualityOp |
+            Ctr__Java__31 RtkPos Expression |
+            Ctr__Java__32 RtkPos ExtendsList |
+            Ctr__Java__33 RtkPos FieldDeclaration |
+            Ctr__Java__34 RtkPos FieldDeclarationList |
+            Ctr__Java__35 RtkPos ForEachHeader |
+            Ctr__Java__36 RtkPos ForStatement |
+            Ctr__Java__37 RtkPos IfStatement |
+            Ctr__Java__38 RtkPos ImplementsList |
+            Ctr__Java__39 RtkPos ImportHead |
+            Ctr__Java__40 RtkPos ImportList |
+            Ctr__Java__41 RtkPos ImportName |
+            Ctr__Java__42 RtkPos ImportStatement |
+            Ctr__Java__43 RtkPos InterfaceDeclaration |
+            Ctr__Java__44 RtkPos LambdaBody |
+            Ctr__Java__45 RtkPos Literal |
+            Ctr__Java__46 RtkPos LocalModifierList1 |
+            Ctr__Java__47 RtkPos MemberAfterFirstId |
+            Ctr__Java__48 RtkPos MemberDeclaration |
+            Ctr__Java__49 RtkPos MemberRest |
+            Ctr__Java__50 RtkPos Modifier |
+            Ctr__Java__51 RtkPos ModifierList |
+            Ctr__Java__52 RtkPos MoreTypeSpecifier |
+            Ctr__Java__53 RtkPos MoreVariableDeclarators |
+            Ctr__Java__54 RtkPos MultiplicativeOp |
+            Ctr__Java__55 RtkPos NonEmptyDims |
+            Ctr__Java__56 RtkPos NonEmptyTypeArguments |
+            Ctr__Java__57 RtkPos NonEmptyTypeParameters |
+            Ctr__Java__58 RtkPos OptDocComment |
+            Ctr__Java__59 RtkPos OptElsePart |
+            Ctr__Java__60 RtkPos OptExpression |
+            Ctr__Java__61 RtkPos OptFinally |
+            Ctr__Java__62 RtkPos OptId |
+            Ctr__Java__63 RtkPos OptVariableInitializer |
+            Ctr__Java__64 RtkPos Package |
+            Ctr__Java__65 RtkPos ParamModifierList |
+            Ctr__Java__66 RtkPos Parameter |
+            Ctr__Java__67 RtkPos ParameterList |
+            Ctr__Java__68 RtkPos PostfixOp |
+            Ctr__Java__69 RtkPos PrefixOp |
+            Ctr__Java__70 RtkPos PrimitiveTypeKeyword |
+            Ctr__Java__71 RtkPos RelationalOp |
+            Ctr__Java__72 RtkPos Resource |
+            Ctr__Java__73 RtkPos ResourceSpec |
+            Ctr__Java__74 RtkPos ShiftOp |
+            Ctr__Java__75 RtkPos Statement |
+            Ctr__Java__76 RtkPos StatementBlock |
+            Ctr__Java__77 RtkPos StatementList |
+            Ctr__Java__78 RtkPos StaticInitializer |
+            Ctr__Java__79 RtkPos SwitchCaseList |
+            Ctr__Java__80 RtkPos SwitchStatement |
+            Ctr__Java__81 RtkPos ThrowsClause |
+            Ctr__Java__82 RtkPos TryStatement |
+            Ctr__Java__83 RtkPos Type |
+            Ctr__Java__84 RtkPos TypeArgument |
+            Ctr__Java__85 RtkPos TypeArguments |
+            Ctr__Java__86 RtkPos TypeDeclRest |
+            Ctr__Java__87 RtkPos TypeDeclaration |
+            Ctr__Java__88 RtkPos TypeDeclarationList |
+            Ctr__Java__89 RtkPos TypeParameter |
+            Ctr__Java__90 RtkPos TypeParameters |
+            Ctr__Java__91 RtkPos TypeSpecifier |
+            Ctr__Java__92 RtkPos VariableDeclaration |
+            Ctr__Java__93 RtkPos VariableDeclarator |
+            Ctr__Java__94 RtkPos VariableDeclaratorList |
+            Ctr__Java__95 RtkPos VariableInitializer |
+            Ctr__Java__96 RtkPos VariableInitializerList |
+            Ctr__Java__97 RtkPos WhileStatement |
+            Ctr__Java__98 RtkPos WildcardType |
             Anti_Java String |
-            Ctr__Java__93 RtkPos CompilationUnit
+            Ctr__Java__99 RtkPos CompilationUnit
             deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Java where
     rtkPosOf (Ctr__Java__0 p _) = p
@@ -1966,8 +2061,14 @@ instance RtkPosOf Java where
     rtkPosOf (Ctr__Java__90 p _) = p
     rtkPosOf (Ctr__Java__91 p _) = p
     rtkPosOf (Ctr__Java__92 p _) = p
-    rtkPosOf (Anti_Java _) = rtkNoPos
     rtkPosOf (Ctr__Java__93 p _) = p
+    rtkPosOf (Ctr__Java__94 p _) = p
+    rtkPosOf (Ctr__Java__95 p _) = p
+    rtkPosOf (Ctr__Java__96 p _) = p
+    rtkPosOf (Ctr__Java__97 p _) = p
+    rtkPosOf (Ctr__Java__98 p _) = p
+    rtkPosOf (Anti_Java _) = rtkNoPos
+    rtkPosOf (Ctr__Java__99 p _) = p
 data AdditiveOp = Anti_AdditiveOp String |
                   Ctr__AdditiveOp__0 RtkPos |
                   Ctr__AdditiveOp__1 RtkPos
@@ -1995,8 +2096,8 @@ instance RtkPosOf AnnotationDeclaration where
     rtkPosOf (Anti_AnnotationDeclaration _) = rtkNoPos
     rtkPosOf (Ctr__AnnotationDeclaration__0 p _ _) = p
 data AnnotationElement = Anti_AnnotationElement String |
-                         Ctr__AnnotationElement__0 RtkPos String Expression |
-                         Ctr__AnnotationElement__1 RtkPos Expression
+                         Ctr__AnnotationElement__0 RtkPos String ElementValue |
+                         Ctr__AnnotationElement__1 RtkPos ElementValue
                          deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf AnnotationElement where
     rtkPosOf (Anti_AnnotationElement _) = rtkNoPos
@@ -2012,12 +2113,18 @@ instance RtkPosOf AnnotationTypeElement where
 type AnnotationTypeElementList = [AnnotationTypeElement]
 data Arglist = Anti_Arglist String |
                Ctr__Arglist__0 RtkPos |
-               Ctr__Arglist__1 RtkPos Rule_88
+               Ctr__Arglist__1 RtkPos Rule_95
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Arglist where
     rtkPosOf (Anti_Arglist _) = rtkNoPos
     rtkPosOf (Ctr__Arglist__0 p) = p
     rtkPosOf (Ctr__Arglist__1 p _) = p
+data ArrayInitializer = Anti_ArrayInitializer String |
+                        Ctr__ArrayInitializer__0 RtkPos VariableInitializerList
+                        deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf ArrayInitializer where
+    rtkPosOf (Anti_ArrayInitializer _) = rtkNoPos
+    rtkPosOf (Ctr__ArrayInitializer__0 p _) = p
 data AssignmentOp = Anti_AssignmentOp String |
                     Ctr__AssignmentOp__0 RtkPos |
                     Ctr__AssignmentOp__1 RtkPos |
@@ -2046,15 +2153,15 @@ instance RtkPosOf AssignmentOp where
     rtkPosOf (Ctr__AssignmentOp__9 p) = p
     rtkPosOf (Ctr__AssignmentOp__10 p) = p
     rtkPosOf (Ctr__AssignmentOp__11 p) = p
-type CatchList = [Rule_65]
+type CatchList = [Rule_70]
 data CatchParameter = Anti_CatchParameter String |
-                      Ctr__CatchParameter__0 RtkPos ParamModifierList Type Rule_67 String
+                      Ctr__CatchParameter__0 RtkPos ParamModifierList Type Rule_72 String
                       deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf CatchParameter where
     rtkPosOf (Anti_CatchParameter _) = rtkNoPos
     rtkPosOf (Ctr__CatchParameter__0 p _ _ _ _) = p
 data ClassDeclaration = Anti_ClassDeclaration String |
-                        Ctr__ClassDeclaration__0 RtkPos String TypeParameters Rule_16 Rule_17 FieldDeclarationList
+                        Ctr__ClassDeclaration__0 RtkPos String TypeParameters Rule_21 Rule_22 FieldDeclarationList
                         deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf ClassDeclaration where
     rtkPosOf (Anti_ClassDeclaration _) = rtkNoPos
@@ -2066,26 +2173,36 @@ instance RtkPosOf ClassOrInterfaceType where
     rtkPosOf (Anti_ClassOrInterfaceType _) = rtkNoPos
     rtkPosOf (Ctr__ClassOrInterfaceType__0 p _ _) = p
 data CompilationUnit = Anti_CompilationUnit String |
-                       Ctr__CompilationUnit__0 RtkPos Rule_1 ImportList Rule_2
+                       Ctr__CompilationUnit__0 RtkPos OptDocComment ModifierList Rule_2
                        deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf CompilationUnit where
     rtkPosOf (Anti_CompilationUnit _) = rtkNoPos
     rtkPosOf (Ctr__CompilationUnit__0 p _ _ _) = p
+data CompilationUnitRest = Anti_CompilationUnitRest String |
+                           UnitPackageFirst RtkPos Package ImportList TypeDeclarationList |
+                           UnitImportsFirst RtkPos ImportStatement ImportList TypeDeclarationList |
+                           UnitTypeFirst RtkPos TypeDeclRest TypeDeclarationList
+                           deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf CompilationUnitRest where
+    rtkPosOf (Anti_CompilationUnitRest _) = rtkNoPos
+    rtkPosOf (UnitPackageFirst p _ _ _) = p
+    rtkPosOf (UnitImportsFirst p _ _ _) = p
+    rtkPosOf (UnitTypeFirst p _ _) = p
 data CompoundName = Anti_CompoundName String |
                     Ctr__CompoundName__0 RtkPos String CompoundNameTail
                     deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf CompoundName where
     rtkPosOf (Anti_CompoundName _) = rtkNoPos
     rtkPosOf (Ctr__CompoundName__0 p _ _) = p
-type CompoundNameTail = [Rule_100]
+type CompoundNameTail = [Rule_106]
 data CreationExpression = Anti_CreationExpression String |
-                          Ctr__CreationExpression__0 RtkPos TypeSpecifier Rule_84
+                          Ctr__CreationExpression__0 RtkPos TypeSpecifier Rule_89
                           deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf CreationExpression where
     rtkPosOf (Anti_CreationExpression _) = rtkNoPos
     rtkPosOf (Ctr__CreationExpression__0 p _ _) = p
-type DimExprs = [Rule_86]
-type Dims = [Rule_31]
+type DimExprs = [Rule_93]
+type Dims = [Rule_36]
 data DoStatement = Anti_DoStatement String |
                    Ctr__DoStatement__0 RtkPos Statement Expression
                    deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
@@ -2098,20 +2215,36 @@ data DocComment = Anti_DocComment String |
 instance RtkPosOf DocComment where
     rtkPosOf (Anti_DocComment _) = rtkNoPos
     rtkPosOf (Ctr__DocComment__0 p _) = p
+data ElementValue = Anti_ElementValue String |
+                    Ctr__ElementValue__0 RtkPos Expression |
+                    Ctr__ElementValue__1 RtkPos Annotation |
+                    Ctr__ElementValue__2 RtkPos ElementValueArrayInitializer
+                    deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf ElementValue where
+    rtkPosOf (Anti_ElementValue _) = rtkNoPos
+    rtkPosOf (Ctr__ElementValue__0 p _) = p
+    rtkPosOf (Ctr__ElementValue__1 p _) = p
+    rtkPosOf (Ctr__ElementValue__2 p _) = p
+data ElementValueArrayInitializer = Anti_ElementValueArrayInitializer String |
+                                    Ctr__ElementValueArrayInitializer__0 RtkPos Rule_9
+                                    deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf ElementValueArrayInitializer where
+    rtkPosOf (Anti_ElementValueArrayInitializer _) = rtkNoPos
+    rtkPosOf (Ctr__ElementValueArrayInitializer__0 p _) = p
 data EnumConstant = Anti_EnumConstant String |
-                    Ctr__EnumConstant__0 RtkPos AnnotationList String Rule_20 Rule_22
+                    Ctr__EnumConstant__0 RtkPos OptDocComment AnnotationList String Rule_25 Rule_27
                     deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf EnumConstant where
     rtkPosOf (Anti_EnumConstant _) = rtkNoPos
-    rtkPosOf (Ctr__EnumConstant__0 p _ _ _ _) = p
+    rtkPosOf (Ctr__EnumConstant__0 p _ _ _ _ _) = p
 data EnumConstantList = Anti_EnumConstantList String |
-                        Ctr__EnumConstantList__0 RtkPos EnumConstant Rule_24 Rule_26
+                        Ctr__EnumConstantList__0 RtkPos EnumConstant Rule_29 Rule_31
                         deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf EnumConstantList where
     rtkPosOf (Anti_EnumConstantList _) = rtkNoPos
     rtkPosOf (Ctr__EnumConstantList__0 p _ _ _) = p
 data EnumDeclaration = Anti_EnumDeclaration String |
-                       Ctr__EnumDeclaration__0 RtkPos String Rule_27 EnumConstantList Rule_28
+                       Ctr__EnumDeclaration__0 RtkPos String Rule_32 EnumConstantList Rule_33
                        deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf EnumDeclaration where
     rtkPosOf (Anti_EnumDeclaration _) = rtkNoPos
@@ -2129,9 +2262,9 @@ data Expression = Anti_Expression String |
                   Ctr__Expression__1 RtkPos |
                   Ctr__Expression__2 RtkPos Expression |
                   Ctr__Expression__3 RtkPos CreationExpression |
-                  Ctr__Expression__4 RtkPos CompoundName Rule_80 |
+                  Ctr__Expression__4 RtkPos CompoundName Rule_85 |
                   Ctr__Expression__5 RtkPos CompoundName Expression |
-                  Ctr__Expression__6 RtkPos String Rule_82 |
+                  Ctr__Expression__6 RtkPos String Rule_87 |
                   Ctr__Expression__7 RtkPos String CompoundNameTail |
                   Ctr__Expression__8 RtkPos String CompoundNameTail |
                   Ctr__Expression__9 RtkPos String CompoundNameTail NonEmptyTypeArguments String Arglist |
@@ -2177,10 +2310,10 @@ data Expression = Anti_Expression String |
                   Ctr__Expression__49 RtkPos Expression Expression |
                   Ctr__Expression__50 RtkPos Expression |
                   Ctr__Expression__51 RtkPos Expression Expression Expression |
-                  Ctr__Expression__52 RtkPos Expression Rule_76 |
+                  Ctr__Expression__52 RtkPos Expression Rule_81 |
                   Ctr__Expression__53 RtkPos String LambdaBody |
                   Ctr__Expression__54 RtkPos LambdaBody |
-                  Ctr__Expression__55 RtkPos String Rule_78 LambdaBody |
+                  Ctr__Expression__55 RtkPos String Rule_83 LambdaBody |
                   Ctr__Expression__56 RtkPos Expression LambdaBody |
                   Ctr__Expression__57 RtkPos Expression
                   deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
@@ -2245,13 +2378,13 @@ instance RtkPosOf Expression where
     rtkPosOf (Ctr__Expression__56 p _ _) = p
     rtkPosOf (Ctr__Expression__57 p _) = p
 data ExtendsList = Anti_ExtendsList String |
-                   Ctr__ExtendsList__0 RtkPos ClassOrInterfaceType Rule_12
+                   Ctr__ExtendsList__0 RtkPos ClassOrInterfaceType Rule_17
                    deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf ExtendsList where
     rtkPosOf (Anti_ExtendsList _) = rtkNoPos
     rtkPosOf (Ctr__ExtendsList__0 p _ _) = p
 data FieldDeclaration = Anti_FieldDeclaration String |
-                        Ctr__FieldDeclaration__0 RtkPos OptDocComment ModifierList Rule_30 |
+                        Ctr__FieldDeclaration__0 RtkPos OptDocComment ModifierList Rule_35 |
                         Ctr__FieldDeclaration__1 RtkPos
                         deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf FieldDeclaration where
@@ -2268,7 +2401,7 @@ instance RtkPosOf ForEachHeader where
     rtkPosOf (Ctr__ForEachHeader__0 p _ _ _) = p
     rtkPosOf (Ctr__ForEachHeader__1 p _ _ _ _) = p
 data ForStatement = Anti_ForStatement String |
-                    Ctr__ForStatement__0 RtkPos Rule_64 OptExpression OptExpression Statement |
+                    Ctr__ForStatement__0 RtkPos Rule_69 OptExpression OptExpression Statement |
                     Ctr__ForStatement__1 RtkPos ForEachHeader Statement
                     deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf ForStatement where
@@ -2282,7 +2415,7 @@ instance RtkPosOf IfStatement where
     rtkPosOf (Anti_IfStatement _) = rtkNoPos
     rtkPosOf (Ctr__IfStatement__0 p _ _ _) = p
 data ImplementsList = Anti_ImplementsList String |
-                      Ctr__ImplementsList__0 RtkPos Rule_14
+                      Ctr__ImplementsList__0 RtkPos Rule_19
                       deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf ImplementsList where
     rtkPosOf (Anti_ImplementsList _) = rtkNoPos
@@ -2311,7 +2444,7 @@ instance RtkPosOf ImportStatement where
     rtkPosOf (Anti_ImportStatement _) = rtkNoPos
     rtkPosOf (Ctr__ImportStatement__0 p _ _) = p
 data InterfaceDeclaration = Anti_InterfaceDeclaration String |
-                            Ctr__InterfaceDeclaration__0 RtkPos String TypeParameters Rule_18 FieldDeclarationList
+                            Ctr__InterfaceDeclaration__0 RtkPos String TypeParameters Rule_23 FieldDeclarationList
                             deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf InterfaceDeclaration where
     rtkPosOf (Anti_InterfaceDeclaration _) = rtkNoPos
@@ -2342,9 +2475,9 @@ instance RtkPosOf Literal where
     rtkPosOf (Ctr__Literal__4 p _) = p
     rtkPosOf (Ctr__Literal__5 p _) = p
     rtkPosOf (Ctr__Literal__6 p) = p
-type LocalModifierList1 = [Rule_48]
+type LocalModifierList1 = [Rule_53]
 data MemberAfterFirstId = Anti_MemberAfterFirstId String |
-                          Ctr__MemberAfterFirstId__0 RtkPos Rule_35 Rule_36 StatementBlock |
+                          Ctr__MemberAfterFirstId__0 RtkPos Rule_40 Rule_41 StatementBlock |
                           Ctr__MemberAfterFirstId__1 RtkPos MoreTypeSpecifier String MemberRest
                           deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf MemberAfterFirstId where
@@ -2354,15 +2487,17 @@ instance RtkPosOf MemberAfterFirstId where
 data MemberDeclaration = Anti_MemberDeclaration String |
                          Ctr__MemberDeclaration__0 RtkPos PrimitiveTypeKeyword Dims String MemberRest |
                          Ctr__MemberDeclaration__1 RtkPos TypeParameters String MoreTypeSpecifier String MemberRest |
-                         Ctr__MemberDeclaration__2 RtkPos String MemberAfterFirstId
+                         Ctr__MemberDeclaration__2 RtkPos NonEmptyTypeParameters PrimitiveTypeKeyword Dims String MemberRest |
+                         Ctr__MemberDeclaration__3 RtkPos String MemberAfterFirstId
                          deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf MemberDeclaration where
     rtkPosOf (Anti_MemberDeclaration _) = rtkNoPos
     rtkPosOf (Ctr__MemberDeclaration__0 p _ _ _ _) = p
     rtkPosOf (Ctr__MemberDeclaration__1 p _ _ _ _ _) = p
-    rtkPosOf (Ctr__MemberDeclaration__2 p _ _) = p
+    rtkPosOf (Ctr__MemberDeclaration__2 p _ _ _ _ _) = p
+    rtkPosOf (Ctr__MemberDeclaration__3 p _ _) = p
 data MemberRest = Anti_MemberRest String |
-                  Ctr__MemberRest__0 RtkPos Rule_39 Dims Rule_40 Rule_41 |
+                  Ctr__MemberRest__0 RtkPos Rule_44 Dims Rule_45 Rule_46 |
                   Ctr__MemberRest__1 RtkPos Dims OptVariableInitializer MoreVariableDeclarators
                   deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf MemberRest where
@@ -2379,7 +2514,8 @@ data Modifier = Anti_Modifier String |
                 Ctr__Modifier__6 RtkPos |
                 Ctr__Modifier__7 RtkPos |
                 Ctr__Modifier__8 RtkPos |
-                Ctr__Modifier__9 RtkPos
+                Ctr__Modifier__9 RtkPos |
+                Ctr__Modifier__10 RtkPos
                 deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Modifier where
     rtkPosOf (Anti_Modifier _) = rtkNoPos
@@ -2393,7 +2529,8 @@ instance RtkPosOf Modifier where
     rtkPosOf (Ctr__Modifier__7 p) = p
     rtkPosOf (Ctr__Modifier__8 p) = p
     rtkPosOf (Ctr__Modifier__9 p) = p
-type ModifierList = [Rule_10]
+    rtkPosOf (Ctr__Modifier__10 p) = p
+type ModifierList = [Rule_15]
 data MoreTypeSpecifier = Anti_MoreTypeSpecifier String |
                          Ctr__MoreTypeSpecifier__0 RtkPos String MoreTypeSpecifier |
                          Ctr__MoreTypeSpecifier__1 RtkPos TypeArguments Dims
@@ -2402,7 +2539,7 @@ instance RtkPosOf MoreTypeSpecifier where
     rtkPosOf (Anti_MoreTypeSpecifier _) = rtkNoPos
     rtkPosOf (Ctr__MoreTypeSpecifier__0 p _ _) = p
     rtkPosOf (Ctr__MoreTypeSpecifier__1 p _ _) = p
-type MoreVariableDeclarators = [Rule_44]
+type MoreVariableDeclarators = [Rule_49]
 data MultiplicativeOp = Anti_MultiplicativeOp String |
                         Ctr__MultiplicativeOp__0 RtkPos |
                         Ctr__MultiplicativeOp__1 RtkPos |
@@ -2413,15 +2550,21 @@ instance RtkPosOf MultiplicativeOp where
     rtkPosOf (Ctr__MultiplicativeOp__0 p) = p
     rtkPosOf (Ctr__MultiplicativeOp__1 p) = p
     rtkPosOf (Ctr__MultiplicativeOp__2 p) = p
-type NonEmptyDims = [Rule_33]
+type NonEmptyDims = [Rule_38]
 data NonEmptyTypeArguments = Anti_NonEmptyTypeArguments String |
-                             Ctr__NonEmptyTypeArguments__0 RtkPos TypeArgument Rule_91 |
+                             Ctr__NonEmptyTypeArguments__0 RtkPos TypeArgument Rule_98 |
                              Ctr__NonEmptyTypeArguments__1 RtkPos
                              deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf NonEmptyTypeArguments where
     rtkPosOf (Anti_NonEmptyTypeArguments _) = rtkNoPos
     rtkPosOf (Ctr__NonEmptyTypeArguments__0 p _ _) = p
     rtkPosOf (Ctr__NonEmptyTypeArguments__1 p) = p
+data NonEmptyTypeParameters = Anti_NonEmptyTypeParameters String |
+                              Ctr__NonEmptyTypeParameters__0 RtkPos TypeParameter Rule_100
+                              deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf NonEmptyTypeParameters where
+    rtkPosOf (Anti_NonEmptyTypeParameters _) = rtkNoPos
+    rtkPosOf (Ctr__NonEmptyTypeParameters__0 p _ _) = p
 data OptDocComment = Anti_OptDocComment String |
                      Ctr__OptDocComment__0 RtkPos |
                      Ctr__OptDocComment__1 RtkPos DocComment
@@ -2432,7 +2575,7 @@ instance RtkPosOf OptDocComment where
     rtkPosOf (Ctr__OptDocComment__1 p _) = p
 data OptElsePart = Anti_OptElsePart String |
                    Ctr__OptElsePart__0 RtkPos |
-                   Ctr__OptElsePart__1 RtkPos Rule_63
+                   Ctr__OptElsePart__1 RtkPos Rule_68
                    deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf OptElsePart where
     rtkPosOf (Anti_OptElsePart _) = rtkNoPos
@@ -2448,7 +2591,7 @@ instance RtkPosOf OptExpression where
     rtkPosOf (Ctr__OptExpression__1 p _) = p
 data OptFinally = Anti_OptFinally String |
                   Ctr__OptFinally__0 RtkPos |
-                  Ctr__OptFinally__1 RtkPos Rule_69
+                  Ctr__OptFinally__1 RtkPos Rule_74
                   deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf OptFinally where
     rtkPosOf (Anti_OptFinally _) = rtkNoPos
@@ -2464,7 +2607,7 @@ instance RtkPosOf OptId where
     rtkPosOf (Ctr__OptId__1 p _) = p
 data OptVariableInitializer = Anti_OptVariableInitializer String |
                               Ctr__OptVariableInitializer__0 RtkPos |
-                              Ctr__OptVariableInitializer__1 RtkPos Rule_50
+                              Ctr__OptVariableInitializer__1 RtkPos Rule_55
                               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf OptVariableInitializer where
     rtkPosOf (Anti_OptVariableInitializer _) = rtkNoPos
@@ -2476,15 +2619,15 @@ data Package = Anti_Package String |
 instance RtkPosOf Package where
     rtkPosOf (Anti_Package _) = rtkNoPos
     rtkPosOf (Ctr__Package__0 p _) = p
-type ParamModifierList = [Rule_57]
+type ParamModifierList = [Rule_62]
 data Parameter = Anti_Parameter String |
-                 Ctr__Parameter__0 RtkPos ParamModifierList Type Rule_59 String Dims
+                 Ctr__Parameter__0 RtkPos ParamModifierList Type Rule_64 String Dims
                  deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Parameter where
     rtkPosOf (Anti_Parameter _) = rtkNoPos
     rtkPosOf (Ctr__Parameter__0 p _ _ _ _ _) = p
 data ParameterList = Anti_ParameterList String |
-                     Ctr__ParameterList__0 RtkPos Parameter Rule_55
+                     Ctr__ParameterList__0 RtkPos Parameter Rule_60
                      deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf ParameterList where
     rtkPosOf (Anti_ParameterList _) = rtkNoPos
@@ -2550,157 +2693,163 @@ instance RtkPosOf Resource where
     rtkPosOf (Anti_Resource _) = rtkNoPos
     rtkPosOf (Ctr__Resource__0 p _ _ _ _) = p
 data ResourceSpec = Anti_ResourceSpec String |
-                    Ctr__ResourceSpec__0 RtkPos Resource Rule_71 Rule_73
+                    Ctr__ResourceSpec__0 RtkPos Resource Rule_76 Rule_78
                     deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf ResourceSpec where
     rtkPosOf (Anti_ResourceSpec _) = rtkNoPos
     rtkPosOf (Ctr__ResourceSpec__0 p _ _ _) = p
-data Rule_1 = Ctr__Rule_1__0 RtkPos |
-              Ctr__Rule_1__1 RtkPos Package
-              deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-instance RtkPosOf Rule_1 where
-    rtkPosOf (Ctr__Rule_1__0 p) = p
-    rtkPosOf (Ctr__Rule_1__1 p _) = p
-data Rule_10 = Anti_Rule_10 String |
-               Ctr__Rule_10__1 RtkPos Modifier |
-               Ctr__Rule_10__2 RtkPos Annotation
+data Rule_10 = Ctr__Rule_10__0 RtkPos ElementValue Rule_11 Rule_13
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_10 where
-    rtkPosOf (Anti_Rule_10 _) = rtkNoPos
-    rtkPosOf (Ctr__Rule_10__1 p _) = p
-    rtkPosOf (Ctr__Rule_10__2 p _) = p
-data Rule_100 = Anti_Rule_100 String |
-                Ctr__Rule_100__1 RtkPos String
+    rtkPosOf (Ctr__Rule_10__0 p _ _ _) = p
+type Rule_100 = [Rule_101]
+data Rule_101 = Ctr__Rule_101__0 RtkPos TypeParameter
                 deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-instance RtkPosOf Rule_100 where
-    rtkPosOf (Anti_Rule_100 _) = rtkNoPos
-    rtkPosOf (Ctr__Rule_100__1 p _) = p
-type Rule_12 = [Rule_13]
-data Rule_13 = Ctr__Rule_13__0 RtkPos ClassOrInterfaceType
+instance RtkPosOf Rule_101 where
+    rtkPosOf (Ctr__Rule_101__0 p _) = p
+data Rule_102 = Ctr__Rule_102__0 RtkPos |
+                Ctr__Rule_102__1 RtkPos Rule_103
+                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_102 where
+    rtkPosOf (Ctr__Rule_102__0 p) = p
+    rtkPosOf (Ctr__Rule_102__1 p _) = p
+data Rule_103 = Ctr__Rule_103__0 RtkPos Type Rule_104
+                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_103 where
+    rtkPosOf (Ctr__Rule_103__0 p _ _) = p
+type Rule_104 = [Rule_105]
+data Rule_105 = Ctr__Rule_105__0 RtkPos Type
+                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_105 where
+    rtkPosOf (Ctr__Rule_105__0 p _) = p
+data Rule_106 = Anti_Rule_106 String |
+                Ctr__Rule_106__1 RtkPos String
+                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_106 where
+    rtkPosOf (Anti_Rule_106 _) = rtkNoPos
+    rtkPosOf (Ctr__Rule_106__1 p _) = p
+type Rule_11 = [Rule_12]
+data Rule_12 = Ctr__Rule_12__0 RtkPos ElementValue
+               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_12 where
+    rtkPosOf (Ctr__Rule_12__0 p _) = p
+data Rule_13 = Ctr__Rule_13__0 RtkPos |
+               Ctr__Rule_13__1 RtkPos
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_13 where
-    rtkPosOf (Ctr__Rule_13__0 p _) = p
-type Rule_14 = [ClassOrInterfaceType]
-data Rule_16 = Ctr__Rule_16__0 RtkPos |
-               Ctr__Rule_16__1 RtkPos ExtendsList
+    rtkPosOf (Ctr__Rule_13__0 p) = p
+    rtkPosOf (Ctr__Rule_13__1 p) = p
+data Rule_15 = Anti_Rule_15 String |
+               Ctr__Rule_15__1 RtkPos Modifier |
+               Ctr__Rule_15__2 RtkPos Annotation
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-instance RtkPosOf Rule_16 where
-    rtkPosOf (Ctr__Rule_16__0 p) = p
-    rtkPosOf (Ctr__Rule_16__1 p _) = p
-data Rule_17 = Ctr__Rule_17__0 RtkPos |
-               Ctr__Rule_17__1 RtkPos ImplementsList
-               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-instance RtkPosOf Rule_17 where
-    rtkPosOf (Ctr__Rule_17__0 p) = p
-    rtkPosOf (Ctr__Rule_17__1 p _) = p
-data Rule_18 = Ctr__Rule_18__0 RtkPos |
-               Ctr__Rule_18__1 RtkPos ExtendsList
+instance RtkPosOf Rule_15 where
+    rtkPosOf (Anti_Rule_15 _) = rtkNoPos
+    rtkPosOf (Ctr__Rule_15__1 p _) = p
+    rtkPosOf (Ctr__Rule_15__2 p _) = p
+type Rule_17 = [Rule_18]
+data Rule_18 = Ctr__Rule_18__0 RtkPos ClassOrInterfaceType
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_18 where
-    rtkPosOf (Ctr__Rule_18__0 p) = p
-    rtkPosOf (Ctr__Rule_18__1 p _) = p
+    rtkPosOf (Ctr__Rule_18__0 p _) = p
+type Rule_19 = [ClassOrInterfaceType]
 data Rule_2 = Ctr__Rule_2__0 RtkPos |
-              Ctr__Rule_2__1 RtkPos TypeDeclaration
+              Ctr__Rule_2__1 RtkPos CompilationUnitRest
               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_2 where
     rtkPosOf (Ctr__Rule_2__0 p) = p
     rtkPosOf (Ctr__Rule_2__1 p _) = p
-data Rule_20 = Ctr__Rule_20__0 RtkPos |
-               Ctr__Rule_20__1 RtkPos Rule_21
-               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-instance RtkPosOf Rule_20 where
-    rtkPosOf (Ctr__Rule_20__0 p) = p
-    rtkPosOf (Ctr__Rule_20__1 p _) = p
-data Rule_21 = Ctr__Rule_21__0 RtkPos Arglist
+data Rule_21 = Ctr__Rule_21__0 RtkPos |
+               Ctr__Rule_21__1 RtkPos ExtendsList
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_21 where
-    rtkPosOf (Ctr__Rule_21__0 p _) = p
+    rtkPosOf (Ctr__Rule_21__0 p) = p
+    rtkPosOf (Ctr__Rule_21__1 p _) = p
 data Rule_22 = Ctr__Rule_22__0 RtkPos |
-               Ctr__Rule_22__1 RtkPos Rule_23
+               Ctr__Rule_22__1 RtkPos ImplementsList
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_22 where
     rtkPosOf (Ctr__Rule_22__0 p) = p
     rtkPosOf (Ctr__Rule_22__1 p _) = p
-data Rule_23 = Ctr__Rule_23__0 RtkPos FieldDeclarationList
+data Rule_23 = Ctr__Rule_23__0 RtkPos |
+               Ctr__Rule_23__1 RtkPos ExtendsList
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_23 where
-    rtkPosOf (Ctr__Rule_23__0 p _) = p
-type Rule_24 = [Rule_25]
-data Rule_25 = Ctr__Rule_25__0 RtkPos EnumConstant
+    rtkPosOf (Ctr__Rule_23__0 p) = p
+    rtkPosOf (Ctr__Rule_23__1 p _) = p
+data Rule_25 = Ctr__Rule_25__0 RtkPos |
+               Ctr__Rule_25__1 RtkPos Rule_26
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_25 where
-    rtkPosOf (Ctr__Rule_25__0 p _) = p
-data Rule_26 = Ctr__Rule_26__0 RtkPos |
-               Ctr__Rule_26__1 RtkPos
+    rtkPosOf (Ctr__Rule_25__0 p) = p
+    rtkPosOf (Ctr__Rule_25__1 p _) = p
+data Rule_26 = Ctr__Rule_26__0 RtkPos Arglist
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_26 where
-    rtkPosOf (Ctr__Rule_26__0 p) = p
-    rtkPosOf (Ctr__Rule_26__1 p) = p
+    rtkPosOf (Ctr__Rule_26__0 p _) = p
 data Rule_27 = Ctr__Rule_27__0 RtkPos |
-               Ctr__Rule_27__1 RtkPos ImplementsList
+               Ctr__Rule_27__1 RtkPos Rule_28
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_27 where
     rtkPosOf (Ctr__Rule_27__0 p) = p
     rtkPosOf (Ctr__Rule_27__1 p _) = p
-data Rule_28 = Ctr__Rule_28__0 RtkPos |
-               Ctr__Rule_28__1 RtkPos Rule_29
+data Rule_28 = Ctr__Rule_28__0 RtkPos FieldDeclarationList
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_28 where
-    rtkPosOf (Ctr__Rule_28__0 p) = p
-    rtkPosOf (Ctr__Rule_28__1 p _) = p
-data Rule_29 = Ctr__Rule_29__0 RtkPos FieldDeclarationList
-               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-instance RtkPosOf Rule_29 where
-    rtkPosOf (Ctr__Rule_29__0 p _) = p
+    rtkPosOf (Ctr__Rule_28__0 p _) = p
+type Rule_29 = [Rule_30]
 data Rule_3 = Ctr__Rule_3__0 RtkPos |
               Ctr__Rule_3__1 RtkPos
               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_3 where
     rtkPosOf (Ctr__Rule_3__0 p) = p
     rtkPosOf (Ctr__Rule_3__1 p) = p
-data Rule_30 = Ctr__Rule_30__0 RtkPos MemberDeclaration |
-               Ctr__Rule_30__1 RtkPos TypeDeclRest |
-               Ctr__Rule_30__2 RtkPos StaticInitializer
+data Rule_30 = Ctr__Rule_30__0 RtkPos EnumConstant
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_30 where
     rtkPosOf (Ctr__Rule_30__0 p _) = p
-    rtkPosOf (Ctr__Rule_30__1 p _) = p
-    rtkPosOf (Ctr__Rule_30__2 p _) = p
-data Rule_31 = Anti_Rule_31 String |
+data Rule_31 = Ctr__Rule_31__0 RtkPos |
                Ctr__Rule_31__1 RtkPos
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_31 where
-    rtkPosOf (Anti_Rule_31 _) = rtkNoPos
+    rtkPosOf (Ctr__Rule_31__0 p) = p
     rtkPosOf (Ctr__Rule_31__1 p) = p
-data Rule_33 = Anti_Rule_33 String |
-               Ctr__Rule_33__1 RtkPos
+data Rule_32 = Ctr__Rule_32__0 RtkPos |
+               Ctr__Rule_32__1 RtkPos ImplementsList
+               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_32 where
+    rtkPosOf (Ctr__Rule_32__0 p) = p
+    rtkPosOf (Ctr__Rule_32__1 p _) = p
+data Rule_33 = Ctr__Rule_33__0 RtkPos |
+               Ctr__Rule_33__1 RtkPos Rule_34
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_33 where
-    rtkPosOf (Anti_Rule_33 _) = rtkNoPos
-    rtkPosOf (Ctr__Rule_33__1 p) = p
-data Rule_35 = Ctr__Rule_35__0 RtkPos |
-               Ctr__Rule_35__1 RtkPos ParameterList
+    rtkPosOf (Ctr__Rule_33__0 p) = p
+    rtkPosOf (Ctr__Rule_33__1 p _) = p
+data Rule_34 = Ctr__Rule_34__0 RtkPos FieldDeclarationList
+               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_34 where
+    rtkPosOf (Ctr__Rule_34__0 p _) = p
+data Rule_35 = Ctr__Rule_35__0 RtkPos MemberDeclaration |
+               Ctr__Rule_35__1 RtkPos TypeDeclRest |
+               Ctr__Rule_35__2 RtkPos StaticInitializer
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_35 where
-    rtkPosOf (Ctr__Rule_35__0 p) = p
+    rtkPosOf (Ctr__Rule_35__0 p _) = p
     rtkPosOf (Ctr__Rule_35__1 p _) = p
-data Rule_36 = Ctr__Rule_36__0 RtkPos |
-               Ctr__Rule_36__1 RtkPos ThrowsClause
+    rtkPosOf (Ctr__Rule_35__2 p _) = p
+data Rule_36 = Anti_Rule_36 String |
+               Ctr__Rule_36__1 RtkPos
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_36 where
-    rtkPosOf (Ctr__Rule_36__0 p) = p
-    rtkPosOf (Ctr__Rule_36__1 p _) = p
-type Rule_37 = [Rule_38]
-data Rule_38 = Ctr__Rule_38__0 RtkPos CompoundName
+    rtkPosOf (Anti_Rule_36 _) = rtkNoPos
+    rtkPosOf (Ctr__Rule_36__1 p) = p
+data Rule_38 = Anti_Rule_38 String |
+               Ctr__Rule_38__1 RtkPos
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_38 where
-    rtkPosOf (Ctr__Rule_38__0 p _) = p
-data Rule_39 = Ctr__Rule_39__0 RtkPos |
-               Ctr__Rule_39__1 RtkPos ParameterList
-               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-instance RtkPosOf Rule_39 where
-    rtkPosOf (Ctr__Rule_39__0 p) = p
-    rtkPosOf (Ctr__Rule_39__1 p _) = p
+    rtkPosOf (Anti_Rule_38 _) = rtkNoPos
+    rtkPosOf (Ctr__Rule_38__1 p) = p
 data Rule_4 = Ctr__Rule_4__0 RtkPos |
               Ctr__Rule_4__1 RtkPos Rule_5
               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
@@ -2708,82 +2857,86 @@ instance RtkPosOf Rule_4 where
     rtkPosOf (Ctr__Rule_4__0 p) = p
     rtkPosOf (Ctr__Rule_4__1 p _) = p
 data Rule_40 = Ctr__Rule_40__0 RtkPos |
-               Ctr__Rule_40__1 RtkPos ThrowsClause
+               Ctr__Rule_40__1 RtkPos ParameterList
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_40 where
     rtkPosOf (Ctr__Rule_40__0 p) = p
     rtkPosOf (Ctr__Rule_40__1 p _) = p
-data Rule_41 = Ctr__Rule_41__0 RtkPos StatementBlock |
-               Ctr__Rule_41__1 RtkPos Rule_42
+data Rule_41 = Ctr__Rule_41__0 RtkPos |
+               Ctr__Rule_41__1 RtkPos ThrowsClause
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_41 where
-    rtkPosOf (Ctr__Rule_41__0 p _) = p
+    rtkPosOf (Ctr__Rule_41__0 p) = p
     rtkPosOf (Ctr__Rule_41__1 p _) = p
-data Rule_42 = Ctr__Rule_42__0 RtkPos |
-               Ctr__Rule_42__1 RtkPos Rule_43
-               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-instance RtkPosOf Rule_42 where
-    rtkPosOf (Ctr__Rule_42__0 p) = p
-    rtkPosOf (Ctr__Rule_42__1 p _) = p
-data Rule_43 = Ctr__Rule_43__0 RtkPos Expression
+type Rule_42 = [Rule_43]
+data Rule_43 = Ctr__Rule_43__0 RtkPos CompoundName
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_43 where
     rtkPosOf (Ctr__Rule_43__0 p _) = p
-data Rule_44 = Anti_Rule_44 String |
-               Ctr__Rule_44__1 RtkPos VariableDeclarator
+data Rule_44 = Ctr__Rule_44__0 RtkPos |
+               Ctr__Rule_44__1 RtkPos ParameterList
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_44 where
-    rtkPosOf (Anti_Rule_44 _) = rtkNoPos
+    rtkPosOf (Ctr__Rule_44__0 p) = p
     rtkPosOf (Ctr__Rule_44__1 p _) = p
-type Rule_46 = [Rule_47]
-data Rule_47 = Ctr__Rule_47__0 RtkPos VariableDeclarator
+data Rule_45 = Ctr__Rule_45__0 RtkPos |
+               Ctr__Rule_45__1 RtkPos ThrowsClause
+               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_45 where
+    rtkPosOf (Ctr__Rule_45__0 p) = p
+    rtkPosOf (Ctr__Rule_45__1 p _) = p
+data Rule_46 = Ctr__Rule_46__0 RtkPos StatementBlock |
+               Ctr__Rule_46__1 RtkPos Rule_47
+               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_46 where
+    rtkPosOf (Ctr__Rule_46__0 p _) = p
+    rtkPosOf (Ctr__Rule_46__1 p _) = p
+data Rule_47 = Ctr__Rule_47__0 RtkPos |
+               Ctr__Rule_47__1 RtkPos Rule_48
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_47 where
-    rtkPosOf (Ctr__Rule_47__0 p _) = p
-data Rule_48 = Anti_Rule_48 String |
-               Ctr__Rule_48__1 RtkPos |
-               Ctr__Rule_48__2 RtkPos Annotation
+    rtkPosOf (Ctr__Rule_47__0 p) = p
+    rtkPosOf (Ctr__Rule_47__1 p _) = p
+data Rule_48 = Ctr__Rule_48__0 RtkPos Expression
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_48 where
-    rtkPosOf (Anti_Rule_48 _) = rtkNoPos
-    rtkPosOf (Ctr__Rule_48__1 p) = p
-    rtkPosOf (Ctr__Rule_48__2 p _) = p
+    rtkPosOf (Ctr__Rule_48__0 p _) = p
+data Rule_49 = Anti_Rule_49 String |
+               Ctr__Rule_49__1 RtkPos VariableDeclarator
+               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_49 where
+    rtkPosOf (Anti_Rule_49 _) = rtkNoPos
+    rtkPosOf (Ctr__Rule_49__1 p _) = p
 data Rule_5 = Ctr__Rule_5__0 RtkPos Rule_6
               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_5 where
     rtkPosOf (Ctr__Rule_5__0 p _) = p
-data Rule_50 = Ctr__Rule_50__0 RtkPos VariableInitializer
+type Rule_51 = [Rule_52]
+data Rule_52 = Ctr__Rule_52__0 RtkPos VariableDeclarator
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-instance RtkPosOf Rule_50 where
-    rtkPosOf (Ctr__Rule_50__0 p _) = p
-data Rule_51 = Ctr__Rule_51__0 RtkPos VariableInitializer Rule_52 Rule_54
-               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-instance RtkPosOf Rule_51 where
-    rtkPosOf (Ctr__Rule_51__0 p _ _ _) = p
-type Rule_52 = [Rule_53]
-data Rule_53 = Ctr__Rule_53__0 RtkPos VariableInitializer
+instance RtkPosOf Rule_52 where
+    rtkPosOf (Ctr__Rule_52__0 p _) = p
+data Rule_53 = Anti_Rule_53 String |
+               Ctr__Rule_53__1 RtkPos |
+               Ctr__Rule_53__2 RtkPos Annotation
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_53 where
-    rtkPosOf (Ctr__Rule_53__0 p _) = p
-data Rule_54 = Ctr__Rule_54__0 RtkPos |
-               Ctr__Rule_54__1 RtkPos
+    rtkPosOf (Anti_Rule_53 _) = rtkNoPos
+    rtkPosOf (Ctr__Rule_53__1 p) = p
+    rtkPosOf (Ctr__Rule_53__2 p _) = p
+data Rule_55 = Ctr__Rule_55__0 RtkPos VariableInitializer
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-instance RtkPosOf Rule_54 where
-    rtkPosOf (Ctr__Rule_54__0 p) = p
-    rtkPosOf (Ctr__Rule_54__1 p) = p
-type Rule_55 = [Rule_56]
-data Rule_56 = Ctr__Rule_56__0 RtkPos Parameter
+instance RtkPosOf Rule_55 where
+    rtkPosOf (Ctr__Rule_55__0 p _) = p
+data Rule_56 = Ctr__Rule_56__0 RtkPos VariableInitializer Rule_57 Rule_59
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_56 where
-    rtkPosOf (Ctr__Rule_56__0 p _) = p
-data Rule_57 = Anti_Rule_57 String |
-               Ctr__Rule_57__1 RtkPos |
-               Ctr__Rule_57__2 RtkPos Annotation
+    rtkPosOf (Ctr__Rule_56__0 p _ _ _) = p
+type Rule_57 = [Rule_58]
+data Rule_58 = Ctr__Rule_58__0 RtkPos VariableInitializer
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-instance RtkPosOf Rule_57 where
-    rtkPosOf (Anti_Rule_57 _) = rtkNoPos
-    rtkPosOf (Ctr__Rule_57__1 p) = p
-    rtkPosOf (Ctr__Rule_57__2 p _) = p
+instance RtkPosOf Rule_58 where
+    rtkPosOf (Ctr__Rule_58__0 p _) = p
 data Rule_59 = Ctr__Rule_59__0 RtkPos |
                Ctr__Rule_59__1 RtkPos
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
@@ -2796,163 +2949,176 @@ data Rule_6 = Ctr__Rule_6__0 RtkPos |
 instance RtkPosOf Rule_6 where
     rtkPosOf (Ctr__Rule_6__0 p) = p
     rtkPosOf (Ctr__Rule_6__1 p _) = p
-data Rule_61 = Ctr__Rule_61__0 RtkPos |
-               Ctr__Rule_61__1 RtkPos Rule_62
+type Rule_60 = [Rule_61]
+data Rule_61 = Ctr__Rule_61__0 RtkPos Parameter
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_61 where
-    rtkPosOf (Ctr__Rule_61__0 p) = p
-    rtkPosOf (Ctr__Rule_61__1 p _) = p
-data Rule_62 = Ctr__Rule_62__0 RtkPos Expression
+    rtkPosOf (Ctr__Rule_61__0 p _) = p
+data Rule_62 = Anti_Rule_62 String |
+               Ctr__Rule_62__1 RtkPos |
+               Ctr__Rule_62__2 RtkPos Annotation
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_62 where
-    rtkPosOf (Ctr__Rule_62__0 p _) = p
-data Rule_63 = Ctr__Rule_63__0 RtkPos Statement
-               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-instance RtkPosOf Rule_63 where
-    rtkPosOf (Ctr__Rule_63__0 p _) = p
-data Rule_64 = Ctr__Rule_64__0 RtkPos VariableDeclaration |
-               Ctr__Rule_64__1 RtkPos Expression |
-               Ctr__Rule_64__2 RtkPos
+    rtkPosOf (Anti_Rule_62 _) = rtkNoPos
+    rtkPosOf (Ctr__Rule_62__1 p) = p
+    rtkPosOf (Ctr__Rule_62__2 p _) = p
+data Rule_64 = Ctr__Rule_64__0 RtkPos |
+               Ctr__Rule_64__1 RtkPos
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_64 where
-    rtkPosOf (Ctr__Rule_64__0 p _) = p
-    rtkPosOf (Ctr__Rule_64__1 p _) = p
-    rtkPosOf (Ctr__Rule_64__2 p) = p
-data Rule_65 = Anti_Rule_65 String |
-               Ctr__Rule_65__1 RtkPos CatchParameter StatementBlock
+    rtkPosOf (Ctr__Rule_64__0 p) = p
+    rtkPosOf (Ctr__Rule_64__1 p) = p
+data Rule_66 = Ctr__Rule_66__0 RtkPos |
+               Ctr__Rule_66__1 RtkPos Rule_67
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-instance RtkPosOf Rule_65 where
-    rtkPosOf (Anti_Rule_65 _) = rtkNoPos
-    rtkPosOf (Ctr__Rule_65__1 p _ _) = p
-type Rule_67 = [Rule_68]
-data Rule_68 = Ctr__Rule_68__0 RtkPos Type
+instance RtkPosOf Rule_66 where
+    rtkPosOf (Ctr__Rule_66__0 p) = p
+    rtkPosOf (Ctr__Rule_66__1 p _) = p
+data Rule_67 = Ctr__Rule_67__0 RtkPos Expression
+               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_67 where
+    rtkPosOf (Ctr__Rule_67__0 p _) = p
+data Rule_68 = Ctr__Rule_68__0 RtkPos Statement
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_68 where
     rtkPosOf (Ctr__Rule_68__0 p _) = p
-data Rule_69 = Ctr__Rule_69__0 RtkPos StatementBlock
+data Rule_69 = Ctr__Rule_69__0 RtkPos VariableDeclaration |
+               Ctr__Rule_69__1 RtkPos Expression |
+               Ctr__Rule_69__2 RtkPos
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_69 where
     rtkPosOf (Ctr__Rule_69__0 p _) = p
+    rtkPosOf (Ctr__Rule_69__1 p _) = p
+    rtkPosOf (Ctr__Rule_69__2 p) = p
 type Rule_7 = [Rule_8]
-data Rule_70 = Ctr__Rule_70__0 RtkPos |
-               Ctr__Rule_70__1 RtkPos ResourceSpec
+data Rule_70 = Anti_Rule_70 String |
+               Ctr__Rule_70__1 RtkPos CatchParameter StatementBlock
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_70 where
-    rtkPosOf (Ctr__Rule_70__0 p) = p
-    rtkPosOf (Ctr__Rule_70__1 p _) = p
-type Rule_71 = [Rule_72]
-data Rule_72 = Ctr__Rule_72__0 RtkPos Resource
-               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-instance RtkPosOf Rule_72 where
-    rtkPosOf (Ctr__Rule_72__0 p _) = p
-data Rule_73 = Ctr__Rule_73__0 RtkPos |
-               Ctr__Rule_73__1 RtkPos
+    rtkPosOf (Anti_Rule_70 _) = rtkNoPos
+    rtkPosOf (Ctr__Rule_70__1 p _ _) = p
+type Rule_72 = [Rule_73]
+data Rule_73 = Ctr__Rule_73__0 RtkPos Type
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_73 where
-    rtkPosOf (Ctr__Rule_73__0 p) = p
-    rtkPosOf (Ctr__Rule_73__1 p) = p
-data Rule_74 = Anti_Rule_74 String |
-               Ctr__Rule_74__1 RtkPos Expression |
-               Ctr__Rule_74__2 RtkPos |
-               Ctr__Rule_74__3 RtkPos Statement
+    rtkPosOf (Ctr__Rule_73__0 p _) = p
+data Rule_74 = Ctr__Rule_74__0 RtkPos StatementBlock
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_74 where
-    rtkPosOf (Anti_Rule_74 _) = rtkNoPos
-    rtkPosOf (Ctr__Rule_74__1 p _) = p
-    rtkPosOf (Ctr__Rule_74__2 p) = p
-    rtkPosOf (Ctr__Rule_74__3 p _) = p
-data Rule_76 = Ctr__Rule_76__0 RtkPos |
-               Ctr__Rule_76__1 RtkPos Rule_77
+    rtkPosOf (Ctr__Rule_74__0 p _) = p
+data Rule_75 = Ctr__Rule_75__0 RtkPos |
+               Ctr__Rule_75__1 RtkPos ResourceSpec
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-instance RtkPosOf Rule_76 where
-    rtkPosOf (Ctr__Rule_76__0 p) = p
-    rtkPosOf (Ctr__Rule_76__1 p _) = p
-data Rule_77 = Ctr__Rule_77__0 RtkPos AssignmentOp Expression
+instance RtkPosOf Rule_75 where
+    rtkPosOf (Ctr__Rule_75__0 p) = p
+    rtkPosOf (Ctr__Rule_75__1 p _) = p
+type Rule_76 = [Rule_77]
+data Rule_77 = Ctr__Rule_77__0 RtkPos Resource
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_77 where
-    rtkPosOf (Ctr__Rule_77__0 p _ _) = p
-type Rule_78 = [Rule_79]
-data Rule_79 = Ctr__Rule_79__0 RtkPos String
+    rtkPosOf (Ctr__Rule_77__0 p _) = p
+data Rule_78 = Ctr__Rule_78__0 RtkPos |
+               Ctr__Rule_78__1 RtkPos
+               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_78 where
+    rtkPosOf (Ctr__Rule_78__0 p) = p
+    rtkPosOf (Ctr__Rule_78__1 p) = p
+data Rule_79 = Anti_Rule_79 String |
+               Ctr__Rule_79__1 RtkPos Expression |
+               Ctr__Rule_79__2 RtkPos |
+               Ctr__Rule_79__3 RtkPos Statement
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_79 where
-    rtkPosOf (Ctr__Rule_79__0 p _) = p
+    rtkPosOf (Anti_Rule_79 _) = rtkNoPos
+    rtkPosOf (Ctr__Rule_79__1 p _) = p
+    rtkPosOf (Ctr__Rule_79__2 p) = p
+    rtkPosOf (Ctr__Rule_79__3 p _) = p
 data Rule_8 = Ctr__Rule_8__0 RtkPos AnnotationElement
               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_8 where
     rtkPosOf (Ctr__Rule_8__0 p _) = p
-data Rule_80 = Ctr__Rule_80__0 RtkPos |
-               Ctr__Rule_80__1 RtkPos Rule_81
-               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-instance RtkPosOf Rule_80 where
-    rtkPosOf (Ctr__Rule_80__0 p) = p
-    rtkPosOf (Ctr__Rule_80__1 p _) = p
-data Rule_81 = Ctr__Rule_81__0 RtkPos Arglist
+data Rule_81 = Ctr__Rule_81__0 RtkPos |
+               Ctr__Rule_81__1 RtkPos Rule_82
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_81 where
-    rtkPosOf (Ctr__Rule_81__0 p _) = p
-data Rule_82 = Ctr__Rule_82__0 RtkPos |
-               Ctr__Rule_82__1 RtkPos Rule_83
+    rtkPosOf (Ctr__Rule_81__0 p) = p
+    rtkPosOf (Ctr__Rule_81__1 p _) = p
+data Rule_82 = Ctr__Rule_82__0 RtkPos AssignmentOp Expression
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_82 where
-    rtkPosOf (Ctr__Rule_82__0 p) = p
-    rtkPosOf (Ctr__Rule_82__1 p _) = p
-data Rule_83 = Ctr__Rule_83__0 RtkPos Arglist
-               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-instance RtkPosOf Rule_83 where
-    rtkPosOf (Ctr__Rule_83__0 p _) = p
-data Rule_84 = Ctr__Rule_84__0 RtkPos Arglist |
-               Ctr__Rule_84__1 RtkPos DimExprs Rule_85
+    rtkPosOf (Ctr__Rule_82__0 p _ _) = p
+type Rule_83 = [Rule_84]
+data Rule_84 = Ctr__Rule_84__0 RtkPos String
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_84 where
     rtkPosOf (Ctr__Rule_84__0 p _) = p
-    rtkPosOf (Ctr__Rule_84__1 p _ _) = p
 data Rule_85 = Ctr__Rule_85__0 RtkPos |
-               Ctr__Rule_85__1 RtkPos NonEmptyDims
+               Ctr__Rule_85__1 RtkPos Rule_86
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_85 where
     rtkPosOf (Ctr__Rule_85__0 p) = p
     rtkPosOf (Ctr__Rule_85__1 p _) = p
-data Rule_86 = Anti_Rule_86 String |
-               Ctr__Rule_86__1 RtkPos Expression
+data Rule_86 = Ctr__Rule_86__0 RtkPos Arglist
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_86 where
-    rtkPosOf (Anti_Rule_86 _) = rtkNoPos
-    rtkPosOf (Ctr__Rule_86__1 p _) = p
-data Rule_88 = Ctr__Rule_88__0 RtkPos Expression Rule_89
+    rtkPosOf (Ctr__Rule_86__0 p _) = p
+data Rule_87 = Ctr__Rule_87__0 RtkPos |
+               Ctr__Rule_87__1 RtkPos Rule_88
+               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_87 where
+    rtkPosOf (Ctr__Rule_87__0 p) = p
+    rtkPosOf (Ctr__Rule_87__1 p _) = p
+data Rule_88 = Ctr__Rule_88__0 RtkPos Arglist
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_88 where
-    rtkPosOf (Ctr__Rule_88__0 p _ _) = p
-type Rule_89 = [Rule_90]
-data Rule_90 = Ctr__Rule_90__0 RtkPos Expression
+    rtkPosOf (Ctr__Rule_88__0 p _) = p
+data Rule_89 = Ctr__Rule_89__0 RtkPos Arglist Rule_90 |
+               Ctr__Rule_89__1 RtkPos DimExprs Rule_92 |
+               Ctr__Rule_89__2 RtkPos NonEmptyDims ArrayInitializer
+               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_89 where
+    rtkPosOf (Ctr__Rule_89__0 p _ _) = p
+    rtkPosOf (Ctr__Rule_89__1 p _ _) = p
+    rtkPosOf (Ctr__Rule_89__2 p _ _) = p
+data Rule_9 = Ctr__Rule_9__0 RtkPos |
+              Ctr__Rule_9__1 RtkPos Rule_10
+              deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_9 where
+    rtkPosOf (Ctr__Rule_9__0 p) = p
+    rtkPosOf (Ctr__Rule_9__1 p _) = p
+data Rule_90 = Ctr__Rule_90__0 RtkPos |
+               Ctr__Rule_90__1 RtkPos Rule_91
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_90 where
-    rtkPosOf (Ctr__Rule_90__0 p _) = p
-type Rule_91 = [Rule_92]
-data Rule_92 = Ctr__Rule_92__0 RtkPos TypeArgument
+    rtkPosOf (Ctr__Rule_90__0 p) = p
+    rtkPosOf (Ctr__Rule_90__1 p _) = p
+data Rule_91 = Ctr__Rule_91__0 RtkPos FieldDeclarationList
+               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
+instance RtkPosOf Rule_91 where
+    rtkPosOf (Ctr__Rule_91__0 p _) = p
+data Rule_92 = Ctr__Rule_92__0 RtkPos |
+               Ctr__Rule_92__1 RtkPos NonEmptyDims
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_92 where
-    rtkPosOf (Ctr__Rule_92__0 p _) = p
-data Rule_93 = Ctr__Rule_93__0 RtkPos TypeParameter Rule_94
+    rtkPosOf (Ctr__Rule_92__0 p) = p
+    rtkPosOf (Ctr__Rule_92__1 p _) = p
+data Rule_93 = Anti_Rule_93 String |
+               Ctr__Rule_93__1 RtkPos Expression
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_93 where
-    rtkPosOf (Ctr__Rule_93__0 p _ _) = p
-type Rule_94 = [Rule_95]
-data Rule_95 = Ctr__Rule_95__0 RtkPos TypeParameter
+    rtkPosOf (Anti_Rule_93 _) = rtkNoPos
+    rtkPosOf (Ctr__Rule_93__1 p _) = p
+data Rule_95 = Ctr__Rule_95__0 RtkPos Expression Rule_96
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_95 where
-    rtkPosOf (Ctr__Rule_95__0 p _) = p
-data Rule_96 = Ctr__Rule_96__0 RtkPos |
-               Ctr__Rule_96__1 RtkPos Rule_97
-               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
-instance RtkPosOf Rule_96 where
-    rtkPosOf (Ctr__Rule_96__0 p) = p
-    rtkPosOf (Ctr__Rule_96__1 p _) = p
-data Rule_97 = Ctr__Rule_97__0 RtkPos Type Rule_98
+    rtkPosOf (Ctr__Rule_95__0 p _ _) = p
+type Rule_96 = [Rule_97]
+data Rule_97 = Ctr__Rule_97__0 RtkPos Expression
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_97 where
-    rtkPosOf (Ctr__Rule_97__0 p _ _) = p
+    rtkPosOf (Ctr__Rule_97__0 p _) = p
 type Rule_98 = [Rule_99]
-data Rule_99 = Ctr__Rule_99__0 RtkPos Type
+data Rule_99 = Ctr__Rule_99__0 RtkPos TypeArgument
                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf Rule_99 where
     rtkPosOf (Ctr__Rule_99__0 p _) = p
@@ -2979,7 +3145,7 @@ data Statement = Anti_Statement String |
                  Ctr__Statement__9 RtkPos SwitchStatement |
                  Ctr__Statement__10 RtkPos Expression Statement |
                  Ctr__Statement__11 RtkPos Expression |
-                 Ctr__Statement__12 RtkPos Expression Rule_61 |
+                 Ctr__Statement__12 RtkPos Expression Rule_66 |
                  Ctr__Statement__13 RtkPos String Statement |
                  Ctr__Statement__14 RtkPos OptId |
                  Ctr__Statement__15 RtkPos OptId |
@@ -3021,7 +3187,7 @@ data StaticInitializer = Anti_StaticInitializer String |
 instance RtkPosOf StaticInitializer where
     rtkPosOf (Anti_StaticInitializer _) = rtkNoPos
     rtkPosOf (Ctr__StaticInitializer__0 p _) = p
-type SwitchCaseList = [Rule_74]
+type SwitchCaseList = [Rule_79]
 data SwitchStatement = Anti_SwitchStatement String |
                        Ctr__SwitchStatement__0 RtkPos Expression SwitchCaseList
                        deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
@@ -3029,13 +3195,13 @@ instance RtkPosOf SwitchStatement where
     rtkPosOf (Anti_SwitchStatement _) = rtkNoPos
     rtkPosOf (Ctr__SwitchStatement__0 p _ _) = p
 data ThrowsClause = Anti_ThrowsClause String |
-                    Ctr__ThrowsClause__0 RtkPos CompoundName Rule_37
+                    Ctr__ThrowsClause__0 RtkPos CompoundName Rule_42
                     deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf ThrowsClause where
     rtkPosOf (Anti_ThrowsClause _) = rtkNoPos
     rtkPosOf (Ctr__ThrowsClause__0 p _ _) = p
 data TryStatement = Anti_TryStatement String |
-                    Ctr__TryStatement__0 RtkPos Rule_70 StatementBlock CatchList OptFinally
+                    Ctr__TryStatement__0 RtkPos Rule_75 StatementBlock CatchList OptFinally
                     deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf TryStatement where
     rtkPosOf (Anti_TryStatement _) = rtkNoPos
@@ -3081,20 +3247,21 @@ instance RtkPosOf TypeDeclRest where
     rtkPosOf (Ctr__TypeDeclRest__2 p _) = p
     rtkPosOf (Ctr__TypeDeclRest__3 p _) = p
 data TypeDeclaration = Anti_TypeDeclaration String |
-                       Ctr__TypeDeclaration__0 RtkPos OptDocComment ModifierList TypeDeclRest
+                       Ctr__TypeDeclaration__1 RtkPos OptDocComment ModifierList TypeDeclRest
                        deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf TypeDeclaration where
     rtkPosOf (Anti_TypeDeclaration _) = rtkNoPos
-    rtkPosOf (Ctr__TypeDeclaration__0 p _ _ _) = p
+    rtkPosOf (Ctr__TypeDeclaration__1 p _ _ _) = p
+type TypeDeclarationList = [TypeDeclaration]
 data TypeParameter = Anti_TypeParameter String |
-                     Ctr__TypeParameter__0 RtkPos String Rule_96
+                     Ctr__TypeParameter__0 RtkPos String Rule_102
                      deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf TypeParameter where
     rtkPosOf (Anti_TypeParameter _) = rtkNoPos
     rtkPosOf (Ctr__TypeParameter__0 p _ _) = p
 data TypeParameters = Anti_TypeParameters String |
                       Ctr__TypeParameters__0 RtkPos |
-                      Ctr__TypeParameters__1 RtkPos Rule_93
+                      Ctr__TypeParameters__1 RtkPos NonEmptyTypeParameters
                       deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf TypeParameters where
     rtkPosOf (Anti_TypeParameters _) = rtkNoPos
@@ -3139,14 +3306,14 @@ instance RtkPosOf VariableDeclarator where
     rtkPosOf (Anti_VariableDeclarator _) = rtkNoPos
     rtkPosOf (Ctr__VariableDeclarator__0 p _ _ _) = p
 data VariableDeclaratorList = Anti_VariableDeclaratorList String |
-                              Ctr__VariableDeclaratorList__0 RtkPos VariableDeclarator Rule_46
+                              Ctr__VariableDeclaratorList__0 RtkPos VariableDeclarator Rule_51
                               deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf VariableDeclaratorList where
     rtkPosOf (Anti_VariableDeclaratorList _) = rtkNoPos
     rtkPosOf (Ctr__VariableDeclaratorList__0 p _ _) = p
 data VariableInitializer = Anti_VariableInitializer String |
                            Ctr__VariableInitializer__0 RtkPos Expression |
-                           Ctr__VariableInitializer__1 RtkPos VariableInitializerList
+                           Ctr__VariableInitializer__1 RtkPos ArrayInitializer
                            deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf VariableInitializer where
     rtkPosOf (Anti_VariableInitializer _) = rtkNoPos
@@ -3154,7 +3321,7 @@ instance RtkPosOf VariableInitializer where
     rtkPosOf (Ctr__VariableInitializer__1 p _) = p
 data VariableInitializerList = Anti_VariableInitializerList String |
                                Ctr__VariableInitializerList__0 RtkPos |
-                               Ctr__VariableInitializerList__1 RtkPos Rule_51
+                               Ctr__VariableInitializerList__1 RtkPos Rule_56
                                deriving (Ord, Eq, Show, Gen.Data, Gen.Typeable)
 instance RtkPosOf VariableInitializerList where
     rtkPosOf (Anti_VariableInitializerList _) = rtkNoPos

--- a/test/golden/java/JavaQQ.hs
+++ b/test/golden/java/JavaQQ.hs
@@ -64,7 +64,7 @@ rtkRenderError err =
                 _ -> err
         _ -> err
 
-qqShortcuts = M.fromList [ ("java","Java"),("additiveOp","AdditiveOp"),("annotation","Annotation"),("annotationArguments","AnnotationArguments"),("annotationDeclaration","AnnotationDeclaration"),("annotationElement","AnnotationElement"),("annotationList","AnnotationList"),("annotationTypeElement","AnnotationTypeElement"),("annotationTypeElementList","AnnotationTypeElementList"),("arglist","Arglist"),("assignmentOp","AssignmentOp"),("catchList","CatchList"),("catchParameter","CatchParameter"),("classDeclaration","ClassDeclaration"),("classOrInterfaceType","ClassOrInterfaceType"),("compilationUnit","CompilationUnit"),("compoundName","CompoundName"),("compoundNameTail","CompoundNameTail"),("creationExpression","CreationExpression"),("dimExprs","DimExprs"),("dims","Dims"),("doStatement","DoStatement"),("docComment","DocComment"),("enumConstant","EnumConstant"),("enumConstantList","EnumConstantList"),("enumDeclaration","EnumDeclaration"),("equalityOp","EqualityOp"),("expression","Expression"),("extendsList","ExtendsList"),("fieldDeclaration","FieldDeclaration"),("fieldDeclarationList","FieldDeclarationList"),("forEachHeader","ForEachHeader"),("forStatement","ForStatement"),("ifStatement","IfStatement"),("implementsList","ImplementsList"),("importHead","ImportHead"),("importList","ImportList"),("importName","ImportName"),("importStatement","ImportStatement"),("interfaceDeclaration","InterfaceDeclaration"),("lambdaBody","LambdaBody"),("literal","Literal"),("localModifierList1","LocalModifierList1"),("memberAfterFirstId","MemberAfterFirstId"),("memberDeclaration","MemberDeclaration"),("memberRest","MemberRest"),("modifier","Modifier"),("modifierList","ModifierList"),("moreTypeSpecifier","MoreTypeSpecifier"),("moreVariableDeclarators","MoreVariableDeclarators"),("multiplicativeOp","MultiplicativeOp"),("nonEmptyDims","NonEmptyDims"),("nonEmptyTypeArguments","NonEmptyTypeArguments"),("optDocComment","OptDocComment"),("optElsePart","OptElsePart"),("optExpression","OptExpression"),("optFinally","OptFinally"),("optId","OptId"),("optVariableInitializer","OptVariableInitializer"),("package","Package"),("paramModifierList","ParamModifierList"),("parameter","Parameter"),("parameterList","ParameterList"),("postfixOp","PostfixOp"),("prefixOp","PrefixOp"),("primitiveTypeKeyword","PrimitiveTypeKeyword"),("relationalOp","RelationalOp"),("resource","Resource"),("resourceSpec","ResourceSpec"),("shiftOp","ShiftOp"),("statement","Statement"),("statementBlock","StatementBlock"),("statementList","StatementList"),("staticInitializer","StaticInitializer"),("switchCaseList","SwitchCaseList"),("switchStatement","SwitchStatement"),("throwsClause","ThrowsClause"),("tryStatement","TryStatement"),("type","Type"),("typeArgument","TypeArgument"),("typeArguments","TypeArguments"),("typeDeclRest","TypeDeclRest"),("typeDeclaration","TypeDeclaration"),("typeParameter","TypeParameter"),("typeParameters","TypeParameters"),("typeSpecifier","TypeSpecifier"),("variableDeclaration","VariableDeclaration"),("variableDeclarator","VariableDeclarator"),("variableDeclaratorList","VariableDeclaratorList"),("variableInitializer","VariableInitializer"),("variableInitializerList","VariableInitializerList"),("whileStatement","WhileStatement"),("wildcardType","WildcardType")]
+qqShortcuts = M.fromList [ ("java","Java"),("additiveOp","AdditiveOp"),("annotation","Annotation"),("annotationArguments","AnnotationArguments"),("annotationDeclaration","AnnotationDeclaration"),("annotationElement","AnnotationElement"),("annotationList","AnnotationList"),("annotationTypeElement","AnnotationTypeElement"),("annotationTypeElementList","AnnotationTypeElementList"),("arglist","Arglist"),("arrayInitializer","ArrayInitializer"),("assignmentOp","AssignmentOp"),("catchList","CatchList"),("catchParameter","CatchParameter"),("classDeclaration","ClassDeclaration"),("classOrInterfaceType","ClassOrInterfaceType"),("compilationUnit","CompilationUnit"),("compilationUnitRest","CompilationUnitRest"),("compoundName","CompoundName"),("compoundNameTail","CompoundNameTail"),("creationExpression","CreationExpression"),("dimExprs","DimExprs"),("dims","Dims"),("doStatement","DoStatement"),("docComment","DocComment"),("elementValue","ElementValue"),("elementValueArrayInitializer","ElementValueArrayInitializer"),("enumConstant","EnumConstant"),("enumConstantList","EnumConstantList"),("enumDeclaration","EnumDeclaration"),("equalityOp","EqualityOp"),("expression","Expression"),("extendsList","ExtendsList"),("fieldDeclaration","FieldDeclaration"),("fieldDeclarationList","FieldDeclarationList"),("forEachHeader","ForEachHeader"),("forStatement","ForStatement"),("ifStatement","IfStatement"),("implementsList","ImplementsList"),("importHead","ImportHead"),("importList","ImportList"),("importName","ImportName"),("importStatement","ImportStatement"),("interfaceDeclaration","InterfaceDeclaration"),("lambdaBody","LambdaBody"),("literal","Literal"),("localModifierList1","LocalModifierList1"),("memberAfterFirstId","MemberAfterFirstId"),("memberDeclaration","MemberDeclaration"),("memberRest","MemberRest"),("modifier","Modifier"),("modifierList","ModifierList"),("moreTypeSpecifier","MoreTypeSpecifier"),("moreVariableDeclarators","MoreVariableDeclarators"),("multiplicativeOp","MultiplicativeOp"),("nonEmptyDims","NonEmptyDims"),("nonEmptyTypeArguments","NonEmptyTypeArguments"),("nonEmptyTypeParameters","NonEmptyTypeParameters"),("optDocComment","OptDocComment"),("optElsePart","OptElsePart"),("optExpression","OptExpression"),("optFinally","OptFinally"),("optId","OptId"),("optVariableInitializer","OptVariableInitializer"),("package","Package"),("paramModifierList","ParamModifierList"),("parameter","Parameter"),("parameterList","ParameterList"),("postfixOp","PostfixOp"),("prefixOp","PrefixOp"),("primitiveTypeKeyword","PrimitiveTypeKeyword"),("relationalOp","RelationalOp"),("resource","Resource"),("resourceSpec","ResourceSpec"),("shiftOp","ShiftOp"),("statement","Statement"),("statementBlock","StatementBlock"),("statementList","StatementList"),("staticInitializer","StaticInitializer"),("switchCaseList","SwitchCaseList"),("switchStatement","SwitchStatement"),("throwsClause","ThrowsClause"),("tryStatement","TryStatement"),("type","Type"),("typeArgument","TypeArgument"),("typeArguments","TypeArguments"),("typeDeclRest","TypeDeclRest"),("typeDeclaration","TypeDeclaration"),("typeDeclarationList","TypeDeclarationList"),("typeParameter","TypeParameter"),("typeParameters","TypeParameters"),("typeSpecifier","TypeSpecifier"),("variableDeclaration","VariableDeclaration"),("variableDeclarator","VariableDeclarator"),("variableDeclaratorList","VariableDeclaratorList"),("variableInitializer","VariableInitializer"),("variableInitializerList","VariableInitializerList"),("whileStatement","WhileStatement"),("wildcardType","WildcardType")]
 
 -- A quasi-quote pattern must match an AST parsed from anywhere in a source
 -- file, while the pattern itself was parsed from the quote body - so every
@@ -81,7 +81,7 @@ quoteJavaExp dummy func s = do
            Left err -> fail (rtkRenderError err)
            Right a -> return a
   let expr = func ast
-  dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiClassOrInterfaceTypeExp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiForEachHeaderExp `Generics.extQ` antiRule_65Exp `Generics.extQ` antiCatchParameterExp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiResourceSpecExp `Generics.extQ` antiResourceExp `Generics.extQ` antiRule_74Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiLambdaBodyExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_86Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiRule_100Exp `Generics.extQ` antiCompoundNameExp) expr
+  dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiCompilationUnitRestExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiElementValueExp `Generics.extQ` antiElementValueArrayInitializerExp `Generics.extQ` antiRule_15Exp `Generics.extQ` antiClassOrInterfaceTypeExp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_36Exp `Generics.extQ` antiRule_38Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_49Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_53Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiArrayInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_62Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiForEachHeaderExp `Generics.extQ` antiRule_70Exp `Generics.extQ` antiCatchParameterExp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiResourceSpecExp `Generics.extQ` antiResourceExp `Generics.extQ` antiRule_79Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiLambdaBodyExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_93Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiNonEmptyTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiRule_106Exp `Generics.extQ` antiCompoundNameExp) expr
 quoteJavaPat :: Data.Data a => String -> (Java -> a) -> String -> TH.PatQ
 quoteJavaPat dummy func s = do
   s1 <- either fail return (replaceAllPatterns s)
@@ -89,19 +89,19 @@ quoteJavaPat dummy func s = do
            Left err -> fail (rtkRenderError err)
            Right a -> return a
   let expr = func ast
-  dataToPatQ (const Nothing `Generics.extQ` rtkPosWildPat `Generics.extQ` antiJavaPat `Generics.extQ` antiOptDocCommentPat `Generics.extQ` antiTypeDeclarationPat `Generics.extQ` antiImportStatementPat `Generics.extQ` antiCompilationUnitPat `Generics.extQ` antiPackagePat `Generics.extQ` antiImportNamePat `Generics.extQ` antiImportHeadPat `Generics.extQ` antiDocCommentPat `Generics.extQ` antiAnnotationPat `Generics.extQ` antiAnnotationArgumentsPat `Generics.extQ` antiAnnotationElementPat `Generics.extQ` antiRule_10Pat `Generics.extQ` antiClassOrInterfaceTypePat `Generics.extQ` antiExtendsListPat `Generics.extQ` antiImplementsListPat `Generics.extQ` antiFieldDeclarationPat `Generics.extQ` antiClassDeclarationPat `Generics.extQ` antiInterfaceDeclarationPat `Generics.extQ` antiAnnotationDeclarationPat `Generics.extQ` antiAnnotationTypeElementPat `Generics.extQ` antiEnumConstantPat `Generics.extQ` antiEnumConstantListPat `Generics.extQ` antiEnumDeclarationPat `Generics.extQ` antiTypeDeclRestPat `Generics.extQ` antiRule_31Pat `Generics.extQ` antiRule_33Pat `Generics.extQ` antiMemberDeclarationPat `Generics.extQ` antiPrimitiveTypeKeywordPat `Generics.extQ` antiMemberAfterFirstIdPat `Generics.extQ` antiMoreTypeSpecifierPat `Generics.extQ` antiThrowsClausePat `Generics.extQ` antiMemberRestPat `Generics.extQ` antiRule_44Pat `Generics.extQ` antiStatementBlockPat `Generics.extQ` antiVariableDeclaratorListPat `Generics.extQ` antiVariableDeclarationPat `Generics.extQ` antiRule_48Pat `Generics.extQ` antiOptVariableInitializerPat `Generics.extQ` antiVariableDeclaratorPat `Generics.extQ` antiVariableInitializerListPat `Generics.extQ` antiVariableInitializerPat `Generics.extQ` antiStaticInitializerPat `Generics.extQ` antiParameterListPat `Generics.extQ` antiRule_57Pat `Generics.extQ` antiParameterPat `Generics.extQ` antiStatementPat `Generics.extQ` antiOptExpressionPat `Generics.extQ` antiOptIdPat `Generics.extQ` antiOptElsePartPat `Generics.extQ` antiIfStatementPat `Generics.extQ` antiDoStatementPat `Generics.extQ` antiWhileStatementPat `Generics.extQ` antiForStatementPat `Generics.extQ` antiForEachHeaderPat `Generics.extQ` antiRule_65Pat `Generics.extQ` antiCatchParameterPat `Generics.extQ` antiOptFinallyPat `Generics.extQ` antiTryStatementPat `Generics.extQ` antiResourceSpecPat `Generics.extQ` antiResourcePat `Generics.extQ` antiRule_74Pat `Generics.extQ` antiSwitchStatementPat `Generics.extQ` antiExpressionPat `Generics.extQ` antiLambdaBodyPat `Generics.extQ` antiAssignmentOpPat `Generics.extQ` antiEqualityOpPat `Generics.extQ` antiRelationalOpPat `Generics.extQ` antiShiftOpPat `Generics.extQ` antiAdditiveOpPat `Generics.extQ` antiMultiplicativeOpPat `Generics.extQ` antiPrefixOpPat `Generics.extQ` antiPostfixOpPat `Generics.extQ` antiCreationExpressionPat `Generics.extQ` antiRule_86Pat `Generics.extQ` antiLiteralPat `Generics.extQ` antiArglistPat `Generics.extQ` antiTypeArgumentsPat `Generics.extQ` antiNonEmptyTypeArgumentsPat `Generics.extQ` antiTypeArgumentPat `Generics.extQ` antiWildcardTypePat `Generics.extQ` antiTypeParametersPat `Generics.extQ` antiTypeParameterPat `Generics.extQ` antiTypePat `Generics.extQ` antiTypeSpecifierPat `Generics.extQ` antiModifierPat `Generics.extQ` antiRule_100Pat `Generics.extQ` antiCompoundNamePat) expr
+  dataToPatQ (const Nothing `Generics.extQ` rtkPosWildPat `Generics.extQ` antiJavaPat `Generics.extQ` antiOptDocCommentPat `Generics.extQ` antiTypeDeclarationPat `Generics.extQ` antiImportStatementPat `Generics.extQ` antiCompilationUnitPat `Generics.extQ` antiCompilationUnitRestPat `Generics.extQ` antiPackagePat `Generics.extQ` antiImportNamePat `Generics.extQ` antiImportHeadPat `Generics.extQ` antiDocCommentPat `Generics.extQ` antiAnnotationPat `Generics.extQ` antiAnnotationArgumentsPat `Generics.extQ` antiAnnotationElementPat `Generics.extQ` antiElementValuePat `Generics.extQ` antiElementValueArrayInitializerPat `Generics.extQ` antiRule_15Pat `Generics.extQ` antiClassOrInterfaceTypePat `Generics.extQ` antiExtendsListPat `Generics.extQ` antiImplementsListPat `Generics.extQ` antiFieldDeclarationPat `Generics.extQ` antiClassDeclarationPat `Generics.extQ` antiInterfaceDeclarationPat `Generics.extQ` antiAnnotationDeclarationPat `Generics.extQ` antiAnnotationTypeElementPat `Generics.extQ` antiEnumConstantPat `Generics.extQ` antiEnumConstantListPat `Generics.extQ` antiEnumDeclarationPat `Generics.extQ` antiTypeDeclRestPat `Generics.extQ` antiRule_36Pat `Generics.extQ` antiRule_38Pat `Generics.extQ` antiMemberDeclarationPat `Generics.extQ` antiPrimitiveTypeKeywordPat `Generics.extQ` antiMemberAfterFirstIdPat `Generics.extQ` antiMoreTypeSpecifierPat `Generics.extQ` antiThrowsClausePat `Generics.extQ` antiMemberRestPat `Generics.extQ` antiRule_49Pat `Generics.extQ` antiStatementBlockPat `Generics.extQ` antiVariableDeclaratorListPat `Generics.extQ` antiVariableDeclarationPat `Generics.extQ` antiRule_53Pat `Generics.extQ` antiOptVariableInitializerPat `Generics.extQ` antiVariableDeclaratorPat `Generics.extQ` antiVariableInitializerListPat `Generics.extQ` antiVariableInitializerPat `Generics.extQ` antiArrayInitializerPat `Generics.extQ` antiStaticInitializerPat `Generics.extQ` antiParameterListPat `Generics.extQ` antiRule_62Pat `Generics.extQ` antiParameterPat `Generics.extQ` antiStatementPat `Generics.extQ` antiOptExpressionPat `Generics.extQ` antiOptIdPat `Generics.extQ` antiOptElsePartPat `Generics.extQ` antiIfStatementPat `Generics.extQ` antiDoStatementPat `Generics.extQ` antiWhileStatementPat `Generics.extQ` antiForStatementPat `Generics.extQ` antiForEachHeaderPat `Generics.extQ` antiRule_70Pat `Generics.extQ` antiCatchParameterPat `Generics.extQ` antiOptFinallyPat `Generics.extQ` antiTryStatementPat `Generics.extQ` antiResourceSpecPat `Generics.extQ` antiResourcePat `Generics.extQ` antiRule_79Pat `Generics.extQ` antiSwitchStatementPat `Generics.extQ` antiExpressionPat `Generics.extQ` antiLambdaBodyPat `Generics.extQ` antiAssignmentOpPat `Generics.extQ` antiEqualityOpPat `Generics.extQ` antiRelationalOpPat `Generics.extQ` antiShiftOpPat `Generics.extQ` antiAdditiveOpPat `Generics.extQ` antiMultiplicativeOpPat `Generics.extQ` antiPrefixOpPat `Generics.extQ` antiPostfixOpPat `Generics.extQ` antiCreationExpressionPat `Generics.extQ` antiRule_93Pat `Generics.extQ` antiLiteralPat `Generics.extQ` antiArglistPat `Generics.extQ` antiTypeArgumentsPat `Generics.extQ` antiNonEmptyTypeArgumentsPat `Generics.extQ` antiTypeArgumentPat `Generics.extQ` antiWildcardTypePat `Generics.extQ` antiTypeParametersPat `Generics.extQ` antiNonEmptyTypeParametersPat `Generics.extQ` antiTypeParameterPat `Generics.extQ` antiTypePat `Generics.extQ` antiTypeSpecifierPat `Generics.extQ` antiModifierPat `Generics.extQ` antiRule_106Pat `Generics.extQ` antiCompoundNamePat) expr
 
 antiCompoundNameExp :: CompoundName -> Maybe (TH.Q TH.Exp )
 antiCompoundNameExp ( Anti_CompoundName v) = Just $ TH.varE (TH.mkName v)
 antiCompoundNameExp _ = Nothing
 
 
-antiRule_100Exp :: [ Rule_100 ] -> Maybe (TH.Q TH.Exp)
-antiRule_100Exp ((Anti_Rule_100 v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiClassOrInterfaceTypeExp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiForEachHeaderExp `Generics.extQ` antiRule_65Exp `Generics.extQ` antiCatchParameterExp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiResourceSpecExp `Generics.extQ` antiResourceExp `Generics.extQ` antiRule_74Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiLambdaBodyExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_86Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiRule_100Exp `Generics.extQ` antiCompoundNameExp) rest
+antiRule_106Exp :: [ Rule_106 ] -> Maybe (TH.Q TH.Exp)
+antiRule_106Exp ((Anti_Rule_106 v):rest) =
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiCompilationUnitRestExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiElementValueExp `Generics.extQ` antiElementValueArrayInitializerExp `Generics.extQ` antiRule_15Exp `Generics.extQ` antiClassOrInterfaceTypeExp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_36Exp `Generics.extQ` antiRule_38Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_49Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_53Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiArrayInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_62Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiForEachHeaderExp `Generics.extQ` antiRule_70Exp `Generics.extQ` antiCatchParameterExp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiResourceSpecExp `Generics.extQ` antiResourceExp `Generics.extQ` antiRule_79Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiLambdaBodyExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_93Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiNonEmptyTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiRule_106Exp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
-antiRule_100Exp _ = Nothing
+antiRule_106Exp _ = Nothing
 
 
 antiModifierExp :: Modifier -> Maybe (TH.Q TH.Exp )
@@ -122,6 +122,11 @@ antiTypeExp _ = Nothing
 antiTypeParameterExp :: TypeParameter -> Maybe (TH.Q TH.Exp )
 antiTypeParameterExp ( Anti_TypeParameter v) = Just $ TH.varE (TH.mkName v)
 antiTypeParameterExp _ = Nothing
+
+
+antiNonEmptyTypeParametersExp :: NonEmptyTypeParameters -> Maybe (TH.Q TH.Exp )
+antiNonEmptyTypeParametersExp ( Anti_NonEmptyTypeParameters v) = Just $ TH.varE (TH.mkName v)
+antiNonEmptyTypeParametersExp _ = Nothing
 
 
 antiTypeParametersExp :: TypeParameters -> Maybe (TH.Q TH.Exp )
@@ -159,12 +164,12 @@ antiLiteralExp ( Anti_Literal v) = Just $ TH.varE (TH.mkName v)
 antiLiteralExp _ = Nothing
 
 
-antiRule_86Exp :: [ Rule_86 ] -> Maybe (TH.Q TH.Exp)
-antiRule_86Exp ((Anti_Rule_86 v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiClassOrInterfaceTypeExp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiForEachHeaderExp `Generics.extQ` antiRule_65Exp `Generics.extQ` antiCatchParameterExp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiResourceSpecExp `Generics.extQ` antiResourceExp `Generics.extQ` antiRule_74Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiLambdaBodyExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_86Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiRule_100Exp `Generics.extQ` antiCompoundNameExp) rest
+antiRule_93Exp :: [ Rule_93 ] -> Maybe (TH.Q TH.Exp)
+antiRule_93Exp ((Anti_Rule_93 v):rest) =
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiCompilationUnitRestExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiElementValueExp `Generics.extQ` antiElementValueArrayInitializerExp `Generics.extQ` antiRule_15Exp `Generics.extQ` antiClassOrInterfaceTypeExp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_36Exp `Generics.extQ` antiRule_38Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_49Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_53Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiArrayInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_62Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiForEachHeaderExp `Generics.extQ` antiRule_70Exp `Generics.extQ` antiCatchParameterExp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiResourceSpecExp `Generics.extQ` antiResourceExp `Generics.extQ` antiRule_79Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiLambdaBodyExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_93Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiNonEmptyTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiRule_106Exp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
-antiRule_86Exp _ = Nothing
+antiRule_93Exp _ = Nothing
 
 
 antiCreationExpressionExp :: CreationExpression -> Maybe (TH.Q TH.Exp )
@@ -227,12 +232,12 @@ antiSwitchStatementExp ( Anti_SwitchStatement v) = Just $ TH.varE (TH.mkName v)
 antiSwitchStatementExp _ = Nothing
 
 
-antiRule_74Exp :: [ Rule_74 ] -> Maybe (TH.Q TH.Exp)
-antiRule_74Exp ((Anti_Rule_74 v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiClassOrInterfaceTypeExp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiForEachHeaderExp `Generics.extQ` antiRule_65Exp `Generics.extQ` antiCatchParameterExp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiResourceSpecExp `Generics.extQ` antiResourceExp `Generics.extQ` antiRule_74Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiLambdaBodyExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_86Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiRule_100Exp `Generics.extQ` antiCompoundNameExp) rest
+antiRule_79Exp :: [ Rule_79 ] -> Maybe (TH.Q TH.Exp)
+antiRule_79Exp ((Anti_Rule_79 v):rest) =
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiCompilationUnitRestExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiElementValueExp `Generics.extQ` antiElementValueArrayInitializerExp `Generics.extQ` antiRule_15Exp `Generics.extQ` antiClassOrInterfaceTypeExp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_36Exp `Generics.extQ` antiRule_38Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_49Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_53Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiArrayInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_62Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiForEachHeaderExp `Generics.extQ` antiRule_70Exp `Generics.extQ` antiCatchParameterExp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiResourceSpecExp `Generics.extQ` antiResourceExp `Generics.extQ` antiRule_79Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiLambdaBodyExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_93Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiNonEmptyTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiRule_106Exp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
-antiRule_74Exp _ = Nothing
+antiRule_79Exp _ = Nothing
 
 
 antiResourceExp :: Resource -> Maybe (TH.Q TH.Exp )
@@ -260,12 +265,12 @@ antiCatchParameterExp ( Anti_CatchParameter v) = Just $ TH.varE (TH.mkName v)
 antiCatchParameterExp _ = Nothing
 
 
-antiRule_65Exp :: [ Rule_65 ] -> Maybe (TH.Q TH.Exp)
-antiRule_65Exp ((Anti_Rule_65 v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiClassOrInterfaceTypeExp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiForEachHeaderExp `Generics.extQ` antiRule_65Exp `Generics.extQ` antiCatchParameterExp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiResourceSpecExp `Generics.extQ` antiResourceExp `Generics.extQ` antiRule_74Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiLambdaBodyExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_86Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiRule_100Exp `Generics.extQ` antiCompoundNameExp) rest
+antiRule_70Exp :: [ Rule_70 ] -> Maybe (TH.Q TH.Exp)
+antiRule_70Exp ((Anti_Rule_70 v):rest) =
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiCompilationUnitRestExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiElementValueExp `Generics.extQ` antiElementValueArrayInitializerExp `Generics.extQ` antiRule_15Exp `Generics.extQ` antiClassOrInterfaceTypeExp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_36Exp `Generics.extQ` antiRule_38Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_49Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_53Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiArrayInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_62Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiForEachHeaderExp `Generics.extQ` antiRule_70Exp `Generics.extQ` antiCatchParameterExp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiResourceSpecExp `Generics.extQ` antiResourceExp `Generics.extQ` antiRule_79Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiLambdaBodyExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_93Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiNonEmptyTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiRule_106Exp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
-antiRule_65Exp _ = Nothing
+antiRule_70Exp _ = Nothing
 
 
 antiForEachHeaderExp :: ForEachHeader -> Maybe (TH.Q TH.Exp )
@@ -310,7 +315,7 @@ antiOptExpressionExp _ = Nothing
 
 antiStatementExp :: [ Statement ] -> Maybe (TH.Q TH.Exp)
 antiStatementExp ((Anti_Statement v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiClassOrInterfaceTypeExp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiForEachHeaderExp `Generics.extQ` antiRule_65Exp `Generics.extQ` antiCatchParameterExp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiResourceSpecExp `Generics.extQ` antiResourceExp `Generics.extQ` antiRule_74Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiLambdaBodyExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_86Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiRule_100Exp `Generics.extQ` antiCompoundNameExp) rest
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiCompilationUnitRestExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiElementValueExp `Generics.extQ` antiElementValueArrayInitializerExp `Generics.extQ` antiRule_15Exp `Generics.extQ` antiClassOrInterfaceTypeExp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_36Exp `Generics.extQ` antiRule_38Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_49Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_53Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiArrayInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_62Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiForEachHeaderExp `Generics.extQ` antiRule_70Exp `Generics.extQ` antiCatchParameterExp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiResourceSpecExp `Generics.extQ` antiResourceExp `Generics.extQ` antiRule_79Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiLambdaBodyExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_93Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiNonEmptyTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiRule_106Exp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
 antiStatementExp _ = Nothing
@@ -321,12 +326,12 @@ antiParameterExp ( Anti_Parameter v) = Just $ TH.varE (TH.mkName v)
 antiParameterExp _ = Nothing
 
 
-antiRule_57Exp :: [ Rule_57 ] -> Maybe (TH.Q TH.Exp)
-antiRule_57Exp ((Anti_Rule_57 v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiClassOrInterfaceTypeExp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiForEachHeaderExp `Generics.extQ` antiRule_65Exp `Generics.extQ` antiCatchParameterExp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiResourceSpecExp `Generics.extQ` antiResourceExp `Generics.extQ` antiRule_74Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiLambdaBodyExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_86Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiRule_100Exp `Generics.extQ` antiCompoundNameExp) rest
+antiRule_62Exp :: [ Rule_62 ] -> Maybe (TH.Q TH.Exp)
+antiRule_62Exp ((Anti_Rule_62 v):rest) =
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiCompilationUnitRestExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiElementValueExp `Generics.extQ` antiElementValueArrayInitializerExp `Generics.extQ` antiRule_15Exp `Generics.extQ` antiClassOrInterfaceTypeExp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_36Exp `Generics.extQ` antiRule_38Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_49Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_53Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiArrayInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_62Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiForEachHeaderExp `Generics.extQ` antiRule_70Exp `Generics.extQ` antiCatchParameterExp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiResourceSpecExp `Generics.extQ` antiResourceExp `Generics.extQ` antiRule_79Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiLambdaBodyExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_93Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiNonEmptyTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiRule_106Exp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
-antiRule_57Exp _ = Nothing
+antiRule_62Exp _ = Nothing
 
 
 antiParameterListExp :: ParameterList -> Maybe (TH.Q TH.Exp )
@@ -337,6 +342,11 @@ antiParameterListExp _ = Nothing
 antiStaticInitializerExp :: StaticInitializer -> Maybe (TH.Q TH.Exp )
 antiStaticInitializerExp ( Anti_StaticInitializer v) = Just $ TH.varE (TH.mkName v)
 antiStaticInitializerExp _ = Nothing
+
+
+antiArrayInitializerExp :: ArrayInitializer -> Maybe (TH.Q TH.Exp )
+antiArrayInitializerExp ( Anti_ArrayInitializer v) = Just $ TH.varE (TH.mkName v)
+antiArrayInitializerExp _ = Nothing
 
 
 antiVariableInitializerExp :: VariableInitializer -> Maybe (TH.Q TH.Exp )
@@ -359,12 +369,12 @@ antiOptVariableInitializerExp ( Anti_OptVariableInitializer v) = Just $ TH.varE 
 antiOptVariableInitializerExp _ = Nothing
 
 
-antiRule_48Exp :: [ Rule_48 ] -> Maybe (TH.Q TH.Exp)
-antiRule_48Exp ((Anti_Rule_48 v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiClassOrInterfaceTypeExp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiForEachHeaderExp `Generics.extQ` antiRule_65Exp `Generics.extQ` antiCatchParameterExp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiResourceSpecExp `Generics.extQ` antiResourceExp `Generics.extQ` antiRule_74Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiLambdaBodyExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_86Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiRule_100Exp `Generics.extQ` antiCompoundNameExp) rest
+antiRule_53Exp :: [ Rule_53 ] -> Maybe (TH.Q TH.Exp)
+antiRule_53Exp ((Anti_Rule_53 v):rest) =
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiCompilationUnitRestExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiElementValueExp `Generics.extQ` antiElementValueArrayInitializerExp `Generics.extQ` antiRule_15Exp `Generics.extQ` antiClassOrInterfaceTypeExp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_36Exp `Generics.extQ` antiRule_38Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_49Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_53Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiArrayInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_62Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiForEachHeaderExp `Generics.extQ` antiRule_70Exp `Generics.extQ` antiCatchParameterExp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiResourceSpecExp `Generics.extQ` antiResourceExp `Generics.extQ` antiRule_79Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiLambdaBodyExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_93Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiNonEmptyTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiRule_106Exp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
-antiRule_48Exp _ = Nothing
+antiRule_53Exp _ = Nothing
 
 
 antiVariableDeclarationExp :: VariableDeclaration -> Maybe (TH.Q TH.Exp )
@@ -382,12 +392,12 @@ antiStatementBlockExp ( Anti_StatementBlock v) = Just $ TH.varE (TH.mkName v)
 antiStatementBlockExp _ = Nothing
 
 
-antiRule_44Exp :: [ Rule_44 ] -> Maybe (TH.Q TH.Exp)
-antiRule_44Exp ((Anti_Rule_44 v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiClassOrInterfaceTypeExp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiForEachHeaderExp `Generics.extQ` antiRule_65Exp `Generics.extQ` antiCatchParameterExp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiResourceSpecExp `Generics.extQ` antiResourceExp `Generics.extQ` antiRule_74Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiLambdaBodyExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_86Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiRule_100Exp `Generics.extQ` antiCompoundNameExp) rest
+antiRule_49Exp :: [ Rule_49 ] -> Maybe (TH.Q TH.Exp)
+antiRule_49Exp ((Anti_Rule_49 v):rest) =
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiCompilationUnitRestExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiElementValueExp `Generics.extQ` antiElementValueArrayInitializerExp `Generics.extQ` antiRule_15Exp `Generics.extQ` antiClassOrInterfaceTypeExp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_36Exp `Generics.extQ` antiRule_38Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_49Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_53Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiArrayInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_62Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiForEachHeaderExp `Generics.extQ` antiRule_70Exp `Generics.extQ` antiCatchParameterExp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiResourceSpecExp `Generics.extQ` antiResourceExp `Generics.extQ` antiRule_79Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiLambdaBodyExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_93Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiNonEmptyTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiRule_106Exp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
-antiRule_44Exp _ = Nothing
+antiRule_49Exp _ = Nothing
 
 
 antiMemberRestExp :: MemberRest -> Maybe (TH.Q TH.Exp )
@@ -420,20 +430,20 @@ antiMemberDeclarationExp ( Anti_MemberDeclaration v) = Just $ TH.varE (TH.mkName
 antiMemberDeclarationExp _ = Nothing
 
 
-antiRule_33Exp :: [ Rule_33 ] -> Maybe (TH.Q TH.Exp)
-antiRule_33Exp ((Anti_Rule_33 v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiClassOrInterfaceTypeExp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiForEachHeaderExp `Generics.extQ` antiRule_65Exp `Generics.extQ` antiCatchParameterExp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiResourceSpecExp `Generics.extQ` antiResourceExp `Generics.extQ` antiRule_74Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiLambdaBodyExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_86Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiRule_100Exp `Generics.extQ` antiCompoundNameExp) rest
+antiRule_38Exp :: [ Rule_38 ] -> Maybe (TH.Q TH.Exp)
+antiRule_38Exp ((Anti_Rule_38 v):rest) =
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiCompilationUnitRestExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiElementValueExp `Generics.extQ` antiElementValueArrayInitializerExp `Generics.extQ` antiRule_15Exp `Generics.extQ` antiClassOrInterfaceTypeExp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_36Exp `Generics.extQ` antiRule_38Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_49Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_53Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiArrayInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_62Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiForEachHeaderExp `Generics.extQ` antiRule_70Exp `Generics.extQ` antiCatchParameterExp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiResourceSpecExp `Generics.extQ` antiResourceExp `Generics.extQ` antiRule_79Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiLambdaBodyExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_93Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiNonEmptyTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiRule_106Exp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
-antiRule_33Exp _ = Nothing
+antiRule_38Exp _ = Nothing
 
 
-antiRule_31Exp :: [ Rule_31 ] -> Maybe (TH.Q TH.Exp)
-antiRule_31Exp ((Anti_Rule_31 v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiClassOrInterfaceTypeExp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiForEachHeaderExp `Generics.extQ` antiRule_65Exp `Generics.extQ` antiCatchParameterExp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiResourceSpecExp `Generics.extQ` antiResourceExp `Generics.extQ` antiRule_74Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiLambdaBodyExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_86Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiRule_100Exp `Generics.extQ` antiCompoundNameExp) rest
+antiRule_36Exp :: [ Rule_36 ] -> Maybe (TH.Q TH.Exp)
+antiRule_36Exp ((Anti_Rule_36 v):rest) =
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiCompilationUnitRestExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiElementValueExp `Generics.extQ` antiElementValueArrayInitializerExp `Generics.extQ` antiRule_15Exp `Generics.extQ` antiClassOrInterfaceTypeExp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_36Exp `Generics.extQ` antiRule_38Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_49Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_53Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiArrayInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_62Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiForEachHeaderExp `Generics.extQ` antiRule_70Exp `Generics.extQ` antiCatchParameterExp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiResourceSpecExp `Generics.extQ` antiResourceExp `Generics.extQ` antiRule_79Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiLambdaBodyExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_93Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiNonEmptyTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiRule_106Exp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
-antiRule_31Exp _ = Nothing
+antiRule_36Exp _ = Nothing
 
 
 antiTypeDeclRestExp :: TypeDeclRest -> Maybe (TH.Q TH.Exp )
@@ -458,7 +468,7 @@ antiEnumConstantExp _ = Nothing
 
 antiAnnotationTypeElementExp :: [ AnnotationTypeElement ] -> Maybe (TH.Q TH.Exp)
 antiAnnotationTypeElementExp ((Anti_AnnotationTypeElement v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiClassOrInterfaceTypeExp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiForEachHeaderExp `Generics.extQ` antiRule_65Exp `Generics.extQ` antiCatchParameterExp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiResourceSpecExp `Generics.extQ` antiResourceExp `Generics.extQ` antiRule_74Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiLambdaBodyExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_86Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiRule_100Exp `Generics.extQ` antiCompoundNameExp) rest
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiCompilationUnitRestExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiElementValueExp `Generics.extQ` antiElementValueArrayInitializerExp `Generics.extQ` antiRule_15Exp `Generics.extQ` antiClassOrInterfaceTypeExp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_36Exp `Generics.extQ` antiRule_38Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_49Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_53Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiArrayInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_62Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiForEachHeaderExp `Generics.extQ` antiRule_70Exp `Generics.extQ` antiCatchParameterExp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiResourceSpecExp `Generics.extQ` antiResourceExp `Generics.extQ` antiRule_79Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiLambdaBodyExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_93Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiNonEmptyTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiRule_106Exp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
 antiAnnotationTypeElementExp _ = Nothing
@@ -481,7 +491,7 @@ antiClassDeclarationExp _ = Nothing
 
 antiFieldDeclarationExp :: [ FieldDeclaration ] -> Maybe (TH.Q TH.Exp)
 antiFieldDeclarationExp ((Anti_FieldDeclaration v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiClassOrInterfaceTypeExp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiForEachHeaderExp `Generics.extQ` antiRule_65Exp `Generics.extQ` antiCatchParameterExp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiResourceSpecExp `Generics.extQ` antiResourceExp `Generics.extQ` antiRule_74Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiLambdaBodyExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_86Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiRule_100Exp `Generics.extQ` antiCompoundNameExp) rest
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiCompilationUnitRestExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiElementValueExp `Generics.extQ` antiElementValueArrayInitializerExp `Generics.extQ` antiRule_15Exp `Generics.extQ` antiClassOrInterfaceTypeExp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_36Exp `Generics.extQ` antiRule_38Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_49Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_53Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiArrayInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_62Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiForEachHeaderExp `Generics.extQ` antiRule_70Exp `Generics.extQ` antiCatchParameterExp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiResourceSpecExp `Generics.extQ` antiResourceExp `Generics.extQ` antiRule_79Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiLambdaBodyExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_93Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiNonEmptyTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiRule_106Exp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
 antiFieldDeclarationExp _ = Nothing
@@ -502,12 +512,22 @@ antiClassOrInterfaceTypeExp ( Anti_ClassOrInterfaceType v) = Just $ TH.varE (TH.
 antiClassOrInterfaceTypeExp _ = Nothing
 
 
-antiRule_10Exp :: [ Rule_10 ] -> Maybe (TH.Q TH.Exp)
-antiRule_10Exp ((Anti_Rule_10 v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiClassOrInterfaceTypeExp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiForEachHeaderExp `Generics.extQ` antiRule_65Exp `Generics.extQ` antiCatchParameterExp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiResourceSpecExp `Generics.extQ` antiResourceExp `Generics.extQ` antiRule_74Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiLambdaBodyExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_86Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiRule_100Exp `Generics.extQ` antiCompoundNameExp) rest
+antiRule_15Exp :: [ Rule_15 ] -> Maybe (TH.Q TH.Exp)
+antiRule_15Exp ((Anti_Rule_15 v):rest) =
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiCompilationUnitRestExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiElementValueExp `Generics.extQ` antiElementValueArrayInitializerExp `Generics.extQ` antiRule_15Exp `Generics.extQ` antiClassOrInterfaceTypeExp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_36Exp `Generics.extQ` antiRule_38Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_49Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_53Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiArrayInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_62Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiForEachHeaderExp `Generics.extQ` antiRule_70Exp `Generics.extQ` antiCatchParameterExp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiResourceSpecExp `Generics.extQ` antiResourceExp `Generics.extQ` antiRule_79Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiLambdaBodyExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_93Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiNonEmptyTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiRule_106Exp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
-antiRule_10Exp _ = Nothing
+antiRule_15Exp _ = Nothing
+
+
+antiElementValueArrayInitializerExp :: ElementValueArrayInitializer -> Maybe (TH.Q TH.Exp )
+antiElementValueArrayInitializerExp ( Anti_ElementValueArrayInitializer v) = Just $ TH.varE (TH.mkName v)
+antiElementValueArrayInitializerExp _ = Nothing
+
+
+antiElementValueExp :: ElementValue -> Maybe (TH.Q TH.Exp )
+antiElementValueExp ( Anti_ElementValue v) = Just $ TH.varE (TH.mkName v)
+antiElementValueExp _ = Nothing
 
 
 antiAnnotationElementExp :: AnnotationElement -> Maybe (TH.Q TH.Exp )
@@ -545,6 +565,11 @@ antiPackageExp ( Anti_Package v) = Just $ TH.varE (TH.mkName v)
 antiPackageExp _ = Nothing
 
 
+antiCompilationUnitRestExp :: CompilationUnitRest -> Maybe (TH.Q TH.Exp )
+antiCompilationUnitRestExp ( Anti_CompilationUnitRest v) = Just $ TH.varE (TH.mkName v)
+antiCompilationUnitRestExp _ = Nothing
+
+
 antiCompilationUnitExp :: CompilationUnit -> Maybe (TH.Q TH.Exp )
 antiCompilationUnitExp ( Anti_CompilationUnit v) = Just $ TH.varE (TH.mkName v)
 antiCompilationUnitExp _ = Nothing
@@ -552,7 +577,7 @@ antiCompilationUnitExp _ = Nothing
 
 antiImportStatementExp :: [ ImportStatement ] -> Maybe (TH.Q TH.Exp)
 antiImportStatementExp ((Anti_ImportStatement v):rest) =
- let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiRule_10Exp `Generics.extQ` antiClassOrInterfaceTypeExp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_31Exp `Generics.extQ` antiRule_33Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_44Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_48Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_57Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiForEachHeaderExp `Generics.extQ` antiRule_65Exp `Generics.extQ` antiCatchParameterExp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiResourceSpecExp `Generics.extQ` antiResourceExp `Generics.extQ` antiRule_74Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiLambdaBodyExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_86Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiRule_100Exp `Generics.extQ` antiCompoundNameExp) rest
+ let restExp =   dataToExpQ (const Nothing `Generics.extQ` antiJavaExp `Generics.extQ` antiOptDocCommentExp `Generics.extQ` antiTypeDeclarationExp `Generics.extQ` antiImportStatementExp `Generics.extQ` antiCompilationUnitExp `Generics.extQ` antiCompilationUnitRestExp `Generics.extQ` antiPackageExp `Generics.extQ` antiImportNameExp `Generics.extQ` antiImportHeadExp `Generics.extQ` antiDocCommentExp `Generics.extQ` antiAnnotationExp `Generics.extQ` antiAnnotationArgumentsExp `Generics.extQ` antiAnnotationElementExp `Generics.extQ` antiElementValueExp `Generics.extQ` antiElementValueArrayInitializerExp `Generics.extQ` antiRule_15Exp `Generics.extQ` antiClassOrInterfaceTypeExp `Generics.extQ` antiExtendsListExp `Generics.extQ` antiImplementsListExp `Generics.extQ` antiFieldDeclarationExp `Generics.extQ` antiClassDeclarationExp `Generics.extQ` antiInterfaceDeclarationExp `Generics.extQ` antiAnnotationDeclarationExp `Generics.extQ` antiAnnotationTypeElementExp `Generics.extQ` antiEnumConstantExp `Generics.extQ` antiEnumConstantListExp `Generics.extQ` antiEnumDeclarationExp `Generics.extQ` antiTypeDeclRestExp `Generics.extQ` antiRule_36Exp `Generics.extQ` antiRule_38Exp `Generics.extQ` antiMemberDeclarationExp `Generics.extQ` antiPrimitiveTypeKeywordExp `Generics.extQ` antiMemberAfterFirstIdExp `Generics.extQ` antiMoreTypeSpecifierExp `Generics.extQ` antiThrowsClauseExp `Generics.extQ` antiMemberRestExp `Generics.extQ` antiRule_49Exp `Generics.extQ` antiStatementBlockExp `Generics.extQ` antiVariableDeclaratorListExp `Generics.extQ` antiVariableDeclarationExp `Generics.extQ` antiRule_53Exp `Generics.extQ` antiOptVariableInitializerExp `Generics.extQ` antiVariableDeclaratorExp `Generics.extQ` antiVariableInitializerListExp `Generics.extQ` antiVariableInitializerExp `Generics.extQ` antiArrayInitializerExp `Generics.extQ` antiStaticInitializerExp `Generics.extQ` antiParameterListExp `Generics.extQ` antiRule_62Exp `Generics.extQ` antiParameterExp `Generics.extQ` antiStatementExp `Generics.extQ` antiOptExpressionExp `Generics.extQ` antiOptIdExp `Generics.extQ` antiOptElsePartExp `Generics.extQ` antiIfStatementExp `Generics.extQ` antiDoStatementExp `Generics.extQ` antiWhileStatementExp `Generics.extQ` antiForStatementExp `Generics.extQ` antiForEachHeaderExp `Generics.extQ` antiRule_70Exp `Generics.extQ` antiCatchParameterExp `Generics.extQ` antiOptFinallyExp `Generics.extQ` antiTryStatementExp `Generics.extQ` antiResourceSpecExp `Generics.extQ` antiResourceExp `Generics.extQ` antiRule_79Exp `Generics.extQ` antiSwitchStatementExp `Generics.extQ` antiExpressionExp `Generics.extQ` antiLambdaBodyExp `Generics.extQ` antiAssignmentOpExp `Generics.extQ` antiEqualityOpExp `Generics.extQ` antiRelationalOpExp `Generics.extQ` antiShiftOpExp `Generics.extQ` antiAdditiveOpExp `Generics.extQ` antiMultiplicativeOpExp `Generics.extQ` antiPrefixOpExp `Generics.extQ` antiPostfixOpExp `Generics.extQ` antiCreationExpressionExp `Generics.extQ` antiRule_93Exp `Generics.extQ` antiLiteralExp `Generics.extQ` antiArglistExp `Generics.extQ` antiTypeArgumentsExp `Generics.extQ` antiNonEmptyTypeArgumentsExp `Generics.extQ` antiTypeArgumentExp `Generics.extQ` antiWildcardTypeExp `Generics.extQ` antiTypeParametersExp `Generics.extQ` antiNonEmptyTypeParametersExp `Generics.extQ` antiTypeParameterExp `Generics.extQ` antiTypeExp `Generics.extQ` antiTypeSpecifierExp `Generics.extQ` antiModifierExp `Generics.extQ` antiRule_106Exp `Generics.extQ` antiCompoundNameExp) rest
      lvar = TH.varE $ TH.mkName v
    in Just [| $lvar ++ $restExp |]
 antiImportStatementExp _ = Nothing
@@ -579,9 +604,9 @@ antiCompoundNamePat ( Anti_CompoundName v) = Just $ TH.varP (TH.mkName v)
 antiCompoundNamePat _ = Nothing
 
 
-antiRule_100Pat :: [ Rule_100 ] -> Maybe (TH.Q TH.Pat)
-antiRule_100Pat [Anti_Rule_100 v] = Just $ TH.varP (TH.mkName v)
-antiRule_100Pat _ = Nothing
+antiRule_106Pat :: [ Rule_106 ] -> Maybe (TH.Q TH.Pat)
+antiRule_106Pat [Anti_Rule_106 v] = Just $ TH.varP (TH.mkName v)
+antiRule_106Pat _ = Nothing
 
 
 antiModifierPat :: Modifier -> Maybe (TH.Q TH.Pat )
@@ -602,6 +627,11 @@ antiTypePat _ = Nothing
 antiTypeParameterPat :: TypeParameter -> Maybe (TH.Q TH.Pat )
 antiTypeParameterPat ( Anti_TypeParameter v) = Just $ TH.varP (TH.mkName v)
 antiTypeParameterPat _ = Nothing
+
+
+antiNonEmptyTypeParametersPat :: NonEmptyTypeParameters -> Maybe (TH.Q TH.Pat )
+antiNonEmptyTypeParametersPat ( Anti_NonEmptyTypeParameters v) = Just $ TH.varP (TH.mkName v)
+antiNonEmptyTypeParametersPat _ = Nothing
 
 
 antiTypeParametersPat :: TypeParameters -> Maybe (TH.Q TH.Pat )
@@ -639,9 +669,9 @@ antiLiteralPat ( Anti_Literal v) = Just $ TH.varP (TH.mkName v)
 antiLiteralPat _ = Nothing
 
 
-antiRule_86Pat :: [ Rule_86 ] -> Maybe (TH.Q TH.Pat)
-antiRule_86Pat [Anti_Rule_86 v] = Just $ TH.varP (TH.mkName v)
-antiRule_86Pat _ = Nothing
+antiRule_93Pat :: [ Rule_93 ] -> Maybe (TH.Q TH.Pat)
+antiRule_93Pat [Anti_Rule_93 v] = Just $ TH.varP (TH.mkName v)
+antiRule_93Pat _ = Nothing
 
 
 antiCreationExpressionPat :: CreationExpression -> Maybe (TH.Q TH.Pat )
@@ -704,9 +734,9 @@ antiSwitchStatementPat ( Anti_SwitchStatement v) = Just $ TH.varP (TH.mkName v)
 antiSwitchStatementPat _ = Nothing
 
 
-antiRule_74Pat :: [ Rule_74 ] -> Maybe (TH.Q TH.Pat)
-antiRule_74Pat [Anti_Rule_74 v] = Just $ TH.varP (TH.mkName v)
-antiRule_74Pat _ = Nothing
+antiRule_79Pat :: [ Rule_79 ] -> Maybe (TH.Q TH.Pat)
+antiRule_79Pat [Anti_Rule_79 v] = Just $ TH.varP (TH.mkName v)
+antiRule_79Pat _ = Nothing
 
 
 antiResourcePat :: Resource -> Maybe (TH.Q TH.Pat )
@@ -734,9 +764,9 @@ antiCatchParameterPat ( Anti_CatchParameter v) = Just $ TH.varP (TH.mkName v)
 antiCatchParameterPat _ = Nothing
 
 
-antiRule_65Pat :: [ Rule_65 ] -> Maybe (TH.Q TH.Pat)
-antiRule_65Pat [Anti_Rule_65 v] = Just $ TH.varP (TH.mkName v)
-antiRule_65Pat _ = Nothing
+antiRule_70Pat :: [ Rule_70 ] -> Maybe (TH.Q TH.Pat)
+antiRule_70Pat [Anti_Rule_70 v] = Just $ TH.varP (TH.mkName v)
+antiRule_70Pat _ = Nothing
 
 
 antiForEachHeaderPat :: ForEachHeader -> Maybe (TH.Q TH.Pat )
@@ -789,9 +819,9 @@ antiParameterPat ( Anti_Parameter v) = Just $ TH.varP (TH.mkName v)
 antiParameterPat _ = Nothing
 
 
-antiRule_57Pat :: [ Rule_57 ] -> Maybe (TH.Q TH.Pat)
-antiRule_57Pat [Anti_Rule_57 v] = Just $ TH.varP (TH.mkName v)
-antiRule_57Pat _ = Nothing
+antiRule_62Pat :: [ Rule_62 ] -> Maybe (TH.Q TH.Pat)
+antiRule_62Pat [Anti_Rule_62 v] = Just $ TH.varP (TH.mkName v)
+antiRule_62Pat _ = Nothing
 
 
 antiParameterListPat :: ParameterList -> Maybe (TH.Q TH.Pat )
@@ -802,6 +832,11 @@ antiParameterListPat _ = Nothing
 antiStaticInitializerPat :: StaticInitializer -> Maybe (TH.Q TH.Pat )
 antiStaticInitializerPat ( Anti_StaticInitializer v) = Just $ TH.varP (TH.mkName v)
 antiStaticInitializerPat _ = Nothing
+
+
+antiArrayInitializerPat :: ArrayInitializer -> Maybe (TH.Q TH.Pat )
+antiArrayInitializerPat ( Anti_ArrayInitializer v) = Just $ TH.varP (TH.mkName v)
+antiArrayInitializerPat _ = Nothing
 
 
 antiVariableInitializerPat :: VariableInitializer -> Maybe (TH.Q TH.Pat )
@@ -824,9 +859,9 @@ antiOptVariableInitializerPat ( Anti_OptVariableInitializer v) = Just $ TH.varP 
 antiOptVariableInitializerPat _ = Nothing
 
 
-antiRule_48Pat :: [ Rule_48 ] -> Maybe (TH.Q TH.Pat)
-antiRule_48Pat [Anti_Rule_48 v] = Just $ TH.varP (TH.mkName v)
-antiRule_48Pat _ = Nothing
+antiRule_53Pat :: [ Rule_53 ] -> Maybe (TH.Q TH.Pat)
+antiRule_53Pat [Anti_Rule_53 v] = Just $ TH.varP (TH.mkName v)
+antiRule_53Pat _ = Nothing
 
 
 antiVariableDeclarationPat :: VariableDeclaration -> Maybe (TH.Q TH.Pat )
@@ -844,9 +879,9 @@ antiStatementBlockPat ( Anti_StatementBlock v) = Just $ TH.varP (TH.mkName v)
 antiStatementBlockPat _ = Nothing
 
 
-antiRule_44Pat :: [ Rule_44 ] -> Maybe (TH.Q TH.Pat)
-antiRule_44Pat [Anti_Rule_44 v] = Just $ TH.varP (TH.mkName v)
-antiRule_44Pat _ = Nothing
+antiRule_49Pat :: [ Rule_49 ] -> Maybe (TH.Q TH.Pat)
+antiRule_49Pat [Anti_Rule_49 v] = Just $ TH.varP (TH.mkName v)
+antiRule_49Pat _ = Nothing
 
 
 antiMemberRestPat :: MemberRest -> Maybe (TH.Q TH.Pat )
@@ -879,14 +914,14 @@ antiMemberDeclarationPat ( Anti_MemberDeclaration v) = Just $ TH.varP (TH.mkName
 antiMemberDeclarationPat _ = Nothing
 
 
-antiRule_33Pat :: [ Rule_33 ] -> Maybe (TH.Q TH.Pat)
-antiRule_33Pat [Anti_Rule_33 v] = Just $ TH.varP (TH.mkName v)
-antiRule_33Pat _ = Nothing
+antiRule_38Pat :: [ Rule_38 ] -> Maybe (TH.Q TH.Pat)
+antiRule_38Pat [Anti_Rule_38 v] = Just $ TH.varP (TH.mkName v)
+antiRule_38Pat _ = Nothing
 
 
-antiRule_31Pat :: [ Rule_31 ] -> Maybe (TH.Q TH.Pat)
-antiRule_31Pat [Anti_Rule_31 v] = Just $ TH.varP (TH.mkName v)
-antiRule_31Pat _ = Nothing
+antiRule_36Pat :: [ Rule_36 ] -> Maybe (TH.Q TH.Pat)
+antiRule_36Pat [Anti_Rule_36 v] = Just $ TH.varP (TH.mkName v)
+antiRule_36Pat _ = Nothing
 
 
 antiTypeDeclRestPat :: TypeDeclRest -> Maybe (TH.Q TH.Pat )
@@ -949,9 +984,19 @@ antiClassOrInterfaceTypePat ( Anti_ClassOrInterfaceType v) = Just $ TH.varP (TH.
 antiClassOrInterfaceTypePat _ = Nothing
 
 
-antiRule_10Pat :: [ Rule_10 ] -> Maybe (TH.Q TH.Pat)
-antiRule_10Pat [Anti_Rule_10 v] = Just $ TH.varP (TH.mkName v)
-antiRule_10Pat _ = Nothing
+antiRule_15Pat :: [ Rule_15 ] -> Maybe (TH.Q TH.Pat)
+antiRule_15Pat [Anti_Rule_15 v] = Just $ TH.varP (TH.mkName v)
+antiRule_15Pat _ = Nothing
+
+
+antiElementValueArrayInitializerPat :: ElementValueArrayInitializer -> Maybe (TH.Q TH.Pat )
+antiElementValueArrayInitializerPat ( Anti_ElementValueArrayInitializer v) = Just $ TH.varP (TH.mkName v)
+antiElementValueArrayInitializerPat _ = Nothing
+
+
+antiElementValuePat :: ElementValue -> Maybe (TH.Q TH.Pat )
+antiElementValuePat ( Anti_ElementValue v) = Just $ TH.varP (TH.mkName v)
+antiElementValuePat _ = Nothing
 
 
 antiAnnotationElementPat :: AnnotationElement -> Maybe (TH.Q TH.Pat )
@@ -989,6 +1034,11 @@ antiPackagePat ( Anti_Package v) = Just $ TH.varP (TH.mkName v)
 antiPackagePat _ = Nothing
 
 
+antiCompilationUnitRestPat :: CompilationUnitRest -> Maybe (TH.Q TH.Pat )
+antiCompilationUnitRestPat ( Anti_CompilationUnitRest v) = Just $ TH.varP (TH.mkName v)
+antiCompilationUnitRestPat _ = Nothing
+
+
 antiCompilationUnitPat :: CompilationUnit -> Maybe (TH.Q TH.Pat )
 antiCompilationUnitPat ( Anti_CompilationUnit v) = Just $ TH.varP (TH.mkName v)
 antiCompilationUnitPat _ = Nothing
@@ -1022,465 +1072,495 @@ quoteJavaDecs _ = fail "this quasi-quoter cannot be used in a declaration contex
 getJava ( Ctr__Java__0 _ s) = s
 
 java :: QuasiQuoter
-java = QuasiQuoter (quoteJavaExp "tok_Java_dummy_194" getJava ) (quoteJavaPat "tok_Java_dummy_194" getJava ) quoteJavaType quoteJavaDecs
+java = QuasiQuoter (quoteJavaExp "tok_Java_dummy_206" getJava ) (quoteJavaPat "tok_Java_dummy_206" getJava ) quoteJavaType quoteJavaDecs
 
 getAdditiveOp ( Ctr__Java__1 _ s) = s
 
 additiveOp :: QuasiQuoter
-additiveOp = QuasiQuoter (quoteJavaExp "tok_AdditiveOp_dummy_193" getAdditiveOp ) (quoteJavaPat "tok_AdditiveOp_dummy_193" getAdditiveOp ) quoteJavaType quoteJavaDecs
+additiveOp = QuasiQuoter (quoteJavaExp "tok_AdditiveOp_dummy_205" getAdditiveOp ) (quoteJavaPat "tok_AdditiveOp_dummy_205" getAdditiveOp ) quoteJavaType quoteJavaDecs
 
 getAnnotation ( Ctr__Java__2 _ s) = s
 
 annotation :: QuasiQuoter
-annotation = QuasiQuoter (quoteJavaExp "tok_Annotation_dummy_192" getAnnotation ) (quoteJavaPat "tok_Annotation_dummy_192" getAnnotation ) quoteJavaType quoteJavaDecs
+annotation = QuasiQuoter (quoteJavaExp "tok_Annotation_dummy_204" getAnnotation ) (quoteJavaPat "tok_Annotation_dummy_204" getAnnotation ) quoteJavaType quoteJavaDecs
 
 getAnnotationArguments ( Ctr__Java__3 _ s) = s
 
 annotationArguments :: QuasiQuoter
-annotationArguments = QuasiQuoter (quoteJavaExp "tok_AnnotationArguments_dummy_191" getAnnotationArguments ) (quoteJavaPat "tok_AnnotationArguments_dummy_191" getAnnotationArguments ) quoteJavaType quoteJavaDecs
+annotationArguments = QuasiQuoter (quoteJavaExp "tok_AnnotationArguments_dummy_203" getAnnotationArguments ) (quoteJavaPat "tok_AnnotationArguments_dummy_203" getAnnotationArguments ) quoteJavaType quoteJavaDecs
 
 getAnnotationDeclaration ( Ctr__Java__4 _ s) = s
 
 annotationDeclaration :: QuasiQuoter
-annotationDeclaration = QuasiQuoter (quoteJavaExp "tok_AnnotationDeclaration_dummy_190" getAnnotationDeclaration ) (quoteJavaPat "tok_AnnotationDeclaration_dummy_190" getAnnotationDeclaration ) quoteJavaType quoteJavaDecs
+annotationDeclaration = QuasiQuoter (quoteJavaExp "tok_AnnotationDeclaration_dummy_202" getAnnotationDeclaration ) (quoteJavaPat "tok_AnnotationDeclaration_dummy_202" getAnnotationDeclaration ) quoteJavaType quoteJavaDecs
 
 getAnnotationElement ( Ctr__Java__5 _ s) = s
 
 annotationElement :: QuasiQuoter
-annotationElement = QuasiQuoter (quoteJavaExp "tok_AnnotationElement_dummy_189" getAnnotationElement ) (quoteJavaPat "tok_AnnotationElement_dummy_189" getAnnotationElement ) quoteJavaType quoteJavaDecs
+annotationElement = QuasiQuoter (quoteJavaExp "tok_AnnotationElement_dummy_201" getAnnotationElement ) (quoteJavaPat "tok_AnnotationElement_dummy_201" getAnnotationElement ) quoteJavaType quoteJavaDecs
 
 getAnnotationList ( Ctr__Java__6 _ s) = s
 
 annotationList :: QuasiQuoter
-annotationList = QuasiQuoter (quoteJavaExp "tok_AnnotationList_dummy_188" getAnnotationList ) (quoteJavaPat "tok_AnnotationList_dummy_188" getAnnotationList ) quoteJavaType quoteJavaDecs
+annotationList = QuasiQuoter (quoteJavaExp "tok_AnnotationList_dummy_200" getAnnotationList ) (quoteJavaPat "tok_AnnotationList_dummy_200" getAnnotationList ) quoteJavaType quoteJavaDecs
 
 getAnnotationTypeElement ( Ctr__Java__7 _ s) = s
 
 annotationTypeElement :: QuasiQuoter
-annotationTypeElement = QuasiQuoter (quoteJavaExp "tok_AnnotationTypeElement_dummy_187" getAnnotationTypeElement ) (quoteJavaPat "tok_AnnotationTypeElement_dummy_187" getAnnotationTypeElement ) quoteJavaType quoteJavaDecs
+annotationTypeElement = QuasiQuoter (quoteJavaExp "tok_AnnotationTypeElement_dummy_199" getAnnotationTypeElement ) (quoteJavaPat "tok_AnnotationTypeElement_dummy_199" getAnnotationTypeElement ) quoteJavaType quoteJavaDecs
 
 getAnnotationTypeElementList ( Ctr__Java__8 _ s) = s
 
 annotationTypeElementList :: QuasiQuoter
-annotationTypeElementList = QuasiQuoter (quoteJavaExp "tok_AnnotationTypeElementList_dummy_186" getAnnotationTypeElementList ) (quoteJavaPat "tok_AnnotationTypeElementList_dummy_186" getAnnotationTypeElementList ) quoteJavaType quoteJavaDecs
+annotationTypeElementList = QuasiQuoter (quoteJavaExp "tok_AnnotationTypeElementList_dummy_198" getAnnotationTypeElementList ) (quoteJavaPat "tok_AnnotationTypeElementList_dummy_198" getAnnotationTypeElementList ) quoteJavaType quoteJavaDecs
 
 getArglist ( Ctr__Java__9 _ s) = s
 
 arglist :: QuasiQuoter
-arglist = QuasiQuoter (quoteJavaExp "tok_Arglist_dummy_185" getArglist ) (quoteJavaPat "tok_Arglist_dummy_185" getArglist ) quoteJavaType quoteJavaDecs
+arglist = QuasiQuoter (quoteJavaExp "tok_Arglist_dummy_197" getArglist ) (quoteJavaPat "tok_Arglist_dummy_197" getArglist ) quoteJavaType quoteJavaDecs
 
-getAssignmentOp ( Ctr__Java__10 _ s) = s
+getArrayInitializer ( Ctr__Java__10 _ s) = s
+
+arrayInitializer :: QuasiQuoter
+arrayInitializer = QuasiQuoter (quoteJavaExp "tok_ArrayInitializer_dummy_196" getArrayInitializer ) (quoteJavaPat "tok_ArrayInitializer_dummy_196" getArrayInitializer ) quoteJavaType quoteJavaDecs
+
+getAssignmentOp ( Ctr__Java__11 _ s) = s
 
 assignmentOp :: QuasiQuoter
-assignmentOp = QuasiQuoter (quoteJavaExp "tok_AssignmentOp_dummy_184" getAssignmentOp ) (quoteJavaPat "tok_AssignmentOp_dummy_184" getAssignmentOp ) quoteJavaType quoteJavaDecs
+assignmentOp = QuasiQuoter (quoteJavaExp "tok_AssignmentOp_dummy_195" getAssignmentOp ) (quoteJavaPat "tok_AssignmentOp_dummy_195" getAssignmentOp ) quoteJavaType quoteJavaDecs
 
-getCatchList ( Ctr__Java__11 _ s) = s
+getCatchList ( Ctr__Java__12 _ s) = s
 
 catchList :: QuasiQuoter
-catchList = QuasiQuoter (quoteJavaExp "tok_CatchList_dummy_183" getCatchList ) (quoteJavaPat "tok_CatchList_dummy_183" getCatchList ) quoteJavaType quoteJavaDecs
+catchList = QuasiQuoter (quoteJavaExp "tok_CatchList_dummy_194" getCatchList ) (quoteJavaPat "tok_CatchList_dummy_194" getCatchList ) quoteJavaType quoteJavaDecs
 
-getCatchParameter ( Ctr__Java__12 _ s) = s
+getCatchParameter ( Ctr__Java__13 _ s) = s
 
 catchParameter :: QuasiQuoter
-catchParameter = QuasiQuoter (quoteJavaExp "tok_CatchParameter_dummy_182" getCatchParameter ) (quoteJavaPat "tok_CatchParameter_dummy_182" getCatchParameter ) quoteJavaType quoteJavaDecs
+catchParameter = QuasiQuoter (quoteJavaExp "tok_CatchParameter_dummy_193" getCatchParameter ) (quoteJavaPat "tok_CatchParameter_dummy_193" getCatchParameter ) quoteJavaType quoteJavaDecs
 
-getClassDeclaration ( Ctr__Java__13 _ s) = s
+getClassDeclaration ( Ctr__Java__14 _ s) = s
 
 classDeclaration :: QuasiQuoter
-classDeclaration = QuasiQuoter (quoteJavaExp "tok_ClassDeclaration_dummy_181" getClassDeclaration ) (quoteJavaPat "tok_ClassDeclaration_dummy_181" getClassDeclaration ) quoteJavaType quoteJavaDecs
+classDeclaration = QuasiQuoter (quoteJavaExp "tok_ClassDeclaration_dummy_192" getClassDeclaration ) (quoteJavaPat "tok_ClassDeclaration_dummy_192" getClassDeclaration ) quoteJavaType quoteJavaDecs
 
-getClassOrInterfaceType ( Ctr__Java__14 _ s) = s
+getClassOrInterfaceType ( Ctr__Java__15 _ s) = s
 
 classOrInterfaceType :: QuasiQuoter
-classOrInterfaceType = QuasiQuoter (quoteJavaExp "tok_ClassOrInterfaceType_dummy_180" getClassOrInterfaceType ) (quoteJavaPat "tok_ClassOrInterfaceType_dummy_180" getClassOrInterfaceType ) quoteJavaType quoteJavaDecs
+classOrInterfaceType = QuasiQuoter (quoteJavaExp "tok_ClassOrInterfaceType_dummy_191" getClassOrInterfaceType ) (quoteJavaPat "tok_ClassOrInterfaceType_dummy_191" getClassOrInterfaceType ) quoteJavaType quoteJavaDecs
 
-getCompilationUnit ( Ctr__Java__15 _ s) = s
+getCompilationUnit ( Ctr__Java__16 _ s) = s
 
 compilationUnit :: QuasiQuoter
-compilationUnit = QuasiQuoter (quoteJavaExp "tok_CompilationUnit_dummy_179" getCompilationUnit ) (quoteJavaPat "tok_CompilationUnit_dummy_179" getCompilationUnit ) quoteJavaType quoteJavaDecs
+compilationUnit = QuasiQuoter (quoteJavaExp "tok_CompilationUnit_dummy_190" getCompilationUnit ) (quoteJavaPat "tok_CompilationUnit_dummy_190" getCompilationUnit ) quoteJavaType quoteJavaDecs
 
-getCompoundName ( Ctr__Java__16 _ s) = s
+getCompilationUnitRest ( Ctr__Java__17 _ s) = s
+
+compilationUnitRest :: QuasiQuoter
+compilationUnitRest = QuasiQuoter (quoteJavaExp "tok_CompilationUnitRest_dummy_189" getCompilationUnitRest ) (quoteJavaPat "tok_CompilationUnitRest_dummy_189" getCompilationUnitRest ) quoteJavaType quoteJavaDecs
+
+getCompoundName ( Ctr__Java__18 _ s) = s
 
 compoundName :: QuasiQuoter
-compoundName = QuasiQuoter (quoteJavaExp "tok_CompoundName_dummy_178" getCompoundName ) (quoteJavaPat "tok_CompoundName_dummy_178" getCompoundName ) quoteJavaType quoteJavaDecs
+compoundName = QuasiQuoter (quoteJavaExp "tok_CompoundName_dummy_188" getCompoundName ) (quoteJavaPat "tok_CompoundName_dummy_188" getCompoundName ) quoteJavaType quoteJavaDecs
 
-getCompoundNameTail ( Ctr__Java__17 _ s) = s
+getCompoundNameTail ( Ctr__Java__19 _ s) = s
 
 compoundNameTail :: QuasiQuoter
-compoundNameTail = QuasiQuoter (quoteJavaExp "tok_CompoundNameTail_dummy_177" getCompoundNameTail ) (quoteJavaPat "tok_CompoundNameTail_dummy_177" getCompoundNameTail ) quoteJavaType quoteJavaDecs
+compoundNameTail = QuasiQuoter (quoteJavaExp "tok_CompoundNameTail_dummy_187" getCompoundNameTail ) (quoteJavaPat "tok_CompoundNameTail_dummy_187" getCompoundNameTail ) quoteJavaType quoteJavaDecs
 
-getCreationExpression ( Ctr__Java__18 _ s) = s
+getCreationExpression ( Ctr__Java__20 _ s) = s
 
 creationExpression :: QuasiQuoter
-creationExpression = QuasiQuoter (quoteJavaExp "tok_CreationExpression_dummy_176" getCreationExpression ) (quoteJavaPat "tok_CreationExpression_dummy_176" getCreationExpression ) quoteJavaType quoteJavaDecs
+creationExpression = QuasiQuoter (quoteJavaExp "tok_CreationExpression_dummy_186" getCreationExpression ) (quoteJavaPat "tok_CreationExpression_dummy_186" getCreationExpression ) quoteJavaType quoteJavaDecs
 
-getDimExprs ( Ctr__Java__19 _ s) = s
+getDimExprs ( Ctr__Java__21 _ s) = s
 
 dimExprs :: QuasiQuoter
-dimExprs = QuasiQuoter (quoteJavaExp "tok_DimExprs_dummy_175" getDimExprs ) (quoteJavaPat "tok_DimExprs_dummy_175" getDimExprs ) quoteJavaType quoteJavaDecs
+dimExprs = QuasiQuoter (quoteJavaExp "tok_DimExprs_dummy_185" getDimExprs ) (quoteJavaPat "tok_DimExprs_dummy_185" getDimExprs ) quoteJavaType quoteJavaDecs
 
-getDims ( Ctr__Java__20 _ s) = s
+getDims ( Ctr__Java__22 _ s) = s
 
 dims :: QuasiQuoter
-dims = QuasiQuoter (quoteJavaExp "tok_Dims_dummy_174" getDims ) (quoteJavaPat "tok_Dims_dummy_174" getDims ) quoteJavaType quoteJavaDecs
+dims = QuasiQuoter (quoteJavaExp "tok_Dims_dummy_184" getDims ) (quoteJavaPat "tok_Dims_dummy_184" getDims ) quoteJavaType quoteJavaDecs
 
-getDoStatement ( Ctr__Java__21 _ s) = s
+getDoStatement ( Ctr__Java__23 _ s) = s
 
 doStatement :: QuasiQuoter
-doStatement = QuasiQuoter (quoteJavaExp "tok_DoStatement_dummy_173" getDoStatement ) (quoteJavaPat "tok_DoStatement_dummy_173" getDoStatement ) quoteJavaType quoteJavaDecs
+doStatement = QuasiQuoter (quoteJavaExp "tok_DoStatement_dummy_183" getDoStatement ) (quoteJavaPat "tok_DoStatement_dummy_183" getDoStatement ) quoteJavaType quoteJavaDecs
 
-getDocComment ( Ctr__Java__22 _ s) = s
+getDocComment ( Ctr__Java__24 _ s) = s
 
 docComment :: QuasiQuoter
-docComment = QuasiQuoter (quoteJavaExp "tok_DocComment_dummy_172" getDocComment ) (quoteJavaPat "tok_DocComment_dummy_172" getDocComment ) quoteJavaType quoteJavaDecs
+docComment = QuasiQuoter (quoteJavaExp "tok_DocComment_dummy_182" getDocComment ) (quoteJavaPat "tok_DocComment_dummy_182" getDocComment ) quoteJavaType quoteJavaDecs
 
-getEnumConstant ( Ctr__Java__23 _ s) = s
+getElementValue ( Ctr__Java__25 _ s) = s
+
+elementValue :: QuasiQuoter
+elementValue = QuasiQuoter (quoteJavaExp "tok_ElementValue_dummy_181" getElementValue ) (quoteJavaPat "tok_ElementValue_dummy_181" getElementValue ) quoteJavaType quoteJavaDecs
+
+getElementValueArrayInitializer ( Ctr__Java__26 _ s) = s
+
+elementValueArrayInitializer :: QuasiQuoter
+elementValueArrayInitializer = QuasiQuoter (quoteJavaExp "tok_ElementValueArrayInitializer_dummy_180" getElementValueArrayInitializer ) (quoteJavaPat "tok_ElementValueArrayInitializer_dummy_180" getElementValueArrayInitializer ) quoteJavaType quoteJavaDecs
+
+getEnumConstant ( Ctr__Java__27 _ s) = s
 
 enumConstant :: QuasiQuoter
-enumConstant = QuasiQuoter (quoteJavaExp "tok_EnumConstant_dummy_171" getEnumConstant ) (quoteJavaPat "tok_EnumConstant_dummy_171" getEnumConstant ) quoteJavaType quoteJavaDecs
+enumConstant = QuasiQuoter (quoteJavaExp "tok_EnumConstant_dummy_179" getEnumConstant ) (quoteJavaPat "tok_EnumConstant_dummy_179" getEnumConstant ) quoteJavaType quoteJavaDecs
 
-getEnumConstantList ( Ctr__Java__24 _ s) = s
+getEnumConstantList ( Ctr__Java__28 _ s) = s
 
 enumConstantList :: QuasiQuoter
-enumConstantList = QuasiQuoter (quoteJavaExp "tok_EnumConstantList_dummy_170" getEnumConstantList ) (quoteJavaPat "tok_EnumConstantList_dummy_170" getEnumConstantList ) quoteJavaType quoteJavaDecs
+enumConstantList = QuasiQuoter (quoteJavaExp "tok_EnumConstantList_dummy_178" getEnumConstantList ) (quoteJavaPat "tok_EnumConstantList_dummy_178" getEnumConstantList ) quoteJavaType quoteJavaDecs
 
-getEnumDeclaration ( Ctr__Java__25 _ s) = s
+getEnumDeclaration ( Ctr__Java__29 _ s) = s
 
 enumDeclaration :: QuasiQuoter
-enumDeclaration = QuasiQuoter (quoteJavaExp "tok_EnumDeclaration_dummy_169" getEnumDeclaration ) (quoteJavaPat "tok_EnumDeclaration_dummy_169" getEnumDeclaration ) quoteJavaType quoteJavaDecs
+enumDeclaration = QuasiQuoter (quoteJavaExp "tok_EnumDeclaration_dummy_177" getEnumDeclaration ) (quoteJavaPat "tok_EnumDeclaration_dummy_177" getEnumDeclaration ) quoteJavaType quoteJavaDecs
 
-getEqualityOp ( Ctr__Java__26 _ s) = s
+getEqualityOp ( Ctr__Java__30 _ s) = s
 
 equalityOp :: QuasiQuoter
-equalityOp = QuasiQuoter (quoteJavaExp "tok_EqualityOp_dummy_168" getEqualityOp ) (quoteJavaPat "tok_EqualityOp_dummy_168" getEqualityOp ) quoteJavaType quoteJavaDecs
+equalityOp = QuasiQuoter (quoteJavaExp "tok_EqualityOp_dummy_176" getEqualityOp ) (quoteJavaPat "tok_EqualityOp_dummy_176" getEqualityOp ) quoteJavaType quoteJavaDecs
 
-getExpression ( Ctr__Java__27 _ s) = s
+getExpression ( Ctr__Java__31 _ s) = s
 
 expression :: QuasiQuoter
-expression = QuasiQuoter (quoteJavaExp "tok_Expression_dummy_167" getExpression ) (quoteJavaPat "tok_Expression_dummy_167" getExpression ) quoteJavaType quoteJavaDecs
+expression = QuasiQuoter (quoteJavaExp "tok_Expression_dummy_175" getExpression ) (quoteJavaPat "tok_Expression_dummy_175" getExpression ) quoteJavaType quoteJavaDecs
 
-getExtendsList ( Ctr__Java__28 _ s) = s
+getExtendsList ( Ctr__Java__32 _ s) = s
 
 extendsList :: QuasiQuoter
-extendsList = QuasiQuoter (quoteJavaExp "tok_ExtendsList_dummy_166" getExtendsList ) (quoteJavaPat "tok_ExtendsList_dummy_166" getExtendsList ) quoteJavaType quoteJavaDecs
+extendsList = QuasiQuoter (quoteJavaExp "tok_ExtendsList_dummy_174" getExtendsList ) (quoteJavaPat "tok_ExtendsList_dummy_174" getExtendsList ) quoteJavaType quoteJavaDecs
 
-getFieldDeclaration ( Ctr__Java__29 _ s) = s
+getFieldDeclaration ( Ctr__Java__33 _ s) = s
 
 fieldDeclaration :: QuasiQuoter
-fieldDeclaration = QuasiQuoter (quoteJavaExp "tok_FieldDeclaration_dummy_165" getFieldDeclaration ) (quoteJavaPat "tok_FieldDeclaration_dummy_165" getFieldDeclaration ) quoteJavaType quoteJavaDecs
+fieldDeclaration = QuasiQuoter (quoteJavaExp "tok_FieldDeclaration_dummy_173" getFieldDeclaration ) (quoteJavaPat "tok_FieldDeclaration_dummy_173" getFieldDeclaration ) quoteJavaType quoteJavaDecs
 
-getFieldDeclarationList ( Ctr__Java__30 _ s) = s
+getFieldDeclarationList ( Ctr__Java__34 _ s) = s
 
 fieldDeclarationList :: QuasiQuoter
-fieldDeclarationList = QuasiQuoter (quoteJavaExp "tok_FieldDeclarationList_dummy_164" getFieldDeclarationList ) (quoteJavaPat "tok_FieldDeclarationList_dummy_164" getFieldDeclarationList ) quoteJavaType quoteJavaDecs
+fieldDeclarationList = QuasiQuoter (quoteJavaExp "tok_FieldDeclarationList_dummy_172" getFieldDeclarationList ) (quoteJavaPat "tok_FieldDeclarationList_dummy_172" getFieldDeclarationList ) quoteJavaType quoteJavaDecs
 
-getForEachHeader ( Ctr__Java__31 _ s) = s
+getForEachHeader ( Ctr__Java__35 _ s) = s
 
 forEachHeader :: QuasiQuoter
-forEachHeader = QuasiQuoter (quoteJavaExp "tok_ForEachHeader_dummy_163" getForEachHeader ) (quoteJavaPat "tok_ForEachHeader_dummy_163" getForEachHeader ) quoteJavaType quoteJavaDecs
+forEachHeader = QuasiQuoter (quoteJavaExp "tok_ForEachHeader_dummy_171" getForEachHeader ) (quoteJavaPat "tok_ForEachHeader_dummy_171" getForEachHeader ) quoteJavaType quoteJavaDecs
 
-getForStatement ( Ctr__Java__32 _ s) = s
+getForStatement ( Ctr__Java__36 _ s) = s
 
 forStatement :: QuasiQuoter
-forStatement = QuasiQuoter (quoteJavaExp "tok_ForStatement_dummy_162" getForStatement ) (quoteJavaPat "tok_ForStatement_dummy_162" getForStatement ) quoteJavaType quoteJavaDecs
+forStatement = QuasiQuoter (quoteJavaExp "tok_ForStatement_dummy_170" getForStatement ) (quoteJavaPat "tok_ForStatement_dummy_170" getForStatement ) quoteJavaType quoteJavaDecs
 
-getIfStatement ( Ctr__Java__33 _ s) = s
+getIfStatement ( Ctr__Java__37 _ s) = s
 
 ifStatement :: QuasiQuoter
-ifStatement = QuasiQuoter (quoteJavaExp "tok_IfStatement_dummy_161" getIfStatement ) (quoteJavaPat "tok_IfStatement_dummy_161" getIfStatement ) quoteJavaType quoteJavaDecs
+ifStatement = QuasiQuoter (quoteJavaExp "tok_IfStatement_dummy_169" getIfStatement ) (quoteJavaPat "tok_IfStatement_dummy_169" getIfStatement ) quoteJavaType quoteJavaDecs
 
-getImplementsList ( Ctr__Java__34 _ s) = s
+getImplementsList ( Ctr__Java__38 _ s) = s
 
 implementsList :: QuasiQuoter
-implementsList = QuasiQuoter (quoteJavaExp "tok_ImplementsList_dummy_160" getImplementsList ) (quoteJavaPat "tok_ImplementsList_dummy_160" getImplementsList ) quoteJavaType quoteJavaDecs
+implementsList = QuasiQuoter (quoteJavaExp "tok_ImplementsList_dummy_168" getImplementsList ) (quoteJavaPat "tok_ImplementsList_dummy_168" getImplementsList ) quoteJavaType quoteJavaDecs
 
-getImportHead ( Ctr__Java__35 _ s) = s
+getImportHead ( Ctr__Java__39 _ s) = s
 
 importHead :: QuasiQuoter
-importHead = QuasiQuoter (quoteJavaExp "tok_ImportHead_dummy_159" getImportHead ) (quoteJavaPat "tok_ImportHead_dummy_159" getImportHead ) quoteJavaType quoteJavaDecs
+importHead = QuasiQuoter (quoteJavaExp "tok_ImportHead_dummy_167" getImportHead ) (quoteJavaPat "tok_ImportHead_dummy_167" getImportHead ) quoteJavaType quoteJavaDecs
 
-getImportList ( Ctr__Java__36 _ s) = s
+getImportList ( Ctr__Java__40 _ s) = s
 
 importList :: QuasiQuoter
-importList = QuasiQuoter (quoteJavaExp "tok_ImportList_dummy_158" getImportList ) (quoteJavaPat "tok_ImportList_dummy_158" getImportList ) quoteJavaType quoteJavaDecs
+importList = QuasiQuoter (quoteJavaExp "tok_ImportList_dummy_166" getImportList ) (quoteJavaPat "tok_ImportList_dummy_166" getImportList ) quoteJavaType quoteJavaDecs
 
-getImportName ( Ctr__Java__37 _ s) = s
+getImportName ( Ctr__Java__41 _ s) = s
 
 importName :: QuasiQuoter
-importName = QuasiQuoter (quoteJavaExp "tok_ImportName_dummy_157" getImportName ) (quoteJavaPat "tok_ImportName_dummy_157" getImportName ) quoteJavaType quoteJavaDecs
+importName = QuasiQuoter (quoteJavaExp "tok_ImportName_dummy_165" getImportName ) (quoteJavaPat "tok_ImportName_dummy_165" getImportName ) quoteJavaType quoteJavaDecs
 
-getImportStatement ( Ctr__Java__38 _ s) = s
+getImportStatement ( Ctr__Java__42 _ s) = s
 
 importStatement :: QuasiQuoter
-importStatement = QuasiQuoter (quoteJavaExp "tok_ImportStatement_dummy_156" getImportStatement ) (quoteJavaPat "tok_ImportStatement_dummy_156" getImportStatement ) quoteJavaType quoteJavaDecs
+importStatement = QuasiQuoter (quoteJavaExp "tok_ImportStatement_dummy_164" getImportStatement ) (quoteJavaPat "tok_ImportStatement_dummy_164" getImportStatement ) quoteJavaType quoteJavaDecs
 
-getInterfaceDeclaration ( Ctr__Java__39 _ s) = s
+getInterfaceDeclaration ( Ctr__Java__43 _ s) = s
 
 interfaceDeclaration :: QuasiQuoter
-interfaceDeclaration = QuasiQuoter (quoteJavaExp "tok_InterfaceDeclaration_dummy_155" getInterfaceDeclaration ) (quoteJavaPat "tok_InterfaceDeclaration_dummy_155" getInterfaceDeclaration ) quoteJavaType quoteJavaDecs
+interfaceDeclaration = QuasiQuoter (quoteJavaExp "tok_InterfaceDeclaration_dummy_163" getInterfaceDeclaration ) (quoteJavaPat "tok_InterfaceDeclaration_dummy_163" getInterfaceDeclaration ) quoteJavaType quoteJavaDecs
 
-getLambdaBody ( Ctr__Java__40 _ s) = s
+getLambdaBody ( Ctr__Java__44 _ s) = s
 
 lambdaBody :: QuasiQuoter
-lambdaBody = QuasiQuoter (quoteJavaExp "tok_LambdaBody_dummy_154" getLambdaBody ) (quoteJavaPat "tok_LambdaBody_dummy_154" getLambdaBody ) quoteJavaType quoteJavaDecs
+lambdaBody = QuasiQuoter (quoteJavaExp "tok_LambdaBody_dummy_162" getLambdaBody ) (quoteJavaPat "tok_LambdaBody_dummy_162" getLambdaBody ) quoteJavaType quoteJavaDecs
 
-getLiteral ( Ctr__Java__41 _ s) = s
+getLiteral ( Ctr__Java__45 _ s) = s
 
 literal :: QuasiQuoter
-literal = QuasiQuoter (quoteJavaExp "tok_Literal_dummy_153" getLiteral ) (quoteJavaPat "tok_Literal_dummy_153" getLiteral ) quoteJavaType quoteJavaDecs
+literal = QuasiQuoter (quoteJavaExp "tok_Literal_dummy_161" getLiteral ) (quoteJavaPat "tok_Literal_dummy_161" getLiteral ) quoteJavaType quoteJavaDecs
 
-getLocalModifierList1 ( Ctr__Java__42 _ s) = s
+getLocalModifierList1 ( Ctr__Java__46 _ s) = s
 
 localModifierList1 :: QuasiQuoter
-localModifierList1 = QuasiQuoter (quoteJavaExp "tok_LocalModifierList1_dummy_152" getLocalModifierList1 ) (quoteJavaPat "tok_LocalModifierList1_dummy_152" getLocalModifierList1 ) quoteJavaType quoteJavaDecs
+localModifierList1 = QuasiQuoter (quoteJavaExp "tok_LocalModifierList1_dummy_160" getLocalModifierList1 ) (quoteJavaPat "tok_LocalModifierList1_dummy_160" getLocalModifierList1 ) quoteJavaType quoteJavaDecs
 
-getMemberAfterFirstId ( Ctr__Java__43 _ s) = s
+getMemberAfterFirstId ( Ctr__Java__47 _ s) = s
 
 memberAfterFirstId :: QuasiQuoter
-memberAfterFirstId = QuasiQuoter (quoteJavaExp "tok_MemberAfterFirstId_dummy_151" getMemberAfterFirstId ) (quoteJavaPat "tok_MemberAfterFirstId_dummy_151" getMemberAfterFirstId ) quoteJavaType quoteJavaDecs
+memberAfterFirstId = QuasiQuoter (quoteJavaExp "tok_MemberAfterFirstId_dummy_159" getMemberAfterFirstId ) (quoteJavaPat "tok_MemberAfterFirstId_dummy_159" getMemberAfterFirstId ) quoteJavaType quoteJavaDecs
 
-getMemberDeclaration ( Ctr__Java__44 _ s) = s
+getMemberDeclaration ( Ctr__Java__48 _ s) = s
 
 memberDeclaration :: QuasiQuoter
-memberDeclaration = QuasiQuoter (quoteJavaExp "tok_MemberDeclaration_dummy_150" getMemberDeclaration ) (quoteJavaPat "tok_MemberDeclaration_dummy_150" getMemberDeclaration ) quoteJavaType quoteJavaDecs
+memberDeclaration = QuasiQuoter (quoteJavaExp "tok_MemberDeclaration_dummy_158" getMemberDeclaration ) (quoteJavaPat "tok_MemberDeclaration_dummy_158" getMemberDeclaration ) quoteJavaType quoteJavaDecs
 
-getMemberRest ( Ctr__Java__45 _ s) = s
+getMemberRest ( Ctr__Java__49 _ s) = s
 
 memberRest :: QuasiQuoter
-memberRest = QuasiQuoter (quoteJavaExp "tok_MemberRest_dummy_149" getMemberRest ) (quoteJavaPat "tok_MemberRest_dummy_149" getMemberRest ) quoteJavaType quoteJavaDecs
+memberRest = QuasiQuoter (quoteJavaExp "tok_MemberRest_dummy_157" getMemberRest ) (quoteJavaPat "tok_MemberRest_dummy_157" getMemberRest ) quoteJavaType quoteJavaDecs
 
-getModifier ( Ctr__Java__46 _ s) = s
+getModifier ( Ctr__Java__50 _ s) = s
 
 modifier :: QuasiQuoter
-modifier = QuasiQuoter (quoteJavaExp "tok_Modifier_dummy_148" getModifier ) (quoteJavaPat "tok_Modifier_dummy_148" getModifier ) quoteJavaType quoteJavaDecs
+modifier = QuasiQuoter (quoteJavaExp "tok_Modifier_dummy_156" getModifier ) (quoteJavaPat "tok_Modifier_dummy_156" getModifier ) quoteJavaType quoteJavaDecs
 
-getModifierList ( Ctr__Java__47 _ s) = s
+getModifierList ( Ctr__Java__51 _ s) = s
 
 modifierList :: QuasiQuoter
-modifierList = QuasiQuoter (quoteJavaExp "tok_ModifierList_dummy_147" getModifierList ) (quoteJavaPat "tok_ModifierList_dummy_147" getModifierList ) quoteJavaType quoteJavaDecs
+modifierList = QuasiQuoter (quoteJavaExp "tok_ModifierList_dummy_155" getModifierList ) (quoteJavaPat "tok_ModifierList_dummy_155" getModifierList ) quoteJavaType quoteJavaDecs
 
-getMoreTypeSpecifier ( Ctr__Java__48 _ s) = s
+getMoreTypeSpecifier ( Ctr__Java__52 _ s) = s
 
 moreTypeSpecifier :: QuasiQuoter
-moreTypeSpecifier = QuasiQuoter (quoteJavaExp "tok_MoreTypeSpecifier_dummy_146" getMoreTypeSpecifier ) (quoteJavaPat "tok_MoreTypeSpecifier_dummy_146" getMoreTypeSpecifier ) quoteJavaType quoteJavaDecs
+moreTypeSpecifier = QuasiQuoter (quoteJavaExp "tok_MoreTypeSpecifier_dummy_154" getMoreTypeSpecifier ) (quoteJavaPat "tok_MoreTypeSpecifier_dummy_154" getMoreTypeSpecifier ) quoteJavaType quoteJavaDecs
 
-getMoreVariableDeclarators ( Ctr__Java__49 _ s) = s
+getMoreVariableDeclarators ( Ctr__Java__53 _ s) = s
 
 moreVariableDeclarators :: QuasiQuoter
-moreVariableDeclarators = QuasiQuoter (quoteJavaExp "tok_MoreVariableDeclarators_dummy_145" getMoreVariableDeclarators ) (quoteJavaPat "tok_MoreVariableDeclarators_dummy_145" getMoreVariableDeclarators ) quoteJavaType quoteJavaDecs
+moreVariableDeclarators = QuasiQuoter (quoteJavaExp "tok_MoreVariableDeclarators_dummy_153" getMoreVariableDeclarators ) (quoteJavaPat "tok_MoreVariableDeclarators_dummy_153" getMoreVariableDeclarators ) quoteJavaType quoteJavaDecs
 
-getMultiplicativeOp ( Ctr__Java__50 _ s) = s
+getMultiplicativeOp ( Ctr__Java__54 _ s) = s
 
 multiplicativeOp :: QuasiQuoter
-multiplicativeOp = QuasiQuoter (quoteJavaExp "tok_MultiplicativeOp_dummy_144" getMultiplicativeOp ) (quoteJavaPat "tok_MultiplicativeOp_dummy_144" getMultiplicativeOp ) quoteJavaType quoteJavaDecs
+multiplicativeOp = QuasiQuoter (quoteJavaExp "tok_MultiplicativeOp_dummy_152" getMultiplicativeOp ) (quoteJavaPat "tok_MultiplicativeOp_dummy_152" getMultiplicativeOp ) quoteJavaType quoteJavaDecs
 
-getNonEmptyDims ( Ctr__Java__51 _ s) = s
+getNonEmptyDims ( Ctr__Java__55 _ s) = s
 
 nonEmptyDims :: QuasiQuoter
-nonEmptyDims = QuasiQuoter (quoteJavaExp "tok_NonEmptyDims_dummy_143" getNonEmptyDims ) (quoteJavaPat "tok_NonEmptyDims_dummy_143" getNonEmptyDims ) quoteJavaType quoteJavaDecs
+nonEmptyDims = QuasiQuoter (quoteJavaExp "tok_NonEmptyDims_dummy_151" getNonEmptyDims ) (quoteJavaPat "tok_NonEmptyDims_dummy_151" getNonEmptyDims ) quoteJavaType quoteJavaDecs
 
-getNonEmptyTypeArguments ( Ctr__Java__52 _ s) = s
+getNonEmptyTypeArguments ( Ctr__Java__56 _ s) = s
 
 nonEmptyTypeArguments :: QuasiQuoter
-nonEmptyTypeArguments = QuasiQuoter (quoteJavaExp "tok_NonEmptyTypeArguments_dummy_142" getNonEmptyTypeArguments ) (quoteJavaPat "tok_NonEmptyTypeArguments_dummy_142" getNonEmptyTypeArguments ) quoteJavaType quoteJavaDecs
+nonEmptyTypeArguments = QuasiQuoter (quoteJavaExp "tok_NonEmptyTypeArguments_dummy_150" getNonEmptyTypeArguments ) (quoteJavaPat "tok_NonEmptyTypeArguments_dummy_150" getNonEmptyTypeArguments ) quoteJavaType quoteJavaDecs
 
-getOptDocComment ( Ctr__Java__53 _ s) = s
+getNonEmptyTypeParameters ( Ctr__Java__57 _ s) = s
+
+nonEmptyTypeParameters :: QuasiQuoter
+nonEmptyTypeParameters = QuasiQuoter (quoteJavaExp "tok_NonEmptyTypeParameters_dummy_149" getNonEmptyTypeParameters ) (quoteJavaPat "tok_NonEmptyTypeParameters_dummy_149" getNonEmptyTypeParameters ) quoteJavaType quoteJavaDecs
+
+getOptDocComment ( Ctr__Java__58 _ s) = s
 
 optDocComment :: QuasiQuoter
-optDocComment = QuasiQuoter (quoteJavaExp "tok_OptDocComment_dummy_141" getOptDocComment ) (quoteJavaPat "tok_OptDocComment_dummy_141" getOptDocComment ) quoteJavaType quoteJavaDecs
+optDocComment = QuasiQuoter (quoteJavaExp "tok_OptDocComment_dummy_148" getOptDocComment ) (quoteJavaPat "tok_OptDocComment_dummy_148" getOptDocComment ) quoteJavaType quoteJavaDecs
 
-getOptElsePart ( Ctr__Java__54 _ s) = s
+getOptElsePart ( Ctr__Java__59 _ s) = s
 
 optElsePart :: QuasiQuoter
-optElsePart = QuasiQuoter (quoteJavaExp "tok_OptElsePart_dummy_140" getOptElsePart ) (quoteJavaPat "tok_OptElsePart_dummy_140" getOptElsePart ) quoteJavaType quoteJavaDecs
+optElsePart = QuasiQuoter (quoteJavaExp "tok_OptElsePart_dummy_147" getOptElsePart ) (quoteJavaPat "tok_OptElsePart_dummy_147" getOptElsePart ) quoteJavaType quoteJavaDecs
 
-getOptExpression ( Ctr__Java__55 _ s) = s
+getOptExpression ( Ctr__Java__60 _ s) = s
 
 optExpression :: QuasiQuoter
-optExpression = QuasiQuoter (quoteJavaExp "tok_OptExpression_dummy_139" getOptExpression ) (quoteJavaPat "tok_OptExpression_dummy_139" getOptExpression ) quoteJavaType quoteJavaDecs
+optExpression = QuasiQuoter (quoteJavaExp "tok_OptExpression_dummy_146" getOptExpression ) (quoteJavaPat "tok_OptExpression_dummy_146" getOptExpression ) quoteJavaType quoteJavaDecs
 
-getOptFinally ( Ctr__Java__56 _ s) = s
+getOptFinally ( Ctr__Java__61 _ s) = s
 
 optFinally :: QuasiQuoter
-optFinally = QuasiQuoter (quoteJavaExp "tok_OptFinally_dummy_138" getOptFinally ) (quoteJavaPat "tok_OptFinally_dummy_138" getOptFinally ) quoteJavaType quoteJavaDecs
+optFinally = QuasiQuoter (quoteJavaExp "tok_OptFinally_dummy_145" getOptFinally ) (quoteJavaPat "tok_OptFinally_dummy_145" getOptFinally ) quoteJavaType quoteJavaDecs
 
-getOptId ( Ctr__Java__57 _ s) = s
+getOptId ( Ctr__Java__62 _ s) = s
 
 optId :: QuasiQuoter
-optId = QuasiQuoter (quoteJavaExp "tok_OptId_dummy_137" getOptId ) (quoteJavaPat "tok_OptId_dummy_137" getOptId ) quoteJavaType quoteJavaDecs
+optId = QuasiQuoter (quoteJavaExp "tok_OptId_dummy_144" getOptId ) (quoteJavaPat "tok_OptId_dummy_144" getOptId ) quoteJavaType quoteJavaDecs
 
-getOptVariableInitializer ( Ctr__Java__58 _ s) = s
+getOptVariableInitializer ( Ctr__Java__63 _ s) = s
 
 optVariableInitializer :: QuasiQuoter
-optVariableInitializer = QuasiQuoter (quoteJavaExp "tok_OptVariableInitializer_dummy_136" getOptVariableInitializer ) (quoteJavaPat "tok_OptVariableInitializer_dummy_136" getOptVariableInitializer ) quoteJavaType quoteJavaDecs
+optVariableInitializer = QuasiQuoter (quoteJavaExp "tok_OptVariableInitializer_dummy_143" getOptVariableInitializer ) (quoteJavaPat "tok_OptVariableInitializer_dummy_143" getOptVariableInitializer ) quoteJavaType quoteJavaDecs
 
-getPackage ( Ctr__Java__59 _ s) = s
+getPackage ( Ctr__Java__64 _ s) = s
 
 package :: QuasiQuoter
-package = QuasiQuoter (quoteJavaExp "tok_Package_dummy_135" getPackage ) (quoteJavaPat "tok_Package_dummy_135" getPackage ) quoteJavaType quoteJavaDecs
+package = QuasiQuoter (quoteJavaExp "tok_Package_dummy_142" getPackage ) (quoteJavaPat "tok_Package_dummy_142" getPackage ) quoteJavaType quoteJavaDecs
 
-getParamModifierList ( Ctr__Java__60 _ s) = s
+getParamModifierList ( Ctr__Java__65 _ s) = s
 
 paramModifierList :: QuasiQuoter
-paramModifierList = QuasiQuoter (quoteJavaExp "tok_ParamModifierList_dummy_134" getParamModifierList ) (quoteJavaPat "tok_ParamModifierList_dummy_134" getParamModifierList ) quoteJavaType quoteJavaDecs
+paramModifierList = QuasiQuoter (quoteJavaExp "tok_ParamModifierList_dummy_141" getParamModifierList ) (quoteJavaPat "tok_ParamModifierList_dummy_141" getParamModifierList ) quoteJavaType quoteJavaDecs
 
-getParameter ( Ctr__Java__61 _ s) = s
+getParameter ( Ctr__Java__66 _ s) = s
 
 parameter :: QuasiQuoter
-parameter = QuasiQuoter (quoteJavaExp "tok_Parameter_dummy_133" getParameter ) (quoteJavaPat "tok_Parameter_dummy_133" getParameter ) quoteJavaType quoteJavaDecs
+parameter = QuasiQuoter (quoteJavaExp "tok_Parameter_dummy_140" getParameter ) (quoteJavaPat "tok_Parameter_dummy_140" getParameter ) quoteJavaType quoteJavaDecs
 
-getParameterList ( Ctr__Java__62 _ s) = s
+getParameterList ( Ctr__Java__67 _ s) = s
 
 parameterList :: QuasiQuoter
-parameterList = QuasiQuoter (quoteJavaExp "tok_ParameterList_dummy_132" getParameterList ) (quoteJavaPat "tok_ParameterList_dummy_132" getParameterList ) quoteJavaType quoteJavaDecs
+parameterList = QuasiQuoter (quoteJavaExp "tok_ParameterList_dummy_139" getParameterList ) (quoteJavaPat "tok_ParameterList_dummy_139" getParameterList ) quoteJavaType quoteJavaDecs
 
-getPostfixOp ( Ctr__Java__63 _ s) = s
+getPostfixOp ( Ctr__Java__68 _ s) = s
 
 postfixOp :: QuasiQuoter
-postfixOp = QuasiQuoter (quoteJavaExp "tok_PostfixOp_dummy_131" getPostfixOp ) (quoteJavaPat "tok_PostfixOp_dummy_131" getPostfixOp ) quoteJavaType quoteJavaDecs
+postfixOp = QuasiQuoter (quoteJavaExp "tok_PostfixOp_dummy_138" getPostfixOp ) (quoteJavaPat "tok_PostfixOp_dummy_138" getPostfixOp ) quoteJavaType quoteJavaDecs
 
-getPrefixOp ( Ctr__Java__64 _ s) = s
+getPrefixOp ( Ctr__Java__69 _ s) = s
 
 prefixOp :: QuasiQuoter
-prefixOp = QuasiQuoter (quoteJavaExp "tok_PrefixOp_dummy_130" getPrefixOp ) (quoteJavaPat "tok_PrefixOp_dummy_130" getPrefixOp ) quoteJavaType quoteJavaDecs
+prefixOp = QuasiQuoter (quoteJavaExp "tok_PrefixOp_dummy_137" getPrefixOp ) (quoteJavaPat "tok_PrefixOp_dummy_137" getPrefixOp ) quoteJavaType quoteJavaDecs
 
-getPrimitiveTypeKeyword ( Ctr__Java__65 _ s) = s
+getPrimitiveTypeKeyword ( Ctr__Java__70 _ s) = s
 
 primitiveTypeKeyword :: QuasiQuoter
-primitiveTypeKeyword = QuasiQuoter (quoteJavaExp "tok_PrimitiveTypeKeyword_dummy_129" getPrimitiveTypeKeyword ) (quoteJavaPat "tok_PrimitiveTypeKeyword_dummy_129" getPrimitiveTypeKeyword ) quoteJavaType quoteJavaDecs
+primitiveTypeKeyword = QuasiQuoter (quoteJavaExp "tok_PrimitiveTypeKeyword_dummy_136" getPrimitiveTypeKeyword ) (quoteJavaPat "tok_PrimitiveTypeKeyword_dummy_136" getPrimitiveTypeKeyword ) quoteJavaType quoteJavaDecs
 
-getRelationalOp ( Ctr__Java__66 _ s) = s
+getRelationalOp ( Ctr__Java__71 _ s) = s
 
 relationalOp :: QuasiQuoter
-relationalOp = QuasiQuoter (quoteJavaExp "tok_RelationalOp_dummy_128" getRelationalOp ) (quoteJavaPat "tok_RelationalOp_dummy_128" getRelationalOp ) quoteJavaType quoteJavaDecs
+relationalOp = QuasiQuoter (quoteJavaExp "tok_RelationalOp_dummy_135" getRelationalOp ) (quoteJavaPat "tok_RelationalOp_dummy_135" getRelationalOp ) quoteJavaType quoteJavaDecs
 
-getResource ( Ctr__Java__67 _ s) = s
+getResource ( Ctr__Java__72 _ s) = s
 
 resource :: QuasiQuoter
-resource = QuasiQuoter (quoteJavaExp "tok_Resource_dummy_127" getResource ) (quoteJavaPat "tok_Resource_dummy_127" getResource ) quoteJavaType quoteJavaDecs
+resource = QuasiQuoter (quoteJavaExp "tok_Resource_dummy_134" getResource ) (quoteJavaPat "tok_Resource_dummy_134" getResource ) quoteJavaType quoteJavaDecs
 
-getResourceSpec ( Ctr__Java__68 _ s) = s
+getResourceSpec ( Ctr__Java__73 _ s) = s
 
 resourceSpec :: QuasiQuoter
-resourceSpec = QuasiQuoter (quoteJavaExp "tok_ResourceSpec_dummy_126" getResourceSpec ) (quoteJavaPat "tok_ResourceSpec_dummy_126" getResourceSpec ) quoteJavaType quoteJavaDecs
+resourceSpec = QuasiQuoter (quoteJavaExp "tok_ResourceSpec_dummy_133" getResourceSpec ) (quoteJavaPat "tok_ResourceSpec_dummy_133" getResourceSpec ) quoteJavaType quoteJavaDecs
 
-getShiftOp ( Ctr__Java__69 _ s) = s
+getShiftOp ( Ctr__Java__74 _ s) = s
 
 shiftOp :: QuasiQuoter
-shiftOp = QuasiQuoter (quoteJavaExp "tok_ShiftOp_dummy_125" getShiftOp ) (quoteJavaPat "tok_ShiftOp_dummy_125" getShiftOp ) quoteJavaType quoteJavaDecs
+shiftOp = QuasiQuoter (quoteJavaExp "tok_ShiftOp_dummy_132" getShiftOp ) (quoteJavaPat "tok_ShiftOp_dummy_132" getShiftOp ) quoteJavaType quoteJavaDecs
 
-getStatement ( Ctr__Java__70 _ s) = s
+getStatement ( Ctr__Java__75 _ s) = s
 
 statement :: QuasiQuoter
-statement = QuasiQuoter (quoteJavaExp "tok_Statement_dummy_124" getStatement ) (quoteJavaPat "tok_Statement_dummy_124" getStatement ) quoteJavaType quoteJavaDecs
+statement = QuasiQuoter (quoteJavaExp "tok_Statement_dummy_131" getStatement ) (quoteJavaPat "tok_Statement_dummy_131" getStatement ) quoteJavaType quoteJavaDecs
 
-getStatementBlock ( Ctr__Java__71 _ s) = s
+getStatementBlock ( Ctr__Java__76 _ s) = s
 
 statementBlock :: QuasiQuoter
-statementBlock = QuasiQuoter (quoteJavaExp "tok_StatementBlock_dummy_123" getStatementBlock ) (quoteJavaPat "tok_StatementBlock_dummy_123" getStatementBlock ) quoteJavaType quoteJavaDecs
+statementBlock = QuasiQuoter (quoteJavaExp "tok_StatementBlock_dummy_130" getStatementBlock ) (quoteJavaPat "tok_StatementBlock_dummy_130" getStatementBlock ) quoteJavaType quoteJavaDecs
 
-getStatementList ( Ctr__Java__72 _ s) = s
+getStatementList ( Ctr__Java__77 _ s) = s
 
 statementList :: QuasiQuoter
-statementList = QuasiQuoter (quoteJavaExp "tok_StatementList_dummy_122" getStatementList ) (quoteJavaPat "tok_StatementList_dummy_122" getStatementList ) quoteJavaType quoteJavaDecs
+statementList = QuasiQuoter (quoteJavaExp "tok_StatementList_dummy_129" getStatementList ) (quoteJavaPat "tok_StatementList_dummy_129" getStatementList ) quoteJavaType quoteJavaDecs
 
-getStaticInitializer ( Ctr__Java__73 _ s) = s
+getStaticInitializer ( Ctr__Java__78 _ s) = s
 
 staticInitializer :: QuasiQuoter
-staticInitializer = QuasiQuoter (quoteJavaExp "tok_StaticInitializer_dummy_121" getStaticInitializer ) (quoteJavaPat "tok_StaticInitializer_dummy_121" getStaticInitializer ) quoteJavaType quoteJavaDecs
+staticInitializer = QuasiQuoter (quoteJavaExp "tok_StaticInitializer_dummy_128" getStaticInitializer ) (quoteJavaPat "tok_StaticInitializer_dummy_128" getStaticInitializer ) quoteJavaType quoteJavaDecs
 
-getSwitchCaseList ( Ctr__Java__74 _ s) = s
+getSwitchCaseList ( Ctr__Java__79 _ s) = s
 
 switchCaseList :: QuasiQuoter
-switchCaseList = QuasiQuoter (quoteJavaExp "tok_SwitchCaseList_dummy_120" getSwitchCaseList ) (quoteJavaPat "tok_SwitchCaseList_dummy_120" getSwitchCaseList ) quoteJavaType quoteJavaDecs
+switchCaseList = QuasiQuoter (quoteJavaExp "tok_SwitchCaseList_dummy_127" getSwitchCaseList ) (quoteJavaPat "tok_SwitchCaseList_dummy_127" getSwitchCaseList ) quoteJavaType quoteJavaDecs
 
-getSwitchStatement ( Ctr__Java__75 _ s) = s
+getSwitchStatement ( Ctr__Java__80 _ s) = s
 
 switchStatement :: QuasiQuoter
-switchStatement = QuasiQuoter (quoteJavaExp "tok_SwitchStatement_dummy_119" getSwitchStatement ) (quoteJavaPat "tok_SwitchStatement_dummy_119" getSwitchStatement ) quoteJavaType quoteJavaDecs
+switchStatement = QuasiQuoter (quoteJavaExp "tok_SwitchStatement_dummy_126" getSwitchStatement ) (quoteJavaPat "tok_SwitchStatement_dummy_126" getSwitchStatement ) quoteJavaType quoteJavaDecs
 
-getThrowsClause ( Ctr__Java__76 _ s) = s
+getThrowsClause ( Ctr__Java__81 _ s) = s
 
 throwsClause :: QuasiQuoter
-throwsClause = QuasiQuoter (quoteJavaExp "tok_ThrowsClause_dummy_118" getThrowsClause ) (quoteJavaPat "tok_ThrowsClause_dummy_118" getThrowsClause ) quoteJavaType quoteJavaDecs
+throwsClause = QuasiQuoter (quoteJavaExp "tok_ThrowsClause_dummy_125" getThrowsClause ) (quoteJavaPat "tok_ThrowsClause_dummy_125" getThrowsClause ) quoteJavaType quoteJavaDecs
 
-getTryStatement ( Ctr__Java__77 _ s) = s
+getTryStatement ( Ctr__Java__82 _ s) = s
 
 tryStatement :: QuasiQuoter
-tryStatement = QuasiQuoter (quoteJavaExp "tok_TryStatement_dummy_117" getTryStatement ) (quoteJavaPat "tok_TryStatement_dummy_117" getTryStatement ) quoteJavaType quoteJavaDecs
+tryStatement = QuasiQuoter (quoteJavaExp "tok_TryStatement_dummy_124" getTryStatement ) (quoteJavaPat "tok_TryStatement_dummy_124" getTryStatement ) quoteJavaType quoteJavaDecs
 
-getType ( Ctr__Java__78 _ s) = s
+getType ( Ctr__Java__83 _ s) = s
 
 __type :: QuasiQuoter
-__type = QuasiQuoter (quoteJavaExp "tok_Type_dummy_116" getType ) (quoteJavaPat "tok_Type_dummy_116" getType ) quoteJavaType quoteJavaDecs
+__type = QuasiQuoter (quoteJavaExp "tok_Type_dummy_123" getType ) (quoteJavaPat "tok_Type_dummy_123" getType ) quoteJavaType quoteJavaDecs
 
-getTypeArgument ( Ctr__Java__79 _ s) = s
+getTypeArgument ( Ctr__Java__84 _ s) = s
 
 typeArgument :: QuasiQuoter
-typeArgument = QuasiQuoter (quoteJavaExp "tok_TypeArgument_dummy_115" getTypeArgument ) (quoteJavaPat "tok_TypeArgument_dummy_115" getTypeArgument ) quoteJavaType quoteJavaDecs
+typeArgument = QuasiQuoter (quoteJavaExp "tok_TypeArgument_dummy_122" getTypeArgument ) (quoteJavaPat "tok_TypeArgument_dummy_122" getTypeArgument ) quoteJavaType quoteJavaDecs
 
-getTypeArguments ( Ctr__Java__80 _ s) = s
+getTypeArguments ( Ctr__Java__85 _ s) = s
 
 typeArguments :: QuasiQuoter
-typeArguments = QuasiQuoter (quoteJavaExp "tok_TypeArguments_dummy_114" getTypeArguments ) (quoteJavaPat "tok_TypeArguments_dummy_114" getTypeArguments ) quoteJavaType quoteJavaDecs
+typeArguments = QuasiQuoter (quoteJavaExp "tok_TypeArguments_dummy_121" getTypeArguments ) (quoteJavaPat "tok_TypeArguments_dummy_121" getTypeArguments ) quoteJavaType quoteJavaDecs
 
-getTypeDeclRest ( Ctr__Java__81 _ s) = s
+getTypeDeclRest ( Ctr__Java__86 _ s) = s
 
 typeDeclRest :: QuasiQuoter
-typeDeclRest = QuasiQuoter (quoteJavaExp "tok_TypeDeclRest_dummy_113" getTypeDeclRest ) (quoteJavaPat "tok_TypeDeclRest_dummy_113" getTypeDeclRest ) quoteJavaType quoteJavaDecs
+typeDeclRest = QuasiQuoter (quoteJavaExp "tok_TypeDeclRest_dummy_120" getTypeDeclRest ) (quoteJavaPat "tok_TypeDeclRest_dummy_120" getTypeDeclRest ) quoteJavaType quoteJavaDecs
 
-getTypeDeclaration ( Ctr__Java__82 _ s) = s
+getTypeDeclaration ( Ctr__Java__87 _ s) = s
 
 typeDeclaration :: QuasiQuoter
-typeDeclaration = QuasiQuoter (quoteJavaExp "tok_TypeDeclaration_dummy_112" getTypeDeclaration ) (quoteJavaPat "tok_TypeDeclaration_dummy_112" getTypeDeclaration ) quoteJavaType quoteJavaDecs
+typeDeclaration = QuasiQuoter (quoteJavaExp "tok_TypeDeclaration_dummy_119" getTypeDeclaration ) (quoteJavaPat "tok_TypeDeclaration_dummy_119" getTypeDeclaration ) quoteJavaType quoteJavaDecs
 
-getTypeParameter ( Ctr__Java__83 _ s) = s
+getTypeDeclarationList ( Ctr__Java__88 _ s) = s
+
+typeDeclarationList :: QuasiQuoter
+typeDeclarationList = QuasiQuoter (quoteJavaExp "tok_TypeDeclarationList_dummy_118" getTypeDeclarationList ) (quoteJavaPat "tok_TypeDeclarationList_dummy_118" getTypeDeclarationList ) quoteJavaType quoteJavaDecs
+
+getTypeParameter ( Ctr__Java__89 _ s) = s
 
 typeParameter :: QuasiQuoter
-typeParameter = QuasiQuoter (quoteJavaExp "tok_TypeParameter_dummy_111" getTypeParameter ) (quoteJavaPat "tok_TypeParameter_dummy_111" getTypeParameter ) quoteJavaType quoteJavaDecs
+typeParameter = QuasiQuoter (quoteJavaExp "tok_TypeParameter_dummy_117" getTypeParameter ) (quoteJavaPat "tok_TypeParameter_dummy_117" getTypeParameter ) quoteJavaType quoteJavaDecs
 
-getTypeParameters ( Ctr__Java__84 _ s) = s
+getTypeParameters ( Ctr__Java__90 _ s) = s
 
 typeParameters :: QuasiQuoter
-typeParameters = QuasiQuoter (quoteJavaExp "tok_TypeParameters_dummy_110" getTypeParameters ) (quoteJavaPat "tok_TypeParameters_dummy_110" getTypeParameters ) quoteJavaType quoteJavaDecs
+typeParameters = QuasiQuoter (quoteJavaExp "tok_TypeParameters_dummy_116" getTypeParameters ) (quoteJavaPat "tok_TypeParameters_dummy_116" getTypeParameters ) quoteJavaType quoteJavaDecs
 
-getTypeSpecifier ( Ctr__Java__85 _ s) = s
+getTypeSpecifier ( Ctr__Java__91 _ s) = s
 
 typeSpecifier :: QuasiQuoter
-typeSpecifier = QuasiQuoter (quoteJavaExp "tok_TypeSpecifier_dummy_109" getTypeSpecifier ) (quoteJavaPat "tok_TypeSpecifier_dummy_109" getTypeSpecifier ) quoteJavaType quoteJavaDecs
+typeSpecifier = QuasiQuoter (quoteJavaExp "tok_TypeSpecifier_dummy_115" getTypeSpecifier ) (quoteJavaPat "tok_TypeSpecifier_dummy_115" getTypeSpecifier ) quoteJavaType quoteJavaDecs
 
-getVariableDeclaration ( Ctr__Java__86 _ s) = s
+getVariableDeclaration ( Ctr__Java__92 _ s) = s
 
 variableDeclaration :: QuasiQuoter
-variableDeclaration = QuasiQuoter (quoteJavaExp "tok_VariableDeclaration_dummy_108" getVariableDeclaration ) (quoteJavaPat "tok_VariableDeclaration_dummy_108" getVariableDeclaration ) quoteJavaType quoteJavaDecs
+variableDeclaration = QuasiQuoter (quoteJavaExp "tok_VariableDeclaration_dummy_114" getVariableDeclaration ) (quoteJavaPat "tok_VariableDeclaration_dummy_114" getVariableDeclaration ) quoteJavaType quoteJavaDecs
 
-getVariableDeclarator ( Ctr__Java__87 _ s) = s
+getVariableDeclarator ( Ctr__Java__93 _ s) = s
 
 variableDeclarator :: QuasiQuoter
-variableDeclarator = QuasiQuoter (quoteJavaExp "tok_VariableDeclarator_dummy_107" getVariableDeclarator ) (quoteJavaPat "tok_VariableDeclarator_dummy_107" getVariableDeclarator ) quoteJavaType quoteJavaDecs
+variableDeclarator = QuasiQuoter (quoteJavaExp "tok_VariableDeclarator_dummy_113" getVariableDeclarator ) (quoteJavaPat "tok_VariableDeclarator_dummy_113" getVariableDeclarator ) quoteJavaType quoteJavaDecs
 
-getVariableDeclaratorList ( Ctr__Java__88 _ s) = s
+getVariableDeclaratorList ( Ctr__Java__94 _ s) = s
 
 variableDeclaratorList :: QuasiQuoter
-variableDeclaratorList = QuasiQuoter (quoteJavaExp "tok_VariableDeclaratorList_dummy_106" getVariableDeclaratorList ) (quoteJavaPat "tok_VariableDeclaratorList_dummy_106" getVariableDeclaratorList ) quoteJavaType quoteJavaDecs
+variableDeclaratorList = QuasiQuoter (quoteJavaExp "tok_VariableDeclaratorList_dummy_112" getVariableDeclaratorList ) (quoteJavaPat "tok_VariableDeclaratorList_dummy_112" getVariableDeclaratorList ) quoteJavaType quoteJavaDecs
 
-getVariableInitializer ( Ctr__Java__89 _ s) = s
+getVariableInitializer ( Ctr__Java__95 _ s) = s
 
 variableInitializer :: QuasiQuoter
-variableInitializer = QuasiQuoter (quoteJavaExp "tok_VariableInitializer_dummy_105" getVariableInitializer ) (quoteJavaPat "tok_VariableInitializer_dummy_105" getVariableInitializer ) quoteJavaType quoteJavaDecs
+variableInitializer = QuasiQuoter (quoteJavaExp "tok_VariableInitializer_dummy_111" getVariableInitializer ) (quoteJavaPat "tok_VariableInitializer_dummy_111" getVariableInitializer ) quoteJavaType quoteJavaDecs
 
-getVariableInitializerList ( Ctr__Java__90 _ s) = s
+getVariableInitializerList ( Ctr__Java__96 _ s) = s
 
 variableInitializerList :: QuasiQuoter
-variableInitializerList = QuasiQuoter (quoteJavaExp "tok_VariableInitializerList_dummy_104" getVariableInitializerList ) (quoteJavaPat "tok_VariableInitializerList_dummy_104" getVariableInitializerList ) quoteJavaType quoteJavaDecs
+variableInitializerList = QuasiQuoter (quoteJavaExp "tok_VariableInitializerList_dummy_110" getVariableInitializerList ) (quoteJavaPat "tok_VariableInitializerList_dummy_110" getVariableInitializerList ) quoteJavaType quoteJavaDecs
 
-getWhileStatement ( Ctr__Java__91 _ s) = s
+getWhileStatement ( Ctr__Java__97 _ s) = s
 
 whileStatement :: QuasiQuoter
-whileStatement = QuasiQuoter (quoteJavaExp "tok_WhileStatement_dummy_103" getWhileStatement ) (quoteJavaPat "tok_WhileStatement_dummy_103" getWhileStatement ) quoteJavaType quoteJavaDecs
+whileStatement = QuasiQuoter (quoteJavaExp "tok_WhileStatement_dummy_109" getWhileStatement ) (quoteJavaPat "tok_WhileStatement_dummy_109" getWhileStatement ) quoteJavaType quoteJavaDecs
 
-getWildcardType ( Ctr__Java__92 _ s) = s
+getWildcardType ( Ctr__Java__98 _ s) = s
 
 wildcardType :: QuasiQuoter
-wildcardType = QuasiQuoter (quoteJavaExp "tok_WildcardType_dummy_102" getWildcardType ) (quoteJavaPat "tok_WildcardType_dummy_102" getWildcardType ) quoteJavaType quoteJavaDecs
+wildcardType = QuasiQuoter (quoteJavaExp "tok_WildcardType_dummy_108" getWildcardType ) (quoteJavaPat "tok_WildcardType_dummy_108" getWildcardType ) quoteJavaType quoteJavaDecs
 


### PR DESCRIPTION
## Summary

This PR extends the Java grammar to support a batch of Phase 4g language features, bringing the parser from 95 blacklisted test files down to 18. The changes add support for anonymous class bodies, array initializers, generic methods with primitive/void returns, annotation value arrays, enum constant doc comments, and package-info/multi-type compilation units.

## Key Changes

- **Grammar updates** (`test-grammars/java.pg`):
  - Refactored `CompilationUnit` to support multiple type declarations and package-info files
  - Added `CreationExpression` rule for anonymous class instantiation with optional body
  - Extended `ArrayCreationExpression` to support array initializers
  - Added generic method support with primitive and void return types
  - Extended annotation syntax to support array-valued elements
  - Added doc comment support for enum constants
  - Updated conflict documentation to reflect Phase 4g additions (zero new conflicts)

- **Parser and lexer regeneration** (`test/golden/java/JavaParser.y`, `JavaLexer.x`, `JavaQQ.hs`):
  - Regenerated from updated grammar specification
  - Maintains zero shift/reduce conflicts for all new constructs

- **Test coverage**:
  - Added test files for new features:
    - `test-grammars/java/test-anon-class.java` - anonymous inner classes
    - `test-grammars/java/test-array-init.java` - array initializers
    - `test-grammars/java/test-annotation-array.java` - annotation value arrays
    - `test-grammars/java/test-generic-void.java` - generic methods with void/primitive returns
    - `test-grammars/java/test-enum-javadoc.java` - enum constant doc comments
    - `test-grammars/java/test-package-info.java` - package-info files
    - `test-grammars/java/test-multiple-types.java` - multiple type declarations per file
  - Updated makefile with test rules for new features
  - Updated token reference files to reflect lexer changes

- **Blacklist reduction**:
  - `commons-lang-parser-blacklist.txt`: Reduced from 89 to 40 blacklisted files
  - `commons-lang-parser-blacklist-tests.txt`: Reduced from 106 to 32 blacklisted files
  - Updated comments to reflect remaining unsupported features (array class literals, lambdas with typed parameters, volatile modifier, etc.)

## Implementation Details

All Phase 4g features were added with **zero new shift/reduce conflicts**. Each construct uses anchor tokens, shared nonterminals, or structural properties (e.g., '{' never following a complete expression) to avoid ambiguity. The empty compilation unit's first nullable is now `OptDocComment` instead of the retired `(Package)?` option, which is reflected in the quasi-quotation conflict documentation.

https://claude.ai/code/session_01HAL6wUrTDWiaGv6oWW4LU7