### PR TITLE
C compiler stage 7: blocks, scoping, and alpha-renaming (task C7)

### DIFF
--- a/tutorials/c-compiler/Codegen.hs
+++ b/tutorials/c-compiler/Codegen.hs
@@ -38,7 +38,9 @@ type Gen = ReaderT VarMap (State Int)
 fresh :: Gen Int
 fresh = state (\n -> (n, n + 1))
 
--- the stack slot an identifier resolves to (Resolve guaranteed it is present)
+-- the stack slot an identifier resolves to. Codegen runs on the RENAMED tree
+-- (every name unique, courtesy of Resolve), so a plain map lookup is correct
+-- even with shadowing.
 offsetOf :: Ident -> Gen Operand
 offsetOf ident = asks (mkMem . (M.! identName ident))
 
@@ -120,6 +122,8 @@ genStatement [statement| if ( $e ) $s1 |] = do
     ++ [jeTo end]
     ++ t
     ++ [label end]
+genStatement [statement| { $stmts } |] =             -- compound: scoping was resolve's job;
+  concat <$> mapM genBlockItem stmts                 -- by codegen it is just a sequence
 genStatement [statement| $e ; |] = genExp e          -- expression statement: evaluate, drop %eax
 genStatement other = error $ "codegen: unsupported statement: " ++ show other
 

--- a/tutorials/c-compiler/Main.hs
+++ b/tutorials/c-compiler/Main.hs
@@ -40,7 +40,9 @@ compileFile path = do
     Left err -> reject err
     Right ast -> case resolve ast of
       Left err -> reject err
-      Right varmap -> return (codegen varmap ast)
+      -- resolve alpha-renames (stage 7: scoping), so codegen gets the
+      -- renamed tree along with the offsets its unique names map to
+      Right (varmap, ast') -> return (codegen varmap ast')
   let asmPath = replaceExtension path "s"
       exePath = dropExtension path
   -- emit renders the program's instruction AST; the GNU-stack note is

--- a/tutorials/c-compiler/README.md
+++ b/tutorials/c-compiler/README.md
@@ -9,30 +9,33 @@ the C front end (lexer, parser, AST types, quasi-quoters) is generated from
 quasi-quotation splices instead of concatenating strings, and a generated
 assembly *parser* (a by-product) round-trip-tests the emitter.
 
-**Status: stage 6**: integer `return`, the unary `-` `~` `!`, binary `+ - * /`
+**Status: stage 7**: integer `return`, the unary `-` `~` `!`, binary `+ - * /`
 (precedence cascade, parentheses), relational/logical `== != < <= > >= && ||`
 with short-circuiting, local variables (declarations, assignment, references)
-with a stack frame and a name-resolution semantic pass, and control flow:
-`if`/`else` (with the dangling-else conflict resolved and pinned) and the
-ternary `?:`, over a statement/declaration split that makes
-`if (5) int i = 0;` a syntax error. C source → resolve → assembly AST → AT&T
-text → executable via gcc. Verified against the official
+with a stack frame, control flow — `if`/`else` (with the dangling-else
+conflict resolved and pinned) and the ternary `?:` over a
+statement/declaration split that makes `if (5) int i = 0;` a syntax error —
+and compound statements with real block scoping: the semantic pass keeps a
+scope stack and **alpha-renames** (shadowing compiles away before codegen).
+C source → resolve (rename) → assembly AST → AT&T text → executable via gcc.
+Verified against the official
 [test suite](https://github.com/nlsandler/write_a_c_compiler) (stage 1: 12/12,
-2: 11/11, 3: 16/16, 4: 27/27, 5: 17/17, 6: 24/24 — 107/107) in addition to the
-local tests under [`tests/`](tests/).
+2: 11/11, 3: 16/16, 4: 27/27, 5: 17/17, 6: 24/24, 7: 12/12 — 119/119) in
+addition to the local tests under [`tests/`](tests/).
 
 ## Companion tutorial
 
 [`tutorial/`](tutorial/) retells Nora Sandler's series page by page with RTK —
 what the generator replaces (lexer, parser, AST, the boilerplate that walks
 it) and what you write instead (grammar rules, quasi-quotation patterns,
-splices). Start at the [index](tutorial/README.md): stages 1–6 are covered by
+splices). Start at the [index](tutorial/README.md): stages 1–7 are covered by
 [00 — Setup](tutorial/00-setup.md), [01 — Integers](tutorial/01-integers.md),
 [02 — Unary operators](tutorial/02-unary.md),
 [03 — Binary operators](tutorial/03-binary.md),
 [04 — Relational and logical](tutorial/04-relational.md),
-[05 — Local variables](tutorial/05-variables.md), and
-[06 — if/else and ?:](tutorial/06-conditionals.md).
+[05 — Local variables](tutorial/05-variables.md),
+[06 — if/else and ?:](tutorial/06-conditionals.md), and
+[07 — Blocks and scoping](tutorial/07-blocks.md).
 This README is the reference companion to those pages: it catalogues the
 conventions and limitations below, which the pages link to as you hit them.
 
@@ -43,7 +46,7 @@ conventions and limitations below, which the pages link to as you hit them.
 | `c.pg` | The C grammar (input language). |
 | `asm.pg` | The assembly grammar (output language). Everything under `gen/` is generated from these two. |
 | `Main.hs` | Compiler driver: `ncc file.c` produces an executable next to the source (the tutorial's test-suite contract), assembling/linking through gcc. |
-| `Resolve.hs` | Semantic pass: resolves variable names to stack slots and rejects undeclared/redeclared variables. QQ for matching, SYB (`listify`) for the whole-tree query. |
+| `Resolve.hs` | Semantic pass: scope stack + alpha-renaming — every local gets a unique name and a stack slot; undeclared/out-of-scope/same-scope-redeclared variables rejected. QQ for the statement walk, monadic SYB (`everywhereM`) for renaming uses. |
 | `Codegen.hs` | C AST → assembly AST; QQ patterns on the C side, QQ construction + splices on the assembly side. |
 | `Emit.hs` | Assembly AST → AT&T text (RTK generates parsers, not pretty-printers; this is the hand-written half, kept honest by the round-trip test). |
 | `TestQQ.hs` | End-to-end tests of the full QQ feature set for both grammars, plus the emit/parse round trip. |
@@ -178,12 +181,12 @@ long time; the causes are avoidable, and `c.pg` is written to avoid them:
 
 ## Roadmap
 
-Following the blog series, one stage at a time. Stages 1–6 (integers, unary
+Following the blog series, one stage at a time. Stages 1–7 (integers, unary
 operators, binary operators with the precedence cascade, relational/logical
 operators with short-circuiting, local variables with a name-resolution
-semantic pass, and if/else with the conditional expression) are done; up next:
+semantic pass, if/else with the conditional expression, and compound
+statements with block scoping via alpha-renaming) are done; up next:
 
-7. compound statements and scoping
 8. loops, `break`/`continue`
 9. function calls (System V calling convention)
 10. global variables

--- a/tutorials/c-compiler/Resolve.hs
+++ b/tutorials/c-compiler/Resolve.hs
@@ -1,70 +1,127 @@
 {-# LANGUAGE QuasiQuotes #-}
 
--- The compiler's first semantic pass. It walks the function body in order,
--- assigning each declared local a stack-frame offset and rejecting programs
--- the grammar cannot: a variable used before (or without) a declaration, or
--- declared twice. (Assignment to a non-lvalue is already a syntax error,
--- because the grammar only allows a bare identifier on the left of `=`;
--- likewise a declaration as an if branch, because declarations are block
--- items, not statements.)
+-- The semantic pass, grown block-scoped for stage 7. It still assigns every
+-- local a stack-frame offset and rejects what the grammar cannot -- a
+-- variable used out of scope, or declared twice in the SAME scope (shadowing
+-- an outer declaration is legal) -- but scoping changes what it returns.
 --
--- Collecting the variables a statement *uses* is a whole-subtree query, so it
--- is one SYB call -- `listify` over the derived Data instances -- rather than a
--- hand-written recursion over the entire Exp cascade. This is the division of
--- labour the plan calls for: quasi-quoters for targeted construction and
--- matching, generic programming for "find every X anywhere in this tree".
+-- The blog interleaves scope resolution with code generation; this compiler
+-- keeps the passes separate, and shadowing is exactly what breaks the naive
+-- interface between them: with two live `a`s, a name no longer identifies a
+-- stack slot. So resolve ALPHA-RENAMES: it walks the tree with a stack of
+-- scopes, gives each declaration a unique name (`a#0`, `a#1`, ...; `#` cannot
+-- occur in a C identifier), rewrites every use to the unique name of the
+-- declaration it refers to, and returns the renamed tree together with the
+-- offset map keyed by unique names. Codegen's lookup-by-name stays exactly as
+-- naive as before -- in the renamed tree it is correct.
+--
+-- Offsets grow monotonically across the whole function (the blog's scheme):
+-- sibling blocks do not reuse slots, the frame is simply big enough for every
+-- declaration that ever lives.
+--
+-- Structure follows what the tree can contain: declarations occur only in
+-- block-item lists and scopes open only at compound statements, so the walk
+-- is a hand recursion over BlockItem/Statement (a handful of QQ-pattern
+-- cases); an expression can contain USES but never declarations, so renaming
+-- one is a whole-subtree generic transform -- `everywhereM` over the derived
+-- Data instances, in the Either monad so an out-of-scope use fails the walk.
 module Resolve (resolve, VarMap) where
 
+import Control.Monad (msum)
 import qualified Data.Map as M
 import Data.Data (Data)
-import Data.Generics (listify)
+import Data.Generics (everywhereM, mkM)
 
 import CParser
 import CQQ
 
--- Each local maps to its byte offset from %rbp (negative: below the frame base).
+-- Each unique-named local maps to its byte offset from %rbp (negative:
+-- below the frame base).
 type VarMap = M.Map String Int
 
-resolve :: Program -> Either String VarMap
-resolve [program| int $name ( ) { $stmts } |] = resolveItems stmts
+-- Scopes, innermost first: source name -> unique name.
+type Scopes = [M.Map String String]
+
+-- Slots handed out so far; slot n lives at offset -4(n+1).
+data Ctx = Ctx { slots :: VarMap, unique :: Int }
+
+resolve :: Program -> Either String (VarMap, Program)
+resolve [program| int $name ( ) { $stmts } |] = do
+  (ctx, _, stmts2) <- renameItems (Ctx M.empty 0) [M.empty] stmts
+  return (slots ctx, [program| int $name ( ) { $stmts2 } |])
 resolve other = Left $ "resolve: unsupported program: " ++ show other
 
--- Declarations only occur as block items (the grammar keeps them out of if
--- branches), so scanning the top-level list visits every one; statements are
--- checked as whole subtrees, which covers uses nested under if/else and ?:.
-resolveItems :: [BlockItem] -> Either String VarMap
-resolveItems = go M.empty
+-- A block-item list runs in ONE scope that its declarations extend as the
+-- walk passes them -- `a = 3; int a = 0;` inside a block assigns to the
+-- OUTER a (official stage-7 declare_late), which falls out of threading the
+-- scope left to right.
+renameItems :: Ctx -> Scopes -> [BlockItem] -> Either String (Ctx, Scopes, [BlockItem])
+renameItems ctx scopes [] = Right (ctx, scopes, [])
+renameItems ctx scopes (item : rest) = do
+  (ctx2, scopes2, item2) <- renameItem ctx scopes item
+  (ctx3, scopes3, rest2) <- renameItems ctx2 scopes2 rest
+  return (ctx3, scopes3, item2 : rest2)
+
+renameItem :: Ctx -> Scopes -> BlockItem -> Either String (Ctx, Scopes, BlockItem)
+renameItem ctx scopes (Decl p (DeclInit dp ident e)) = do
+  e2 <- renameUses scopes e     -- the initializer sees the scope BEFORE the
+                                -- declaration: `int a = a;` is out-of-scope
+  (ctx2, scopes2, ident2) <- declare ctx scopes ident
+  return (ctx2, scopes2, Decl p (DeclInit dp ident2 e2))
+renameItem ctx scopes (Decl p (Declare dp ident)) = do
+  (ctx2, scopes2, ident2) <- declare ctx scopes ident
+  return (ctx2, scopes2, Decl p (Declare dp ident2))
+renameItem ctx scopes (Stmt p s) = do
+  (ctx2, s2) <- renameStmt ctx scopes s
+  return (ctx2, scopes, Stmt p s2)
+renameItem _ _ other = Left $ "resolve: unexpected block item: " ++ show other
+
+-- Statements never extend the current scope; a compound statement opens a
+-- fresh one, which pops with the recursion (the returned Scopes of the inner
+-- walk is dropped).
+renameStmt :: Ctx -> Scopes -> Statement -> Either String (Ctx, Statement)
+renameStmt ctx scopes [statement| { $stmts } |] = do
+  (ctx2, _, stmts2) <- renameItems ctx (M.empty : scopes) stmts
+  return (ctx2, [statement| { $stmts2 } |])
+renameStmt ctx scopes [statement| if ( $e ) $s1 else $s2 |] = do
+  e2 <- renameUses scopes e
+  (ctx2, s3) <- renameStmt ctx scopes s1
+  (ctx3, s4) <- renameStmt ctx2 scopes s2
+  return (ctx3, [statement| if ( $e2 ) $s3 else $s4 |])
+renameStmt ctx scopes [statement| if ( $e ) $s1 |] = do
+  e2 <- renameUses scopes e
+  (ctx2, s3) <- renameStmt ctx scopes s1
+  return (ctx2, [statement| if ( $e2 ) $s3 |])
+renameStmt ctx scopes [statement| return $e ; |] = do
+  e2 <- renameUses scopes e
+  return (ctx, [statement| return $e2 ; |])
+renameStmt ctx scopes [statement| $e ; |] = do
+  e2 <- renameUses scopes e
+  return (ctx, [statement| $e2 ; |])
+renameStmt _ _ other = Left $ "resolve: unsupported statement: " ++ show other
+
+-- Add a declaration to the CURRENT scope: an error only if that same scope
+-- already has the name (shadowing an outer scope is what stage 7 is for).
+declare :: Ctx -> Scopes -> Ident -> Either String (Ctx, Scopes, Ident)
+declare _ [] _ = Left "resolve: no scope open (impossible)"
+declare ctx (scope : outer) (Name p v)
+  | v `M.member` scope = Left $ "duplicate declaration of variable '" ++ v ++ "'"
+  | otherwise = Right ( Ctx (M.insert u (-4 * (unique ctx + 1)) (slots ctx)) (unique ctx + 1)
+                      , M.insert v u scope : outer
+                      , Name p u )
+  where u = v ++ "#" ++ show (unique ctx)
+declare _ _ other = Left $ "resolve: unexpected identifier node: " ++ show other
+
+-- Rewrite every use in an expression to its unique name. Expressions contain
+-- no declarations, so this is scope-blind within the subtree: one monadic SYB
+-- transform over every Name node, failing on the first unresolvable one.
+renameUses :: Data a => Scopes -> a -> Either String a
+renameUses scopes = everywhereM (mkM rename)
   where
-    go env [] = Right env
-    go env (item : rest) = case item of
-      Decl _ (DeclInit _ ident e) -> declare env rest (identName ident) (checkUses env e)
-      Decl _ (Declare _ ident)    -> declare env rest (identName ident) (Right ())
-      Decl _ other                -> Left $ "resolve: unexpected declaration node: " ++ show other
-      Stmt _ s                    -> checkUses env s >> go env rest
-      other                       -> Left $ "resolve: unexpected block item: " ++ show other
+    rename (Name p v) = case lookupScopes v scopes of
+      Just u  -> Right (Name p u)
+      Nothing -> Left $ "undeclared variable '" ++ v ++ "'"
 
-    -- add a fresh local after validating its initializer against the vars in
-    -- scope *before* it (so `int a = a;` and a redeclaration are rejected)
-    declare env rest v initOk =
-      if v `M.member` env
-        then Left $ "duplicate declaration of variable '" ++ v ++ "'"
-        else initOk >> go (M.insert v (-4 * (M.size env + 1)) env) rest
-
-    -- every variable referenced by `node` must already be in scope
-    checkUses env node =
-      case filter (`M.notMember` env) (referenced node) of
-        []      -> Right ()
-        (v : _) -> Left $ "undeclared variable '" ++ v ++ "'"
-
--- every identifier appearing anywhere in `node` (a use, or an assignment
--- target -- both must be declared)
-referenced :: Data a => a -> [String]
-referenced = map nameOf . listify isName
-  where isName (Name _ _) = True
-        isName _          = False
-        nameOf (Name _ s) = s
-        nameOf _          = ""
-
-identName :: Ident -> String
-identName (Name _ s) = s
-identName other = error $ "resolve: unexpected identifier node: " ++ show other
+-- innermost scope wins: the first hit in the stack
+lookupScopes :: String -> Scopes -> Maybe String
+lookupScopes v = msum . map (M.lookup v)

--- a/tutorials/c-compiler/TestQQ.hs
+++ b/tutorials/c-compiler/TestQQ.hs
@@ -185,6 +185,22 @@ main = do
           rejects "int main() { if (5) int i = 0; return 0; }"
       , check "assignment in a ternary false branch is a SYNTAX error" $
           rejects "int main() { int a = 2; a > 1 ? a = 1 : a = 0; return a; }"
+      , check "compound construction: [statement| { return 1 ; } |]" $
+          [statement| { return 1 ; } |]
+            == Compound rtkNoPos [Stmt rtkNoPos (Return rtkNoPos (IntLit rtkNoPos 1))]
+      , check "compound pattern binds its item list: [statement| { $stmts } |]" $
+          -- a LIST antiquote nested inside the (scalar) statement quoter
+          case [statement| { int x ; x = 1 ; } |] of
+            [statement| { $stmts } |] -> length stmts == 2
+            _ -> False
+      , check "mixed list splice inside a compound: { $stmts0 return 9 ; }" $
+          let stmts0 = [[blockItem| int x ; |]]
+          in [statement| { $stmts0 return 9 ; } |]
+               == parseStmt "{ int x; return 9; }"
+      , check "shadowing resolves; same-scope redeclaration does not" $
+          resolves "int main() { int a = 2; { int a = 1; } return a; }"
+            && not (resolves "int main() { { int a; int a; } return 0; }")
+            && not (resolves "int main() { { int a = 2; } return a; }")
       ]
 
   putStrLn "-- assembly grammar --"
@@ -222,13 +238,11 @@ main = do
                            ret |]
           in parseAsmText (emit prog) == prog
       , check "full pipeline: parse C -> resolve -> codegen -> emit -> parse Asm" $
-          let p = parse "int main() { int a = 2; return a; }"
-              a = codegen (either error id (resolve p)) p
-          in parseAsmText (emit a) == a
+          pipelineRoundTrips "int main() { int a = 2; return a; }"
       , check "full pipeline with if/else and ?: (stage 6 jump diamonds)" $
-          let p = parse "int main() { int a = 1; if (a) return a ? 2 : 3; else return 4; }"
-              a = codegen (either error id (resolve p)) p
-          in parseAsmText (emit a) == a
+          pipelineRoundTrips "int main() { int a = 1; if (a) return a ? 2 : 3; else return 4; }"
+      , check "full pipeline with blocks and shadowing (stage 7 renaming)" $
+          pipelineRoundTrips "int main() { int a = 2; { int a = 1; a = a + 1; } return a; }"
       ]
 
   unless (and (cResults ++ asmResults)) exitFailure
@@ -239,6 +253,23 @@ parse src = either error id (scanTokens src >>= parseC)
 
 rejects :: String -> Bool
 rejects src = either (const True) (const False) (scanTokens src >>= parseC)
+
+-- parse a single statement by wrapping it in a main and unwrapping the body
+parseStmt :: String -> Statement
+parseStmt src = case parse ("int main() { " ++ src ++ " }") of
+  [program| int $name ( ) { $stmts } |] | [Stmt _ s] <- stmts -> s
+  _ -> error $ "parseStmt: not a single statement: " ++ src
+
+-- resolve renames (stage 7), so codegen runs on the tree it returns
+pipelineRoundTrips :: String -> Bool
+pipelineRoundTrips src =
+  let p = parse src
+      (varmap, p2) = either error id (resolve p)
+      a = codegen varmap p2
+  in parseAsmText (emit a) == a
+
+resolves :: String -> Bool
+resolves src = either (const False) (const True) (resolve (parse src))
 
 parseAsmText :: String -> Asm
 parseAsmText src = either error id (AsmLexer.scanTokens src >>= parseAsm)

--- a/tutorials/c-compiler/c.pg
+++ b/tutorials/c-compiler/c.pg
@@ -1,6 +1,6 @@
 grammar 'C';
 
-# Stages 1-6 of Nora Sandler's "Writing a C Compiler"
+# Stages 1-7 of Nora Sandler's "Writing a C Compiler"
 # (https://norasandler.com/2017/11/29/Write-a-Compiler.html):
 #
 #   <program>    ::= <function>
@@ -10,6 +10,7 @@ grammar 'C';
 #   <statement>  ::= "return" <exp> ";" | <exp> ";"
 #                  | "if" "(" <exp> ")" <statement>          # stage 6: if/else
 #                    [ "else" <statement> ]
+#                  | "{" { <block-item> } "}"                # stage 7: blocks
 #   <exp>        ::= <id> "=" <exp> | <cond>                 # stage 5: assign
 #   <cond>       ::= <lor> [ "?" <exp> ":" <cond> ]          # stage 6: ternary
 #   <lor>        ::= <lor> "||" <land>    | <land>           # stage 4: logical
@@ -74,7 +75,8 @@ Declaration = DeclInit: 'int' Ident '=' Exp ';'
 Statement = Return: 'return' Exp ';'
           | ExpStmt: Exp ';'
           | If: 'if' '(' Exp ')' Statement
-          | IfElse: 'if' '(' Exp ')' Statement 'else' Statement ;
+          | IfElse: 'if' '(' Exp ')' Statement 'else' Statement
+          | Compound: '{' BlockItemList '}' ;
 
 # The expression grammar is a precedence cascade: assignment (lowest) over
 # logical-or over logical-and over equality over relational over additive over

--- a/tutorials/c-compiler/tests/invalid/double_define_scope.c
+++ b/tutorials/c-compiler/tests/invalid/double_define_scope.c
@@ -1,0 +1,7 @@
+int main() {
+    {
+        int a;
+        int a;
+    }
+    return 0;
+}

--- a/tutorials/c-compiler/tests/invalid/out_of_scope.c
+++ b/tutorials/c-compiler/tests/invalid/out_of_scope.c
@@ -1,0 +1,6 @@
+int main() {
+    {
+        int a = 2;
+    }
+    return a;
+}

--- a/tutorials/c-compiler/tests/valid/shadow.c
+++ b/tutorials/c-compiler/tests/valid/shadow.c
@@ -1,0 +1,9 @@
+int main() {
+    int a = 2;
+    {
+        a = 3;
+        int a = 0;
+        a = a + 1;
+    }
+    return a;
+}

--- a/tutorials/c-compiler/tests/valid/sibling_scopes.c
+++ b/tutorials/c-compiler/tests/valid/sibling_scopes.c
@@ -1,0 +1,16 @@
+int main() {
+    int total = 0;
+    {
+        int x = 5;
+        total = total + x;
+    }
+    {
+        int x = 7;
+        total = total + x;
+    }
+    if (total > 10) {
+        int x = 100;
+        total = total + x;
+    }
+    return total;
+}

--- a/tutorials/c-compiler/tutorial/07-blocks.md
+++ b/tutorials/c-compiler/tutorial/07-blocks.md
@@ -1,0 +1,176 @@
+# 07 — Compound statements and scoping
+
+← [06 — if/else and ?:](06-conditionals.md) · [Tutorial index](README.md)
+
+Companion to **[Writing a C Compiler, Part 7](https://norasandler.com/2018/03/14/Write-a-Compiler-7.html)**.
+
+Stage 7 adds compound statements — `{ ... }` as a statement — and with them
+real block scoping: declarations local to their block, shadowing, and
+out-of-scope uses rejected. The grammar change is one line. Everything
+interesting happens in the semantic pass, which meets the classic question of
+separated compiler passes: **once two variables can share a name, what do you
+hand the code generator?**
+
+## 1. One grammar line
+
+> **Blog ⇄ RTK.** The blog adds `Compound(block_item list)` to its statement
+> AST. Here that is one alternative — stage 6 already built everything it
+> needs.
+
+```
+Statement = ...
+          | Compound: '{' BlockItemList '}' ;
+```
+
+`BlockItemList` and the statement/declaration split arrived in
+[stage 6](06-conditionals.md), so a block body is *the same sort* as a
+function body. LALR-wise the alternative is free — no statement starts with
+`{`, so `make conflict-check` still reports exactly the pinned inventory
+(dangling else + QQ dummy bracket). The official `syntax_err_extra_brace` /
+`syntax_err_missing_brace` tests fall out of brace balancing in the grammar.
+
+## 2. Scoping breaks the pass boundary — renaming fixes it
+
+> **Blog ⇄ RTK.** This is the page's real fork. The blog resolves scopes
+> *during code generation* — its codegen walks blocks carrying a variable map.
+> This compiler keeps resolve and codegen separate, and shadowing is exactly
+> what breaks their interface: `resolve` used to return a `name → offset` map,
+> but with two live `a`s a *name* no longer identifies a slot.
+
+The classic fix (and a first taste of what real compilers do on the way to
+SSA) is **alpha-renaming**: [`Resolve.hs`](../Resolve.hs) walks the tree with
+a stack of scopes, gives each declaration a unique name — `a#0`, `a#1`, … (`#`
+cannot appear in a C identifier, so no collision is possible) — and rewrites
+every use to the unique name of the declaration it refers to. It returns the
+**renamed tree** along with offsets keyed by unique names:
+
+```haskell
+resolve :: Program -> Either String (VarMap, Program)
+```
+
+After renaming, shadowing is *gone* — every variable in the tree is distinct —
+so [`Codegen.hs`](../Codegen.hs) keeps its naive map lookup untouched and its
+only new case is a sequence:
+
+```haskell
+genStatement [statement| { $stmts } |] =
+  concat <$> mapM genBlockItem stmts
+```
+
+The scope rules live in one small function. A scope is a `source name →
+unique name` map; the stack grows at `{` and pops with the recursion; a
+declaration extends the *current* scope and is an error only if that same
+scope already has the name:
+
+```haskell
+declare ctx (scope : outer) (Name p v)
+  | v `M.member` scope = Left ("duplicate declaration of variable '" ++ v ++ "'")
+  | otherwise          = ...  -- fresh unique name, next slot, extend scope
+```
+
+Threading the scope left to right through the item list gets the official
+suite's trickiest case right for free. In `declare_late`:
+
+```c
+int a = 2;
+{
+    a = 3;          // the OUTER a: the inner one is not declared yet
+    int a = 0;
+}
+return a;           // 3
+```
+
+the `a = 3;` is renamed *before* the walk reaches `int a = 0;`, so it
+resolves to the outer `a#0` — declarations take effect mid-block, exactly
+where they stand.
+
+## 3. The walk, structured by what the tree allows
+
+The pass is a hand recursion over statements — but only because scopes and
+declarations live there. Two shapes of traversal split the work:
+
+- **`BlockItem`/`Statement` level — hand recursion, QQ patterns.**
+  Declarations occur only in item lists; scopes open only at `{`. A handful
+  of cases (`return`/expression/if/if-else/compound), each destructured and
+  rebuilt with quasi-quotes — the compound case is just
+  `renameItems ctx (M.empty : scopes) stmts` with the popped result rebuilt
+  as `[statement| { $stmts2 } |]`.
+- **`Exp` level — one generic transform.** An expression can contain *uses*
+  but never declarations, so renaming inside one is scope-blind: a single
+  monadic SYB pass in the `Either` monad, failing on the first unresolvable
+  name:
+
+```haskell
+renameUses scopes = everywhereM (mkM rename)
+  where rename (Name p v) = case lookupScopes v scopes of
+          Just u  -> Right (Name p u)
+          Nothing -> Left ("undeclared variable '" ++ v ++ "'")
+```
+
+Stage 5 introduced the division of labour as *QQ for targeted matching, SYB
+for whole-tree queries*; stage 7 upgrades the SYB half from a query
+(`listify`) to a **rewrite** (`everywhereM`) — the same `everywhere`/`mkT`
+machinery the RTK rewrite recipe (task 8d) ships for every generated grammar,
+here in its monadic form because the rewrite can fail.
+
+Offsets keep growing monotonically across the whole function (the blog's
+scheme): sibling blocks do not reuse slots, the frame is simply sized for
+every declaration that ever lives. `frameSize` did not change.
+
+## 4. Run it
+
+```bash
+make build
+./ncc tests/valid/shadow.c && tests/valid/shadow; echo "exit: $?"
+```
+
+```
+exit: 3
+```
+
+(the outer `a` — assigned `3` *before* the shadow appears — survives the
+block; the inner `a` lives and dies at `-8(%rbp)` while the outer keeps
+`-4(%rbp)`).
+
+## 5. Test it
+
+```bash
+make test                              # 112 checks
+/tmp/wacc/test_compiler.sh "$PWD/ncc" 7
+```
+
+```
+PASS  compound pattern binds its item list: [statement| { $stmts } |]
+PASS  shadowing resolves; same-scope redeclaration does not
+PASS  full pipeline with blocks and shadowing (stage 7 renaming)
+PASS  tests/valid/shadow.c (exit code 3)
+...
+===================Stage 7 Summary=================
+12 successes, 0 failures
+```
+
+All previous stages stay green — **119/119** across the official suite for
+stages 1–7.
+
+## What changed from stage 6
+
+| | Stage 6 | Stage 7 |
+|---|---|---|
+| `c.pg` | statement/declaration split | `+ Compound` — one alternative |
+| conflicts | 1, pinned | unchanged (`{` starts nothing else) |
+| **`Resolve.hs`** | flat map, walks `[BlockItem]` | **scope stack + alpha-renaming; returns the renamed tree** |
+| `Codegen.hs` | jump diamonds | `+ Compound` = sequence; lookup untouched (renamed tree) |
+| `Main.hs` | `resolve` → map | `resolve` → (map, renamed tree) |
+| `asm.pg` / `Emit.hs` | — | unchanged |
+
+The structural step: the first pass that *rewrites* the tree rather than just
+checking it — and the pass boundary (`resolve` hands codegen a tree in which
+scoping has already been compiled away) is a miniature of how real compilers
+lower scoped source into flat IR.
+
+## Next
+
+Stage 8 adds loops — `for`, `while`, `do`, and `break`/`continue`, which need
+a *loop context* threaded through statement codegen for their jump targets.
+It is task **C8** in
+[`docs/c-compiler-tutorial-plan.md`](../../../docs/c-compiler-tutorial-plan.md).

--- a/tutorials/c-compiler/tutorial/README.md
+++ b/tutorials/c-compiler/tutorial/README.md
@@ -29,10 +29,11 @@ verified against the build.
 | [04 — Relational and logical](04-relational.md) | [Part 4](https://norasandler.com/2018/01/08/Write-a-Compiler-4.html) | `== != < <= > >= && ||`, short-circuiting, and the first stateful codegen. |
 | [05 — Local variables](05-variables.md) | [Part 5](https://norasandler.com/2018/01/25/Write-a-Compiler-5.html) | Declarations, assignment, a stack frame, and the first semantic pass (SYB). |
 | [06 — if/else and ?:](06-conditionals.md) | [Part 6](https://norasandler.com/2018/02/25/Write-a-Compiler-6.html) | The statement/declaration split, the dangling else (a pinned, intentional conflict), and jump diamonds. |
+| [07 — Blocks and scoping](07-blocks.md) | [Part 7](https://norasandler.com/2018/03/14/Write-a-Compiler-7.html) | Compound statements, the scope stack, and alpha-renaming: the first pass that rewrites the tree (monadic SYB). |
 
-Stages 7–10 (compound statements through file-scope variables) are implemented
-one at a time; each adds a page here. Until then they live as task descriptions
-in [`docs/c-compiler-tutorial-plan.md`](../../../docs/c-compiler-tutorial-plan.md).
+Stages 8–10 (loops through file-scope variables) are implemented one at a
+time; each adds a page here. Until then they live as task descriptions in
+[`docs/c-compiler-tutorial-plan.md`](../../../docs/c-compiler-tutorial-plan.md).
 
 ## Conventions on these pages
 


### PR DESCRIPTION
Compound statements and block scoping, following blog part 7. One grammar
line; the substance is in the semantic pass.

- **The design fork**: the blog resolves scopes *during* codegen; we keep the
  passes separate, and shadowing breaks their old interface — with two live
  `a`s, a name no longer identifies a stack slot. `Resolve` therefore
  **alpha-renames**: scope stack, unique names (`a#0`, `a#1`, … — `#` can't
  occur in a C identifier), every use rewritten to its declaration's unique
  name, returning the renamed tree + offsets keyed by unique names. Codegen's
  lookup stays untouched; its only new case is `Compound` = sequence.
- **Traversal structured by the tree**: declarations occur only in item
  lists and scopes open only at `{`, so the statement walk is a hand
  recursion in QQ patterns (rebuilt with QQ construction); expressions
  contain uses but never declarations, so renaming one is a single
  scope-blind `everywhereM` in `Either` — the monadic form of the task-8d
  rewrite recipe.
- **Semantics** per the official suite: shadowing legal, duplicate
  declaration an error only within the *same* scope, out-of-scope rejected;
  left-to-right scope threading gets `declare_late` (use before an inner
  shadow declaration → outer variable) right for free. Offsets grow
  monotonically (the blog's scheme).
- **Conflict inventory unchanged** — `{` starts no other statement;
  `make conflict-check` still pins dangling else + QQ dummy bracket.
- **Tests**: 4 new QQ checks (incl. a list antiquote nested inside the
  scalar statement quoter and a shadowing pipeline round trip), 2 valid + 2
  invalid local programs.

Verified: tutorial suite **112/112 from a clean build**; official
write_a_c_compiler **stages 1–7: 119/119** (12, 11, 16, 27, 17, 24, 12).
Adds `tutorial/07-blocks.md` and updates index, status, layout, roadmap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)