### PR TITLE
Mark the stack non-executable in ncc output

### DIFF
--- a/tutorials/c-compiler/Main.hs
+++ b/tutorials/c-compiler/Main.hs
@@ -41,7 +41,17 @@ compileFile path = do
     Right ast -> return (ast :: Program)
   let asmPath = replaceExtension path "s"
       exePath = dropExtension path
-  writeFile asmPath (emit (codegen ast))
+  -- emit renders the program's instruction AST; the GNU-stack note is
+  -- file-level ELF metadata, identical for every program and not modelled by
+  -- the assembly grammar, so the driver appends it here next to the gcc call
+  -- rather than threading it through codegen or the round-trippable emitter.
+  writeFile asmPath (emit (codegen ast) ++ gnuStackNote)
   rc <- rawSystem "gcc" [asmPath, "-o", exePath]
   removeFile asmPath
   when (rc /= ExitSuccess) exitFailure
+
+-- Marks the stack non-executable. Without this section ld warns "missing
+-- .note.GNU-stack section implies executable stack" on every link. Linux/ELF
+-- and x86 (@progbits) specific; a Mach-O or ARM port would change or drop it.
+gnuStackNote :: String
+gnuStackNote = ".section .note.GNU-stack,\"\",@progbits\n"


### PR DESCRIPTION
Small polish on top of the merged R4 work: every `ncc` link printed

```
/usr/bin/ld: warning: <obj>: missing .note.GNU-stack section implies executable stack
```

because the emitted assembly carried no GNU-stack note. This appends `.section .note.GNU-stack,"",@progbits` when writing the `.s` file, silencing the warning (and producing a non-executable stack, which is what you want anyway).

## Where it lives, and why

The note goes in the **driver** (`Main.hs`), not in codegen or `Emit.hs`:

- It's file-level ELF metadata — identical bytes for every program, not part of the instruction stream — so the assembly grammar deliberately doesn't model it.
- `Emit.hs` is a round-trippable bijection: `TestQQ` asserts `parseAsm (emit a) == a`, and the parser can't consume a `.section` line. Appending the note in `emit` would break that property; appending it in the driver keeps `emit` pure.
- The driver is already where the sibling `gcc` invocation lives, so platform-packaging concerns belong here.

A comment marks it Linux/ELF + x86 (`@progbits`) specific, so a future Mach-O or ARM port knows to change or drop it.

## Verification

- `ncc sample.c` now links with **empty stderr**; the program still exits 42
- tutorial suite `make -C tutorials/c-compiler test` — 29/29 (round-trip test still green, since `emit` is untouched)
- official `nlsandler/write_a_c_compiler` stage 1 — 12/12

One file, +11/−1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TXSeYgnZJZWC6dczN6d5E9

---
_Generated by [Claude Code](https://claude.ai/code/session_01TXSeYgnZJZWC6dczN6d5E9)_