### PR TITLE
Document why Emit.hs is hand-written; propose the PP feature (R7) that would change it

### DIFF
--- a/docs/c-compiler-tutorial-plan.md
+++ b/docs/c-compiler-tutorial-plan.md
@@ -403,6 +403,78 @@ a real program.
   keeps later stages extending the tutorial).
 - The tutorial README links the pages; `tutorials/README.md` mentions them.
 
+## Task R7 — A pretty-printer line-break option for unbracketed lists (RTK core)
+
+### TL;DR
+
+RTK's generated pretty-printer (`--generate-pp`) cannot stand in for the
+tutorial's hand-written `Emit.hs`, but it comes much closer than it looks, and
+one small, generally-useful feature would close the gap. This task adds that
+feature.
+
+### What we found (measured, not assumed)
+
+`Emit.hs` renders the assembly AST to gas-valid AT&T text. The obvious
+question is whether the generated `AsmPP` (`ppAsm :: Asm -> String`) could
+replace it. Today it cannot, for one reason:
+
+- `ppAsm` guarantees `parseAsm (ppAsm a) == a` — a round trip through *RTK's
+  own* assembly parser, which (by design) treats newlines as insignificant
+  whitespace. So the printer renders the whole program on one line:
+  `.globl main main : movl $ 2 , %eax ret …`. gas is line-oriented and rejects
+  it ("junk at end of line").
+
+The decisive measurement: gas **tolerates everything except the missing line
+breaks**. `main :` (space before the label colon) and `$ 2` (space after the
+immediate sigil) both assemble and run correctly once each instruction is on
+its own line. So the one fatal gap is inter-element line breaks.
+
+The reason the breaks are missing is specific and fixable. The `block` layout
+*does* break list elements onto separate lines — but only when the list is
+enclosed in bracket tokens (it emits `PpOpen`/`PpBreak`/`PpClose` for a
+`'{' StatementList '}'`, which is how the C grammar's body indents). Assembly's
+instructions are a top-level `AsmItems = AsmItem*` with no enclosing brackets,
+so the layout renders them with `intercalate [PpTok ""]` — spaces, no breaks.
+
+### The feature
+
+Let a list rule opt into line-broken layout regardless of brackets — e.g. a
+`@layout(lines)` annotation:
+
+```
+@layout(lines)
+AsmItems = AsmItem* ;
+```
+
+so the block-mode printer emits `intercalate [PpBreak]` (and, if wanted,
+wraps the list in `PpOpen`/`PpClose` for indentation) for that rule. This is
+not asm-specific: any language with a top-level sequence of statements or
+declarations that is *not* brace-enclosed (assembly, a Makefile, a flat
+script) wants exactly this. Scope it in `GenPP.hs`; add a golden and a
+round-trip case; the `--pp-layout=block` machinery (`PpBreak` etc.) already
+exists, so this is wiring an annotation through to it.
+
+### Acceptance
+
+- `asm.pg`'s `AsmItems` marked `@layout(lines)` makes `ppAsm` emit one
+  instruction per line; the result assembles with gcc and runs (a stage-1
+  program still exits with the right code).
+- The semantic round trip `parseAsm (ppAsm a) == a` still holds.
+- Goldens/round-trip tests cover the new annotation; the bracket-enclosed
+  case (C's `StatementList`) is unchanged.
+
+### Not in scope (deliberately)
+
+Even with line breaks, `ppAsm` output stays *ugly* — `main :` not `main:`,
+`$ 2` not `$2`, no instruction indentation. Making it *idiomatic* would need
+token-glue control (no space before `:`, none after `$`) and an
+indent-without-brackets rule. That is a much larger PP surface for cosmetic
+gain, and for a *compiler* the assembly is intermediate (gcc deletes it), so
+ugly-but-valid is enough. The tutorial may still prefer `Emit.hs` for the
+pretty output it *shows* on the page; the point of R7 is to make the generated
+printer a viable choice, not necessarily the chosen one. (See the "Why not the
+generated pretty-printer?" note in `01-integers.md`.)
+
 ---
 
 Deferred idea (not scheduled): a TACKY-style IR as a third RTK grammar

--- a/tutorials/c-compiler/tutorial/01-integers.md
+++ b/tutorials/c-compiler/tutorial/01-integers.md
@@ -257,6 +257,31 @@ from. `TestQQ.hs` asserts exactly that — `parseAsm (emit a) == a` — so a
 formatting bug that produced unparseable or wrong assembly would fail a test
 rather than ship.
 
+> **Why not the generated pretty-printer?** RTK *does* generate one
+> (`--generate-pp` produces an `AsmPP` module with `ppAsm :: Asm -> String`),
+> so it is fair to ask why `Emit.hs` is hand-written. The generated `ppAsm`
+> guarantees the round trip `parseAsm (ppAsm a) == a` — but against *RTK's
+> own* parser, which treats newlines as insignificant whitespace. That is what
+> lets the assembly grammar round-trip loosely; it is also why the printer
+> puts the whole program on **one line**:
+>
+> ```
+> .globl main main : movl $ 2 , %eax ret movl $ 0 , %eax ret
+> ```
+>
+> The consumer here is **gas**, which is line-oriented, and it rejects that
+> with "junk at end of line". Tellingly, gas tolerates the rest of the
+> printer's spacing — `main :` and `$ 2` both assemble fine *once the
+> statements are on separate lines* — so the only fatal gap is the missing
+> line breaks between list elements. RTK's `block` layout inserts breaks for
+> bracket-enclosed lists (a `{ … }` statement list), but assembly's
+> instructions are a top-level `AsmItem*` with no enclosing brackets, so they
+> stay on one line. A small PP option could close that gap (task R7 in the
+> [plan](../../../docs/c-compiler-tutorial-plan.md)); until it exists,
+> `Emit.hs` is the ~30 lines that produce gas-valid text — and, as a bonus,
+> idiomatic formatting (indentation, `main:`, `$2`) the structural printer
+> would not give.
+
 > **Antiquote spacing.** The label pattern is written `[asmItem| $sym : |]`
 > with a space before the `:`. Written `$sym:`, the `:` would be read as part
 > of the explicit `$Rule:name` antiquote form and would not scan. Emitted


### PR DESCRIPTION
Follow-up to the question of whether RTK's new `--generate-pp` could replace the hand-written `Emit.hs`. Adds a "Why not the generated pretty-printer?" note to the tutorial (where Emit is introduced) and a feature proposal (task R7) for what would actually close the gap. Both are grounded in measurement.

## What I measured

`ppAsm` guarantees `parseAsm (ppAsm a) == a` — a round trip through *RTK's own* assembly parser, which treats newlines as insignificant whitespace by design. So it prints the whole program on one line, and gas (line-oriented) rejects it:

```
.globl main main : movl $ 2 , %eax ret movl $ 0 , %eax ret      # gas: "junk at end of line"
```

The decisive finding: **gas tolerates everything except the missing line breaks.** I tested it — `main :` (space before the label colon) and `$ 2` (space after the immediate sigil) both assemble *and run correctly* (exit 5 on `return 2+3`) once each instruction is on its own line. So the entire gap is one capability: breaking an unbracketed list onto separate lines.

And the reason that capability is missing is specific: RTK's `block` layout breaks list elements only when the list is **bracket-enclosed** (C's `{ StatementList }` gets `PpOpen`/`PpBreak`/`PpClose`); assembly's top-level `AsmItem*` has no brackets, so it stays on one line (`intercalate [PpTok ""]`).

## The proposal (task R7)

A `@layout(lines)` annotation that opts an unbracketed list into line-broken layout — emitting `PpBreak` between elements, reusing the block-mode machinery that already exists. It's generally useful (any top-level statement/declaration sequence: assembly, a flat script), not asm-specific. With it, `ppAsm` would produce gas-valid (if ugly) output, making the generated printer a viable `Emit.hs` replacement — relevant for a real compiler, where the assembly is intermediate and gcc deletes it. I scoped idiomatic prettiness (token glue for `$2`/`main:`, indentation) explicitly **out**, as a much larger surface for cosmetic gain.

So the bottom line stands: **keep `Emit.hs` today** (it's ~30 lines that produce gas-valid *and* idiomatic output); R7 is the small, well-scoped RTK improvement that would make the generated PP a real alternative later.

## Notes

- **Docs only** — `01-integers.md` and the plan doc. Disjoint from the open C3 PR (#155), so they merge cleanly in any order. (CI ignores docs-only pushes by `paths-ignore`.)
- The one-line PP output quoted in the note is copied from an actual `ppAsm` run on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TXSeYgnZJZWC6dczN6d5E9

---
_Generated by [Claude Code](https://claude.ai/code/session_01TXSeYgnZJZWC6dczN6d5E9)_