### PR TITLE
Release 0.12: widen GHC support to 9.4-9.14, date the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.12] - 2026-07-02
+
+### Changed
+- Widened GHC support: the boot-library bounds now span GHC 9.4 through 9.14
+  (`base < 4.23`, `template-haskell < 2.25`, `containers < 0.9`,
+  `time < 1.16`). The endpoints are CI-tested — the pinned 9.4.7 toolchain
+  runs the full battery and the newest-GHC canary builds `-Werror` and runs
+  the cabal suites on 9.14.1. 0.11 capped `base` at 4.19 (GHC 9.6), which
+  made the package uninstallable on current compilers and failed Hackage's
+  own doc builder (GHC 9.8). Version bounds are now also stated once per
+  dependency instead of repeated across components, per Hackage guidance —
+  the executable's own stale `base < 4.19` copy is exactly the drift this
+  prevents
 
 ### Added
 - Block layout for generated pretty-printers (task 9b), the "pretty" layer on

--- a/rtk.cabal
+++ b/rtk.cabal
@@ -18,7 +18,7 @@ Homepage:            https://github.com/prozak/rtk
 Bug-Reports:         https://github.com/prozak/rtk/issues
 Category:            Language, Development
 Build-Type:          Simple
-Tested-With:         GHC == 9.4.7 || == 9.6.4
+Tested-With:         GHC == 9.4.7 || == 9.6.4 || == 9.14.1
 
 Extra-Source-Files:
     CHANGELOG.md
@@ -73,13 +73,13 @@ Library generated-frontend
                      GrammarParser,
                      GrammarQQ
   Build-Depends:
-                     base                 >= 4.17 && < 4.19,
+                     base                 >= 4.17 && < 4.23,
                      array                >= 0.5  && < 0.6,
                      syb                  >= 0.7  && < 0.8,
                      -- grammar.pg's imports section pulls in Data.Map
-                     containers           >= 0.6  && < 0.7,
+                     containers           >= 0.6  && < 0.9,
                      -- the generated quasi-quoter builds TH splices
-                     template-haskell     >= 2.19 && < 2.21
+                     template-haskell     >= 2.19 && < 2.25
   Build-Tool-Depends: happy:happy == 2.2.*, alex:alex == 3.5.*
   Default-Extensions:  DeriveDataTypeable, StandaloneDeriving
 
@@ -107,11 +107,11 @@ Library
                      Frontend
   Build-Depends:
                      generated-frontend,
-                     base                 >= 4.17 && < 4.19,
+                     base                 >= 4.17 && < 4.23,
                      array                >= 0.5  && < 0.6,
                      syb                  >= 0.7  && < 0.8,
-                     template-haskell     >= 2.19 && < 2.21,
-                     containers           >= 0.6  && < 0.7,
+                     template-haskell     >= 2.19 && < 2.25,
+                     containers           >= 0.6  && < 0.9,
                      mtl                  >= 2.2  && < 2.4,
                      pretty               >= 1.1  && < 1.2,
                      pretty-show          >= 1.10 && < 1.11,
@@ -120,7 +120,7 @@ Library
                      haskell-src-meta     >= 0.8  && < 0.9,
                      lens                 >= 5.2  && < 5.4,
                      optparse-applicative >= 0.18 && < 0.20,
-                     time                 >= 1.12 && < 1.13,
+                     time                 >= 1.12 && < 1.16,
                      ansi-terminal        >= 1.0  && < 1.2
   -- CI pins the exact tool versions (alex-3.5.4.2, happy-2.2 in
   -- .github/workflows/ci.yml); these ranges must stay compatible with them.
@@ -131,7 +131,10 @@ Executable rtk
   Import:            warnings
   Main-is:           main.hs
   Hs-Source-Dirs:    app
-  Build-Depends:     base      >= 4.17 && < 4.19,
+  -- Version bounds live where a dependency first appears (the libraries
+  -- above, or here for directory); per Hackage guidance they are stated
+  -- once, so components below use bare names for already-bounded packages.
+  Build-Depends:     base,
                      directory >= 1.3  && < 1.4,
                      rtk
   ghc-options:       -rtsopts
@@ -146,16 +149,16 @@ Test-Suite unit
   Hs-Source-Dirs:    test
   Other-Modules:     TestSupport
   Build-Depends:
-                     base       >= 4.17 && < 4.19,
+                     base,
                      rtk,
                      -- the compiled-in snapshot front end, for the GrammarQQ
                      -- smoke test (its quoters produce the generated AST types)
                      generated-frontend,
                      HUnit      >= 1.6  && < 1.7,
-                     containers >= 0.6  && < 0.7,
-                     directory  >= 1.3  && < 1.4,
+                     containers,
+                     directory,
                      filepath   >= 1.4  && < 1.6,
-                     syb        >= 0.7  && < 0.8
+                     syb
 
 -- Golden tests: generated .x/.y/QQ.hs output for every grammar under
 -- test-grammars/ is compared against snapshots in test/golden/.
@@ -168,11 +171,11 @@ Test-Suite golden
   Hs-Source-Dirs:    test
   Other-Modules:     TestSupport
   Build-Depends:
-                     base       >= 4.17 && < 4.19,
+                     base,
                      rtk,
                      -- the parsed-grammar type in TestSupport's signatures is
                      -- the generated AST (GrammarParser.Grammar)
                      generated-frontend,
-                     HUnit      >= 1.6  && < 1.7,
-                     directory  >= 1.3  && < 1.4,
-                     filepath   >= 1.4  && < 1.6
+                     HUnit,
+                     directory,
+                     filepath


### PR DESCRIPTION
Release-prep for cutting 0.12 to Hackage.

- Boot-library bounds widen to the CI-tested endpoints — the pinned 9.4.7
  toolchain runs the full battery, the newest-GHC canary builds `-Werror` and
  runs the cabal suites on 9.14.1: `base <4.23`, `template-haskell <2.25`,
  `containers <0.9`, `time <1.16`. Exact 9.14.1 boot versions confirmed
  against the GHC version-history table (base 4.22, TH 2.24, containers 0.8,
  time 1.15); the Hackage doc builder's GHC 9.8.4 (base 4.19) now falls in
  range, so 0.12 should get docs and a green build report without manual
  uploads. GHC 9.14.1 joins `Tested-With`.
- Bounds are stated once per dependency (Hackage trustee guidance): exe and
  test suites drop their duplicated ranges. The executable carried its own
  `base >= 4.17 && < 4.19` — left in place, it would have silently kept the
  package uninstallable on GHC 9.8+ despite the library widening.
- CHANGELOG `[Unreleased]` → `[0.12] - 2026-07-02`, with a Changed entry for
  the above.

`cabal check` is clean. After merge: tag v0.12, pre-flight (sdist,
build+test from tarball, haddock), candidate upload, publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)