### PR TITLE
Bump to 0.13 after publishing 0.12 to Hackage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## [0.12] - 2026-07-02
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ RTK (Rewrite ToolKit) is a tool for generating parser and rewrite facilities fro
 
 **Language**: Haskell
 **Build System**: Cabal + Make
-**Version**: 0.12 (development; 0.11 is the latest release on [Hackage](https://hackage.haskell.org/package/rtk))
+**Version**: 0.13 (development; 0.12 is the latest release on [Hackage](https://hackage.haskell.org/package/rtk))
 
 ## What RTK Does
 
@@ -161,7 +161,7 @@ cabal build
 This will:
 - Download and build ~58 Haskell dependencies
 - Build the RTK library and executable
-- Place the executable in: dist-newstyle/build/x86_64-linux/ghc-9.4.7/rtk-0.12/x/rtk/build/rtk/rtk
+- Place the executable in: dist-newstyle/build/x86_64-linux/ghc-9.4.7/rtk-0.13/x/rtk/build/rtk/rtk
 
 ### Environment Variables for Tests
 
@@ -184,7 +184,7 @@ cabal --version      # Should show: 3.8.1.0
 
 ### Build Artifacts
 
-- **Executable**: `dist-newstyle/build/x86_64-linux/ghc-9.4.7/rtk-0.12/x/rtk/build/rtk/rtk`
+- **Executable**: `dist-newstyle/build/x86_64-linux/ghc-9.4.7/rtk-0.13/x/rtk/build/rtk/rtk`
 - **Test output**: `test-out/` directory
 - **Cabal binaries**: `~/.cabal/bin/` (happy, alex)
 - **Cabal packages**: `~/.cabal/store/`

--- a/rtk.cabal
+++ b/rtk.cabal
@@ -1,6 +1,6 @@
 Cabal-Version:       2.4
 Name:                rtk
-Version:             0.12
+Version:             0.13
 Synopsis:            Parser and rewrite facility generator from grammar specifications
 Description:         RTK (Rewrite ToolKit) generates Alex lexer and Happy parser
                      files from grammar specifications. It supports quasi-quotation


### PR DESCRIPTION
rtk-0.12 is published: https://hackage.haskell.org/package/rtk-0.12 —
candidate validated (bounds, changelog, module list, zero warnings), then
promoted. Same close-out as 0.11: bump master so dev builds don't claim the
published version, update CLAUDE.md's version note and executable paths,
reopen CHANGELOG's `[Unreleased]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)