### PR TITLE
Task 8d: Rewrites as quasi-quoted patterns with SYB

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,9 @@ jobs:
         run_test "Java Test Suite" "make test-all-java"
         run_test "Java Lexer Golden Tests" "make test-lex-java"
         run_test "Java QQ Tests" "make test-java-qq"
+        # The user-facing rewrite recipe (task 8d): QQ patterns + SYB over
+        # parsed Java, per docs/java-quasi-quotation-tests.md.
+        run_test "Java QQ Rewrite Recipe" "make test-java-rewrite"
         # Quoters and splices against a type that exists only through rule
         # annotations (the synthesized cover rule, issue #14).
         run_test "Issue 14 QQ Tests" "make test-i14-qq"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   itself, still with the rule named as context
 
 ### Added
-- Named constructors (task 8a): an alternative may carry a leading label —
+- Rewrites as quasi-quoted patterns (task 8d) — the headline: the "rewrite
+  toolkit" finally means it. Every generated `<Name>QQ` now comes with a
+  documented, tested rewrite recipe ("Rewriting parsed Java" in
+  docs/java-quasi-quotation-tests.md, exercised by `make
+  test-java-rewrite`): a rewrite is an ordinary function whose match arms
+  are quasi-quoted patterns and whose results are quasi-quoted
+  expressions, applied to every node of any AST value with SYB's
+  `everywhere`/`extT` — the packages generated code already depends on, so
+  there is no new API surface and no change to generated artifacts. The
+  same patterns drive queries via `everything`/`mkQ`. rtk eats this
+  cooking: its own pipeline now matches clause shapes with its own
+  compiled-in quoter — `Frontend.altElems`/`seqElems` flatten the `'|'`
+  and juxtaposition spines by matching `[clause| $cl1 | $cl2 |]` /
+  `[clause| $cl1 $cl2 |]`, `StringLiterals` picks string literals out of
+  syntax rules with `[clause| $StrLit:s |]`, and `Normalize`'s
+  repetition/option shaping matches `[clause| $cl1 * ~ $cl2 |]`-style
+  patterns — each conversion landed golden-neutral (artifacts
+  byte-identical, bootstrap fixed point intact). Steps where the
+  constructor spelling reads better (wildcard tests, scalar-`Name`
+  binders, state-threading plumbing) deliberately stay plain; the
+  conversion record and the discovered pattern-matching boundaries live
+  in docs/qq-grammar-rewrites-plan.md §8d
   `Expr = Add: Expr '+' Term | Term ;` — that names its generated AST
   constructor (`Add RtkPos Expr Term`) instead of the positional
   `Ctr__<Rule>__<index>` default, so code and quasi-quote patterns written

--- a/Normalize.hs
+++ b/Normalize.hs
@@ -1,10 +1,12 @@
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE QuasiQuotes #-}
 -- | Clause normalization: from the parsed grammar (the GENERATED AST,
 -- 'GP.Grammar') down to the 'NormalGrammar' the code generators consume.
 module Normalize(normalizeTopLevelClauses, fillConstructorNames)
     where
 
 import qualified GrammarParser as GP
+import GrammarQQ (clause)
 
 import Syntax
 import Diagnostics (Diagnostic(..), SourcePos, showSourcePos)
@@ -102,8 +104,8 @@ saveProxyRuleName ruleName0 = do
   return ()
 
 addRule :: ID -> ID -> SyntaxTopClause -> Normalization ()
-addRule tdName ruleName0 clause = do
-  let doAdd rs = Just $ (SyntaxRule ruleName0 clause) : (maybe [] id rs)
+addRule tdName ruleName0 clause0 = do
+  let doAdd rs = Just $ (SyntaxRule ruleName0 clause0) : (maybe [] id rs)
   normSRules %= M.alter doAdd tdName
   return ()
 
@@ -162,14 +164,14 @@ addAntiRuleCached tdName isList = do
       return constr
 
 addRuleWithQQ :: ID -> ID -> SyntaxTopClause -> Normalization ()
-addRuleWithQQ tdName ruleName0 clause = do
-  case clause of
+addRuleWithQQ tdName ruleName0 clause0 = do
+  case clause0 of
     STAltOfSeq altseqs ->
         case L.find (\(STSeq _ ssc) -> case ssc of
                                          (SSLifted _ : _) -> True
                                          _ -> False)
                     altseqs of
-          Just _ -> addRule tdName ruleName0 clause
+          Just _ -> addRule tdName ruleName0 clause0
           Nothing -> qqAdd altseqs
     STMany opType (SSId rule) mcl -> do
                 -- For list rules, look up the actual type data name for the element rule
@@ -178,7 +180,7 @@ addRuleWithQQ tdName ruleName0 clause = do
                 let elemTypeName = M.findWithDefault rule rule typeMap
                 newRule <- addListProxyRule elemTypeName rule ruleName0
                 addRule tdName ruleName0 $ STMany opType (SSId newRule) mcl
-    _ -> addRule tdName ruleName0 clause
+    _ -> addRule tdName ruleName0 clause0
   where qqAdd altseqs = do
           -- The QQ machinery (lexical rule, anti rule) is created at the first
           -- eligible rule of the type, as before; but the splice alternative
@@ -194,7 +196,7 @@ addRuleWithQQ tdName ruleName0 clause = do
           let attachHere = S.member ruleName0 $ M.findWithDefault S.empty tdName attachMap
           if attachHere
             then addRule tdName ruleName0 $ STAltOfSeq (STSeq constr [SSId qqLexRule] : altseqs)
-            else addRule tdName ruleName0 clause
+            else addRule tdName ruleName0 clause0
 
 addListProxyRule :: ID -> ID -> ID -> Normalization ID
 addListProxyRule tdName elemRuleName listName = do
@@ -253,6 +255,13 @@ isSymmacroOption _             = False
 -- - 'c?' becomes an alternation with an empty alternative - since the
 -- generated AST cannot represent empty sequences (the old removeOpts
 -- pre-pass rewrote them on the retired IClause representation).
+--
+-- Repetition and option shapes are matched with rtk's own quasi-quoter
+-- ([clause| $cl1 * ~ $cl2 |] is the shape in grammar syntax; see Frontend's
+-- module notes for the metavariable convention). The constructor spelling
+-- stays where it reads better: wildcard tests like GP.Lifted{}, and arms
+-- that bind a scalar Name, which the quoter cannot (grammar.pg's Name
+-- splices are list-shaped, registered by IdList).
 --------------------------------------------------------------------------------
 
 -- A clause in rule (or parenthesized-group) position: an alternation of
@@ -277,11 +286,11 @@ checkSingleAlt alt = case seqElems alt of
 
 checkSoleElement :: GP.Clause -> Normalization SyntaxTopClause
 checkSoleElement c = case c of
-  GP.Star _ el        -> STMany STStar <$> checkRepeated el <*> pure Nothing
-  GP.StarDelim _ el d -> STMany STStar <$> checkRepeated el <*> (Just <$> checkSimple d)
-  GP.Plus _ el        -> STMany STPlus <$> checkRepeated el <*> pure Nothing
-  GP.PlusDelim _ el d -> STMany STPlus <$> checkRepeated el <*> (Just <$> checkSimple d)
-  GP.Opt _ el         -> desugarOpt el
+  [clause| $cl1 *        |] -> STMany STStar <$> checkRepeated cl1 <*> pure Nothing
+  [clause| $cl1 * ~ $cl2 |] -> STMany STStar <$> checkRepeated cl1 <*> (Just <$> checkSimple cl2)
+  [clause| $cl1 +        |] -> STMany STPlus <$> checkRepeated cl1 <*> pure Nothing
+  [clause| $cl1 + ~ $cl2 |] -> STMany STPlus <$> checkRepeated cl1 <*> (Just <$> checkSimple cl2)
+  [clause| $cl1 ?        |] -> desugarOpt cl1
   GP.Lifted{}         -> checkLiftedAlone c
   GP.Ignored{}        -> checkIgnoredAlone c
   GP.Ref _ n          -> return $ STAltOfSeq [STSeq "" [SSId (nameText n)]]
@@ -599,11 +608,11 @@ synthesizeTypeCovers rules
     -- addRuleWithQQ/addListProxyRule). A non-reference element is extracted
     -- into a fresh proxy group of its own and can never hit the start group.
     topRepetitionElemType r = case ruleClause r of
-        GP.Star _ c         -> elemType c
-        GP.StarDelim _ c _  -> elemType c
-        GP.Plus _ c         -> elemType c
-        GP.PlusDelim _ c _  -> elemType c
-        _                   -> Nothing
+        [clause| $cl1 *                  |] -> elemType cl1
+        [clause| $cl1 * ~ $Clause:_delim |] -> elemType cl1
+        [clause| $cl1 +                  |] -> elemType cl1
+        [clause| $cl1 + ~ $Clause:_delim |] -> elemType cl1
+        _                                   -> Nothing
       where elemType (GP.Ref _ n) = Just (M.findWithDefault (nameText n) (nameText n) typeOfName)
             elemType _            = Nothing
 
@@ -686,9 +695,9 @@ computeQQAttachPoints rules = M.fromList $ map attachFor groups
     -- checkClause/desugarOpt.
     topAlts :: GP.Clause -> [[GP.Clause]]
     topAlts c = case c of
-                  GP.Alt{}    -> map seqElems (altElems c)
-                  GP.Opt _ c1 -> [[], [c1]]
-                  _           -> [seqElems c]
+                  GP.Alt{}           -> map seqElems (altElems c)
+                  [clause| $cl1 ? |] -> [[], [cl1]]
+                  _                  -> [seqElems c]
 
     -- The non-nullable core of an alternative: Just n for a nonterminal
     -- whose value passes through (a plain or lifted reference), Nothing for

--- a/README.md
+++ b/README.md
@@ -58,6 +58,13 @@ generated modules:
 build-depends: base, array, syb, containers, template-haskell
 ```
 
+The quasi-quoter is also the rewrite facility: quasi-quoted patterns as
+match arms plus SYB's `everywhere`/`everything` rewrite and query parsed
+ASTs with no further API — see "Rewriting parsed Java" in
+[docs/java-quasi-quotation-tests.md](docs/java-quasi-quotation-tests.md)
+for the worked recipe (rtk's own pipeline and the
+write-you-a-haskell tutorial use the same shape).
+
 ## Grammar Format
 
 Grammar files use a simple specification format. Each file starts with a

--- a/StringLiterals.hs
+++ b/StringLiterals.hs
@@ -1,7 +1,9 @@
+{-# LANGUAGE QuasiQuotes #-}
 module StringLiterals (normalizeStringLiterals)
     where
 
 import qualified GrammarParser as GP
+import GrammarQQ (clause)
 
 import Frontend (mapGrammarRules, ruleName, strLitText)
 import Syntax (isLexicalRule)
@@ -58,12 +60,16 @@ addStrLit str = do
       return tokName
     Just tokName -> return tokName
 
--- A string literal in a syntax rule becomes an ignored reference to a shared
--- keyword token; the replacement keeps the literal's source position, so
--- later normalization diagnostics still point at the literal.
+-- A string literal in a syntax rule - the quasi-quoted pattern is "a clause
+-- that is just a string literal" - becomes an ignored reference to a shared
+-- keyword token. The replacement is built by hand, not quoted: it must keep
+-- the literal's source position so later normalization diagnostics still
+-- point at the literal, and a quote would embed its own compile-time
+-- position instead.
 normalizeClause :: GP.Clause -> StringLiteralsNormalization GP.Clause
-normalizeClause (GP.Lit p s) = do
+normalizeClause c@[clause| $StrLit:s |] = do
   tokName <- addStrLit (strLitText s)
+  let p = GP.rtkPosOf c
   return $ GP.Ignored p (GP.Ref p (GP.Ident p tokName))
 normalizeClause c = return c
 

--- a/docs/java-quasi-quotation-tests.md
+++ b/docs/java-quasi-quotation-tests.md
@@ -50,14 +50,19 @@ let stmt1 = [statement| return; |]
 let block1 = [statementBlock| { return x; } |]
 ```
 
-### What's Not Supported
+### Pattern Matching and Splicing
 
-**Pattern Matching** and **Anti-Quotation (Splicing)** are not currently functional for the Java grammar:
+Pattern matching and anti-quotation (splicing), which used to fail with
+parse errors for hierarchical grammars, work since the shared-type +
+attach-point machinery landed (see `Normalize.computeQQAttachPoints` and
+the summary block at the end of `java-qq-test.hs`). The metavariable
+must name the type explicitly: `$Expression:x`.
 
-- ❌ Pattern matching: `case expr of [expression| $e1 + $e2 |] -> ...` fails with parse errors
-- ❌ Anti-quotation: `let e = [expression| x |] in [expression| $e + 1 |]` fails with parse errors
+- ✅ Pattern matching: `case expr of [expression| $Expression:l + $Expression:r |] -> ...`
+- ✅ Splicing: `let e = [expression| x |] in [expression| $Expression:e + 1 |]`
 
-Only **construction** mode works: directly building AST nodes from Java syntax literals.
+Parts 2, 3 and 5 of `java-qq-test.hs` exercise both, and the rewrite
+recipe below builds on them.
 
 ## Building and Running Tests
 
@@ -74,10 +79,11 @@ This will generate:
 ### Run the quasi-quotation tests:
 ```bash
 make test-java-qq
+make test-java-rewrite   # the rewrite recipe (QQ patterns + SYB) below
 ```
 
 This will:
-1. Copy `java-qq-test.hs` to test-out
+1. Copy `java-qq-test.hs` (resp. `java-rewrite-test.hs`) to test-out
 2. Compile it with the generated Java parser modules
 3. Run the quasi-quotation tests
 
@@ -135,7 +141,7 @@ make test-all-java
 
 ## Quasi-Quotation Features
 
-### Supported: Construction
+### Construction
 Build AST nodes directly from Java syntax:
 ```haskell
 let expr = [expression| x + y * z |]
@@ -143,23 +149,108 @@ let stmt = [statement| return x; |]
 let block = [statementBlock| { x = 1; return x; } |]
 ```
 
-### Not Supported: Anti-Quotation and Pattern Matching
-
-**Anti-Quotation (Splicing)**: Not functional - produces parse errors
+### Anti-Quotation (Splicing)
+A `$Type:name` metavariable in an expression quote splices a Haskell
+variable of that AST type into the quoted syntax:
 ```haskell
--- This does NOT work for Java grammar:
 let e1 = [expression| a |]
-let e2 = [expression| $e1 + b |]  -- Parse error
+let e2 = [expression| $Expression:e1 + b |]
 ```
 
-**Pattern Matching**: Not functional - produces parse errors
+### Pattern Matching
+The same metavariables in a pattern quote bind sub-trees; every source
+position in the pattern is a wildcard, so patterns written in a quote
+match ASTs parsed from anywhere:
 ```haskell
--- This does NOT work for Java grammar:
 case expr of
-    [expression| $e1 + $e2 |] -> ...  -- Parse error
+    [expression| $Expression:l + $Expression:r |] -> ...  -- binds l and r
 ```
 
-Only construction mode is currently supported for the Java quasi-quoter.
+## Rewriting parsed Java (QQ patterns + SYB)
+
+The pieces above combine into the rewrite recipe — the reason the toolkit
+is called a *rewrite* toolkit. A rewrite is an ordinary function whose
+match arms are quasi-quoted patterns and whose results are quasi-quoted
+expressions; SYB applies it to every node of any AST value. No rtk-specific
+API is involved: the generated parser derives `Data` for every AST type
+(your project already depends on `syb` for it), so `Data.Generics` is the
+traversal library, and the quasi-quoter contributes only the arms.
+
+The worked example, exercised by `make test-java-rewrite`
+(`test-grammars/java-rewrite-test.hs`): turn comparisons against `null`
+into Yoda style, everywhere in a block.
+
+```haskell
+import Data.Generics (everywhere, everything, mkT, mkQ)
+
+-- one arm per shape, Java on both sides; everything else passes through
+yoda :: JP.Expression -> JP.Expression
+yoda [J.expression| $Expression:x == null |] = [J.expression| null == $Expression:x |]
+yoda [J.expression| $Expression:x != null |] = [J.expression| null != $Expression:x |]
+yoda e = e
+
+-- bottom-up over ANY value containing expressions: a block, a method,
+-- a whole compilation unit
+rewritten = everywhere (mkT yoda) body
+```
+
+Because positions are equality-transparent, the expected result can be
+written as a quote too, and the test is two quotes and a traversal:
+
+```haskell
+body      = [J.statementBlock| { if (name == null) { return defaultName; } ... } |]
+expected  = [J.statementBlock| { if (null == name) { return defaultName; } ... } |]
+-- everywhere (mkT yoda) body == expected
+```
+
+The same patterns drive queries with `everything`/`mkQ` — e.g. counting
+the comparisons the pass would rewrite (deliberately unused metavariables
+are spelled with a leading underscore, `$Expression:_x`, to stay clean
+under `-Wunused-matches`):
+
+```haskell
+pendingNullChecks [J.expression| $Expression:_x == null |] = 1
+pendingNullChecks [J.expression| $Expression:_x != null |] = 1
+pendingNullChecks _ = 0
+
+everything (+) (0 `mkQ` pendingNullChecks) body  -- 2 before, 0 after
+```
+
+To rewrite several AST types in one pass, chain per-type functions with
+`extT` (`everywhere (mkT onExpr `extT` onStmt)`) — rtk's own pipeline does
+exactly this over its grammar AST (`cleanGrammarTokens` in
+`src/generated/Frontend.hs`), and since task 8d the pipeline's own
+clause-shape matches are QQ patterns (`Frontend.altElems`,
+`StringLiterals.normalizeClause`, `Normalize.checkSoleElement`). For a
+larger, end-to-end example, the write-you-a-haskell tutorial's evaluator
+(`tutorials/write-you-a-haskell/lc-main.hs`) implements capture-avoiding
+substitution and free-variable analysis this way: QQ arms for the binder
+cases, `gmapT`/`gmapQ` generic recursion for everything else.
+
+### Where patterns match (the chain-position rule)
+
+In a hierarchical grammar the splice alternative sits at one rule of each
+shared-type group — for `Expression` that is `PrimaryNoPostfix`, the
+bottom of the precedence chain (see `Normalize.computeQQAttachPoints`).
+A pattern metavariable therefore matches scrutinees whose corresponding
+operand parses at that chain position: identifiers, literals, method
+calls, parenthesized expressions. An operand produced higher in the chain
+(say the `a + b` in `a + b == null`) does not reach the attach point, so
+the pattern passes it by — matches simply fail, nothing breaks. When a
+rewrite must catch every operand shape, parenthesize at the call site or
+match on the printed form; `java-rewrite-test.hs` asserts both sides of
+this boundary.
+
+### Scalar vs. list metavariables
+
+`$Type:x` binds a single node when the type's splice is scalar and a
+whole list when the splice was registered by a list rule (`Type*`) — in
+pattern context a list metavariable binds the entire remaining list, in
+expression context it prepends a list. A type whose splice is list-shaped
+cannot bind a lone (scalar) occurrence: the metavariable then matches
+nothing and GHC reports the variable as unbound. Check the generated
+`JavaQQ.hs`: `anti<Type>Pat` taking `[Type]` means list-shaped,
+`Type` means scalar.
 
 ## Extending Tests
 
@@ -182,7 +273,8 @@ Based on the Java grammar (partial list):
 - `[modifier| public |]` - Access modifiers
 - `[literal| "hello" |]` - Literals
 
-**Note**: Pattern matching is not currently supported for the Java grammar.
+All of them work in expression and pattern context alike (see "Rewriting
+parsed Java" above for patterns in anger).
 
 ## References
 

--- a/docs/qq-grammar-rewrites-plan.md
+++ b/docs/qq-grammar-rewrites-plan.md
@@ -6,7 +6,10 @@ Term`, grammar.pg fully labeled); 8b DONE (GrammarQQ compiled into rtk);
 `IRule`/`IClause` retired, the AST adapter replaced by
 `src/generated/Frontend.hs`, the reference `Parser.y` ported to construct
 generated-AST values — option B; full reference-front-end retirement,
-option A, remains a separate later sign-off); 8d PLANNED.
+option A, remains a separate later sign-off); 8d DONE (three pipeline
+steps converted to QQ-pattern matching, each landed golden-neutral; the
+user-facing half shipped as a documented recipe rather than an exported
+helper — see the record at the end of the Task 8d section).
 
 The flip made grammar.pg authoritative and the generated front end the
 default, but the pipeline still computes over the original hand-written data
@@ -271,6 +274,73 @@ rewrite hook.
 - At least two normalization steps run as QQ rewrites with byte-identical
   goldens; a documented, tested recipe (or API) exists for user grammars.
 - Fixed point + full battery green.
+
+### 8d record (what landed, what was declined, and why)
+
+Converted, one golden-neutral commit each (no snapshot touched; goldens
+byte-identical and the bootstrap fixed point checked per commit):
+
+- `Frontend.altElems`/`seqElems`: the Alt/Seq spine flatteners are now the
+  laws they implement — `[clause| $cl1 | $cl2 |]` and
+  `[clause| $cl1 $cl2 |]`.
+- `StringLiterals.normalizeClause`: the everywhereM walk selects its
+  target with `[clause| $StrLit:s |]` ("a clause that is just a string
+  literal"). The REPLACEMENT stays hand-built: it must reuse the
+  literal's source position (recovered via `rtkPosOf` from the matched
+  clause) so later diagnostics still point at the literal — a quoted
+  expression would embed its compile-time position instead.
+- `Normalize`'s repetition/option shaping: `checkSoleElement`'s
+  rule-shaping arms, `topAlts`'s option arm and
+  `synthesizeTypeCovers.topRepetitionElemType` match
+  `[clause| $cl1 * ~ $cl2 |]`-style patterns. Deliberately-unused binders
+  use the explicit `$Clause:_delim` form (shortcut metavariables cannot
+  start with `_`, and `-Wunused-matches` applies to QQ binders).
+
+Declined, per the honesty clause (the constructor spelling reads better
+or QQ cannot express the step):
+
+- `cleanGrammarTokens`: token-text edits plus position preservation —
+  neither is expressible in a quote.
+- `fillConstructorNames`: walks `NormalGrammar` (`STSeq`), a
+  representation the quoters do not produce.
+- Wildcard shape tests (`isStarPlus`, `eligibleClause`, `GP.Lifted{}`
+  arms) and `clauseNullable`'s table: `GP.Star{}`-style wildcards already
+  read best; QQ arms would only add unused metavariables.
+- Anything binding a scalar `Name` (`allIdRefs`, `ctorLabels`,
+  `checkSimple`'s lifted-ref arm): grammar.pg's `Name` splices are
+  list-shaped — `IdList = Name* ~ ','` registers `Anti_Name` first, and
+  the per-type anti-rule cache keeps the list flavor — so a scalar
+  `$Name:n` pattern binds nothing (the metavariable becomes a literal
+  `Anti_Name` sub-pattern; using `n` is a compile error). Making scalar
+  and list anti functions coexist per type would be a GenQ feature
+  (golden-churning), out of 8d's refactoring scope.
+- The doc's original `removeOpts` sketch (`[cl| $c ? |] → [cl| ( | $c ) |]`):
+  the pre-pass no longer exists and the generated AST cannot represent
+  the empty alternative; the MATCH side lives on in `checkSoleElement`'s
+  `[clause| $cl1 ? |]` arm, the construction side stays `desugarOpt`.
+
+Constraint discovered for future arms: literal-text patterns
+(`[clause| 'x' |]`) never match pipeline values — quote-time ASTs keep
+token delimiters because `cleanGrammarTokens` runs in
+`parseWithGenerated`, after the generated parser, not in the quote path.
+Metavariable and structural patterns are unaffected. (User grammars are
+immune: their token processing is the lexer rules' own `func`s, applied
+identically in both paths.)
+
+User-facing half — design call: a documented recipe, not an exported
+`rewrite<Name>` helper. `everywhere`/`extT`/`everything` from syb (which
+generated code already depends on for its `Data` instances) IS the
+rewrite API; a generated wrapper would rename a one-liner, churn every
+`*QQ.hs` golden plus a two-phase bootstrap accept, and add API surface
+without removing any of the actual learning content — which is how to
+write the match arms. That content now lives in "Rewriting parsed Java"
+in docs/java-quasi-quotation-tests.md (including the chain-position rule
+for where patterns match and the scalar-vs-list metavariable rule),
+exercised end to end by `make test-java-rewrite`
+(test-grammars/java-rewrite-test.hs, wired into CI), with the
+write-you-a-haskell evaluator (tutorials/write-you-a-haskell/lc-main.hs)
+cited as the larger real-world proof and rtk's own converted pipeline
+steps as the in-tree one.
 
 ---
 

--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-.PHONY: clean help test test-unit test-golden accept-golden test-compile-goldens test-wyah-tutorial test-lex-java accept-lex-java test-all-java test-i14-qq test-debug test-debug-all test-debug-options test-suite-commons-lang test-suite-commons-lang-tests test-suite-commons-lang-all test-lex-commons-lang test-lex-commons-lang-tests test-lex-commons-lang-all test-parse-commons-lang test-parse-commons-lang-tests test-parse-commons-lang-all analyze-failures test-suite $(GRAMMAR_TARGETS)
+.PHONY: clean help test test-unit test-golden accept-golden test-compile-goldens test-wyah-tutorial test-lex-java accept-lex-java test-all-java test-i14-qq test-java-rewrite test-debug test-debug-all test-debug-options test-suite-commons-lang test-suite-commons-lang-tests test-suite-commons-lang-all test-lex-commons-lang test-lex-commons-lang-tests test-lex-commons-lang-all test-parse-commons-lang test-parse-commons-lang-tests test-parse-commons-lang-all analyze-failures test-suite $(GRAMMAR_TARGETS)
 
 # ============================================================================
 # Configuration
@@ -225,6 +225,14 @@ test-java-qq: build test-out/JavaLexer.hs test-out/JavaParser.hs | test-out
 	$(CP) test-grammars/java-qq-test.hs test-out
 	cabal exec -- ghc --make -itest-out test-out/java-qq-test.hs -o test-out/java-qq-test
 	test-out/java-qq-test
+
+# The user-facing rewrite recipe (task 8d): QQ patterns as match arms of an
+# ordinary function, applied everywhere with SYB - see "Rewriting parsed
+# Java" in docs/java-quasi-quotation-tests.md, which this test exercises.
+test-java-rewrite: build test-out/JavaLexer.hs test-out/JavaParser.hs | test-out
+	$(CP) test-grammars/java-rewrite-test.hs test-out
+	cabal exec -- ghc --make -itest-out test-out/java-rewrite-test.hs -o test-out/java-rewrite-test
+	test-out/java-rewrite-test
 
 # Quasi-quotation against covered pure types (issue #14): i14.pg's 'Shape'
 # and 'Label' exist only through rule annotations; the synthesized cover

--- a/src/generated/Frontend.hs
+++ b/src/generated/Frontend.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE QuasiQuotes #-}
 -- | The front-end surface of the pipeline. Since task 8c the pipeline
 -- computes directly over the GENERATED AST ('GrammarParser''s types, compiled
 -- from the @test/golden/grammar/@ snapshot): there is no separate
@@ -26,6 +27,14 @@
 -- so diagnostics can point at the offending clause, not just the rule
 -- header. Positions are equality-transparent ('GP.RtkPos'), which is why the
 -- AST-equality harness projects them explicitly via 'sourcePosOf'.
+--
+-- Clause-shape matches here and in the later pipeline stages are written
+-- with rtk's own generated quasi-quoter where that reads better than the
+-- constructor spelling (task 8d): a @[clause| ... |]@ pattern is the clause
+-- shape in grammar syntax, with @$cl...@ metavariables binding sub-clauses
+-- (the names resolve through grammar.pg's @\@shortcuts@ table, so they must
+-- start with a declared shortcut such as @cl@, or use the explicit
+-- @$Clause:name@ form) and every position wildcarded.
 module Frontend
     ( -- * Parsing entry points (the generated front end)
       parseWithGenerated
@@ -62,6 +71,7 @@ import Data.List (intercalate)
 
 import qualified GrammarLexer as GL
 import qualified GrammarParser as GP
+import GrammarQQ (clause)
 
 import Diagnostics (Diagnostic, SourcePos(..), diagnosticFromPositioned)
 import TokenProcessing (unBackQuote)
@@ -186,13 +196,13 @@ rulePos r                          = sourcePosOf (GP.rtkPosOf r)
 -- The right operand of each node is a single alternative, never another
 -- alternation (parenthesized alternations stay as elements).
 altElems :: GP.Clause -> [GP.Clause]
-altElems (GP.Alt _ l r) = altElems l ++ [r]
-altElems c              = [c]
+altElems [clause| $cl1 | $cl2 |] = altElems cl1 ++ [cl2]
+altElems c                       = [c]
 
 -- | Flatten the left-recursive juxtaposition spine of one alternative.
 seqElems :: GP.Clause -> [GP.Clause]
-seqElems (GP.Seq _ l r) = seqElems l ++ [r]
-seqElems c              = [c]
+seqElems [clause| $cl1 $cl2 |] = seqElems cl1 ++ [cl2]
+seqElems c                     = [c]
 
 nameText :: GP.Name -> String
 nameText (GP.Ident _ s)   = s

--- a/test-grammars/java-rewrite-test.hs
+++ b/test-grammars/java-rewrite-test.hs
@@ -1,0 +1,91 @@
+{-# LANGUAGE QuasiQuotes #-}
+
+-- The user-facing rewrite recipe of task 8d, exercised end to end
+-- (`make test-java-rewrite`; the worked walkthrough is the "Rewriting
+-- parsed Java" section of docs/java-quasi-quotation-tests.md):
+-- a rewrite over a generated AST is an ordinary function whose match arms
+-- are quasi-quoted patterns and whose results are quasi-quoted expressions,
+-- applied to every node of any AST value with SYB's `everywhere`, and the
+-- same patterns drive queries through `everything`. rtk's own pipeline
+-- (Frontend/StringLiterals/Normalize) and the write-you-a-haskell
+-- tutorial's evaluator use exactly this shape.
+
+import qualified JavaQQ as J
+import qualified JavaParser as JP
+import Data.Generics (everywhere, everything, mkT, mkQ)
+import Text.Show.Pretty (ppShow)
+
+-- Comparisons against null become Yoda-style (null first): one arm per
+-- shape, Java syntax on both sides, everything else passes through.
+yoda :: JP.Expression -> JP.Expression
+yoda [J.expression| $Expression:x == null |] = [J.expression| null == $Expression:x |]
+yoda [J.expression| $Expression:x != null |] = [J.expression| null != $Expression:x |]
+yoda e = e
+
+-- The same patterns as a query: count the comparisons yoda would rewrite.
+pendingNullChecks :: JP.Expression -> Int
+pendingNullChecks [J.expression| $Expression:_x == null |] = 1
+pendingNullChecks [J.expression| $Expression:_x != null |] = 1
+pendingNullChecks _ = 0
+
+main :: IO ()
+main = do
+    putStrLn "=========================================================="
+    putStrLn "Java Rewrite Recipe Test (QQ patterns + SYB)"
+    putStrLn "=========================================================="
+    putStrLn ""
+
+    -- `everywhere (mkT yoda)` rewrites every expression inside the block -
+    -- the if condition and the while condition here - in one pass; the
+    -- expected result is written in Java too, so the whole test is two
+    -- quotes and a traversal. Positions are equality-transparent, which is
+    -- why ASTs from different quotes compare equal structurally.
+    let body = [J.statementBlock| {
+            if (name == null) { return defaultName; }
+            while (cursor != null) { cursor = cursor.next(); }
+            return name;
+        } |]
+        expected = [J.statementBlock| {
+            if (null == name) { return defaultName; }
+            while (null != cursor) { cursor = cursor.next(); }
+            return name;
+        } |]
+        rewritten = everywhere (mkT yoda) body
+
+    check "comparisons at every statement depth become Yoda-style"
+          (rewritten == expected)
+          (ppShow rewritten)
+
+    -- The query runs over the same block: two rewritable comparisons
+    -- before the pass, none after (the rewritten form no longer matches).
+    check "the query counts both pending comparisons"
+          (everything (+) (0 `mkQ` pendingNullChecks) body == 2)
+          (show (everything (+) (0 `mkQ` pendingNullChecks) body))
+    check "after the rewrite no pending comparison remains"
+          (everything (+) (0 `mkQ` pendingNullChecks) rewritten == 0)
+          (show (everything (+) (0 `mkQ` pendingNullChecks) rewritten))
+
+    -- The honest boundary (see the docs section): a pattern metavariable
+    -- sits at the splice attach point of the expression chain, so it
+    -- matches comparands that parse at that chain position (identifiers,
+    -- literals, calls, parenthesized expressions) - a binary comparand
+    -- lives higher in the chain and passes through unmatched.
+    let call = [J.expression| getName() == null |]
+        sums = [J.expression| a + b == null |]
+    check "a method-call comparand is matched and rewritten"
+          (everywhere (mkT yoda) call == [J.expression| null == getName() |])
+          (ppShow (everywhere (mkT yoda) call))
+    check "a binary comparand is beyond the pattern and passes through"
+          (everywhere (mkT yoda) sums == sums)
+          (ppShow (everywhere (mkT yoda) sums))
+
+    putStrLn ""
+    putStrLn "=========================================================="
+    putStrLn "All rewrite recipe tests passed!"
+    putStrLn "=========================================================="
+
+-- A wrong result must fail the test binary (and `make test-java-rewrite`).
+check :: String -> Bool -> String -> IO ()
+check what ok got
+    | ok        = putStrLn $ "OK " ++ what
+    | otherwise = error $ "FAILED: " ++ what ++ ", got:\n" ++ got


### PR DESCRIPTION
## Summary

Implements the user-facing rewrite recipe for task 8d: quasi-quoted patterns as match arms combined with SYB's `everywhere`/`everything` for rewriting and querying parsed ASTs. Converts three pipeline normalization steps to use quasi-quotation internally, and documents the complete pattern with a worked example and test.

## Key Changes

**Documentation & User-Facing Recipe**
- Updated `docs/java-quasi-quotation-tests.md` to document pattern matching and splicing as now-functional (previously marked unsupported)
- Added comprehensive "Rewriting parsed Java (QQ patterns + SYB)" section with worked example: converting null comparisons to Yoda style
- Documented the chain-position rule (where patterns match in hierarchical grammars) and scalar vs. list metavariable behavior
- Updated `docs/qq-grammar-rewrites-plan.md` with detailed task 8d record: what was converted, what was declined and why, and constraints discovered

**New Test**
- Added `test-grammars/java-rewrite-test.hs`: end-to-end rewrite recipe exercising pattern matching and splicing with SYB
- Wired into CI via `make test-java-rewrite` target in makefile and `.github/workflows/ci.yml`
- Tests both the rewrite (comparisons become Yoda-style) and the query (counting pending comparisons)
- Demonstrates the chain-position boundary: method calls match and rewrite, but binary operands pass through

**Pipeline Conversions (Golden-Neutral)**
- `Frontend.hs`: `altElems` and `seqElems` now match `[clause| $cl1 | $cl2 |]` and `[clause| $cl1 $cl2 |]` patterns instead of constructor spelling
- `StringLiterals.hs`: `normalizeClause` matches `[clause| $StrLit:s |]` pattern; replacement stays hand-built to preserve source position
- `Normalize.hs`: `checkSoleElement` and `synthesizeTypeCovers.topRepetitionElemType` match repetition/option shapes with `[clause| $cl1 * ~ $cl2 |]`-style patterns; deliberately-unused binders use explicit `$Clause:_delim` form

**Supporting Changes**
- Added `{-# LANGUAGE QuasiQuotes #-}` pragmas to `Frontend.hs`, `StringLiterals.hs`, and `Normalize.hs`
- Imported `GrammarQQ (clause)` in affected modules
- Updated `README.md` to explain quasi-quotation as the rewrite facility
- Updated `CHANGELOG.md` with task 8d summary

## Implementation Details

The rewrite recipe requires no new API surface: SYB's `Data` instances (already generated for all AST types) and `everywhere`/`extT`/`everything` from the `syb` package (already a dependency) are the complete rewrite API. The quasi-quoter contributes only the pattern-matching arms.

Pipeline conversions landed golden-neutral: generated artifacts remain byte-identical and the bootstrap fixed point is intact per commit. Steps where constructor spelling reads better (wildcard tests like `GP.Lifted{}`, scalar `Name` binders which the quoter cannot express, state-threading plumbing) deliberately stay plain.

The discovered constraint: literal-text patterns never match pipeline values because quote-time ASTs keep token delimiters (cleaned by `cleanGrammarTokens` after the generated parser, not in the quote path). Metavariable and structural patterns are unaffected.

https://claude.ai/code/session_013QU18SeZ4bbyp5T7XW3RGy