### PR TITLE
C compiler stage 6: if/else and the conditional expression (task C6)

### DIFF
--- a/tutorials/c-compiler/Codegen.hs
+++ b/tutorials/c-compiler/Codegen.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE QuasiQuotes #-}
 
--- Stages 1-5 code generation: C AST -> assembly AST. Both sides of the
+-- Stages 1-6 code generation: C AST -> assembly AST. Both sides of the
 -- translation are RTK-generated: the input is destructured with CQQ
 -- quasi-quotation patterns, the output is built with AsmQQ construction
 -- quotes and $-antiquote splices.
@@ -8,8 +8,9 @@
 -- Generation runs in a monad carrying two things: a Reader of the
 -- variable->offset map that the Resolve pass computed (so a variable reference
 -- knows its stack slot), and a State Int handing out unique labels for
--- short-circuit jumps. The functions that need either are monadic; the pure
--- helpers (apply*/genUnaryOp/compareSet and the leaf builders) stay outside.
+-- short-circuit, if/else and ?: jumps. The functions that need either are
+-- monadic; the pure helpers (apply*/genUnaryOp/compareSet and the leaf
+-- builders) stay outside.
 --
 -- Token payloads (the integer literal, the variable/function name) cannot be
 -- bound or spliced by an antiquote, so leaf nodes go through the named
@@ -47,7 +48,7 @@ codegen vm prog = evalState (runReaderT (genProgram prog) vm) 0
 genProgram :: Program -> Gen Asm
 genProgram [program| int $name ( ) { $stmts } |] = do
   frame <- asks frameSize
-  body <- concat <$> mapM genStatement stmts
+  body <- concat <$> mapM genBlockItem stmts
   let sym = mkSym (identName name)
       -- C99 5.1.2.2.3: falling off the end of main returns 0
       items = prologue frame ++ body ++ [asmItems| movl $0, %eax |] ++ epilogue
@@ -76,15 +77,49 @@ epilogue = [asmItems| movq %rbp, %rsp
                       pop %rbp
                       ret |]
 
+genBlockItem :: BlockItem -> Gen [AsmItem]
+genBlockItem (Stmt _ s) = genStatement s
+genBlockItem (Decl _ d) = genDeclaration d
+genBlockItem other = error $ "codegen: unsupported block item: " ++ show other
+
+genDeclaration :: Declaration -> Gen [AsmItem]
+genDeclaration [declaration| int $name = $e ; |] = do   -- declaration with initializer
+  e' <- genExp e
+  dst <- offsetOf name
+  return (e' ++ [asmItems| movl %eax, $dst |])
+genDeclaration [declaration| int $name ; |] = return []  -- uninitialized: no code
+genDeclaration other = error $ "codegen: unsupported declaration: " ++ show other
+
+-- Statement is scalar-shaped now (it left list position when BlockItem took
+-- over the body), so if branches bind with plain $s1/$s2 antiquotes.
 genStatement :: Statement -> Gen [AsmItem]
 genStatement [statement| return $e ; |] = do
   e' <- genExp e
   return (e' ++ epilogue)
-genStatement [statement| int $name = $e ; |] = do   -- declaration with initializer
-  e' <- genExp e
-  dst <- offsetOf name
-  return (e' ++ [asmItems| movl %eax, $dst |])
-genStatement [statement| int $name ; |] = return []  -- declaration, uninitialized: no code
+genStatement [statement| if ( $e ) $s1 else $s2 |] = do
+  n <- fresh
+  let alt = mkSym ("_if_else_" ++ show n)
+      end = mkSym ("_if_end_" ++ show n)
+  c <- genExp e
+  t <- genStatement s1
+  f <- genStatement s2
+  return $ c
+    ++ [asmItems| cmpl $0, %eax |]
+    ++ [jeTo alt]
+    ++ t
+    ++ [jmpTo end, label alt]
+    ++ f
+    ++ [label end]
+genStatement [statement| if ( $e ) $s1 |] = do
+  n <- fresh
+  let end = mkSym ("_if_end_" ++ show n)
+  c <- genExp e
+  t <- genStatement s1
+  return $ c
+    ++ [asmItems| cmpl $0, %eax |]
+    ++ [jeTo end]
+    ++ t
+    ++ [label end]
 genStatement [statement| $e ; |] = genExp e          -- expression statement: evaluate, drop %eax
 genStatement other = error $ "codegen: unsupported statement: " ++ show other
 
@@ -97,6 +132,7 @@ genExp [exp| $name = $e |] = do        -- assignment is an expression: store, ke
 genExp [exp| $name |] = do             -- variable reference: load from the stack slot
   src <- offsetOf name
   return [asmItems| movl $src, %eax |]
+genExp [exp| $e1 ? $e2 : $e3 |] = genCond e1 e2 e3
 genExp [exp| $e1 || $e2 |]     = genOr e1 e2
 genExp [exp| $e1 && $e2 |]     = genAnd e1 e2
 genExp [exp| $e1 $eqop $e2 |]  = genBinary e1 e2 (applyEqOp eqop)
@@ -116,6 +152,24 @@ genBinary e1 e2 apply = do
   r <- genExp e2
   l <- genExp e1
   return (r ++ [asmItems| push %rax |] ++ l ++ [asmItems| pop %rcx |] ++ apply)
+
+-- c ? t : f -- the same jump diamond as if/else, but as an expression: both
+-- branches leave their value in %eax, so the diamond IS the value selection.
+genCond :: Exp -> Exp -> Exp -> Gen [AsmItem]
+genCond e1 e2 e3 = do
+  n <- fresh
+  let alt = mkSym ("_cond_else_" ++ show n)
+      end = mkSym ("_cond_end_" ++ show n)
+  c <- genExp e1
+  t <- genExp e2
+  f <- genExp e3
+  return $ c
+    ++ [asmItems| cmpl $0, %eax |]
+    ++ [jeTo alt]
+    ++ t
+    ++ [jmpTo end, label alt]
+    ++ f
+    ++ [label end]
 
 -- a && b: if a is 0 the result is 0 and b is never evaluated; otherwise (b != 0)
 genAnd :: Exp -> Exp -> Gen [AsmItem]

--- a/tutorials/c-compiler/Makefile
+++ b/tutorials/c-compiler/Makefile
@@ -16,11 +16,30 @@ GEN  := gen
 GENERATED := $(GEN)/CLexer.hs $(GEN)/CParser.hs $(GEN)/CQQ.hs \
              $(GEN)/AsmLexer.hs $(GEN)/AsmParser.hs $(GEN)/AsmQQ.hs
 
-.PHONY: all build test clean
+.PHONY: all build test conflict-check clean
 
 all: build
 
 build: ncc test-qq
+
+# Pin the parsers' LALR conflict inventory (the C6 gotcha in the plan): c.pg
+# owns exactly ONE shift/reduce conflict - the dangling else, resolved by
+# happy's shift preference to bind the else to the nearest if - and asm.pg
+# exactly one, the QQ bootstrap dummy-bracket conflict every generated
+# grammar's whole-file entry carries (see java.pg's conflict family 6). A
+# grammar change that adds conflicts can't hide behind either: this target
+# fails the build the moment the counts move.
+conflict-check: $(GEN)/CParser.hs $(GEN)/AsmParser.hs
+	@c=$$(grep -oh "contains [0-9]* shift/reduce" $(GEN)/CParser.info | awk '{s+=$$2} END {print s+0}'); \
+	a=$$(grep -oh "contains [0-9]* shift/reduce" $(GEN)/AsmParser.info | awk '{s+=$$2} END {print s+0}'); \
+	rr=$$(grep -oh "contains [0-9]* reduce/reduce" $(GEN)/CParser.info $(GEN)/AsmParser.info | awk '{s+=$$2} END {print s+0}'); \
+	if [ "$$c" != "1" ] || [ "$$a" != "1" ] || [ "$$rr" != "0" ]; then \
+		echo "conflict-check: expected exactly 1 s/r in CParser (dangling else),"; \
+		echo "  1 s/r in AsmParser (QQ dummy bracket), 0 r/r anywhere;"; \
+		echo "  got CParser=$$c AsmParser=$$a reduce/reduce=$$rr"; \
+		exit 1; \
+	fi; \
+	echo "conflict-check: dangling else + QQ dummy bracket, as pinned."
 
 $(GEN)/CLexer.x $(GEN)/CParser.y $(GEN)/CQQ.hs &: c.pg
 	mkdir -p $(GEN)
@@ -42,7 +61,7 @@ ncc: Main.hs Resolve.hs Codegen.hs Emit.hs $(GENERATED)
 test-qq: TestQQ.hs Resolve.hs Codegen.hs Emit.hs $(GENERATED)
 	cd $(ROOT) && cabal exec -- ghc --make $(HERE)/TestQQ.hs -i$(HERE) -i$(HERE)/$(GEN) -outputdir $(HERE)/build/test-qq -o $(HERE)/test-qq
 
-test: build
+test: build conflict-check
 	./test-qq
 	./run_tests.sh
 

--- a/tutorials/c-compiler/README.md
+++ b/tutorials/c-compiler/README.md
@@ -9,26 +9,30 @@ the C front end (lexer, parser, AST types, quasi-quoters) is generated from
 quasi-quotation splices instead of concatenating strings, and a generated
 assembly *parser* (a by-product) round-trip-tests the emitter.
 
-**Status: stage 5**: integer `return`, the unary `-` `~` `!`, binary `+ - * /`
+**Status: stage 6**: integer `return`, the unary `-` `~` `!`, binary `+ - * /`
 (precedence cascade, parentheses), relational/logical `== != < <= > >= && ||`
-with short-circuiting, and local variables (declarations, assignment,
-references) with a stack frame and a name-resolution semantic pass. C source →
-resolve → assembly AST → AT&T text → executable via gcc. Verified against the
-official [test suite](https://github.com/nlsandler/write_a_c_compiler) (stage
-1: 12/12, 2: 11/11, 3: 16/16, 4: 27/27, 5: 17/17) in addition to the local
-tests under [`tests/`](tests/).
+with short-circuiting, local variables (declarations, assignment, references)
+with a stack frame and a name-resolution semantic pass, and control flow:
+`if`/`else` (with the dangling-else conflict resolved and pinned) and the
+ternary `?:`, over a statement/declaration split that makes
+`if (5) int i = 0;` a syntax error. C source → resolve → assembly AST → AT&T
+text → executable via gcc. Verified against the official
+[test suite](https://github.com/nlsandler/write_a_c_compiler) (stage 1: 12/12,
+2: 11/11, 3: 16/16, 4: 27/27, 5: 17/17, 6: 24/24 — 107/107) in addition to the
+local tests under [`tests/`](tests/).
 
 ## Companion tutorial
 
 [`tutorial/`](tutorial/) retells Nora Sandler's series page by page with RTK —
 what the generator replaces (lexer, parser, AST, the boilerplate that walks
 it) and what you write instead (grammar rules, quasi-quotation patterns,
-splices). Start at the [index](tutorial/README.md): stages 1–5 are covered by
+splices). Start at the [index](tutorial/README.md): stages 1–6 are covered by
 [00 — Setup](tutorial/00-setup.md), [01 — Integers](tutorial/01-integers.md),
 [02 — Unary operators](tutorial/02-unary.md),
 [03 — Binary operators](tutorial/03-binary.md),
-[04 — Relational and logical](tutorial/04-relational.md), and
-[05 — Local variables](tutorial/05-variables.md).
+[04 — Relational and logical](tutorial/04-relational.md),
+[05 — Local variables](tutorial/05-variables.md), and
+[06 — if/else and ?:](tutorial/06-conditionals.md).
 This README is the reference companion to those pages: it catalogues the
 conventions and limitations below, which the pages link to as you hit them.
 
@@ -44,6 +48,13 @@ conventions and limitations below, which the pages link to as you hit them.
 | `Emit.hs` | Assembly AST → AT&T text (RTK generates parsers, not pretty-printers; this is the hand-written half, kept honest by the round-trip test). |
 | `TestQQ.hs` | End-to-end tests of the full QQ feature set for both grammars, plus the emit/parse round trip. |
 | `run_tests.sh` | Compiles `tests/valid`/`tests/invalid` and checks exit codes against a gcc-built reference. |
+
+`make test` also runs `conflict-check`, which pins the parsers' LALR conflict
+inventory: exactly one shift/reduce in `CParser` (the dangling else — shift
+binds the `else` to the nearest `if`, the C rule) and one in `AsmParser` (the
+quasi-quoter bootstrap dummy-bracket conflict every generated grammar's
+whole-file entry carries), zero reduce/reduce anywhere. A grammar change that
+adds a conflict cannot hide behind the expected ones.
 
 ## Building and testing
 
@@ -143,12 +154,15 @@ long time; the causes are avoidable, and `c.pg` is written to avoid them:
 ## Known RTK limitations to design around
 
 - **One antiquote shape per AST type** (scalar or list, whichever is
-  normalized first — see `_antiRuleCache` in `Normalize.hs`). `c.pg` orders
-  `StatementList = Statement*` before `Statement`, so type `Statement` gets
-  the *list* shape: `$stmts` binds/splices a whole `[Statement]`, while a
-  scalar `$statement1` antiquote would misbehave silently. Scalar antiquotes
-  are fine for types never used in a list rule (`$e`, `$name`, `$src`,
-  `$sym`).
+  normalized first — see `_antiRuleCache` in `Normalize.hs`, and #162 for the
+  planned fix). `c.pg` orders `BlockItemList = BlockItem*` before `BlockItem`,
+  so type `BlockItem` gets the *list* shape: `$stmts` binds/splices a whole
+  `[BlockItem]`, while a scalar `$blockItem1` antiquote would misbehave
+  silently. Scalar antiquotes are fine for types never used in a list rule
+  (`$e`, `$s`, `$name`, `$src`, `$sym`) — and shapes can *move*: through
+  stage 5 `Statement` was the list type, and the stage-6 statement/declaration
+  split handed the list position to `BlockItem`, flipping `Statement` to
+  scalar (which is what the if/else codegen patterns want).
 - **List antiquotes in patterns bind the whole list only** (`{ $stmts }`);
   mixed list patterns (`{ $stmts return 0 ; }`) only work in construction.
 - **Token payloads cannot be antiquoted.** `$x` splices/matches whole syntax
@@ -164,12 +178,11 @@ long time; the causes are avoidable, and `c.pg` is written to avoid them:
 
 ## Roadmap
 
-Following the blog series, one stage at a time. Stages 1–5 (integers, unary
+Following the blog series, one stage at a time. Stages 1–6 (integers, unary
 operators, binary operators with the precedence cascade, relational/logical
 operators with short-circuiting, local variables with a name-resolution
-semantic pass) are done; up next:
+semantic pass, and if/else with the conditional expression) are done; up next:
 
-6. `if`/`else` and the conditional expression
 7. compound statements and scoping
 8. loops, `break`/`continue`
 9. function calls (System V calling convention)

--- a/tutorials/c-compiler/Resolve.hs
+++ b/tutorials/c-compiler/Resolve.hs
@@ -4,7 +4,9 @@
 -- assigning each declared local a stack-frame offset and rejecting programs
 -- the grammar cannot: a variable used before (or without) a declaration, or
 -- declared twice. (Assignment to a non-lvalue is already a syntax error,
--- because the grammar only allows a bare identifier on the left of `=`.)
+-- because the grammar only allows a bare identifier on the left of `=`;
+-- likewise a declaration as an if branch, because declarations are block
+-- items, not statements.)
 --
 -- Collecting the variables a statement *uses* is a whole-subtree query, so it
 -- is one SYB call -- `listify` over the derived Data instances -- rather than a
@@ -24,17 +26,22 @@ import CQQ
 type VarMap = M.Map String Int
 
 resolve :: Program -> Either String VarMap
-resolve [program| int $name ( ) { $stmts } |] = resolveStmts stmts
+resolve [program| int $name ( ) { $stmts } |] = resolveItems stmts
 resolve other = Left $ "resolve: unsupported program: " ++ show other
 
-resolveStmts :: [Statement] -> Either String VarMap
-resolveStmts = go M.empty
+-- Declarations only occur as block items (the grammar keeps them out of if
+-- branches), so scanning the top-level list visits every one; statements are
+-- checked as whole subtrees, which covers uses nested under if/else and ?:.
+resolveItems :: [BlockItem] -> Either String VarMap
+resolveItems = go M.empty
   where
     go env [] = Right env
-    go env (s : rest) = case s of
-      DeclInit _ ident e -> declare env rest (identName ident) (checkUses env e)
-      Declare _ ident    -> declare env rest (identName ident) (Right ())
-      _                  -> checkUses env s >> go env rest
+    go env (item : rest) = case item of
+      Decl _ (DeclInit _ ident e) -> declare env rest (identName ident) (checkUses env e)
+      Decl _ (Declare _ ident)    -> declare env rest (identName ident) (Right ())
+      Decl _ other                -> Left $ "resolve: unexpected declaration node: " ++ show other
+      Stmt _ s                    -> checkUses env s >> go env rest
+      other                       -> Left $ "resolve: unexpected block item: " ++ show other
 
     -- add a fresh local after validating its initializer against the vars in
     -- scope *before* it (so `int a = a;` and a redeclaration are rejected)

--- a/tutorials/c-compiler/TestQQ.hs
+++ b/tutorials/c-compiler/TestQQ.hs
@@ -70,11 +70,11 @@ main = do
               name == Name rtkNoPos "main" && length stmts == 2
             _ -> False
       , check "list splice in construction: { $stmts0 }" $
-          let stmts0 = [[statement| return 1 ; |], [statement| return 2 ; |]]
+          let stmts0 = [[blockItem| return 1 ; |], [blockItem| return 2 ; |]]
           in [program| int main ( ) { $stmts0 } |]
                == parse "int main() { return 1; return 2; }"
       , check "mixed list splice: { $stmts0 return 9 ; }" $
-          let stmts0 = [[statement| return 1 ; |]]
+          let stmts0 = [[blockItem| return 1 ; |]]
           in [program| int main ( ) { $stmts0 return 9 ; } |]
                == parse "int main() { return 1; return 9; }"
       , check "quasi-quoted construction == parsed file" $
@@ -139,13 +139,52 @@ main = do
           [exp| a = b = c |]
             == Assign rtkNoPos (Name rtkNoPos "a")
                  (Assign rtkNoPos (Name rtkNoPos "b") (VarRef rtkNoPos (Name rtkNoPos "c")))
-      , check "declaration statement: [statement| int x = 5 ; |]" $
-          [statement| int x = 5 ; |]
+      , check "declaration is its own sort now: [declaration| int x = 5 ; |]" $
+          [declaration| int x = 5 ; |]
             == DeclInit rtkNoPos (Name rtkNoPos "x") (IntLit rtkNoPos 5)
+      , check "a block item wraps either: [blockItem| int x ; |]" $
+          [blockItem| int x ; |]
+            == Decl rtkNoPos (Declare rtkNoPos (Name rtkNoPos "x"))
       , check "assignment pattern binds the target name: [exp| $name = $e |]" $
           case [exp| count = 0 |] of
             [exp| $name = $e |] -> name == [ident| count |] && e == [exp| 0 |]
             _ -> False
+      , check "if construction: [statement| if ( 1 ) return 2 ; |]" $
+          [statement| if ( 1 ) return 2 ; |]
+            == If rtkNoPos (IntLit rtkNoPos 1) (Return rtkNoPos (IntLit rtkNoPos 2))
+      , check "if/else pattern with SCALAR statement binders: $s1 / $s2" $
+          -- Statement left list position in stage 6 (BlockItem holds the
+          -- body now), so its antiquotes switched to the scalar shape
+          case [statement| if ( 1 ) return 2 ; else return 3 ; |] of
+            [statement| if ( $e ) $s1 else $s2 |] ->
+              e == [exp| 1 |]
+                && s1 == [statement| return 2 ; |]
+                && s2 == [statement| return 3 ; |]
+            _ -> False
+      , check "dangling else binds to the NEAREST if" $
+          [statement| if ( 0 ) if ( 0 ) return 1 ; else return 2 ; |]
+            == If rtkNoPos (IntLit rtkNoPos 0)
+                 (IfElse rtkNoPos (IntLit rtkNoPos 0)
+                    (Return rtkNoPos (IntLit rtkNoPos 1))
+                    (Return rtkNoPos (IntLit rtkNoPos 2)))
+      , check "ternary construction and precedence: [exp| 1 || 0 ? 2 : 3 |]" $
+          [exp| 1 || 0 ? 2 : 3 |]
+            == Cond rtkNoPos
+                 (Or rtkNoPos (IntLit rtkNoPos 1) (IntLit rtkNoPos 0))
+                 (IntLit rtkNoPos 2) (IntLit rtkNoPos 3)
+      , check "ternary is right-associative: [exp| 1 ? 2 : 3 ? 4 : 5 |]" $
+          [exp| 1 ? 2 : 3 ? 4 : 5 |]
+            == Cond rtkNoPos (IntLit rtkNoPos 1) (IntLit rtkNoPos 2)
+                 (Cond rtkNoPos (IntLit rtkNoPos 3) (IntLit rtkNoPos 4) (IntLit rtkNoPos 5))
+      , check "ternary pattern binders: [exp| $e1 ? $e2 : $e3 |]" $
+          case [exp| a ? 1 : 2 |] of
+            [exp| $e1 ? $e2 : $e3 |] ->
+              e1 == [exp| a |] && e2 == [exp| 1 |] && e3 == [exp| 2 |]
+            _ -> False
+      , check "declaration as an if branch is a SYNTAX error" $
+          rejects "int main() { if (5) int i = 0; return 0; }"
+      , check "assignment in a ternary false branch is a SYNTAX error" $
+          rejects "int main() { int a = 2; a > 1 ? a = 1 : a = 0; return a; }"
       ]
 
   putStrLn "-- assembly grammar --"
@@ -186,6 +225,10 @@ main = do
           let p = parse "int main() { int a = 2; return a; }"
               a = codegen (either error id (resolve p)) p
           in parseAsmText (emit a) == a
+      , check "full pipeline with if/else and ?: (stage 6 jump diamonds)" $
+          let p = parse "int main() { int a = 1; if (a) return a ? 2 : 3; else return 4; }"
+              a = codegen (either error id (resolve p)) p
+          in parseAsmText (emit a) == a
       ]
 
   unless (and (cResults ++ asmResults)) exitFailure
@@ -193,6 +236,9 @@ main = do
 
 parse :: String -> Program
 parse src = either error id (scanTokens src >>= parseC)
+
+rejects :: String -> Bool
+rejects src = either (const True) (const False) (scanTokens src >>= parseC)
 
 parseAsmText :: String -> Asm
 parseAsmText src = either error id (AsmLexer.scanTokens src >>= parseAsm)

--- a/tutorials/c-compiler/c.pg
+++ b/tutorials/c-compiler/c.pg
@@ -1,13 +1,17 @@
 grammar 'C';
 
-# Stages 1-5 of Nora Sandler's "Writing a C Compiler"
+# Stages 1-6 of Nora Sandler's "Writing a C Compiler"
 # (https://norasandler.com/2017/11/29/Write-a-Compiler.html):
 #
 #   <program>    ::= <function>
-#   <function>   ::= "int" <id> "(" ")" "{" { <statement> } "}"
-#   <statement>  ::= "return" <exp> ";" | <exp> ";"          # stage 5: locals,
-#                  | "int" <id> [ "=" <exp> ] ";"            #   assignment
-#   <exp>        ::= <id> "=" <exp> | <lor>                  # stage 5: assign
+#   <function>   ::= "int" <id> "(" ")" "{" { <block-item> } "}"
+#   <block-item> ::= <statement> | <declaration>             # stage 6: split
+#   <declaration>::= "int" <id> [ "=" <exp> ] ";"
+#   <statement>  ::= "return" <exp> ";" | <exp> ";"
+#                  | "if" "(" <exp> ")" <statement>          # stage 6: if/else
+#                    [ "else" <statement> ]
+#   <exp>        ::= <id> "=" <exp> | <cond>                 # stage 5: assign
+#   <cond>       ::= <lor> [ "?" <exp> ":" <cond> ]          # stage 6: ternary
 #   <lor>        ::= <lor> "||" <land>    | <land>           # stage 4: logical
 #   <land>       ::= <land> "&&" <eq>     | <eq>             #   and relational
 #   <eq>         ::= <eq> <eqop> <rel>    | <rel>
@@ -21,7 +25,12 @@ grammar 'C';
 #
 # Deviation from the blog grammar: the function body is a statement LIST
 # (the blog switches to that in part 5 anyway). This also exercises RTK's
-# list anti-quotation: $stmts binds/splices a whole [Statement].
+# list anti-quotation: $stmts binds/splices a whole [BlockItem].
+#
+# The statement/declaration split (blog part 6) is what makes
+# `if (5) int i = 0;` a SYNTAX error, as the official stage-6 suite
+# requires: an if branch is a Statement, and declarations are not
+# statements - they are only reachable as block items.
 
 # The leading label on each alternative (Prog:, Func:, ...) names the AST
 # constructor RTK generates for it. Without a label the constructor is
@@ -33,18 +42,39 @@ grammar 'C';
 
 Program = Prog: Function ;
 
-Function = Func: 'int' Ident '(' ')' '{' StatementList '}' ;
+Function = Func: 'int' Ident '(' ')' '{' BlockItemList '}' ;
 
-# NOTE: StatementList must be normalized BEFORE Statement: RTK allows one
+# NOTE: BlockItemList must be normalized BEFORE BlockItem: RTK allows one
 # anti-quote shape per AST type (scalar or list), and we want the list shape
-# ($stmts :: [Statement]) for type Statement.
+# ($stmts :: [BlockItem]) for type BlockItem. Statement, no longer in any
+# list position, gets the SCALAR shape - which is exactly what the if/else
+# codegen patterns need ($s1, $s2 bind one Statement each).
 @shortcuts(stmts)
-StatementList = Statement* ;
+BlockItemList = BlockItem* ;
 
+BlockItem = Stmt: Statement
+          | Decl: Declaration ;
+
+@shortcuts(d)
+Declaration = DeclInit: 'int' Ident '=' Exp ';'
+            | Declare: 'int' Ident ';' ;
+
+# If/IfElse are separate alternatives rather than an inline ('else'
+# Statement)? option: the option would be extracted into a synthesized
+# rule whose empty/present alternatives cannot carry constructor labels,
+# and the passes would be back to matching positional Ctr__* names. The
+# price is the grammar's first intentional LALR conflict - the dangling
+# else. After `if ( Exp ) Statement` with `else` in the lookahead, the
+# parser can shift (extend THIS if into an IfElse) or reduce (close it as
+# an If and give the else to an enclosing if). Happy resolves shift/reduce
+# in favour of shift, so the else binds to the NEAREST if - the C rule
+# (and the same resolution java.pg documents for its IfStatement). This is
+# the grammar's only conflict; `make conflict-check` pins the count.
+@shortcuts(s)
 Statement = Return: 'return' Exp ';'
           | ExpStmt: Exp ';'
-          | DeclInit: 'int' Ident '=' Exp ';'
-          | Declare: 'int' Ident ';' ;
+          | If: 'if' '(' Exp ')' Statement
+          | IfElse: 'if' '(' Exp ')' Statement 'else' Statement ;
 
 # The expression grammar is a precedence cascade: assignment (lowest) over
 # logical-or over logical-and over equality over relational over additive over
@@ -63,7 +93,16 @@ Statement = Return: 'return' Exp ';'
 # flow (short-circuit), not operators over two computed values.
 @shortcuts(e)
 Exp = Assign: Ident '=' Exp
-    | ,LOrExp ;
+    | ,CondExp ;
+
+# The ternary sits between assignment and logical-or (blog part 6). Its
+# true branch is a full Exp (so `flag ? a = 1 : ...` assigns), but the
+# false branch is CondExp itself: right-recursion makes `a ? 1 : b ? 2 : 3`
+# associate as `a ? 1 : (b ? 2 : 3)`, and it puts assignment out of reach
+# there - `... : a = 0` is a syntax error (official stage-6 ternary_assign),
+# while the parenthesized `... : (a = 0)` still works through Factor.
+Exp: CondExp = Cond: LOrExp '?' Exp ':' CondExp
+             | ,LOrExp ;
 
 Exp: LOrExp = Or: LOrExp '||' LAndExp
             | ,LAndExp ;

--- a/tutorials/c-compiler/tests/invalid/declare_in_if.c
+++ b/tutorials/c-compiler/tests/invalid/declare_in_if.c
@@ -1,0 +1,5 @@
+int main() {
+    if (5)
+        int i = 0;
+    return 0;
+}

--- a/tutorials/c-compiler/tests/invalid/incomplete_ternary.c
+++ b/tutorials/c-compiler/tests/invalid/incomplete_ternary.c
@@ -1,0 +1,3 @@
+int main() {
+    return 1 ? 2;
+}

--- a/tutorials/c-compiler/tests/valid/if_else.c
+++ b/tutorials/c-compiler/tests/valid/if_else.c
@@ -1,0 +1,11 @@
+int main() {
+    int a = 1;
+    int b = 0;
+    if (a)
+        b = 2;
+    else
+        b = 3;
+    if (b == 3)
+        return 99;
+    return b;
+}

--- a/tutorials/c-compiler/tests/valid/nested_else.c
+++ b/tutorials/c-compiler/tests/valid/nested_else.c
@@ -1,0 +1,11 @@
+int main() {
+    int a = 0;
+    if (0)
+        if (0)
+            a = 3;
+        else
+            a = 4;
+    else
+        a = 1;
+    return a;
+}

--- a/tutorials/c-compiler/tests/valid/ternary.c
+++ b/tutorials/c-compiler/tests/valid/ternary.c
@@ -1,0 +1,5 @@
+int main() {
+    int a = 2;
+    int b = a > 1 ? 4 : 5;
+    return b == 4 ? 1 ? 10 : 20 : 30;
+}

--- a/tutorials/c-compiler/tutorial/01-integers.md
+++ b/tutorials/c-compiler/tutorial/01-integers.md
@@ -71,7 +71,10 @@ A few things to notice, each of which the blog does differently:
 - **The function body is a statement list** (`StatementList = Statement*`),
   not the single `<statement>` of the part-1 BNF. The blog switches to a list
   in part 5; starting there costs nothing now and lets stage 1 exercise list
-  antiquotation. `*` means zero-or-more and produces a Haskell list.
+  antiquotation. `*` means zero-or-more and produces a Haskell list. (The
+  snippets on this page show the grammar as of stage 1; in
+  [stage 6](06-conditionals.md) the list becomes `BlockItemList` when
+  statements and declarations split.)
 - **`Int: intLit = [0-9]+`** says the `intLit` token carries an `Int` payload
   (RTK will `read` the matched digits), rather than the raw string.
 - **`Ignore:`** rules are lexed and discarded — whitespace and both comment

--- a/tutorials/c-compiler/tutorial/06-conditionals.md
+++ b/tutorials/c-compiler/tutorial/06-conditionals.md
@@ -1,0 +1,225 @@
+# 06 — if/else and the conditional expression
+
+← [05 — Local variables](05-variables.md) · [Tutorial index](README.md)
+
+Companion to **[Writing a C Compiler, Part 6](https://norasandler.com/2018/02/25/Write-a-Compiler-6.html)**.
+
+Stage 6 adds the first *control flow* in the source language: `if`/`else`
+statements and the ternary `?:` expression. The code generation is a reprise —
+the same compare-and-jump the stage-4 short-circuits used, now shaped into a
+diamond. The parsing is where the new ideas live: the grammar meets its first
+**intentional LALR conflict** (the dangling else), and the blog's
+statement/declaration split quietly flips a quasi-quotation shape in our
+favour.
+
+## 1. Statements are not declarations
+
+> **Blog ⇄ RTK.** Part 6 splits `Declaration` out of `Statement` and makes the
+> function body a list of *block items*. Same split here — and it is what makes
+> `if (5) int i = 0;` a **syntax** error, as the official suite requires.
+
+An `if` branch is a statement, and C says a declaration is not one — you
+cannot conditionally declare a variable. The blog encodes that in the AST;
+[`c.pg`](../c.pg) encodes it in three rules:
+
+```
+Function = Func: 'int' Ident '(' ')' '{' BlockItemList '}' ;
+
+@shortcuts(stmts)
+BlockItemList = BlockItem* ;
+
+BlockItem = Stmt: Statement
+          | Decl: Declaration ;
+
+@shortcuts(d)
+Declaration = DeclInit: 'int' Ident '=' Exp ';'
+            | Declare: 'int' Ident ';' ;
+
+@shortcuts(s)
+Statement = Return: 'return' Exp ';'
+          | ExpStmt: Exp ';'
+          | If: 'if' '(' Exp ')' Statement
+          | IfElse: 'if' '(' Exp ')' Statement 'else' Statement ;
+```
+
+Declarations are only reachable through `BlockItem`, so
+`if (5) int i = 0;` fails in the *parser* (the official stage-6
+`declare_statement` test), not in a later pass. LALR-wise the split is free:
+`int` anchors a declaration, and no statement starts with it.
+
+There is a second, RTK-specific payoff. RTK gives each AST type **one
+antiquote shape** — list if the type appears under a `*` rule, scalar
+otherwise (see the README's
+[known limitations](../README.md#known-rtk-limitations-to-design-around)).
+Through stage 5, `Statement` was the list type (`$stmts` bound the whole
+body). Now `BlockItem` holds the list and `Statement` drops to scalar shape —
+exactly what if/else needs: `$s1` and `$s2` bind one branch each in the
+codegen patterns below.
+
+## 2. The dangling else — a conflict on purpose
+
+> **Blog ⇄ RTK.** The blog's recursive-descent parser gets the dangling else
+> right by construction (it parses the optional `else` greedily). An LALR
+> parser gets it right by *resolving a conflict* — the interesting part is
+> knowing that, pinning it, and not letting it hide anything else.
+
+`If` and `IfElse` are separate alternatives rather than one rule with an
+inline `('else' Statement)?` option. An extracted option would synthesize a
+rule whose empty/present alternatives cannot carry constructor labels, putting
+the passes back to matching positional `Ctr__*` names — the thing named
+constructors exist to avoid.
+
+The price is a genuine shift/reduce conflict. After
+
+```
+if ( Exp ) Statement .        -- with 'else' as the next token
+```
+
+the parser can **shift** the `else` (extend *this* if into an `IfElse`) or
+**reduce** (close it as an `If`, handing the `else` to an enclosing if).
+happy resolves shift/reduce in favour of shift, so the else binds to the
+**nearest** if — precisely the C rule. `if (a) if (b) s1 else s2` parses as
+`If a (IfElse b s1 s2)`, and the official `if_nested_*` tests all hinge on it.
+(The Java grammar documents the same resolution as its conflict family 1; see
+the inventory at the top of `test-grammars/java.pg`.)
+
+A resolved conflict you rely on is a liability if new conflicts can hide
+beside it, so the Makefile pins the inventory — `make conflict-check` fails
+the moment the counts move:
+
+```
+conflict-check: dangling else + QQ dummy bracket, as pinned.
+```
+
+(the second being the one-per-grammar quasi-quoter bootstrap conflict that
+asm.pg has carried since milestone 0).
+
+## 3. The ternary slots into the cascade
+
+> **Blog ⇄ RTK.** The blog inserts `<conditional-exp>` between assignment and
+> logical-or. One rule here, with the same subtle asymmetry.
+
+```
+@shortcuts(e)
+Exp = Assign: Ident '=' Exp
+    | ,CondExp ;
+
+Exp: CondExp = Cond: LOrExp '?' Exp ':' CondExp
+             | ,LOrExp ;
+```
+
+Two choices worth noticing, both straight from the blog's grammar:
+
+- **The false branch is `CondExp`, not `Exp`** — right-recursion, so
+  `a ? 1 : b ? 2 : 3` associates as `a ? 1 : (b ? 2 : 3)`, and assignment is
+  out of reach there: `flag ? a = 1 : a = 0` is a syntax error (the official
+  `ternary_assign` test), while the parenthesized `(a = 0)` still works
+  because parentheses re-enter the cascade at `Factor`.
+- **The true branch is a full `Exp`** — `flag ? a = 1 : 0` assigns. The `?`
+  and `:` bracket the middle like parentheses, so no ambiguity arises.
+
+As always with the cascade, the precedence is baked into the tree:
+`1 || 0 ? 2 : 3` parses as `Cond (Or 1 0) 2 3` with no precedence table
+anywhere.
+
+## 4. Codegen: the jump diamond, twice
+
+> **Blog ⇄ RTK.** Compare, jump on false, run one branch, jump over the other.
+> The statement form and the expression form are the *same* diamond — the only
+> difference is that the expression's branches each leave a value in `%eax`.
+
+The if/else patterns are the first users of `Statement`'s new scalar shape
+([`Codegen.hs`](../Codegen.hs)):
+
+```haskell
+genStatement [statement| if ( $e ) $s1 else $s2 |] = do
+  n <- fresh
+  let alt = mkSym ("_if_else_" ++ show n)
+      end = mkSym ("_if_end_"  ++ show n)
+  c <- genExp e
+  t <- genStatement s1
+  f <- genStatement s2
+  return $ c ++ [asmItems| cmpl $0, %eax |]
+             ++ [jeTo alt] ++ t ++ [jmpTo end, label alt] ++ f ++ [label end]
+```
+
+The plain `if` drops the middle of the diamond (`jeTo end`), and the ternary
+is the identical shape over `genExp` — `t` and `f` are expression code, so
+whichever side runs leaves the diamond's *value* in `%eax`. All three reuse
+the stage-4 label supply (`fresh`); nothing new happens in
+[`asm.pg`](../asm.pg) or [`Emit.hs`](../Emit.hs) — `cmpl`, `je`, `jmp` and
+labels have been there since stage 4.
+
+[`Resolve.hs`](../Resolve.hs) barely notices the stage: declarations still
+only occur in the top-level item list (the grammar guarantees it), and
+`checkUses` was already a whole-subtree SYB query, so variables referenced
+under an `if` or a `?:` were covered before the constructs existed.
+
+## 5. Run it
+
+```bash
+make build
+printf 'int main() { int a = 1; return a ? 2 : 3; }\n' > p.c
+./ncc p.c && ./p; echo "exit: $?"
+```
+
+```
+exit: 2
+```
+
+The diamond is visible in the emitted assembly:
+
+```asm
+    movl    -4(%rbp), %eax     # a
+    cmpl    $0, %eax
+    je      _cond_else_0
+    movl    $2, %eax           # true branch
+    jmp     _cond_end_0
+_cond_else_0:
+    movl    $3, %eax           # false branch
+_cond_end_0:
+    movq    %rbp, %rsp         # epilogue (return)
+    pop     %rbp
+    ret
+```
+
+## 6. Test it
+
+```bash
+make test                              # 103 checks, incl. conflict-check
+/tmp/wacc/test_compiler.sh "$PWD/ncc" 6
+```
+
+```
+PASS  dangling else binds to the NEAREST if
+PASS  ternary is right-associative: [exp| 1 ? 2 : 3 ? 4 : 5 |]
+PASS  declaration as an if branch is a SYNTAX error
+PASS  tests/valid/nested_else.c (exit code 1)
+...
+===================Stage 6 Summary=================
+24 successes, 0 failures
+```
+
+Stages 1–5 stay green (12, 11, 16, 27, 17) — 107/107 across the official
+suite.
+
+## What changed from stage 5
+
+| | Stage 5 | Stage 6 |
+|---|---|---|
+| `c.pg` | declarations as statements | **statement/declaration split** (`BlockItem`); `If`/`IfElse`; `CondExp` |
+| conflicts | none in c.pg | **1, intentional** (dangling else) — pinned by `make conflict-check` |
+| `Resolve.hs` | walks `[Statement]` | walks `[BlockItem]`; nested uses already covered by SYB |
+| `Codegen.hs` | frame + load/store | jump diamonds: `genStatement` if/else (scalar `$s1`/`$s2` patterns), `genCond` |
+| `asm.pg` / `Emit.hs` | — | unchanged — stage 4's jumps suffice |
+
+The structural step was in the *grammar*, not the code generator: a
+deliberate, documented, pinned parsing conflict — and a type changing
+antiquote shape as a side effect of where it sits in the rules.
+
+## Next
+
+Stage 7 adds compound statements (`{ ... }` as a statement) and real block
+scoping — the resolve pass grows a scope stack, and shadowing gets its
+semantics. It is task **C7** in
+[`docs/c-compiler-tutorial-plan.md`](../../../docs/c-compiler-tutorial-plan.md).

--- a/tutorials/c-compiler/tutorial/README.md
+++ b/tutorials/c-compiler/tutorial/README.md
@@ -28,10 +28,11 @@ verified against the build.
 | [03 — Binary operators](03-binary.md) | [Part 3](https://norasandler.com/2017/12/15/Write-a-Compiler-3.html) | `+ - * /`, the precedence cascade, and a stack-machine codegen. |
 | [04 — Relational and logical](04-relational.md) | [Part 4](https://norasandler.com/2018/01/08/Write-a-Compiler-4.html) | `== != < <= > >= && ||`, short-circuiting, and the first stateful codegen. |
 | [05 — Local variables](05-variables.md) | [Part 5](https://norasandler.com/2018/01/25/Write-a-Compiler-5.html) | Declarations, assignment, a stack frame, and the first semantic pass (SYB). |
+| [06 — if/else and ?:](06-conditionals.md) | [Part 6](https://norasandler.com/2018/02/25/Write-a-Compiler-6.html) | The statement/declaration split, the dangling else (a pinned, intentional conflict), and jump diamonds. |
 
-Stages 6–10 (`if`/`else` through file-scope variables) are implemented one at a
-time; each adds a page here. Until then they live as task descriptions in
-[`docs/c-compiler-tutorial-plan.md`](../../../docs/c-compiler-tutorial-plan.md).
+Stages 7–10 (compound statements through file-scope variables) are implemented
+one at a time; each adds a page here. Until then they live as task descriptions
+in [`docs/c-compiler-tutorial-plan.md`](../../../docs/c-compiler-tutorial-plan.md).
 
 ## Conventions on these pages
 


### PR DESCRIPTION
if/else statements and the ternary `?:`, following blog part 6. The codegen is
a reprise of stage 4's compare-and-jump shaped into diamonds; the parsing
carries the stage's ideas.

- **c.pg — statement/declaration split** (pulled forward from the C7 blob:
  part 6 and the official `declare_statement` test both demand it): the body
  becomes `BlockItemList`, `BlockItem = Stmt | Decl`, declarations leave
  `Statement`, so `if (5) int i = 0;` is a *syntax* error. The split also
  flips `Statement` to the scalar antiquote shape (`BlockItem` took the list
  position) — exactly what the if/else codegen patterns need (`$s1`/`$s2`
  bind one branch each).
- **The dangling else, on purpose**: `If`/`IfElse` are separate labeled
  alternatives (an inline `('else' Statement)?` would synthesize unnameable
  constructors), giving the grammar its first intentional shift/reduce
  conflict — happy's shift preference binds the `else` to the nearest `if`,
  the C rule. Per the C6 gotcha, the new **`make conflict-check`** target
  (wired into `make test`) pins the inventory: exactly 1 s/r in CParser
  (dangling else), 1 in AsmParser (pre-existing QQ bootstrap dummy bracket),
  0 r/r anywhere.
- **`CondExp`** between assignment and logical-or with the blog's asymmetry:
  full-`Exp` true branch (`flag ? a = 1 : 0` assigns), right-recursive
  `CondExp` false branch (right associativity; `... : a = 0` is a syntax
  error per official `ternary_assign`, the parenthesized form works).
- **Codegen**: `genBlockItem`/`genDeclaration` split off; if / if-else /
  `?:` jump diamonds sharing the stage-4 label supply. `asm.pg` and
  `Emit.hs` untouched.
- **TestQQ**: the mechanical churn the C7 blob predicted, plus 10 stage-6
  checks (scalar statement binders, nearest-if binding, ternary
  associativity/precedence, both syntax-error guarantees, a stage-6 pipeline
  round trip). `tests/` gains 3 valid + 2 invalid programs.

Verified: tutorial suite **103/103 from a clean build**; official
write_a_c_compiler **stages 1–6: 107/107** (12, 11, 16, 27, 17, 24). Adds
`tutorial/06-conditionals.md` and updates the index, status, roadmap, and the
antiquote-shape limitation note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)