### PR TITLE
Name the C-tutorial AST constructors (task R4)

### DIFF
--- a/tutorials/c-compiler/Codegen.hs
+++ b/tutorials/c-compiler/Codegen.hs
@@ -7,8 +7,8 @@
 --
 -- Token payloads (the integer literal, the function name) cannot be bound
 -- or spliced by an antiquote ($x works on whole syntax sorts only), so leaf
--- nodes go through the generated constructors: expValue/identName on the C
--- side, mkImm/mkSym on the assembly side (positioned with rtkNoPos; AST
+-- nodes go through the grammar's named constructors: expValue/identName on
+-- the C side, mkImm/mkSym on the assembly side (positioned with rtkNoPos; AST
 -- equality ignores positions by design).
 module Codegen (codegen) where
 
@@ -51,17 +51,17 @@ genStatement other = error $ "codegen: unsupported statement: " ++ show other
 -- assembly leaf constructors
 
 mkImm :: Int -> Operand
-mkImm = Ctr__Operand__0 rtkNoPos
+mkImm = Imm rtkNoPos
 
 mkSym :: String -> AsmId
-mkSym = Ctr__AsmId__0 rtkNoPos
+mkSym = Sym rtkNoPos
 
 -- C leaf destructors
 
 identName :: Ident -> String
-identName (Ctr__Ident__0 _ s) = s
+identName (Name _ s) = s
 identName other = error $ "codegen: unexpected identifier node: " ++ show other
 
 expValue :: Exp -> Int
-expValue (Ctr__Exp__0 _ n) = n
+expValue (IntLit _ n) = n
 expValue other = error $ "codegen: unexpected expression node: " ++ show other

--- a/tutorials/c-compiler/Emit.hs
+++ b/tutorials/c-compiler/Emit.hs
@@ -25,9 +25,9 @@ emitItem other = error $ "emitItem: unsupported item: " ++ show other
 
 emitOperand :: Operand -> String
 emitOperand [operand| %eax |] = "%eax"
-emitOperand (Ctr__Operand__0 _ n) = "$" ++ show n
+emitOperand (Imm _ n) = "$" ++ show n
 emitOperand other = error $ "emitOperand: unsupported operand: " ++ show other
 
 symName :: AsmId -> String
-symName (Ctr__AsmId__0 _ s) = s
+symName (Sym _ s) = s
 symName other = error $ "symName: unexpected symbol: " ++ show other

--- a/tutorials/c-compiler/README.md
+++ b/tutorials/c-compiler/README.md
@@ -110,6 +110,16 @@ long time; the causes are avoidable, and `c.pg` is written to avoid them:
 5. **Antiquote names need a following non-name, non-colon character.**
    `$sym :` parses as a label with an antiquoted symbol, but `$sym:` is read
    as the explicit `$Rule:name` antiquote form and won't scan.
+6. **Name the alternatives' constructors.** A leading label
+   (`Exp = IntLit: intLit ;`) names the generated AST constructor; without it
+   the name is positional (`Ctr__Exp__0`), encoding the alternative's index,
+   so reordering the grammar silently renames it. `c.pg`/`asm.pg` name every
+   alternative, which is what lets the passes read `IntLit _ n` instead of
+   `Ctr__Exp__0 _ n`. Names must be unique across the grammar — and, by the
+   same unqualified-import reasoning as (4), across both grammars: the C side
+   uses `IntLit`/`Return`/`Name`/..., the asm side `Imm`/`Movl`/`Sym`/....
+   (The start sort keeps one auto-generated `Ctr__*` wrapper for the
+   quasi-quoter scaffolding; no pass references it.)
 
 ## Known RTK limitations to design around
 
@@ -124,9 +134,9 @@ long time; the causes are avoidable, and `c.pg` is written to avoid them:
   mixed list patterns (`{ $stmts return 0 ; }`) only work in construction.
 - **Token payloads cannot be antiquoted.** `$x` splices/matches whole syntax
   sorts; the `Int` of an `intLit` or the `String` of an `id` is reached
-  through the generated constructors (`Ctr__Exp__0 _ n`, `Ctr__Ident__0 _ s`;
-  the first field is the node's source position) — see `expValue`/`identName`
-  in `Codegen.hs`. Nodes built in code take `rtkNoPos` there; AST equality
+  through the alternative's named constructor (`IntLit _ n`, `Name _ s`; the
+  first field is the node's source position) — see `expValue`/`identName` in
+  `Codegen.hs`. Nodes built in code take `rtkNoPos` there; AST equality
   ignores positions by design, so built and parsed trees still compare equal.
 - **Quoter names are lowercased rule names** and can collide with Prelude
   names: the `Exp` quoter is `exp`, hence `import Prelude hiding (exp)`.

--- a/tutorials/c-compiler/TestQQ.hs
+++ b/tutorials/c-compiler/TestQQ.hs
@@ -48,11 +48,11 @@ main = do
   cResults <-
     sequence
       [ check "construction: [exp| 42 |]" $
-          [exp| 42 |] == Ctr__Exp__0 rtkNoPos 42
+          [exp| 42 |] == IntLit rtkNoPos 42
       , check "construction with scalar splice: [statement| return $e ; |]" $
           let e = [exp| 42 |]
           in [statement| return $e ; |]
-               == Ctr__Statement__0 rtkNoPos (Ctr__Exp__0 rtkNoPos 42)
+               == Return rtkNoPos (IntLit rtkNoPos 42)
       , check "pattern with antiquote binder: [statement| return $e1 ; |]" $
           case [statement| return 7 ; |] of
             [statement| return $e1 ; |] -> e1 == [exp| 7 |]
@@ -66,7 +66,7 @@ main = do
       , check "whole-list pattern binding: { $stmts }" $
           case parse "int main() { return 1; return 2; }" of
             [program| int $name ( ) { $stmts } |] ->
-              name == Ctr__Ident__0 rtkNoPos "main" && length stmts == 2
+              name == Name rtkNoPos "main" && length stmts == 2
             _ -> False
       , check "list splice in construction: { $stmts0 }" $
           let stmts0 = [[statement| return 1 ; |], [statement| return 2 ; |]]
@@ -85,22 +85,22 @@ main = do
   asmResults <-
     sequence
       [ check "construction: [operand| $5 |] and [operand| %eax |]" $
-          [operand| $5 |] == Ctr__Operand__0 A.rtkNoPos 5
+          [operand| $5 |] == Imm A.rtkNoPos 5
             && [operand| %eax |]
-                 == Ctr__Operand__1 A.rtkNoPos (Ctr__Reg__0 A.rtkNoPos)
+                 == RegOp A.rtkNoPos (Eax A.rtkNoPos)
       , check "construction with scalar splice: movl $src, %eax" $
-          let src = Ctr__Operand__0 A.rtkNoPos 7
+          let src = Imm A.rtkNoPos 7
           in [asmItem| movl $src, %eax |]
-               == Ctr__AsmItem__2 A.rtkNoPos
-                    (Ctr__Operand__0 A.rtkNoPos 7)
-                    (Ctr__Operand__1 A.rtkNoPos (Ctr__Reg__0 A.rtkNoPos))
+               == Movl A.rtkNoPos
+                    (Imm A.rtkNoPos 7)
+                    (RegOp A.rtkNoPos (Eax A.rtkNoPos))
       , check "pattern with antiquote binders: movl $src, $dst" $
           case [asmItem| movl $3, %eax |] of
             [asmItem| movl $src, $dst |] ->
               src == [operand| $3 |] && dst == [operand| %eax |]
             _ -> False
       , check "scalar + list splices: .globl $sym / $sym : / $items" $
-          let sym = Ctr__AsmId__0 A.rtkNoPos "main"
+          let sym = Sym A.rtkNoPos "main"
               items = [asmItems| movl $2, %eax
                                  ret |]
           in [asm| .globl $sym
@@ -133,5 +133,5 @@ parseAsmText :: String -> Asm
 parseAsmText src = either error id (AsmLexer.scanTokens src >>= parseAsm)
 
 expValue :: Exp -> Int
-expValue (Ctr__Exp__0 _ n) = n
+expValue (IntLit _ n) = n
 expValue other = error $ "expValue: unexpected expression node: " ++ show other

--- a/tutorials/c-compiler/asm.pg
+++ b/tutorials/c-compiler/asm.pg
@@ -14,7 +14,11 @@ grammar 'Asm';
 #   numeric ($2), antiquote names always start with a letter ($src), and the
 #   longest lexer match keeps them apart.
 
-Asm = AsmItems ;
+# Leading labels (AsmUnit:, Globl:, ...) name the generated AST constructors;
+# see the matching note in c.pg. Names are kept distinct from c.pg's so both
+# generated parsers can be imported unqualified into the compiler modules.
+
+Asm = AsmUnit: AsmItems ;
 
 # AsmItems must be normalized BEFORE AsmItem: RTK allows one anti-quote shape
 # per AST type (scalar or list), and we want the list shape for AsmItem
@@ -22,19 +26,19 @@ Asm = AsmItems ;
 @shortcuts(items)
 AsmItems = AsmItem* ;
 
-AsmItem = '.globl' AsmId
-        | AsmId ':'
-        | 'movl' Operand ',' Operand
-        | 'ret' ;
+AsmItem = Globl: '.globl' AsmId
+        | Label: AsmId ':'
+        | Movl: 'movl' Operand ',' Operand
+        | Ret: 'ret' ;
 
 @shortcuts(src, dst)
-Operand = '$' num
-        | Reg ;
+Operand = Imm: '$' num
+        | RegOp: Reg ;
 
-Reg = '%eax' ;
+Reg = Eax: '%eax' ;
 
 @shortcuts(sym)
-AsmId = asmid ;
+AsmId = Sym: asmid ;
 
 # ----------------------------------------------------------------------------
 # Lexical rules

--- a/tutorials/c-compiler/c.pg
+++ b/tutorials/c-compiler/c.pg
@@ -19,9 +19,17 @@ grammar 'C';
 # expression node directly. (Splice-token placement itself is handled by
 # RTK's unit-production cover analysis either way; see Normalize.hs.)
 
-Program = Function ;
+# The leading label on each alternative (Prog:, Func:, ...) names the AST
+# constructor RTK generates for it. Without a label the constructor is
+# positional (Ctr__Exp__0), encoding the alternative's index, so any
+# reordering silently renames it; named constructors are stable and let the
+# passes read `IntLit _ n` instead of `Ctr__Exp__0 _ n`. Names must be unique
+# across the whole grammar, and across asm.pg too: Codegen/TestQQ import both
+# generated parsers unqualified, so a shared name would be an ambiguous use.
 
-Function = 'int' Ident '(' ')' '{' StatementList '}' ;
+Program = Prog: Function ;
+
+Function = Func: 'int' Ident '(' ')' '{' StatementList '}' ;
 
 # NOTE: StatementList must be normalized BEFORE Statement: RTK allows one
 # anti-quote shape per AST type (scalar or list), and we want the list shape
@@ -29,13 +37,13 @@ Function = 'int' Ident '(' ')' '{' StatementList '}' ;
 @shortcuts(stmts)
 StatementList = Statement* ;
 
-Statement = 'return' Exp ';' ;
+Statement = Return: 'return' Exp ';' ;
 
 @shortcuts(e)
-Exp = intLit ;
+Exp = IntLit: intLit ;
 
 @shortcuts(name)
-Ident = id ;
+Ident = Name: id ;
 
 # ----------------------------------------------------------------------------
 # Lexical rules


### PR DESCRIPTION
Task R4 from `docs/c-compiler-tutorial-plan.md` (the follow-up plan in #137), done as its own PR so it can be reviewed before the companion tutorial (R6) is written on top of it.

## What this does

The stage-1 tutorial passes destructured **positional** constructors — `expValue (Ctr__Exp__0 _ n)`, `mkImm = Ctr__Operand__0 rtkNoPos`, and six more like them. Those names encode the alternative's *index* within its rule, so reordering the grammar silently renames them, and they read poorly in a tutorial meant to teach.

The named-constructor feature (task 8a, now on master) lets an alternative carry a leading label that names its generated constructor. This PR labels **every** alternative in `c.pg` and `asm.pg`, so the generated AST is fully readable and the passes/tests reference stable names:

| positional | named |
|---|---|
| `Ctr__Exp__0 _ n` | `IntLit _ n` |
| `Ctr__Statement__0 _ e` | `Return _ e` |
| `Ctr__Ident__0 _ s` | `Name _ s` |
| `Ctr__Operand__0 _ n` | `Imm _ n` |
| `Ctr__Operand__1 _ r` | `RegOp _ r` |
| `Ctr__AsmItem__2 _ a b` | `Movl _ a b` |
| `Ctr__AsmId__0 _ s` | `Sym _ s` |

## Notes for review

- **Pure rename, no behavior change.** Constructor arity and field layout are identical (the `RtkPos` first field is unchanged); only the names differ.
- **Names are distinct across the two grammars** (C side `IntLit`/`Return`/`Name`/…, asm side `Imm`/`Movl`/`Sym`/…) because `Codegen.hs` and `TestQQ.hs` import both generated parsers unqualified — a shared name would be an ambiguous occurrence. The README's existing "two parsers in one program" convention is extended to cover constructor names.
- **One `Ctr__*` remains by design**: the start sort (`Program`/`Asm`) keeps an auto-generated wrapper constructor for the quasi-quoter scaffolding. It can't be labeled from the grammar and no pass references it; the README notes this.
- Files touched: `c.pg`, `asm.pg`, `Codegen.hs`, `Emit.hs`, `TestQQ.hs`, `README.md` (generated `gen/` is gitignored).

## Verification

- `make -C tutorials/c-compiler test` — 29/29 (QQ feature matrix + compiler tests)
- official `nlsandler/write_a_c_compiler` stage 1 — 12/12
- `return 42;` compiles and the resulting executable exits 42

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TXSeYgnZJZWC6dczN6d5E9

---
_Generated by [Claude Code](https://claude.ai/code/session_01TXSeYgnZJZWC6dczN6d5E9)_