### PR TITLE
Bump to 0.12 after publishing 0.11 to Hackage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   binders, state-threading plumbing) deliberately stay plain; the
   conversion record and the discovered pattern-matching boundaries live
   in docs/qq-grammar-rewrites-plan.md §8d
+- Named constructors (task 8a): an alternative may carry a leading label —
   `Expr = Add: Expr '+' Term | Term ;` — that names its generated AST
   constructor (`Add RtkPos Expr Term`) instead of the positional
   `Ctr__<Rule>__<index>` default, so code and quasi-quote patterns written

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ RTK (Rewrite ToolKit) is a tool for generating parser and rewrite facilities fro
 
 **Language**: Haskell
 **Build System**: Cabal + Make
-**Version**: 0.10
+**Version**: 0.12 (development; 0.11 is the latest release on [Hackage](https://hackage.haskell.org/package/rtk))
 
 ## What RTK Does
 
@@ -161,7 +161,7 @@ cabal build
 This will:
 - Download and build ~58 Haskell dependencies
 - Build the RTK library and executable
-- Place the executable in: dist-newstyle/build/x86_64-linux/ghc-9.4.7/rtk-0.10/x/rtk/build/rtk/rtk
+- Place the executable in: dist-newstyle/build/x86_64-linux/ghc-9.4.7/rtk-0.12/x/rtk/build/rtk/rtk
 
 ### Environment Variables for Tests
 
@@ -184,7 +184,7 @@ cabal --version      # Should show: 3.8.1.0
 
 ### Build Artifacts
 
-- **Executable**: `dist-newstyle/build/x86_64-linux/ghc-9.4.7/rtk-0.10/x/rtk/build/rtk/rtk`
+- **Executable**: `dist-newstyle/build/x86_64-linux/ghc-9.4.7/rtk-0.12/x/rtk/build/rtk/rtk`
 - **Test output**: `test-out/` directory
 - **Cabal binaries**: `~/.cabal/bin/` (happy, alex)
 - **Cabal packages**: `~/.cabal/store/`

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # RTK - Rewrite ToolKit
 
+[![Hackage](https://img.shields.io/hackage/v/rtk.svg)](https://hackage.haskell.org/package/rtk)
+
 RTK generates parser and rewrite facilities from grammar specifications. It produces Alex lexer and Happy parser files, with support for quasi-quotation to embed parsed syntax directly in Haskell code.
 
 ## Features

--- a/rtk.cabal
+++ b/rtk.cabal
@@ -1,6 +1,6 @@
 Cabal-Version:       2.4
 Name:                rtk
-Version:             0.11
+Version:             0.12
 Synopsis:            Parser and rewrite facility generator from grammar specifications
 Description:         RTK (Rewrite ToolKit) generates Alex lexer and Happy parser
                      files from grammar specifications. It supports quasi-quotation


### PR DESCRIPTION
rtk-0.11 is published on Hackage (https://hackage.haskell.org/package/rtk) with
docs uploaded, verified end-to-end: `cabal install rtk` from the index builds
all three components, and the installed binary reproduces the v0.11 golden
snapshot for grammar.pg byte-for-byte (the self-hosting fixed point).

Master is ~40 commits past the tag while still claiming version 0.11, so dev
builds misidentify themselves as the published release. This PR:

- bumps `rtk.cabal` to 0.12 (the existing `[Unreleased]` CHANGELOG section
  becomes 0.12 at release time)
- adds the Hackage version badge to README
- fixes CLAUDE.md's stale version (0.10!) and dist-newstyle paths
- restores the first line of the CHANGELOG's named-constructors (task 8a)
  entry, which a later edit clobbered, leaving the bullet starting mid-sentence
  and fused onto the task-8d entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)