### PR TITLE
C compiler stage 2: unary operators (task C2)

### DIFF
--- a/tutorials/c-compiler/Codegen.hs
+++ b/tutorials/c-compiler/Codegen.hs
@@ -1,15 +1,15 @@
 {-# LANGUAGE QuasiQuotes #-}
 
--- Stage 1 code generation: C AST -> assembly AST. Both sides of the
+-- Stages 1-2 code generation: C AST -> assembly AST. Both sides of the
 -- translation are RTK-generated: the input is destructured with CQQ
 -- quasi-quotation patterns, the output is built with AsmQQ construction
 -- quotes and $-antiquote splices.
 --
--- Token payloads (the integer literal, the function name) cannot be bound
--- or spliced by an antiquote ($x works on whole syntax sorts only), so leaf
--- nodes go through the grammar's named constructors: expValue/identName on
--- the C side, mkImm/mkSym on the assembly side (positioned with rtkNoPos; AST
--- equality ignores positions by design).
+-- Token payloads (the integer literal, the function name) cannot be bound or
+-- spliced by an antiquote ($x works on whole syntax sorts only), so leaf
+-- nodes go through the grammar's named constructors: matching IntLit/Name to
+-- read a payload, mkImm/mkSym to build an assembly leaf (positioned with
+-- rtkNoPos; AST equality ignores positions by design).
 module Codegen (codegen) where
 
 import Prelude hiding (exp) -- the Exp quoter is named exp, like Prelude.exp
@@ -40,13 +40,31 @@ codegen [program| int $name ( ) { $stmts } |] =
 codegen other = error $ "codegen: unsupported program: " ++ show other
 
 genStatement :: Statement -> [AsmItem]
-genStatement [statement| return $e ; |] =
-  let src = mkImm (expValue e)
-  in [asmItems|
-       movl $src, %eax
-       ret
-     |]
+genStatement [statement| return $e ; |] = genExp e ++ [asmItems| ret |]
 genStatement other = error $ "codegen: unsupported statement: " ++ show other
+
+-- Evaluate an expression, leaving its value in %eax. Recursive over the
+-- prefix-unary nesting: the operand is generated first, then the operator
+-- transforms %eax in place.
+genExp :: Exp -> [AsmItem]
+genExp [exp| $op1 $e1 |] = genExp e1 ++ genUnaryOp op1
+genExp (IntLit _ n) = [asmItems| movl $src, %eax |]
+  where src = mkImm n
+genExp other = error $ "codegen: unsupported expression: " ++ show other
+
+-- Apply a unary operator to the value already in %eax. The operators are
+-- payload-free leaves, so they are matched by their named constructors rather
+-- than quasi-quotes (the structured Exp above is what QQ is good for).
+genUnaryOp :: UnaryOp -> [AsmItem]
+genUnaryOp (Neg _)        = [asmItems| negl %eax |]
+genUnaryOp (Complement _) = [asmItems| notl %eax |]
+-- logical not: set %eax to 1 if the value was 0, else 0
+genUnaryOp (Not _)        = [asmItems|
+                              cmpl $0, %eax
+                              movl $0, %eax
+                              sete %al
+                            |]
+genUnaryOp other = error $ "codegen: unsupported unary operator: " ++ show other
 
 -- assembly leaf constructors
 
@@ -56,12 +74,8 @@ mkImm = Imm rtkNoPos
 mkSym :: String -> AsmId
 mkSym = Sym rtkNoPos
 
--- C leaf destructors
+-- C leaf destructor
 
 identName :: Ident -> String
 identName (Name _ s) = s
 identName other = error $ "codegen: unexpected identifier node: " ++ show other
-
-expValue :: Exp -> Int
-expValue (IntLit _ n) = n
-expValue other = error $ "codegen: unexpected expression node: " ++ show other

--- a/tutorials/c-compiler/Emit.hs
+++ b/tutorials/c-compiler/Emit.hs
@@ -20,11 +20,17 @@ emitItem [asmItem| .globl $sym |] = "    .globl " ++ symName sym
 emitItem [asmItem| $sym : |] = symName sym ++ ":"
 emitItem [asmItem| movl $src, $dst |] =
   "    movl    " ++ emitOperand src ++ ", " ++ emitOperand dst
+emitItem [asmItem| negl $dst |] = "    negl    " ++ emitOperand dst
+emitItem [asmItem| notl $dst |] = "    notl    " ++ emitOperand dst
+emitItem [asmItem| cmpl $src, $dst |] =
+  "    cmpl    " ++ emitOperand src ++ ", " ++ emitOperand dst
+emitItem [asmItem| sete $dst |] = "    sete    " ++ emitOperand dst
 emitItem [asmItem| ret |] = "    ret"
 emitItem other = error $ "emitItem: unsupported item: " ++ show other
 
 emitOperand :: Operand -> String
 emitOperand [operand| %eax |] = "%eax"
+emitOperand [operand| %al |] = "%al"
 emitOperand (Imm _ n) = "$" ++ show n
 emitOperand other = error $ "emitOperand: unsupported operand: " ++ show other
 

--- a/tutorials/c-compiler/README.md
+++ b/tutorials/c-compiler/README.md
@@ -9,18 +9,20 @@ the C front end (lexer, parser, AST types, quasi-quoters) is generated from
 quasi-quotation splices instead of concatenating strings, and a generated
 assembly *parser* (a by-product) round-trip-tests the emitter.
 
-**Status: stage 1** (proof of concept): `int main() { return <int>; }` →
-assembly AST → AT&T text → executable via gcc. Verified against the official
-[stage-1 test suite](https://github.com/nlsandler/write_a_c_compiler)
-(12/12) in addition to the local tests under [`tests/`](tests/).
+**Status: stage 2**: integer `return`, then the prefix unary operators `-`,
+`~`, `!` (with nesting). C source → assembly AST → AT&T text → executable via
+gcc. Verified against the official
+[test suite](https://github.com/nlsandler/write_a_c_compiler) (stage 1: 12/12,
+stage 2: 11/11) in addition to the local tests under [`tests/`](tests/).
 
 ## Companion tutorial
 
 [`tutorial/`](tutorial/) retells Nora Sandler's series page by page with RTK —
 what the generator replaces (lexer, parser, AST, the boilerplate that walks
 it) and what you write instead (grammar rules, quasi-quotation patterns,
-splices). Start at the [index](tutorial/README.md); stage 1 is covered by
-[00 — Setup](tutorial/00-setup.md) and [01 — Integers](tutorial/01-integers.md).
+splices). Start at the [index](tutorial/README.md): stages 1–2 are covered by
+[00 — Setup](tutorial/00-setup.md), [01 — Integers](tutorial/01-integers.md),
+and [02 — Unary operators](tutorial/02-unary.md).
 This README is the reference companion to those pages: it catalogues the
 conventions and limitations below, which the pages link to as you hit them.
 
@@ -145,18 +147,19 @@ long time; the causes are avoidable, and `c.pg` is written to avoid them:
 - **Token payloads cannot be antiquoted.** `$x` splices/matches whole syntax
   sorts; the `Int` of an `intLit` or the `String` of an `id` is reached
   through the alternative's named constructor (`IntLit _ n`, `Name _ s`; the
-  first field is the node's source position) — see `expValue`/`identName` in
-  `Codegen.hs`. Nodes built in code take `rtkNoPos` there; AST equality
-  ignores positions by design, so built and parsed trees still compare equal.
+  first field is the node's source position) — see the `IntLit` match in
+  `genExp` and `identName` in `Codegen.hs`. Nodes built in code take `rtkNoPos`
+  there; AST equality ignores positions by design, so built and parsed trees
+  still compare equal.
 - **Quoter names are lowercased rule names** and can collide with Prelude
   names: the `Exp` quoter is `exp`, hence `import Prelude hiding (exp)`.
   Avoid rule names that lowercase to Haskell keywords (`If`, `Do`, `Type`...).
 
 ## Roadmap
 
-Following the blog series, one stage at a time:
+Following the blog series, one stage at a time. Stages 1–2 (integers, unary
+operators) are done; up next:
 
-2. unary operators (`-` `~` `!`)
 3. binary operators `+ - * /` and the precedence cascade
 4. relational/logical operators, short-circuit evaluation
 5. local variables (first semantic pass: variable resolution)

--- a/tutorials/c-compiler/TestQQ.hs
+++ b/tutorials/c-compiler/TestQQ.hs
@@ -79,6 +79,20 @@ main = do
       , check "quasi-quoted construction == parsed file" $
           [program| int main ( ) { return 42 ; } |]
             == parse "int main() {\n  // a comment\n  return 42; /* another */\n}\n"
+      , check "unary construction: [exp| -5 |]" $
+          [exp| -5 |] == Unary rtkNoPos (Neg rtkNoPos) (IntLit rtkNoPos 5)
+      , check "unary construction with operator splice: [exp| $op 7 |]" $
+          let op = [unaryOp| ~ |]
+          in [exp| $op 7 |]
+               == Unary rtkNoPos (Complement rtkNoPos) (IntLit rtkNoPos 7)
+      , check "unary pattern with antiquote binders: [exp| $op1 $e1 |]" $
+          case [exp| -5 |] of
+            [exp| $op1 $e1 |] -> op1 == [unaryOp| - |] && e1 == [exp| 5 |]
+            _ -> False
+      , check "nested unary construction: [exp| !-3 |]" $
+          [exp| !-3 |]
+            == Unary rtkNoPos (Not rtkNoPos)
+                 (Unary rtkNoPos (Neg rtkNoPos) (IntLit rtkNoPos 3))
       ]
 
   putStrLn "-- assembly grammar --"

--- a/tutorials/c-compiler/asm.pg
+++ b/tutorials/c-compiler/asm.pg
@@ -1,6 +1,6 @@
 grammar 'Asm';
 
-# x86-64 assembly (AT&T syntax), the subset emitted for stage 1.
+# x86-64 assembly (AT&T syntax), the subset emitted for stages 1-2.
 # Grows stage by stage alongside c.pg.
 #
 # Design notes:
@@ -29,13 +29,18 @@ AsmItems = AsmItem* ;
 AsmItem = Globl: '.globl' AsmId
         | Label: AsmId ':'
         | Movl: 'movl' Operand ',' Operand
+        | Negl: 'negl' Operand
+        | Notl: 'notl' Operand
+        | Cmpl: 'cmpl' Operand ',' Operand
+        | Sete: 'sete' Operand
         | Ret: 'ret' ;
 
 @shortcuts(src, dst)
 Operand = Imm: '$' num
         | RegOp: Reg ;
 
-Reg = Eax: '%eax' ;
+Reg = Eax: '%eax'
+    | Al: '%al' ;
 
 @shortcuts(sym)
 AsmId = Sym: asmid ;

--- a/tutorials/c-compiler/c.pg
+++ b/tutorials/c-compiler/c.pg
@@ -1,12 +1,13 @@
 grammar 'C';
 
-# Stage 1 of Nora Sandler's "Writing a C Compiler"
+# Stages 1-2 of Nora Sandler's "Writing a C Compiler"
 # (https://norasandler.com/2017/11/29/Write-a-Compiler.html):
 #
-#   <program>   ::= <function>
-#   <function>  ::= "int" <id> "(" ")" "{" <statement> "}"
-#   <statement> ::= "return" <exp> ";"
-#   <exp>       ::= <int>
+#   <program>    ::= <function>
+#   <function>   ::= "int" <id> "(" ")" "{" <statement> "}"
+#   <statement>  ::= "return" <exp> ";"
+#   <exp>        ::= <unary_op> <exp> | <int>   # stage 2: prefix unary ops
+#   <unary_op>   ::= "-" | "~" | "!"
 #
 # Deviation from the blog grammar: the function body is a statement LIST
 # (the blog switches to that in part 5 anyway). This also exercises RTK's
@@ -40,7 +41,16 @@ StatementList = Statement* ;
 Statement = Return: 'return' Exp ';' ;
 
 @shortcuts(e)
-Exp = IntLit: intLit ;
+Exp = Unary: UnaryOp Exp
+    | IntLit: intLit ;
+
+# Each operator is its own sort so it becomes one constructor (Neg/Complement/
+# Not) and codegen can match the shape generically with [exp| $op1 $e1 |].
+# '-' is prefix-only here, so `4-` is a syntax error (4 is a complete Exp).
+@shortcuts(op)
+UnaryOp = Neg: '-'
+        | Complement: '~'
+        | Not: '!' ;
 
 @shortcuts(name)
 Ident = Name: id ;

--- a/tutorials/c-compiler/tests/invalid/unary_missing_operand.c
+++ b/tutorials/c-compiler/tests/invalid/unary_missing_operand.c
@@ -1,0 +1,3 @@
+int main() {
+    return ~;
+}

--- a/tutorials/c-compiler/tests/valid/bitwise_complement.c
+++ b/tutorials/c-compiler/tests/valid/bitwise_complement.c
@@ -1,0 +1,3 @@
+int main() {
+    return ~12;
+}

--- a/tutorials/c-compiler/tests/valid/logical_not.c
+++ b/tutorials/c-compiler/tests/valid/logical_not.c
@@ -1,0 +1,3 @@
+int main() {
+    return !5;
+}

--- a/tutorials/c-compiler/tests/valid/neg.c
+++ b/tutorials/c-compiler/tests/valid/neg.c
@@ -1,0 +1,3 @@
+int main() {
+    return -5;
+}

--- a/tutorials/c-compiler/tests/valid/nested_unary.c
+++ b/tutorials/c-compiler/tests/valid/nested_unary.c
@@ -1,0 +1,3 @@
+int main() {
+    return -~0;
+}

--- a/tutorials/c-compiler/tests/valid/not_zero.c
+++ b/tutorials/c-compiler/tests/valid/not_zero.c
@@ -1,0 +1,3 @@
+int main() {
+    return !0;
+}

--- a/tutorials/c-compiler/tutorial/02-unary.md
+++ b/tutorials/c-compiler/tutorial/02-unary.md
@@ -1,0 +1,233 @@
+# 02 — Unary operators
+
+← [01 — Integers](01-integers.md) · [Tutorial index](README.md)
+
+Companion to **[Writing a C Compiler, Part 2](https://norasandler.com/2017/12/05/Write-a-Compiler-2.html)**.
+
+Stage 2 adds the three prefix unary operators — negation `-`, bitwise
+complement `~`, and logical negation `!` — and lets them nest, so
+`return !-3;` and `return -~0;` compile. This is where code generation first
+becomes *recursive*. The changes are small and local: the grammar grows by
+one sort, codegen grows by one recursive function, and the assembly grammar
+grows by four instructions.
+
+## 1. The grammar grows by one sort
+
+> **Blog ⇄ RTK.** Part 2 extends the lexer with three operator tokens, the AST
+> with a `UnaryOp` node, and the parser with a case for it. Here that is one
+> edit to [`c.pg`](../c.pg) — the token, the AST, and the parse rule are again
+> one thing.
+
+`Exp` gains a recursive alternative, and the operators get their own sort:
+
+```
+@shortcuts(e)
+Exp = Unary: UnaryOp Exp
+    | IntLit: intLit ;
+
+@shortcuts(op)
+UnaryOp = Neg: '-'
+        | Complement: '~'
+        | Not: '!' ;
+```
+
+Giving each operator its own alternative (rather than inlining `'-' Exp | '~'
+Exp | …` into `Exp`) means each becomes one named constructor, so codegen can
+match the *shape* `UnaryOp Exp` once and dispatch on the operator separately.
+RTK derives:
+
+```haskell
+data Exp     = Anti_Exp String     | Unary RtkPos UnaryOp Exp | IntLit RtkPos Int
+data UnaryOp = Anti_UnaryOp String | Neg RtkPos | Complement RtkPos | Not RtkPos
+```
+
+`Unary` is recursive (`Unary RtkPos UnaryOp Exp`), which is what lets
+`!-3` parse as `Unary Not (Unary Neg (IntLit 3))`.
+
+> **A grammar choice with teeth.** `-` here is *prefix only*: `Exp` can start
+> with a `UnaryOp` or be an `intLit`, but nothing makes `4-` legal — once `4`
+> is parsed as a complete `Exp`, a trailing `-` has nowhere to go, and the
+> parser rejects it. That is exactly what the official suite's `wrong_order.c`
+> (`return 4-;`) expects. Binary `-` arrives in stage 3, in a different
+> position in the grammar.
+
+`--analyze-conflicts` stays quiet: the new rule is right-recursive, so it adds
+no LALR conflicts.
+
+## 2. Code generation becomes recursive
+
+> **Blog ⇄ RTK.** Part 2's `generate_expression` recurses: emit the operand,
+> then emit the instruction for the operator. The RTK version is the same
+> shape, but the recursion is driven by a quasi-quote pattern.
+
+Stage 1's `genStatement` handled only `return <int>`. Now it defers to a
+recursive `genExp` that leaves the expression's value in `%eax`:
+
+```haskell
+genStatement [statement| return $e ; |] = genExp e ++ [asmItems| ret |]
+
+-- Evaluate an expression, leaving its value in %eax.
+genExp :: Exp -> [AsmItem]
+genExp [exp| $op1 $e1 |] = genExp e1 ++ genUnaryOp op1
+genExp (IntLit _ n) = [asmItems| movl $src, %eax |]
+  where src = mkImm n
+```
+
+The first pattern, `[exp| $op1 $e1 |]`, matches a `Unary` node and binds
+`op1 :: UnaryOp` and `e1 :: Exp` — two adjacent antiquotes standing for the
+operator and its operand. It generates the operand first (`genExp e1`,
+recursing into any nesting), then the operator's instruction. For `-~0` that
+unfolds to: load `0`, complement, negate.
+
+The operators themselves are payload-free leaves, so they are matched by their
+**named constructors** rather than quasi-quotes — quasi-quotes earn their keep
+on *structured* nodes like `Unary`, while a one-token operator is clearest as
+`Neg _`:
+
+```haskell
+-- Apply a unary operator to the value already in %eax.
+genUnaryOp :: UnaryOp -> [AsmItem]
+genUnaryOp (Neg _)        = [asmItems| negl %eax |]
+genUnaryOp (Complement _) = [asmItems| notl %eax |]
+-- logical not: set %eax to 1 if the value was 0, else 0
+genUnaryOp (Not _)        = [asmItems|
+                              cmpl $0, %eax
+                              movl $0, %eax
+                              sete %al
+                            |]
+```
+
+`negl` and `notl` are one instruction each. Logical `!` is the blog's
+three-instruction idiom: compare to zero (setting the zero flag), clear
+`%eax` without disturbing flags, then `sete %al` writes 1 into the low byte if
+the value had been zero. The `$0` in `cmpl $0, %eax` is a literal immediate,
+not an antiquote — immediates are numeric and antiquotes start with a letter,
+so the assembly lexer keeps them apart.
+
+## 3. The assembly grammar grows to match
+
+> **Blog ⇄ RTK.** The blog just prints the new mnemonics. Because our assembly
+> is itself a parsed AST, the four new instructions and the byte register
+> `%al` are four new alternatives in [`asm.pg`](../asm.pg).
+
+```
+AsmItem = Globl: '.globl' AsmId
+        | Label: AsmId ':'
+        | Movl: 'movl' Operand ',' Operand
+        | Negl: 'negl' Operand
+        | Notl: 'notl' Operand
+        | Cmpl: 'cmpl' Operand ',' Operand
+        | Sete: 'sete' Operand
+        | Ret: 'ret' ;
+
+Reg = Eax: '%eax'
+    | Al: '%al' ;
+```
+
+[`Emit.hs`](../Emit.hs) gains one line per instruction and one for the new
+register:
+
+```haskell
+emitItem [asmItem| negl $dst |] = "    negl    " ++ emitOperand dst
+emitItem [asmItem| notl $dst |] = "    notl    " ++ emitOperand dst
+emitItem [asmItem| cmpl $src, $dst |] =
+  "    cmpl    " ++ emitOperand src ++ ", " ++ emitOperand dst
+emitItem [asmItem| sete $dst |] = "    sete    " ++ emitOperand dst
+...
+emitOperand [operand| %al |] = "%al"
+```
+
+The round-trip test (`parseAsm (emit a) == a`) now covers the new instructions
+for free: any of them that emitted text the assembly parser couldn't read back
+would fail a test.
+
+## 4. Run it
+
+```bash
+make build
+printf 'int main() { return -5; }\n' > neg.c
+./ncc neg.c && ./neg; echo "exit: $?"     # -5 & 0xFF
+```
+
+```
+exit: 251
+```
+
+The assembly for `return -5;` — the operand loaded, then negated:
+
+```asm
+    .globl main
+main:
+    movl    $5, %eax
+    negl    %eax
+    ret
+    movl    $0, %eax
+    ret
+```
+
+and for `return !5;`, the compare/clear/set idiom:
+
+```asm
+    .globl main
+main:
+    movl    $5, %eax
+    cmpl    $0, %eax
+    movl    $0, %eax
+    sete    %al
+    ret
+    movl    $0, %eax
+    ret
+```
+
+## 5. Test it
+
+The tutorial suite now stands at 39 checks — the stage-1 set plus four
+quasi-quotation cases for unary construction/pattern matching and six
+compiler programs:
+
+```bash
+make test
+```
+
+```
+PASS  unary construction: [exp| -5 |]
+PASS  unary pattern with antiquote binders: [exp| $op1 $e1 |]
+PASS  nested unary construction: [exp| !-3 |]
+PASS  tests/valid/nested_unary.c (exit code 1)
+...
+All stage-1 compiler tests passed.
+```
+
+And the acceptance test — stage 2 passes, and stage 1 stays green:
+
+```bash
+/tmp/wacc/test_compiler.sh "$PWD/ncc" 1
+/tmp/wacc/test_compiler.sh "$PWD/ncc" 2
+```
+
+```
+===================Stage 1 Summary=================
+12 successes, 0 failures
+===================Stage 2 Summary=================
+11 successes, 0 failures
+```
+
+## What changed from stage 1
+
+| | Stage 1 | Stage 2 |
+|---|---|---|
+| `c.pg` | `Exp = intLit` | `+ Unary: UnaryOp Exp`, `+ UnaryOp` sort |
+| `asm.pg` | `movl`, `ret`, `%eax` | `+ negl notl cmpl sete`, `+ %al` |
+| `Codegen.hs` | flat `genStatement` | recursive `genExp` + `genUnaryOp` |
+| `Emit.hs` | 4 item kinds | 8 item kinds, `+ %al` operand |
+
+The grammar carried most of the change; the passes grew by two small,
+total functions.
+
+## Next
+
+Stage 3 adds the binary operators `+ - * /` and, with them, the expression
+**precedence cascade** — the first place the `,`-lifted grammar style the
+[project README](../README.md) keeps mentioning actually matters. It is task
+**C3** in
+[`docs/c-compiler-tutorial-plan.md`](../../../docs/c-compiler-tutorial-plan.md).

--- a/tutorials/c-compiler/tutorial/README.md
+++ b/tutorials/c-compiler/tutorial/README.md
@@ -24,8 +24,9 @@ verified against the build.
 |------|-----------|--------|
 | [00 — Setup](00-setup.md) | (preamble) | The toolchain, the pipeline, the driver contract, and how to build and test. |
 | [01 — Integers](01-integers.md) | [Part 1](https://norasandler.com/2017/11/29/Write-a-Compiler.html) | `int main() { return 2; }` → an executable. The whole pipeline, end to end. |
+| [02 — Unary operators](02-unary.md) | [Part 2](https://norasandler.com/2017/12/05/Write-a-Compiler-2.html) | `-`, `~`, `!` and nesting; codegen becomes recursive. |
 
-Stages 2–10 (unary operators through file-scope variables) are implemented
+Stages 3–10 (binary operators through file-scope variables) are implemented
 one at a time; each adds a page here. Until then they live as task
 descriptions in
 [`docs/c-compiler-tutorial-plan.md`](../../../docs/c-compiler-tutorial-plan.md).


### PR DESCRIPTION
Task C2 from `docs/c-compiler-tutorial-plan.md`: the three prefix unary operators `-`, `~`, `!` (with nesting), following [blog part 2](https://norasandler.com/2017/12/05/Write-a-Compiler-2.html). This is the first stage with recursive code generation, and the change stays small and grammar-driven.

## What changed

- **`c.pg`** — `Exp` gains a recursive `Unary: UnaryOp Exp` alternative; a new `UnaryOp` sort gives `Neg`/`Complement`/`Not` one constructor each so codegen can match the shape `[exp| $op1 $e1 |]` and dispatch on the operator separately. `--analyze-conflicts` stays quiet (right-recursive, no new LALR conflicts).
- **`asm.pg`** — four instructions (`negl`, `notl`, `cmpl`, `sete`) and the byte register `%al`.
- **`Codegen.hs`** — `genStatement` defers to a recursive `genExp` (value left in `%eax`); `genUnaryOp` dispatches on the operator's named constructor. QQ patterns for the *structured* `Exp`, named constructors for the payload-free operator leaves. The stage-1 `expValue` helper is removed — `genExp` reads the `IntLit` payload inline.
- **`Emit.hs`** — four `emitItem` cases plus the `%al` operand; the existing round-trip test (`parseAsm (emit a) == a`) now covers the new instructions for free.
- **`TestQQ.hs` / `tests/`** — four unary QQ cases (construction, operator splice, antiquote pattern, nested construction), five valid programs, one invalid.
- **`tutorial/02-unary.md`** — the stage-2 page, with the index/status/roadmap updated and the now-stale `expValue` README reference fixed.

## A grammar detail worth a look

`-` is **prefix-only** here, so `return 4-;` is a syntax error — once `4` parses as a complete `Exp`, the trailing `-` has nowhere to go. That's exactly what the official suite's `wrong_order.c` expects; binary `-` arrives in stage 3 in a different grammar position.

## Verification

- tutorial suite `make -C tutorials/c-compiler test` — **39/39** (was 29)
- official `nlsandler/write_a_c_compiler` — **stage 2: 11/11**, **stage 1: 12/12** (regression)
- assembly spot-checked: `return -5;` → `movl $5,%eax; negl %eax; …` (exit 251); `return !5;` → the `cmpl`/`movl`/`sete %al` idiom (exit 0)
- every page snippet grep-verified against the live code; all page links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TXSeYgnZJZWC6dczN6d5E9

---
_Generated by [Claude Code](https://claude.ai/code/session_01TXSeYgnZJZWC6dczN6d5E9)_